### PR TITLE
Fix MoE engine bugs, prune dead code, and de-Mixtral the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ router resident in RAM and **hot-swaps individual experts on demand** from a
 PCIe-attached NVMe drive into a pool of pre-allocated, page-aligned RAM
 buffers using **`O_DIRECT`** positional reads (`pread(2)` via
 `tokio::task::block_in_place`, kernel-page-cache bypass). Each routed
-expert then **executes a real Mixtral / Llama-style
-SwiGLU FFN forward pass** directly over the bytes that just arrived from the
-drive.
+expert then **executes a real SwiGLU FFN forward pass** — the Mixtral /
+Llama expert shape shared by every supported family — directly over the
+bytes that just arrived from the drive.
 
 The premise is straightforward: a **modern PCIe-4 / 5 NVMe SSD sustains
 6-14 GB/s** of sequential read; a single Mixtral-8x7B expert is
@@ -18,12 +18,32 @@ therefore costs a small fraction of a second of I/O per MoE layer, and
 is 10-100× DRAM. Quantisation is what makes the trade-off practical
 on real models: 4-bit weights cut SSD bytes per token by ~3.5× vs bf16
 and let a single PCIe-4 NVMe sustain interactive token rates on
-Mixtral-class checkpoints. So you can run much larger models on much
+modern MoE checkpoints (Mixtral, Qwen3-MoE, DeepSeek-V3, MiMo-V2-Flash,
+GPT-OSS, …). So you can run much larger models on much
 more modest hardware by treating the SSD as the main weight store and
 DRAM as a small cache of *active* experts. This engine is the
 substrate that makes that trade-off observable and measurable.
 
 The engine lives under [`rust-engine/`](./rust-engine).
+
+### Supported model families
+
+The loader is **architecture-aware**: point it at a HuggingFace
+`.safetensors` checkpoint and the engine auto-detects the family from its
+`config.json`, remaps every tensor name and hyperparameter, and runs the
+unified dense + SSD-streamed-MoE forward path — no hand-edited config
+required. Supported families:
+
+* **Mixtral 8x7B / 8x22B** (`mixtral`) — the original, fully-streamed MoE path.
+* **Qwen3-MoE** (`qwen3_moe`) + **Qwen3 dense** (`qwen3`) — `mlp.experts.*` names, QK-Norm attention.
+* **DeepSeek-V3 / V3.1** (`deepseek_v3`) — MLA latent-KV attention, FP8 `e4m3` weights, shared expert, sigmoid grouped-top-K routing, `first_k_dense_replace` dense prefix.
+* **Xiaomi MiMo-V2-Flash** (`mimo_v2_flash`) + **OpenAI GPT-OSS 20B / 120B** (`gpt_oss`) — per-layer **hybrid** sliding-window / global attention.
+* **Mistral Small 3** (`mistral3`) + **Phi-4** (`phi3`) — dense decoders (fused QKV / gate-up split at load).
+
+Mixtral remains the canonical streamed example (and the model behind the
+benchmark below), but it is no longer the only target. See
+[Supported model architectures](#supported-model-architectures) for the
+per-family tensor schemas, routing and attention details.
 
 ---
 
@@ -67,6 +87,7 @@ Our latest endurance tests demonstrate the engine's ability to maintain stable p
 
 ## Table of Contents
 
+- [Supported model families](#supported-model-families)
 - [Benchmark Results](#-benchmark-results-endurance-scaling)
 - [What it actually does](#what-it-actually-does)
   - [End-to-end pipeline](#end-to-end-pipeline)
@@ -96,7 +117,7 @@ Our latest endurance tests demonstrate the engine's ability to maintain stable p
   - [Sample output](#sample-output)
     - [Enabling the predictive prefetcher (and A/B testing it)](#enabling-the-predictive-prefetcher-and-ab-testing-it)
   - [CLI reference](#cli-reference)
-  - [Running on real Mixtral weights](#running-on-real-mixtral-weights)
+  - [Running on real MoE weights](#running-on-real-moe-weights)
   - [Routing model, Markov chain, transition matrix, or LinearGate](#routing-model-markov-chain-transition-matrix-or-lineargate)
   - [macOS](#macos)
 - [What can it actually run today?](#what-can-it-actually-run-today)
@@ -108,7 +129,7 @@ Our latest endurance tests demonstrate the engine's ability to maintain stable p
   - [GPU promotion regression test](#gpu-promotion-regression-test)
 - [Energy Efficiency Features](#energy-efficiency-features)
   - [1. On-disk quantization (`--dtype`)](#1-on-disk-quantization---dtype)
-  - [Persistent, page-aligned KV cache](#persistent-page-aligned-kv-cache)
+  - [Page-aligned KV cache buffer](#page-aligned-kv-cache-buffer)
   - [Cold-start manifest](#cold-start-manifest)
   - [2. 2nd-order Markov + gate-lookahead prefetching](#2-2nd-order-markov--gate-lookahead-prefetching)
   - [3. Partial weight loading (`--partial-load-fraction`)](#3-partial-weight-loading---partial-load-fraction)
@@ -125,7 +146,7 @@ Our latest endurance tests demonstrate the engine's ability to maintain stable p
 
 ## What it actually does
 
-A standard Mixtral-style transformer activates only `K` of `N` experts per
+A sparse Mixture-of-Experts (MoE) transformer activates only `K` of `N` experts per
 token (e.g. `K=2`, `N=64`). For inference on hardware whose DRAM cannot hold
 all `N` experts you have two options:
 
@@ -409,7 +430,7 @@ The Rust crate (`rust-engine/`) is organised into single-responsibility modules:
 
 | Module | Responsibility |
 |---|---|
-| `aligned_buffer` | Heap-allocated, page-aligned buffer (`std::alloc::alloc` with a `Layout`). The defining requirement of `O_DIRECT`: kernel rejects unaligned buffers with `EINVAL`. Reused by [`AlignedKvCache`](#persistent-page-aligned-kv-cache) so the session-scoped K/V state can be snapshotted to NVMe with no extra copy. |
+| `aligned_buffer` | Heap-allocated, page-aligned buffer (`std::alloc::alloc` with a `Layout`). The defining requirement of `O_DIRECT`: kernel rejects unaligned buffers with `EINVAL`. Reused by [`AlignedKvCache`](#page-aligned-kv-cache-buffer) so the session-scoped K/V state can be snapshotted to NVMe with no extra copy. |
 | `buffer_pool` | Fixed-capacity slab of `AlignedBuffer`s, optionally split into **primary** + **shadow** halves sharing one `Notify`. Hands out `PooledBuffer` RAII guards; `try_acquire`/`try_acquire_shadow` route to the corresponding free list; dropping a guard returns the buffer to its originating list and wakes waiters. `promote_shadow` does the zero-copy slot-tag swap when a speculative prefetch is confirmed. The literal "pre-allocated RAM buffer" the spec asks for. |
 | `expert_cache` | LRU map `expert_id → Arc<ExpertResident>`, with a separate **pin set** so frequency-pinned and locality-hot experts skip eviction. Eviction returns the `Arc`; once all references drop, the buffer goes back to the pool automatically. |
 | `multi_layer_cache` | Per-layer `ExpertCache` wrapper keyed on `(layer, expert)`. Lets multi-layer Mixtral / DeepSeek configurations give each layer its own LRU budget instead of sharing one global cache. **Now wired into the engine hot path** (gist Part 1 fix #2): `EngineCore::cache` is an `Arc<MultiLayerExpertCache>` and `run`/`serve` distribute `--cache-slots` across `num_layers` (uniform per-layer caps via `MultiLayerExpertCache::with_capacities`, with any remainder going to the lowest-indexed layers). Single-layer / `--io-only` mode collapses to `MultiLayerExpertCache::single_layer(cap)` so existing benchmark paths are byte-identical. |
@@ -425,8 +446,8 @@ The Rust crate (`rust-engine/`) is organised into single-responsibility modules:
 | `sampling` | OpenAI-compatible next-token sampler, temperature, top-K, top-P (nucleus), `(seed, position)`-driven RNG. `temperature == 0.0` short-circuits to greedy `argmax`. |
 | `tokenizer` | HuggingFace `tokenizers` crate when the `tokenizer` cargo feature is enabled and a `tokenizer.json` is configured; deterministic byte-level fallback otherwise. |
 | `session` | In-memory KV-cache session store (`DashMap`-backed) for multi-turn chat. Per-session position cursor + idle-TTL evictor. TTL-driven `evict_expired` now zeroizes each expired session's KV buffers **before** the `Arc<SessionState>` is dropped (gist Part 1 fix #1) so residual user context cannot survive in freed heap pages; `delete` does the same on explicit removal. |
-| `batch_scheduler` | **Continuous batching + multi-tenant fair-share.** An `mpsc`-fed background task drains per-token `StepRequest`s, fuses up to `max_batch_size` requests (or whatever has arrived within `batch_timeout_ms`) into a single batch, and runs their `RealModel::step` calls concurrently against the shared `Engine`. Owns a central `RequestRegistry` so the channel carries only `{ id, token, pos, params }` per token, never the full `Vec<KvCache>`, and optionally owns the shared `BlockPool` for paged KV. Each batched step starts with a **peek/warm pre-pass** that calls `RealModel::peek_experts` for every request, unions the predicted expert ids, and fires one `engine.warm_with(&ids)` so the NVMe sees one read per unique expert across the entire batch (gist Phase 1). Registered sessions carry a **`SessionClass`** (`Interactive` weight 4, `Audit` weight 1) consumed by the **Weighted Round-Robin admission policy** so an Audit flood cannot starve Interactive callers, plus a monotonic `last_activity_us` timestamp used by **`evict_idle_blocks`** to reclaim KV blocks from sessions idle ≥ `idle_eviction_threshold` (default 5 s) when the pool crosses its soft-cap. Under `PressureLevel::Critical` the scheduler suspends the shared `SpeculationController` so prefetch depth is clamped to zero. |
-| `engine` | Top-level orchestrator. Owns the router, predictor (`S` + `L` + `M`), cache, pool, storage, alias map, frequency-pin counters, HDR histograms, and the alias/locality/speculator atomic telemetry. Drives the per-token cycle (`Engine::generate` and `Engine::moe_step`), schedules `union_prefetch`es, and reconciles the locality hot set with the cache's pin set. Also home to [`AlignedKvCache`](#persistent-page-aligned-kv-cache), a session-scoped, page-aligned, rolling-window K/V buffer attached via `Engine::with_kv_cache`. `spawn_prefetch` is **bounded** by a `tokio::sync::Semaphore` sized from `EngineOptions::max_concurrent_prefetches` (default 64, configurable via `[real_transformer].max_concurrent_prefetches`, gist Part 1 fix #3): an owned permit is acquired *before* `tokio::spawn`, so the bound is enforced before any task work happens; refusals bump `Counters::prefetch_dropped_concurrency` (also surfaced on `EngineReport`). `Engine::fetch_once` likewise bounds its `tokio::task::yield_now()` spin loop at `EngineOptions::max_fetch_yields` (default 128, configurable via `[real_transformer].max_fetch_yields`, gist feedback #1.3): when the cache is full of pinned residents and no `PooledBuffer` frees within the budget, `fetch_once` returns `FetchOnceError::PoolStarved` instead of yielding indefinitely. |
+| `batch_scheduler` | **Continuous batching + multi-tenant fair-share.** An `mpsc`-fed background task drains per-token `StepRequest`s, fuses up to `max_batch_size` requests (or whatever has arrived within `batch_timeout_ms`) into a single batch, and runs their `RealModel::step` calls concurrently against the shared `Engine`. Owns a central `RequestRegistry` so the channel carries only `{ id, token, pos, params }` per token, never the full `Vec<KvCache>`, and optionally owns the shared `BlockPool` for paged KV. Each batched step starts with a **peek/warm pre-pass** that calls `RealModel::peek_experts` for every request, unions the predicted expert ids, and fires one `engine.warm_with(&ids)` so the NVMe sees one read per unique expert across the entire batch (gist Phase 1). Registered sessions carry a **`SessionClass`** (`Interactive` weight 4, `Audit` weight 1) consumed by the **Weighted Round-Robin admission policy** so an Audit flood cannot starve Interactive callers, plus a monotonic `last_activity_us` timestamp the scheduler loop uses to **reclaim KV blocks** from sessions idle ≥ `idle_eviction_threshold` (default 5 s) when the pool crosses its soft-cap. Under `PressureLevel::Critical` the scheduler suspends the shared `SpeculationController` so prefetch depth is clamped to zero. |
+| `engine` | Top-level orchestrator. Owns the router, predictor (`S` + `L` + `M`), cache, pool, storage, alias map, frequency-pin counters, HDR histograms, and the alias/locality/speculator atomic telemetry. Drives the per-token cycle (`Engine::generate` and `Engine::moe_step`), schedules `union_prefetch`es, and reconciles the locality hot set with the cache's pin set. `spawn_prefetch` is **bounded** by a `tokio::sync::Semaphore` sized from `EngineOptions::max_concurrent_prefetches` (default 64, configurable via `[real_transformer].max_concurrent_prefetches`, gist Part 1 fix #3): an owned permit is acquired *before* `tokio::spawn`, so the bound is enforced before any task work happens; refusals bump `Counters::prefetch_dropped_concurrency` (also surfaced on `EngineReport`). `Engine::fetch_once` likewise bounds its `tokio::task::yield_now()` spin loop at `EngineOptions::max_fetch_yields` (default 128, configurable via `[real_transformer].max_fetch_yields`, gist feedback #1.3): when the cache is full of pinned residents and no `PooledBuffer` frees within the budget, `fetch_once` returns `FetchOnceError::PoolStarved` instead of yielding indefinitely. |
 | `gguf` | Minimal **GGUF reader** (versions 1, 2, 3): magic / metadata / tensor table, recognises `F32`, `F16`, `Q4_0`, `Q4_K`, `Q6_K`, `Q8_0`. Two readers ship side-by-side: `GgufFile::open` (eager, slurps the file into RAM, useful for tests) and `GgufStreamReader::open` (streaming, keeps only the header resident and seeks tensor bodies on demand, the default for `gguf-convert`). Both implement the `GgufSource` trait so the loader is reader-agnostic. |
 | `gguf_loader` | Glue from a `GgufSource` → per-expert `.bin` files + `metadata.json` + dense weight files. Each expert file is page-aligned and (by default) prefixed with a 64-byte **Unified Tensor Header**; `--no-uth` opts out. Pass `--native-quant` to write raw `Q4_0` / `Q4_K` / `Q8_0` block streams to disk instead of dequantising to F32 (~7× smaller `.bin` files for the 4-bit dtypes, ~4× smaller for `Q8_0`; falls back automatically if the source dtype is ineligible). Driven by the `gguf-convert` subcommand. |
 | `tensor_header` | 64-byte **U.T.H.** (`UTH1` magic, dtype, shape, quant-scale offset, AMX tile hint, flags). Self-describing prefix written by `gguf-convert` and transparently stripped by `ExpertResident::data()` so downstream kernels never see it. |
@@ -1056,7 +1077,7 @@ compute overlap. The knobs live under `[real_transformer]`:
 ```toml
 max_batch_size            = 8     # max concurrent requests fused per step (1 disables batching)
 batch_timeout_ms          = 5     # how long to wait for more requests to join a partial batch
-idle_eviction_threshold_ms = 5000 # idle-cutoff for evict_idle_blocks under pool pressure (default 5 s)
+idle_eviction_threshold_ms = 5000 # idle-cutoff for the scheduler's idle-eviction pass under pool pressure (default 5 s)
 speculation_base_depth     = 1    # baseline prefetch depth in tokens-ahead (grows to base+2 under SSD stall)
 max_concurrent_prefetches  = 64   # gist Part 1 fix #3, semaphore ceiling for engine.spawn_prefetch (refusals bump `prefetch_dropped_concurrency`)
 max_fetch_yields           = 128  # gist feedback #1.3, bound on `tokio::yield_now` spins in `Engine::fetch_once` before returning `FetchOnceError::PoolStarved`
@@ -1074,7 +1095,7 @@ one Interactive + N Audit sessions still leaves Interactive with
 regardless of how many Audit streams are running.
 
 The scheduler additionally tracks each session's monotonic
-`last_activity_us` and runs **`evict_idle_blocks(idle_threshold)`**
+`last_activity_us` and runs an **idle-eviction pass**
 whenever the `BlockPool` crosses its soft-cap (90 % primary
 utilisation). Sessions idle for ≥ `idle_eviction_threshold_ms` have
 their attached `BlockManager` dropped, returning every block to the
@@ -1083,7 +1104,7 @@ chat sessions retain their KV memory under pressure.
 
 Under `BlockPool::PressureLevel::Critical` (≥ 98 % primary
 utilisation) the scheduler **suspends the shared
-`SpeculationController`**, clamping `current_speculation_depth()` to
+`SpeculationController`**, clamping the **speculation depth** to
 0. The controller stays suspended through `High` (≥ 90 %) and only
 resumes when the pool reverts to `Normal` — resuming at `High` would
 oscillate the pool straight back into `Critical`. Once resumed,
@@ -1699,10 +1720,11 @@ micro-expert-router monitor          # requires `--features tui` (on by default)
   --refresh-ms <MS>          Dashboard refresh interval (default 500).
 ```
 
-### Running on real Mixtral weights
+### Running on real MoE weights
 
-There are **three** ways to feed real Mixtral / Llama-MoE weights into
-the engine, depending on what format you have them in:
+There are **three** ways to feed real MoE weights (Mixtral / Llama-MoE,
+Qwen3-MoE, DeepSeek-V3, …) into the engine, depending on what format you
+have them in:
 
 **1. From a Hugging Face checkpoint (per-expert `.bin` files).**
 `scripts/extract_mixtral_experts.py` dumps a transformer layer's expert
@@ -1799,6 +1821,14 @@ auto-detection from a `config.json` in `weights_dir` (which also remaps
 all hyperparameters, so a real checkpoint loads without hand-editing the
 TOML `[model]` section). An **unrecognised** architecture is a hard
 error — the engine never silently mislabels a checkpoint.
+
+Every family below **executes** through the unified forward path:
+`Architecture::compute_support()` returns `Supported` for all of them, so
+none are refused at compute time. *Full* marks the original, battle-tested
+streamed path; *Loadable* marks families that load and run but are newer
+and have had less end-to-end validation against published checkpoints;
+*(dense)* marks models with no MoE layers (they run but do not exercise
+SSD expert streaming).
 
 | Family | `model_type` | Status | Notes |
 |---|---|---|---|
@@ -1984,8 +2014,9 @@ for clean numbers.
 
 ## What can it actually run today?
 
-**Today, in this repository: a real Mixtral / Llama-style transformer
-forward pass with weights streamed from NVMe.** When
+**Today, in this repository: a real, architecture-aware MoE transformer
+forward pass with experts streamed from NVMe** — Mixtral, Qwen3-MoE,
+DeepSeek-V3 (MLA), MiMo-V2-Flash and GPT-OSS all run the same path. When
 `[real_transformer].enabled = true` the server runs the full decoder
 
 ```
@@ -2020,7 +2051,7 @@ What is **still synthetic by default**:
   matrix via `--router-matrix`). When `[real_transformer]` is enabled
   routing instead goes through the per-layer learned `LinearGate`
   driven by the actual hidden state, the same `softmax`-over-gate-
-  logits a real Mixtral implementation uses. The Markov path stays
+  logits a real MoE implementation uses. The Markov path stays
   available for benchmarks where you want a fixed, reproducible
   routing distribution independent of the model weights.
 - **Combining** uses the gate's softmax probabilities as weights on
@@ -2042,11 +2073,12 @@ while the matmul + `silu` activation use Candle's built-in kernels.
 Swapping in a different backend (e.g. a GPU-enabled Candle build, or
 `tch` / `cudarc`) is a localised change inside `inference.rs`.
 
-Real Mixtral expert weights can already be fed to the engine end-to-end
-via [`scripts/extract_mixtral_experts.py`](./scripts/extract_mixtral_experts.py),
-which dumps a single layer's experts into the on-disk format the
-engine expects (plus a `metadata.json` that `run` auto-loads). See
-[Running on real Mixtral weights](#running-on-real-mixtral-weights).
+Real MoE expert weights can already be fed to the engine end-to-end
+via [`scripts/extract_mixtral_experts.py`](./scripts/extract_mixtral_experts.py)
+(architecture-aware despite the name — Mixtral, Qwen3-MoE and DeepSeek
+schemas are auto-detected), which dumps a layer's experts into the
+on-disk format the engine expects (plus a `metadata.json` that `run`
+auto-loads). See [Running on real MoE weights](#running-on-real-moe-weights).
 
 That said, the architecture (per-expert files, fixed expert size,
 top-K activation, LRU + prefetch) is shaped specifically for **sparse
@@ -2353,34 +2385,28 @@ additionally avoids the `O(d_model · d_ff)` dequantise write per
 forward pass, which is the largest L1/L2 win on the hot per-token
 critical path.
 
-### Persistent, page-aligned KV cache
+### Page-aligned KV cache buffer
 
-Multi-call chat / completion sessions need to retain attention
-context across `Engine::generate` calls so the prefix isn't
-recomputed on every token. `engine::AlignedKvCache` is a
-session-scoped K/V buffer backed by [`AlignedBuffer`](#architecture)
-(4096-byte page-aligned) so the K/V bytes are cheap to spill to an
-`O_DIRECT` snapshot file or share with `io_uring`'s registered
-fixed buffers without any rebuffering.
+`engine::AlignedKvCache` is a rolling-window, page-aligned K/V buffer
+backed by [`AlignedBuffer`](#architecture) (4096-byte aligned) so the K/V
+bytes are cheap to spill to an `O_DIRECT` snapshot file or share with
+`io_uring`'s registered fixed buffers without any rebuffering.
 
 Key properties:
 
-* **Rolling window.** Once `seq_len` reaches `window_tokens` (default
-  `KV_CACHE_DEFAULT_WINDOW_TOKENS = 4096`), `append` evicts the oldest
-  K/V row and writes the new one at the tail. Memory is bounded at
-  `2 · window_tokens · kv_dim · 4` bytes per session.
+* **Rolling window.** Once `seq_len` reaches its `window_tokens` bound,
+  `append` evicts the oldest K/V row and writes the new one at the tail.
+  Memory is bounded at `2 · window_tokens · kv_dim · 4` bytes.
 * **Page-aligned base.** `keys_ptr() % 4096 == 0` is an invariant
   enforced by [`AlignedBuffer`].
-* **Zero-on-reset.** `reset_kv_cache()` calls `zeroize()` so a
-  subsequent allocation that lands in the same heap region cannot
-  observe the previous tenant's state.
-* **Mounted on `Engine`** via the builder method `Engine::with_kv_cache`.
-  Accessors are `Engine::kv_cache()`, `Engine::kv_cache_append(k, v)`,
-  `Engine::kv_cache_seq_len()`, and `Engine::reset_kv_cache()`.
+* **Zero-on-reset.** `reset` calls `zeroize()` so a subsequent allocation
+  that lands in the same heap region cannot observe the previous tenant's
+  state.
 
-This complements the per-layer paged KV cache in `transformer.rs`
-(used inside one model forward pass) with a session-scoped,
-contiguous version that survives across token cycles.
+Cross-call session KV persistence in the HTTP server is handled by the
+[Session API](#session-api) — each session owns its `Vec<KvCache>` — so
+this contiguous, page-aligned buffer is the substrate for snapshotting /
+fixed-buffer sharing rather than the live session store.
 
 ### Cold-start manifest
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ substrate that makes that trade-off observable and measurable.
 
 The engine lives under [`rust-engine/`](./rust-engine).
 
-### Supported model families
+## Supported model families
 
 The loader is **architecture-aware**: point it at a HuggingFace
 `.safetensors` checkpoint and the engine auto-detects the family from its

--- a/rust-engine/src/backend/mod.rs
+++ b/rust-engine/src/backend/mod.rs
@@ -289,6 +289,19 @@ pub struct GpuBackend {
     /// (microseconds), so contention is negligible.
     conversion_scratch: ParkingMutex<Vec<f32>>,
 
+    /// Serializes the *whole* dense-op execution (`matmul_into`,
+    /// `swiglu_into`, `softmax`, `kv_attend`) against the backend-global
+    /// `work_a`/`work_b`/`work_out`/`staging_dn` buffers and their
+    /// pre-built bind groups. The `conversion_scratch` lock above only
+    /// guards the host upload; without this lock two concurrent callers
+    /// (the documented "two Tokio tasks share one `Arc<GpuBackend>`"
+    /// case) could overwrite each other's `work_*` inputs between upload
+    /// and dispatch, or double-`map_async` the single `staging_dn`
+    /// readback buffer. The expert FFN path is unaffected: it runs on
+    /// per-workspace buffers (`ExpertWorkspace`) and never takes this
+    /// lock, so expert dispatches still overlap freely.
+    dense_exec_lock: ParkingMutex<()>,
+
     num_heads: usize,
     num_kv_heads: usize,
     head_dim: usize,
@@ -680,6 +693,7 @@ impl GpuBackend {
             softmax_bind_group,
             attention_bind_group,
             conversion_scratch,
+            dense_exec_lock: ParkingMutex::new(()),
             num_heads,
             num_kv_heads,
             head_dim,
@@ -721,6 +735,16 @@ impl GpuBackend {
             d_ff <= MAX_EXPERT_D_FF,
             "d_ff={} exceeds MAX_EXPERT_D_FF={}; increase the constant",
             d_ff, MAX_EXPERT_D_FF
+        );
+        // `d_model` flows through the same `MAX_EXPERT_D_FF`-sized workspace
+        // buffers (`x_buf`, and `mid_1` reused for the [d_model] down output)
+        // and host scratch, so bound it here too — otherwise an oversized
+        // `d_model` only trips a late `assert!` mid-dispatch instead of
+        // failing cleanly at load time.
+        anyhow::ensure!(
+            d_model <= MAX_EXPERT_D_FF,
+            "d_model={} exceeds MAX_EXPERT_D_FF={}; increase the constant",
+            d_model, MAX_EXPERT_D_FF
         );
 
         // ── Upload weights to VRAM ────────────────────────────────────────────
@@ -800,6 +824,13 @@ impl GpuBackend {
             d_ff <= MAX_EXPERT_D_FF,
             "d_ff={} exceeds MAX_EXPERT_D_FF={}; increase the constant",
             d_ff, MAX_EXPERT_D_FF
+        );
+        // Same `MAX_EXPERT_D_FF` workspace bound applies to `d_model`
+        // (the down projection writes [d_model] into a workspace buffer).
+        anyhow::ensure!(
+            d_model <= MAX_EXPERT_D_FF,
+            "d_model={} exceeds MAX_EXPERT_D_FF={}; increase the constant",
+            d_model, MAX_EXPERT_D_FF
         );
 
         // `checked_mul` guards against `usize` overflow on user-configurable
@@ -1131,11 +1162,14 @@ impl GpuBackend {
             .map_err(|e| anyhow::anyhow!("buffer map error on expert readback: {e:?}"))?;
 
         {
+            use half::slice::HalfFloatSliceExt;
             let view   = slice.get_mapped_range();
             let floats: &[f32] = bytemuck::cast_slice(&view);
-            for i in 0..d_model {
-                out.data[i] = half::f16::from_f32(floats[i]);
-            }
+            // Vectorized f32 → f16 downcast. `half`'s slice conversion does
+            // runtime CPU-feature detection (F16C/AVX2/AVX-512), so this picks
+            // up hardware float-to-half on capable hosts without compile-time
+            // target-feature gating, and falls back to scalar elsewhere.
+            out.data[..d_model].convert_from_f32_slice(&floats[..d_model]);
         }
         ws.staging.unmap();
         Ok(())
@@ -1152,13 +1186,16 @@ impl Backend for GpuBackend {
     }
 
     fn matmul_into(&self, a: TensorView, b: TensorView, out: &mut TensorViewMut) -> Result<()> {
+        // Serialize the whole op: the shared `work_*`/`staging_dn` buffers
+        // and bind groups can't be safely shared across concurrent callers
+        // (see `dense_exec_lock`). Held until readback completes.
+        let _exec = self.dense_exec_lock.lock();
         let a_len = a.data.len();
         let b_len = b.data.len();
         let out_len = out.rows * out.cols;
 
-        // Scope the scratch lock to the host-side conversions + uploads only,
-        // releasing it before encoding/submitting GPU work so the blocking
-        // readback below doesn't serialize concurrent callers.
+        // Host-side conversions + uploads. The `dense_exec_lock` already
+        // serializes callers, so `conversion_scratch` is uncontended here.
         {
             let mut scratch = self.conversion_scratch.lock();
             assert!(a_len <= scratch.len());
@@ -1233,13 +1270,15 @@ impl Backend for GpuBackend {
     }
 
     fn swiglu_into(&self, gate: TensorView, up: TensorView, out: &mut TensorViewMut) -> Result<()> {
+        // Serialize the whole op against the shared `work_*`/`staging_dn`
+        // buffers (see `dense_exec_lock`).
+        let _exec = self.dense_exec_lock.lock();
         let len = gate.data.len();
         let out_len = out.rows * out.cols;
         assert_eq!(up.data.len(), len);
         assert_eq!(out_len, len);
 
-        // Scope the scratch lock to the host-side conversions + uploads only,
-        // releasing it before the dispatch + blocking readback below.
+        // Host-side conversions + uploads (serialized by `dense_exec_lock`).
         {
             let mut scratch = self.conversion_scratch.lock();
             assert!(len <= scratch.len());
@@ -1308,10 +1347,12 @@ impl Backend for GpuBackend {
     }
 
     fn softmax(&self, x: &mut TensorViewMut) -> Result<()> {
+        // Serialize the whole op against the shared `work_a`/`staging_dn`
+        // buffers (see `dense_exec_lock`).
+        let _exec = self.dense_exec_lock.lock();
         let len = x.data.len();
 
-        // Scope the scratch lock to the upload only, releasing it before the
-        // softmax dispatch + blocking readback below.
+        // Host-side upload (serialized by `dense_exec_lock`).
         {
             let mut scratch = self.conversion_scratch.lock();
             assert!(len <= scratch.len());
@@ -1419,11 +1460,13 @@ impl Backend for GpuBackend {
         seq_len: usize,
         out: &mut TensorViewMut,
     ) -> Result<()> {
+        // Serialize the whole op against the shared `work_*`/`staging_dn`
+        // buffers (see `dense_exec_lock`).
+        let _exec = self.dense_exec_lock.lock();
         let q_len = q.data.len();
         let out_len = out.rows * out.cols;
 
-        // Scope the scratch lock to the Q upload only, releasing it before the
-        // attention dispatch + blocking readback below.
+        // Host-side Q upload (serialized by `dense_exec_lock`).
         {
             let mut scratch = self.conversion_scratch.lock();
             assert!(q_len <= scratch.len());

--- a/rust-engine/src/backend/mod.rs
+++ b/rust-engine/src/backend/mod.rs
@@ -1416,41 +1416,20 @@ impl Backend for GpuBackend {
 
     fn kv_cache_insert(
         &self,
-        layer: usize,
-        position: usize,
-        k: TensorView,
-        v: TensorView,
+        _layer: usize,
+        _position: usize,
+        _k: TensorView,
+        _v: TensorView,
     ) -> Result<()> {
-        let k_len = k.data.len();
-        let v_len = v.data.len();
-
-        let mut scratch = self.conversion_scratch.lock();
-        assert!(k_len <= scratch.len());
-        assert!(v_len <= scratch.len());
-
-        // Upload K
-        for i in 0..k_len {
-            scratch[i] = k.data[i].to_f32();
-        }
-        let offset_k = self.kv_cache.offset_bytes(layer, 0, position);
-        self.queue.write_buffer(
-            &self.kv_cache.buffer,
-            offset_k,
-            bytemuck::cast_slice(&scratch[..k_len]),
-        );
-
-        // Upload V
-        for i in 0..v_len {
-            scratch[i] = v.data[i].to_f32();
-        }
-        let offset_v = self.kv_cache.offset_bytes(layer, 1, position);
-        self.queue.write_buffer(
-            &self.kv_cache.buffer,
-            offset_v,
-            bytemuck::cast_slice(&scratch[..v_len]),
-        );
-
-        Ok(())
+        // The VRAM KV cache is process-wide and addressed only by
+        // `(layer, position)`. BatchScheduler can run multiple requests at
+        // the same position concurrently against this backend, so using the
+        // GPU KV path would let those requests overwrite each other's slots.
+        // Fail safely and let transformer.rs use its per-request CPU KvCache
+        // until the GPU cache grows a request/session namespace.
+        anyhow::bail!(
+            "GPU KV cache is disabled because it is not request-isolated under concurrent batching"
+        )
     }
 
     fn kv_attend(

--- a/rust-engine/src/batch_scheduler.rs
+++ b/rust-engine/src/batch_scheduler.rs
@@ -116,13 +116,12 @@ impl Default for SessionClass {
 struct SessionMeta {
     class: SessionClass,
     /// Monotonic microseconds since scheduler start. Updated on every
-    /// `step_registered` call so [`BatchScheduler::evict_idle_blocks`]
-    /// can identify sessions that have stopped producing tokens.
+    /// `step_registered` call so the scheduler can identify sessions
+    /// that have stopped producing tokens.
     last_activity_us: AtomicU64,
-    /// Optional [`BlockManager`] handle. Populated by
-    /// [`BatchScheduler::bind_block_manager`] when the HTTP request
-    /// owns paged-KV blocks; the scheduler tears it down on idle
-    /// eviction, dropping every block back into the pool's free list.
+    /// Optional [`BlockManager`] handle owned by a paged-KV request; the
+    /// scheduler tears it down on idle eviction, dropping every block
+    /// back into the pool's free list.
     block_manager: parking_lot::Mutex<Option<BlockManager>>,
 }
 
@@ -275,9 +274,9 @@ pub struct BatchConfig {
     /// request touches it.
     pub block_pool_capacity: usize,
     pub block_pool_kv_dim: usize,
-    /// Cutoff after which a session's KV blocks become candidates
-    /// for [`BatchScheduler::evict_idle_blocks`] when the pool is
-    /// above its soft-cap. Default: 5 seconds, matching the gist.
+    /// Cutoff after which a session's KV blocks become candidates for
+    /// idle eviction when the pool is above its soft-cap. Default:
+    /// 5 seconds, matching the gist.
     pub idle_eviction_threshold: Duration,
     /// Baseline speculation depth (tokens-ahead) for the predictor's
     /// prefetch. The scheduler's [`SpeculationController`] grows this
@@ -356,22 +355,17 @@ pub struct BatchScheduler {
     /// adjustments.
     started_at: Instant,
     /// Latency-aware speculation window controller. Shared with the
-    /// scheduler loop (which calls `update_from_stall` on every batch
-    /// using the engine's cumulative SSD-stall telemetry) and exposed
-    /// to HTTP / prefetch callers via
-    /// [`Self::current_speculation_depth`] so they know how far ahead
-    /// to prefetch.
+    /// scheduler loop, which calls `update_from_stall` on every batch
+    /// using the engine's cumulative SSD-stall telemetry.
     speculation: Arc<SpeculationController>,
     /// Number of requests that have spilled into the block pool's
     /// overflow slab since startup (cumulative; never decremented).
-    /// Snapshot via [`Self::overflow_requests_total`].
     overflow_requests: Arc<AtomicUsize>,
     /// Latches `true` on the first overflow occurrence so the
     /// warning log is emitted exactly once per scheduler instance.
     overflow_warned: Arc<AtomicBool>,
-    /// Cumulative count of idle-eviction passes that actually
-    /// reclaimed at least one block. Snapshot via
-    /// [`Self::idle_evictions_total`]; useful for stress-test assertions.
+    /// Cumulative count of idle-eviction passes that actually reclaimed
+    /// at least one block; useful for stress-test assertions.
     idle_evictions: Arc<AtomicU64>,
     /// Expert-placement layer the warm pre-pass consults before
     /// issuing `Engine::warm_with`. [`LocalShardRouter`] (every id
@@ -494,40 +488,11 @@ impl BatchScheduler {
         self.remote_fetch_failures.load(Ordering::Relaxed)
     }
 
-    /// Configuration the scheduler was built with.
-    pub fn config(&self) -> BatchConfig { self.cfg }
-
     /// Shared physical block pool, if one is configured. Returns
     /// `None` when the scheduler was built without a paged-cache
     /// budget (the default).
     pub fn block_pool(&self) -> Option<Arc<BlockPool>> {
         self.block_pool.clone()
-    }
-
-    /// Convenience: allocate a per-request [`BlockManager`] backed by
-    /// the scheduler's shared pool. Returns `None` when the scheduler
-    /// was built without a paged-cache budget. The caller owns the
-    /// returned manager; on `Drop` it will release every block back
-    /// to the pool.
-    pub fn new_block_manager(&self) -> Option<BlockManager> {
-        self.block_pool.clone().map(BlockManager::new)
-    }
-
-    /// Number of block-pool overflow blocks currently in use across
-    /// all requests, or `0` when no pool is configured. `> 0`
-    /// indicates the primary slab was exhausted and the pool is
-    /// servicing requests out of its heap-backed fallback; operators
-    /// should size [`BatchConfig::block_pool_capacity`] up if this is
-    /// non-zero in steady state.
-    pub fn overflow_in_use(&self) -> usize {
-        self.block_pool.as_ref().map(|p| p.overflow_in_use()).unwrap_or(0)
-    }
-
-    /// Cumulative number of requests observed to be running with at
-    /// least one overflow block since the scheduler started. Useful
-    /// for monitoring (this counter never decrements).
-    pub fn overflow_requests_total(&self) -> usize {
-        self.overflow_requests.load(Ordering::Relaxed)
     }
 
     /// Number of currently registered requests. Mostly diagnostic.
@@ -550,8 +515,7 @@ impl BatchScheduler {
 
     /// Register a request with an explicit service class. The class
     /// drives the WRR admission policy and the order in which sessions
-    /// become candidates for [`Self::evict_idle_blocks`] under
-    /// pressure.
+    /// become idle-eviction candidates under pressure.
     pub fn register_with_class(&self, kv: Vec<KvCache>, class: SessionClass) -> RequestId {
         let id = self.registry.register(kv);
         let now_us = self.now_us();
@@ -560,29 +524,12 @@ impl BatchScheduler {
         id
     }
 
-    /// Attach a [`BlockManager`] handle to a registered request. When
-    /// the scheduler later evicts the session for being idle, it
-    /// takes the manager and drops it, returning every block the
-    /// session owned to the shared pool's free list. No-op if the
-    /// request id is not registered.
-    pub fn bind_block_manager(&self, id: RequestId, manager: BlockManager) {
-        if let Some(meta) = self.sessions.get(&id.0) {
-            *meta.block_manager.lock() = Some(manager);
-        }
-    }
-
-    /// Look up the service class for a registered request, or `None`
-    /// if the id has been released.
-    pub fn session_class(&self, id: RequestId) -> Option<SessionClass> {
-        self.sessions.get(&id.0).map(|m| m.class)
-    }
-
     /// Tear down a registered request, returning its (now-mutated)
     /// KV cache. Returns `None` if the id was already released. The
     /// scheduler also probes the block pool's overflow state at
-    /// release time so the cumulative `overflow_requests_total`
-    /// counter stays accurate even when the request never
-    /// re-touched the scheduler after a burst.
+    /// release time so the cumulative overflow counter stays accurate
+    /// even when the request never re-touched the scheduler after a
+    /// burst.
     pub fn release(&self, id: RequestId) -> Option<Vec<KvCache>> {
         let kv = self.registry.release(id);
         // Removing the session meta drops the held `BlockManager`
@@ -593,73 +540,6 @@ impl BatchScheduler {
         // point to surface whether the pool was ever stressed.
         self.maybe_warn_overflow();
         kv
-    }
-
-    /// Memory-pressure classification of the underlying block pool.
-    /// Returns [`PressureLevel::Normal`] when no pool is configured.
-    pub fn pressure_level(&self) -> PressureLevel {
-        self.block_pool
-            .as_ref()
-            .map(|p| p.pressure_level())
-            .unwrap_or(PressureLevel::Normal)
-    }
-
-    /// Currently-active speculation depth, in tokens-ahead. The
-    /// predictor reads this on every batch and clamps its prefetch
-    /// fanout accordingly: `0` under
-    /// [`PressureLevel::Critical`], `base_depth` under normal
-    /// conditions, up to `base_depth + MAX_LATENCY_BUMP` under
-    /// rising SSD stall.
-    pub fn current_speculation_depth(&self) -> usize {
-        self.speculation.current_depth()
-    }
-
-    /// Shared [`SpeculationController`]. Useful for tests and for
-    /// instrumentation code that wants to read more than just the
-    /// current depth (e.g. whether the controller is suspended).
-    pub fn speculation_controller(&self) -> Arc<SpeculationController> {
-        self.speculation.clone()
-    }
-
-    /// Walk the session map and release every block owned by a
-    /// session that hasn't produced a token in `idle_threshold` (or
-    /// the configured default when `None`). Returns the number of
-    /// sessions whose blocks were reclaimed. Idempotent — sessions
-    /// that don't own a `BlockManager` are skipped.
-    ///
-    /// Audit-class sessions are evicted **first** (sorted ahead of
-    /// Interactive) so a flurry of low-priority bulk jobs cannot
-    /// starve a latency-sensitive chat session of KV memory. The
-    /// scheduler loop also calls this method itself whenever
-    /// [`PressureLevel::High`] is reached, but operators can invoke
-    /// it manually for an off-cycle reclamation pass.
-    pub fn evict_idle_blocks(&self, idle_threshold: Option<Duration>) -> usize {
-        let threshold = idle_threshold.unwrap_or(self.cfg.idle_eviction_threshold);
-        let reclaimed = run_idle_eviction(&self.sessions, threshold, self.now_us());
-        if reclaimed > 0 {
-            self.idle_evictions.fetch_add(1, Ordering::Relaxed);
-        }
-        reclaimed
-    }
-
-    /// Total number of `evict_idle_blocks` passes that reclaimed at
-    /// least one session. Snapshot via [`Self::idle_evictions_total`].
-    pub fn idle_evictions_total(&self) -> u64 {
-        self.idle_evictions.load(Ordering::Relaxed)
-    }
-
-    /// Number of registered sessions, partitioned by class.
-    /// Useful for diagnostics and for stress-test assertions.
-    pub fn session_counts_by_class(&self) -> (usize, usize) {
-        let mut interactive = 0;
-        let mut audit = 0;
-        for kv in self.sessions.iter() {
-            match kv.value().class {
-                SessionClass::Interactive => interactive += 1,
-                SessionClass::Audit => audit += 1,
-            }
-        }
-        (interactive, audit)
     }
 
     fn now_us(&self) -> u64 {

--- a/rust-engine/src/block_pool.rs
+++ b/rust-engine/src/block_pool.rs
@@ -461,21 +461,11 @@ impl BlockPool {
         self.utilization() >= self.thresholds.high
     }
 
-    /// Currently configured back-pressure thresholds.
-    pub fn thresholds(&self) -> PressureThresholds {
-        self.thresholds
-    }
-
     /// Total physical capacity of the **primary** slab, in blocks
     /// (constant for the pool's lifetime). The overflow slab is
     /// reported separately by [`Self::overflow_in_use`].
     pub fn capacity(&self) -> usize {
         self.capacity
-    }
-
-    /// Per-block embedding width (one of K or V; the other is identical).
-    pub fn kv_dim(&self) -> usize {
-        self.kv_dim
     }
 
     /// Write the `(k, v)` pair for one token into block `id` at

--- a/rust-engine/src/buffer_pool.rs
+++ b/rust-engine/src/buffer_pool.rs
@@ -116,11 +116,6 @@ impl BufferPool {
         self.inner.buffer_size
     }
 
-    /// Required alignment of each buffer (matches `O_DIRECT` requirements).
-    pub fn align(&self) -> usize {
-        self.inner.align
-    }
-
     /// Snapshot the raw `(ptr, len)` of every currently-free buffer
     /// (primary **and** shadow, in that order).
     ///

--- a/rust-engine/src/draft.rs
+++ b/rust-engine/src/draft.rs
@@ -408,28 +408,33 @@ impl RealModel {
     /// gist flagged: the previous "append zeros" loop polluted the
     /// peek pre-pass for $i > 0$.
     fn advance_preview_kv(&self, kv0: &mut KvCache, draft_tok: u32, abs_pos: usize) {
-        use crate::transformer::{apply_rope_inplace, matmul_row_major};
         let x = self.embed(draft_tok);
-        let attn = &self.layers[0].attn;
-        debug_assert_eq!(kv0.kv_dim, attn.kv_dim());
-        // Project K/V from the draft-token embedding. This is the
-        // same projection the verifier's `attn_block` would do —
-        // *modulo* attention output residuals, which `peek_experts`
-        // does not re-read. Skipping Q/wo + attention sum keeps the
-        // helper "lightweight" (the gist's term): one matmul each
-        // for K and V, no softmax, no scaled-dot, no weighted sum.
-        let mut k = matmul_row_major(&attn.wk, &x, attn.kv_dim(), attn.d_model);
-        let v = matmul_row_major(&attn.wv, &x, attn.kv_dim(), attn.d_model);
-        // RoPE must be applied at the absolute position the verifier
-        // *would* attend at, otherwise the rotational phase of K
-        // drifts and the peek's attention becomes meaningless. The
-        // verifier appends to position `abs_pos + 1` next, so the
-        // K/V we synthesise here represents position `abs_pos + 1`.
-        let rope_pos = abs_pos + 1;
-        for h in 0..attn.num_kv_heads {
-            let s = h * attn.head_dim;
-            apply_rope_inplace(&mut k[s..s + attn.head_dim], rope_pos, attn.rope_base);
+        let layer = &self.layers[0];
+        // Mirror the verifier's `attn_block` dispatch: MLA layers cache a
+        // single latent vector (k == v == latent), the standard path caches
+        // projected K/V. Using the matching projection keeps the peek
+        // pre-pass faithful and, critically, matches the cache width
+        // `fresh_kv_caches` allocated for this layer (MLA → `latent_dim`),
+        // so the `append` below cannot hit a `copy_from_slice` mismatch.
+        if let Some(mla) = layer.mla.as_ref() {
+            debug_assert_eq!(kv0.kv_dim, mla.latent_dim());
+            debug_assert_eq!(kv0.v_dim, mla.latent_dim());
+            mla.project_and_cache_kv(&x, abs_pos, kv0);
+            return;
         }
+        let attn = &layer.attn;
+        debug_assert_eq!(kv0.kv_dim, attn.kv_dim());
+        debug_assert_eq!(kv0.v_dim, attn.v_proj_dim());
+        // Project K/V exactly as the verifier's `attn_block` does — the
+        // shared `project_kv` applies QKV bias, QK-Norm and partial/scaled
+        // RoPE at the same absolute position the verifier will consume
+        // this token at (`abs_pos`, i.e. `pos + i`). Using the shared
+        // helper keeps the peek pre-pass faithful and prevents the V-width
+        // (`v_proj_dim`, not `kv_dim`) and RoPE-position drift the previous
+        // hand-rolled copy introduced. Skipping Q/wo + the attention sum
+        // keeps the helper lightweight; `peek_experts` only re-reads
+        // layer 0's K/V slots.
+        let (k, v) = attn.project_kv(&x, abs_pos);
         kv0.append(&k, &v);
     }
 }

--- a/rust-engine/src/engine.rs
+++ b/rust-engine/src/engine.rs
@@ -52,13 +52,6 @@ use tracing::{debug, info, warn};
 /// snapshot path without re-allocating into a new aligned region.
 pub const KV_CACHE_BLOCK_ALIGN: usize = 4096;
 
-/// Default rolling-window capacity (in tokens) for [`AlignedKvCache`].
-/// Once `seq_len` reaches this value an `append` evicts the oldest
-/// token and shifts the tail down — the standard sliding-window
-/// transformer attention pattern. Zero means "unbounded": the cache
-/// will keep growing until the host runs out of memory.
-pub const KV_CACHE_DEFAULT_WINDOW_TOKENS: usize = 4096;
-
 /// Decompose a **global** expert id into its `(layer, layer-local)`
 /// pair given a layer-qualified geometry of `per_layer` experts each
 /// (`global = layer * per_layer + local`). The inverse of
@@ -168,21 +161,6 @@ impl AlignedKvCache {
     #[inline]
     pub fn window_tokens(&self) -> usize {
         self.window_tokens
-    }
-
-    /// Hidden dimension per row.
-    #[inline]
-    pub fn kv_dim(&self) -> usize {
-        self.kv_dim
-    }
-
-    /// Dtype hint describing the model's hidden-layer K/V layout.
-    /// The cache stores rows as `f32`; callers in the attention path
-    /// use this to confirm no cast is required (and panic / log when
-    /// the hint disagrees with the model config).
-    #[inline]
-    pub fn kv_dtype(&self) -> WeightDtype {
-        self.kv_dtype
     }
 
     /// Page-aligned base address of the key buffer (for `O_DIRECT`
@@ -409,9 +387,8 @@ impl Drop for SingleflightLeaderGuard {
     }
 }
 
-/// Boot-time engine error. Returned by helpers like
-/// [`Engine::verify_manifest_dtype`] that run startup-only invariant
-/// checks the synchronous `Engine::new` constructor doesn't perform.
+/// Boot-time engine error reserved for startup-only invariant checks
+/// the synchronous `Engine::new` constructor doesn't perform.
 #[derive(Debug)]
 pub enum EngineError {
     /// The cold-start manifest observed at least two experts whose
@@ -422,8 +399,7 @@ pub enum EngineError {
     /// per-token math kernel.
     IncompatibleExpertTypes(crate::io_provider::IncompatibleExpertTypes),
     /// The manifest indexed experts whose unique on-disk dtype does
-    /// not match the engine's configured `WeightDtype`. Surfaced by
-    /// [`Engine::verify_manifest_dtype`].
+    /// not match the engine's configured `WeightDtype`.
     ManifestDtypeMismatch {
         expected: WeightDtype,
         found: WeightDtype,
@@ -999,14 +975,6 @@ pub(crate) struct EngineCore {
     /// fire-and-forget.
     pub(super) gpu_promotion_tx:
         Option<tokio::sync::mpsc::UnboundedSender<(u32, Arc<ExpertResident>)>>,
-    /// Optional persistent, page-aligned KV cache attached at
-    /// construction time via [`Engine::with_kv_cache`]. Lives on
-    /// `EngineCore` (gist feedback #2.4 — complete the I/O-runtime
-    /// split) alongside the other I/O-runtime fields the synthetic
-    /// `generate` path doesn't append to (no real attention runs at
-    /// this layer in the benchmark configuration), but the
-    /// real-transformer / server path does — see `server.rs`.
-    pub(super) kv_cache: Option<Arc<Mutex<AlignedKvCache>>>,
     /// In-flight read singleflight (gist Phase 1 — SSD Read
     /// De-Duplication). Lives on `EngineCore` (gist feedback #2.4)
     /// because it is part of the I/O-runtime infrastructure that
@@ -1280,7 +1248,6 @@ impl EngineCore {
             options,
             gpu_cache: None,
             gpu_promotion_tx: None,
-            kv_cache: None,
             in_flight: Arc::new(DashMap::new()),
             prefetch_semaphore: Arc::new(tokio::sync::Semaphore::new(prefetch_permits)),
             // Default to the CPU backend; `install_gpu_cache` swaps in a
@@ -1525,15 +1492,6 @@ impl Engine {
         }
     }
 
-    /// Attach a persistent, page-aligned KV cache (one per session
-    /// when called from a session-aware server path). The cache is
-    /// owned by the engine and its window / kv_dim are immutable.
-    /// Returns `self` for builder-style chaining.
-    pub fn with_kv_cache(mut self, cache: AlignedKvCache) -> Self {
-        self.core.kv_cache = Some(Arc::new(Mutex::new(cache)));
-        self
-    }
-
     /// Whether the configured expert dtype is eligible for the GPU
     /// `Backend::expert_matmul` fast path. F32 always qualifies. Q4_0
     /// qualifies only when both `d_model` and `d_ff` are
@@ -1672,8 +1630,7 @@ impl Engine {
         // Phase 3: try to bring up a real `GpuBackend` now that a
         // `GpuExpertCache` is available. The `num_layers`/`max_seq_len`/
         // `num_heads`/`head_dim` parameters drive `GpuKvCache` sizing,
-        // which is **not** on the expert-FFN dispatch path; the engine
-        // already owns its own KV cache (see `EngineCore::kv_cache`).
+        // which is **not** on the expert-FFN dispatch path.
         // `BackendBox::init_blocking` returns `BackendBox::Cpu`
         // automatically when no adapter is present, so this never
         // panics.
@@ -1686,11 +1643,6 @@ impl Engine {
             gpu,
         );
         self.core.backend = Arc::new(backend);
-    }
-
-    /// Borrow the engine's VRAM (GPU) expert cache, if any.
-    pub fn gpu_cache(&self) -> Option<Arc<GpuExpertCache>> {
-        self.core.gpu_cache.clone()
     }
 
     /// **Test-only** wiring of the GPU promotion channel without
@@ -1715,75 +1667,6 @@ impl Engine {
         self.core.gpu_cache = Some(gpu);
         self.core.gpu_promotion_tx = Some(tx);
         rx
-    }
-
-    /// Borrow the engine's KV cache, if any. Callers acquire the
-    /// inner `parking_lot::Mutex` to read or append.
-    pub fn kv_cache(&self) -> Option<Arc<Mutex<AlignedKvCache>>> {
-        self.core.kv_cache.clone()
-    }
-
-    /// Append `(k, v)` to the persistent KV cache. No-op (returns
-    /// `Ok(false)`) when no cache is attached. The boolean return
-    /// value mirrors [`AlignedKvCache::append`]: `true` ⇔ the
-    /// rolling window evicted its oldest token to make room.
-    pub fn kv_cache_append(&self, k: &[f32], v: &[f32]) -> bool {
-        match &self.core.kv_cache {
-            Some(c) => c.lock().append(k, v),
-            None => false,
-        }
-    }
-
-    /// Reset the persistent KV cache (drop every resident token but
-    /// keep the page-aligned allocation). No-op when no cache is
-    /// attached. Called by the session-delete path before the engine
-    /// state is swapped for a new tenant.
-    pub fn reset_kv_cache(&self) {
-        if let Some(c) = &self.core.kv_cache {
-            c.lock().zeroize();
-        }
-    }
-
-    /// Number of tokens currently resident in the persistent KV
-    /// cache, or `0` when no cache is attached.
-    pub fn kv_cache_seq_len(&self) -> usize {
-        self.core.kv_cache
-            .as_ref()
-            .map(|c| c.lock().seq_len())
-            .unwrap_or(0)
-    }
-
-    /// Cross-check a cold-start manifest against the engine's
-    /// configured dtype. Returns:
-    ///
-    /// * `Ok(Some(dtype))` if every indexed expert agrees on a
-    ///   single on-disk dtype, **and** that dtype matches the
-    ///   engine's configured `WeightDtype`. The returned dtype is
-    ///   guaranteed to be the one the dispatch table will use.
-    /// * `Ok(None)` if the manifest is empty or holds only legacy
-    ///   bare-payload files (no UTH dtype to verify against).
-    /// * `Err(EngineError::IncompatibleExpertTypes)` if the
-    ///   manifest indexed at least two experts whose dtypes
-    ///   disagree, **or** if the unique dtype in the manifest
-    ///   doesn't match `expected_dtype`. The engine refuses to
-    ///   serve traffic in either case.
-    ///
-    /// This is the runtime hook that backs the gist's "verify the
-    /// manifest invariant on engine startup" requirement; it's a
-    /// constant-time iteration over the already-resident manifest
-    /// (no I/O).
-    pub fn verify_manifest_dtype(
-        manifest: &crate::io_provider::Manifest,
-        expected_dtype: WeightDtype,
-    ) -> Result<Option<WeightDtype>, EngineError> {
-        match manifest.verify_uniform_dtype()? {
-            None => Ok(None),
-            Some(d) if d == expected_dtype => Ok(Some(d)),
-            Some(d) => Err(EngineError::ManifestDtypeMismatch {
-                expected: expected_dtype,
-                found: d,
-            }),
-        }
     }
 
     /// Install a JSONL routing trace sink. Every subsequent
@@ -1901,10 +1784,6 @@ impl Engine {
             }
         }
         id
-    }
-
-    pub fn shape(&self) -> ModelShape {
-        self.core.shape
     }
 
     /// Total number of distinct experts the engine's router can
@@ -2768,11 +2647,6 @@ if let Some(gpu) = me.core.gpu_cache.as_ref() {
                 Err(e) => warn!(expert = id, error = %e, "prefetch failed"),
             }
         });
-    }
-
-    /// Account for the fact that an expert was a hit *because* we prefetched it.
-    pub fn note_prefetch_hit(&self) {
-        self.metrics.counters.prefetch_used.fetch_add(1, Ordering::Relaxed);
     }
 
     /// A speculative prefetch was dropped because no pool buffer could

--- a/rust-engine/src/expert_cache.rs
+++ b/rust-engine/src/expert_cache.rs
@@ -86,15 +86,6 @@ impl ExpertResident {
         self.hits.fetch_add(1, Ordering::Relaxed) + 1
     }
 
-    /// Current value of the per-resident hit counter. Snapshot only —
-    /// the underlying counter may have been bumped by a concurrent
-    /// caller by the time this returns. Used by diagnostics and the
-    /// VRAM promotion controller.
-    #[inline]
-    pub fn hits(&self) -> u64 {
-        self.hits.load(Ordering::Relaxed)
-    }
-
     /// Whether this resident's bytes live in a **shadow** (Buffer B)
     /// pool buffer — i.e. it entered the cache via a speculative
     /// prefetch (`Engine::spawn_prefetch`) rather than a foreground
@@ -174,12 +165,6 @@ pub struct ExpertCache {
     /// (see [`crate::engine::Engine`] / `pin_after_observations`).
     pinned: Mutex<HashSet<u32>>,
     capacity: usize,
-}
-
-#[derive(Default, Debug, Clone, Copy)]
-pub struct CacheStats {
-    pub hits: u64,
-    pub misses: u64,
 }
 
 impl ExpertCache {
@@ -449,14 +434,6 @@ pub enum GpuLookup {
 }
 
 impl GpuLookup {
-    /// Convenience: pull the resident out of any hit variant.
-    pub fn into_resident(self) -> Option<Arc<GpuResident>> {
-        match self {
-            GpuLookup::AnchorHit(r) | GpuLookup::LruHit(r) => Some(r),
-            GpuLookup::Miss => None,
-        }
-    }
-
     pub fn is_hit(&self) -> bool {
         !matches!(self, GpuLookup::Miss)
     }
@@ -559,18 +536,6 @@ impl GpuExpertCache {
         self.anchor_capacity_bytes + self.lru_capacity_bytes
     }
 
-    /// Capacity of the Anchor Core region in bytes.
-    #[inline]
-    pub fn anchor_capacity_bytes(&self) -> usize {
-        self.anchor_capacity_bytes
-    }
-
-    /// Capacity of the LRU Edge region in bytes.
-    #[inline]
-    pub fn lru_capacity_bytes(&self) -> usize {
-        self.lru_capacity_bytes
-    }
-
     /// Currently-resident VRAM bytes (anchor + LRU).
     #[inline]
     pub fn used_bytes(&self) -> u64 {
@@ -593,12 +558,6 @@ impl GpuExpertCache {
     #[inline]
     pub fn misses(&self) -> u64 {
         self.misses.load(Ordering::Relaxed)
-    }
-
-    /// Promotion threshold (`gpu_cache.promote_after_hits`).
-    #[inline]
-    pub fn promote_after_hits(&self) -> u64 {
-        self.promote_after_hits
     }
 
     /// Look up an expert in VRAM. Returns the [`GpuLookup`] discriminator
@@ -750,16 +709,7 @@ impl GpuExpertCache {
         true
     }
 
-    /// Snapshot of VRAM-resident expert ids (anchor first, then LRU
-    /// in most-recently-used order). Used by the admin health
-    /// endpoint and the TUI dashboard.
-    pub fn resident_ids(&self) -> Vec<u32> {
-        let g = self.inner.lock();
-        let mut v: Vec<u32> = g.anchor.keys().copied().collect();
-        v.sort_unstable();
-        v.extend(g.lru.iter().map(|(k, _)| *k));
-        v
-    }
+
 
     /// Number of Anchor Core entries.
     pub fn anchor_len(&self) -> usize {

--- a/rust-engine/src/io_provider.rs
+++ b/rust-engine/src/io_provider.rs
@@ -733,13 +733,6 @@ impl NvmeStorage {
             .load(Ordering::Acquire)
     }
 
-    /// Borrow the per-drive breaker for a given drive index. Mostly
-    /// useful in tests; callers in production should rely on the
-    /// transparent short-circuit in [`Self::read_at_with_retries`].
-    pub fn drive_breaker(&self, drive_index: usize) -> Option<Arc<DriveBreakerState>> {
-        self.drive_breakers.get(drive_index).cloned()
-    }
-
     /// Record one failed read. Returns `(just_tripped, count)`:
     /// `just_tripped` is `true` only on the call that flips the
     /// breaker from closed to open (so callers can log once);
@@ -1252,44 +1245,6 @@ impl NvmeStorage {
         Ok(pos)
     }
 
-    #[cfg(target_os = "linux")]
-    async fn read_into(&self, file: &File, buf: &mut PooledBuffer) -> io::Result<usize> {
-        // Run the synchronous `pread(2)` on the current Tokio worker via
-        // `block_in_place`. Other ready tasks are migrated to sibling
-        // workers, so we don't stall the runtime; we also avoid the
-        // `'static` requirement of `spawn_blocking`, which lets us keep
-        // the borrow on `buf`.
-        //
-        // We *must* return the byte count `read_at` reports, not
-        // `buf.len()`: a truncated expert file (or any short read on a
-        // network-mounted FS) would otherwise look like a full read and
-        // the caller's "got `n` bytes, expected …" check would never
-        // fire. See `read_expert` / `read_experts_batch` for the
-        // surface-level validation that depends on this.
-        tokio::task::block_in_place(|| {
-            // `read_at` is a positional read (`pread`) that does not touch
-            // the file offset, so concurrent reads against the same fd
-            // from multiple workers are safe.
-            file.read_at(buf.as_mut_slice(), 0)
-        })
-    }
-
-    #[cfg(all(unix, not(target_os = "linux")))]
-    async fn read_into(&self, file: &File, buf: &mut PooledBuffer) -> io::Result<usize> {
-        // Same logic on macOS for development. `O_DIRECT` is unavailable;
-        // the user is expected to pass `--no-direct` on those hosts.
-        // As on Linux, return the actual count from `read_at` so short
-        // reads are surfaced — see the Linux branch's note.
-        tokio::task::block_in_place(|| file.read_at(buf.as_mut_slice(), 0))
-    }
-
-    #[cfg(not(unix))]
-    async fn read_into(&self, _file: &File, _buf: &mut PooledBuffer) -> io::Result<usize> {
-        Err(io::Error::new(
-            io::ErrorKind::Unsupported,
-            "this engine targets Unix; non-Unix platforms are not supported",
-        ))
-    }
 }
 
 #[cfg(target_os = "linux")]
@@ -1858,24 +1813,6 @@ impl Manifest {
     #[inline]
     pub fn len(&self) -> usize {
         self.entries.len()
-    }
-
-    /// Whether the manifest indexed any experts.
-    #[inline]
-    pub fn is_empty(&self) -> bool {
-        self.entries.is_empty()
-    }
-
-    /// Block alignment the manifest was scanned with. Every
-    /// `payload_offset` is a multiple of this value.
-    #[inline]
-    pub fn block_align(&self) -> usize {
-        self.block_align
-    }
-
-    /// Iterate over `(id, entry)` pairs in arbitrary order.
-    pub fn iter(&self) -> impl Iterator<Item = (u32, &ManifestEntry)> + '_ {
-        self.entries.iter().map(|(k, v)| (*k, v))
     }
 
     /// Convenience: zero-latency lookup of the byte offset where the

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -1147,6 +1147,7 @@ async fn cmd_serve(config_path: PathBuf) -> Result<(), Box<dyn std::error::Error
         )))
     };
 
+    let metrics = Metrics::new();
     let mut engine_builder = Engine::with_options(
         cache,
         pool,
@@ -1247,7 +1248,7 @@ async fn cmd_serve(config_path: PathBuf) -> Result<(), Box<dyn std::error::Error
         );
         engine_builder.install_gpu_cache(gpu_expert_cache.clone());
     }
-    let engine = Arc::new(engine_builder);
+    let engine = Arc::new(engine_builder.with_metrics(metrics.clone()));
 
     let tokenizer = match cfg.tokenizer.path.as_ref() {
         Some(p) => match Tokenizer::from_file(p) {
@@ -1416,7 +1417,7 @@ async fn cmd_serve(config_path: PathBuf) -> Result<(), Box<dyn std::error::Error
     let state = AppState {
         engine,
         tokenizer,
-        metrics: Metrics::new(),
+        metrics,
         real_model,
         batch_scheduler,
         draft_engine,

--- a/rust-engine/src/mla.rs
+++ b/rust-engine/src/mla.rs
@@ -189,7 +189,7 @@ impl MultiHeadLatentAttention {
     /// (post-RoPE) for symmetry with the cached entries; the caller does
     /// not need them (it re-reads from the cache), but exposing them
     /// keeps the function testable.
-    fn project_and_cache_kv(&self, x: &[f32], pos: usize, kv: &mut KvCache) {
+    pub fn project_and_cache_kv(&self, x: &[f32], pos: usize, kv: &mut KvCache) {
         let proj_dim = self.kv_lora_rank + self.qk_rope_head_dim;
         let kv_a = matmul_row_major(&self.kv_a_proj_with_mqa, x, proj_dim, self.d_model);
         let mut latent = vec![0.0f32; self.latent_dim()];
@@ -306,12 +306,6 @@ impl MultiHeadLatentAttention {
 /// are NaN) to f32. Matches the OCP `e4m3` / DeepSeek `float8_e4m3fn`
 /// definition: the all-exponent-ones encoding is *not* infinity, the max
 /// finite magnitude is 448.
-/// Largest finite magnitude representable in the FP8 `e4m3fn` format
-/// (`S.1110.111` = `1.875 * 2^8`). The `S.1111.111` bit pattern is
-/// reserved for NaN and is decoded to `0.0` so it contributes nothing
-/// to downstream matmuls.
-pub const F8_E4M3_MAX_FINITE: f32 = 448.0;
-
 pub fn f8_e4m3_to_f32(b: u8) -> f32 {
     let sign = if (b & 0x80) != 0 { -1.0f32 } else { 1.0f32 };
     let exp = ((b >> 3) & 0x0F) as i32;

--- a/rust-engine/src/model.rs
+++ b/rust-engine/src/model.rs
@@ -1574,7 +1574,7 @@ let gate_vec = Self::read_full_f32(&dir.join(format!("gate_{l}.bin")))
     pub fn fresh_kv_caches(&self) -> Vec<KvCache> {
         self.layers
             .iter()
-            .map(|l| KvCache::new_kv(l.attn.kv_dim(), l.attn.v_proj_dim()))
+            .map(|l| KvCache::new_kv(l.kv_dim(), l.v_dim()))
             .collect()
     }
 
@@ -2378,6 +2378,51 @@ mod tests {
         let r = engine.report();
         assert!(r.misses > 0, "first step should miss the cache");
         assert!(r.bytes_read > 0, "engine should have read expert bytes from disk");
+    }
+
+    /// Regression test for MLA KV-cache sizing. `fresh_kv_caches` must
+    /// allocate the *latent* width (`kv_lora_rank + qk_rope_head_dim`,
+    /// 20 here) for MLA layers, not the unused standard `num_kv_heads *
+    /// head_dim` (32 here). Before the fix the per-layer cache was sized
+    /// with `attn.kv_dim()`, so the very first `step` panicked inside
+    /// `KvCache::append` (`copy_from_slice` / debug-assert width
+    /// mismatch) the moment `mla.forward` appended its latent vector.
+    /// Stepping twice also exercises multi-position latent append.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn mla_model_steps_through_fresh_kv_caches() {
+        let dir = TempDir::new("mla-step");
+        let mut advanced = AdvancedConfig::default();
+        advanced.mla = Some(MlaDims {
+            q_lora_rank: 0,
+            kv_lora_rank: 16,
+            qk_nope_head_dim: 4,
+            qk_rope_head_dim: 4,
+            v_head_dim: 8,
+        });
+        let cfg = RealModelConfig {
+            architecture: Architecture::DeepSeekV3,
+            advanced,
+            num_layers: 2,
+            ..RealModelConfig::tiny()
+        };
+        let engine = build_engine_for_model(&dir.path, &cfg);
+        let model = RealModel::new_seeded(cfg.clone(), 0x5EED);
+        assert!(model.layers.iter().all(|l| l.mla.is_some()), "all layers MLA");
+
+        let mut kv = model.fresh_kv_caches();
+        let latent = 16 + 4; // kv_lora_rank + qk_rope_head_dim
+        for c in &kv {
+            assert_eq!(c.kv_dim, latent, "MLA K cache must be latent-width");
+            assert_eq!(c.v_dim, latent, "MLA V cache must be latent-width");
+        }
+
+        let t1 = model.step(&engine, 7, 0, &mut kv, &crate::sampling::SamplingParams::greedy()).await;
+        let t2 = model.step(&engine, t1, 1, &mut kv, &crate::sampling::SamplingParams::greedy()).await;
+        assert!((t1 as usize) < cfg.vocab_size);
+        assert!((t2 as usize) < cfg.vocab_size);
+        for c in &kv {
+            assert_eq!(c.seq_len, 2, "each MLA layer cached two positions");
+        }
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/rust-engine/src/multi_layer_cache.rs
+++ b/rust-engine/src/multi_layer_cache.rs
@@ -101,10 +101,6 @@ impl MultiLayerExpertCache {
         self.caches.len()
     }
 
-    pub fn experts_per_layer(&self) -> u32 {
-        self.experts_per_layer
-    }
-
     /// Decode a global expert id into the index of its per-layer
     /// cache. Clamps to the last layer when `id` is out of range so
     /// downstream callers never panic on a malformed router output —
@@ -393,10 +389,4 @@ impl MultiLayerExpertCache {
             .unwrap_or(false)
     }
 
-    /// `(layer, local)` lookup using the same global-id encoding the
-    /// rest of the engine emits.
-    pub fn get_at(&self, key: ExpertKey) -> Option<Arc<ExpertResident>> {
-        let cache = self.caches.get(key.layer as usize)?;
-        cache.get(self.global_id(key))
-    }
 }

--- a/rust-engine/src/router.rs
+++ b/rust-engine/src/router.rs
@@ -859,12 +859,6 @@ struct LocalityInner {
 }
 
 impl LocalityMonitor {
-    /// Default sliding-window length when no explicit value is configured.
-    /// 512 tokens matches the value called out in the design spec — long
-    /// enough to smooth out per-token noise, short enough to track topic
-    /// shifts that warrant repinning.
-    pub const DEFAULT_WINDOW: usize = 512;
-
     /// Default heat threshold (10% of the window) for declaring an
     /// expert "hot". Mirrors the spec's example.
     pub const DEFAULT_THRESHOLD_PCT: f32 = 0.10;
@@ -897,9 +891,8 @@ impl LocalityMonitor {
                 }
             }
         }
-        // `total` is the cumulative observation counter (saturating
-        // semantics promised by [`Self::total_observations`]); count
-        // every observation, not just the ones that grew the window.
+        // `total` is the cumulative observation counter; count every
+        // observation, not just the ones that grew the window.
         inner.total = inner.total.saturating_add(1);
         inner.window.push_back(id);
         inner.counts[id as usize] = inner.counts[id as usize].saturating_add(1);
@@ -910,11 +903,6 @@ impl LocalityMonitor {
         for &id in ids {
             self.observe_one(id);
         }
-    }
-
-    /// Window capacity (the maximum number of observations kept).
-    pub fn capacity(&self) -> usize {
-        self.capacity
     }
 
     /// Number of observations currently in the window.
@@ -983,11 +971,6 @@ impl LocalityMonitor {
             return 0;
         }
         self.inner.read().counts[id as usize]
-    }
-
-    /// Aggregate observation count since construction (saturating).
-    pub fn total_observations(&self) -> u64 {
-        self.inner.read().total
     }
 
     /// Reset the monitor back to its empty state. Useful for tests and
@@ -1111,9 +1094,6 @@ struct SpeculatorWeights {
 }
 
 impl NeuralSpeculator {
-    /// Default hidden size called out in the design spec.
-    pub const DEFAULT_HIDDEN: usize = 128;
-
     /// Default learning rate for the online SGD step. Small by design:
     /// the speculator is trained continuously over every token and a
     /// large lr would let occasional outlier routings dominate.
@@ -1189,14 +1169,6 @@ impl NeuralSpeculator {
 
     pub fn d_model(&self) -> usize {
         self.d_model
-    }
-
-    pub fn hidden(&self) -> usize {
-        self.hidden
-    }
-
-    pub fn num_experts(&self) -> u32 {
-        self.num_experts
     }
 
     /// Forward pass returning the full logit vector of length `num_experts`.
@@ -1764,11 +1736,6 @@ impl ExpertAffinity {
         }
     }
 
-    /// Number of experts the matrix was sized for.
-    pub fn num_experts(&self) -> u32 {
-        self.num_experts
-    }
-
     /// Total `observe_layer` calls recorded since construction.
     pub fn total_observations(&self) -> u64 {
         self.observations.load(Ordering::Relaxed)
@@ -1933,16 +1900,6 @@ impl LayeredExpertAffinity {
         }
     }
 
-    /// Number of layers the matrix was sized for.
-    pub fn num_layers(&self) -> usize {
-        self.layers.len()
-    }
-
-    /// Number of experts each layer's matrix was sized for.
-    pub fn num_experts(&self) -> u32 {
-        self.num_experts
-    }
-
     /// Record that every pair `(i, j)` in `experts` was activated
     /// together by the same MoE step inside `layer_idx`. Hot-path
     /// safe — delegates to the single-layer
@@ -2065,27 +2022,15 @@ impl LayeredExpertAffinity {
 /// carry a `#[must_use]` attribute — letting the value bind to `_` or
 /// fall out of scope at the end of an engine's lifetime is exactly
 /// the intended shutdown path. Callers that want to retire the worker
-/// earlier can call [`Self::shutdown`] (cooperative) or
-/// [`Self::abort`] (synonym, kept for ergonomic symmetry with
-/// `tokio::JoinHandle::abort`).
+/// earlier can call [`Self::shutdown`] cooperatively.
 pub struct DecayWorkerHandle {
     shutdown: std::sync::Arc<std::sync::atomic::AtomicBool>,
     /// `None` after the handle has been joined explicitly via
-    /// [`Self::shutdown`] / [`Self::abort`]; the `Drop` impl then has
-    /// nothing to do.
+    /// [`Self::shutdown`]; the `Drop` impl then has nothing to do.
     join: Option<std::thread::JoinHandle<()>>,
 }
 
 impl DecayWorkerHandle {
-    /// Direct accessor for the shutdown flag — exposed for the
-    /// integration test that needs to flip the flag while the
-    /// `Drop` impl is still in scope (i.e. it cannot move `self`).
-    /// In production the engine never calls this directly; it just
-    /// drops the handle on shutdown.
-    pub fn shutdown_flag(&self) -> std::sync::Arc<std::sync::atomic::AtomicBool> {
-        self.shutdown.clone()
-    }
-
     /// Cooperative shutdown: clear the flag and join the worker.
     /// Subsequent calls / `Drop` are no-ops.
     pub fn shutdown(mut self) {
@@ -2095,11 +2040,6 @@ impl DecayWorkerHandle {
         }
     }
 
-    /// Alias for [`Self::shutdown`] — provided so callers used to
-    /// `tokio::task::JoinHandle::abort` can use the same name.
-    pub fn abort(self) {
-        self.shutdown();
-    }
 }
 
 impl Drop for DecayWorkerHandle {
@@ -2198,11 +2138,6 @@ impl SpeculationController {
             last_stall_us: AtomicU64::new(0),
             calm_streak: AtomicU64::new(0),
         }
-    }
-
-    /// Baseline depth this controller was built with.
-    pub fn base_depth(&self) -> usize {
-        self.base_depth
     }
 
     /// Currently active speculation depth, in tokens. Returns `0`

--- a/rust-engine/src/session.rs
+++ b/rust-engine/src/session.rs
@@ -154,10 +154,6 @@ impl SessionStore {
         self.inner.len()
     }
 
-    pub fn is_empty(&self) -> bool {
-        self.inner.is_empty()
-    }
-
     /// Atomically remove and return the session state for `id`. The
     /// caller is expected to call [`Self::put`] with the returned
     /// checkout guard when finished so the session resumes on the next

--- a/rust-engine/src/tensor_header.rs
+++ b/rust-engine/src/tensor_header.rs
@@ -271,11 +271,6 @@ impl TensorHeader {
         })
     }
 
-    /// Returns true if `bytes` starts with the U.T.H. magic.
-    pub fn has_magic(bytes: &[u8]) -> bool {
-        bytes.len() >= 4 && bytes[0..4] == UTH_MAGIC
-    }
-
     /// If `bytes` starts with a valid U.T.H., return the *payload*
     /// (post-header, post-padding) slice paired with the parsed header.
     /// Otherwise return `(None, bytes)` so the caller can treat the
@@ -457,7 +452,7 @@ mod tests {
         // 16 K iterations × up to 256 B input ≈ 4 MiB of work, well
         // under the test budget even in debug mode.
         for trial in 0..16384u64 {
-            let len = ((trial * 0x9E37_79B9_7F4A_7C15) % (4 * UTH_BYTES as u64 + 1)) as usize;
+            let len = ((trial.wrapping_mul(0x9E37_79B9_7F4A_7C15)) % (4 * UTH_BYTES as u64 + 1)) as usize;
             let mut buf = vec![0u8; len];
             fill_random(&mut buf, trial.wrapping_mul(0x1234_5678) ^ 0xDEAD_BEEF);
             // Property: probe must return either `None` or a fully-
@@ -496,7 +491,7 @@ mod tests {
         // a panic here would crash the engine on a malformed
         // expert_<id>.bin.
         for trial in 0..4096u64 {
-            let len = ((trial * 0x517C_C1B7_2722_0A95) % (3 * UTH_BYTES as u64 + 1)) as usize;
+            let len = ((trial.wrapping_mul(0x517C_C1B7_2722_0A95)) % (3 * UTH_BYTES as u64 + 1)) as usize;
             let mut buf = vec![0u8; len];
             fill_random(&mut buf, trial.wrapping_add(0x0123_4567_89AB_CDEF));
             for block in [16usize, 64, 512, 4096] {

--- a/rust-engine/src/transformer.rs
+++ b/rust-engine/src/transformer.rs
@@ -688,7 +688,7 @@ impl MultiHeadSelfAttention {
 
     /// Project a single token embedding `x` into this layer's
     /// cache-ready **K** and **V** vectors at absolute position `pos`:
-    /// `wk`/`wv` matmul, optional QKV bias, optional K QK-Norm, and
+    /// `wk`/`wv` matmul, optional K/V bias, optional K QK-Norm, and
     /// RoPE on K over the partial `rope_dim` with optional YaRN scaling
     /// — exactly the steps [`Self::forward`] performs before
     /// `kv.append`. V is returned at its full `v_proj_dim()` width

--- a/rust-engine/src/transformer.rs
+++ b/rust-engine/src/transformer.rs
@@ -686,6 +686,32 @@ impl MultiHeadSelfAttention {
         }
     }
 
+    /// Project a single token embedding `x` into this layer's
+    /// cache-ready **K** and **V** vectors at absolute position `pos`:
+    /// `wk`/`wv` matmul, optional QKV bias, optional K QK-Norm, and
+    /// RoPE on K over the partial `rope_dim` with optional YaRN scaling
+    /// — exactly the steps [`Self::forward`] performs before
+    /// `kv.append`. V is returned at its full `v_proj_dim()` width
+    /// (which differs from `kv_dim()` on MiMo-V2-Flash). Shared by the
+    /// verifier forward and the speculative KV preview so the two can
+    /// never drift out of sync.
+    pub fn project_kv(&self, x: &[f32], pos: usize) -> (Vec<f32>, Vec<f32>) {
+        let mut k = matmul_row_major(&self.wk, x, self.kv_dim(), self.d_model);
+        let mut v = matmul_row_major(&self.wv, x, self.v_proj_dim(), self.d_model);
+        if let Some(bk) = self.bk.as_ref() {
+            for (ki, bi) in k.iter_mut().zip(bk.iter()) { *ki += bi; }
+        }
+        if let Some(bv) = self.bv.as_ref() {
+            for (vi, bi) in v.iter_mut().zip(bv.iter()) { *vi += bi; }
+        }
+        self.apply_k_norm(&mut k);
+        for h in 0..self.num_kv_heads {
+            let s = h * self.head_dim;
+            apply_rope_maybe_scaled(&mut k[s..s + self.rope_dim], pos, self.rope_base, self.rope_yarn.as_ref());
+        }
+        (k, v)
+    }
+
     /// Forward one token at absolute position `pos`. Updates `kv` with
     /// the new K/V for this position. Returns a new hidden state of
     /// length `d_model`.
@@ -749,13 +775,12 @@ impl MultiHeadSelfAttention {
                 // within the attention span (`t_start == 0`), so the sink
                 // token's slot is `scores[0]`. `None` (every other
                 // architecture / global layers) is a no-op.
-if let Some(bias) = self.sink_bias.as_ref() {
-    if t_start == 0 && !scores.is_empty() {
-        if let Some(b) = bias.get(h) {
-            scores[0] += *b;
-        }
-    }
-}
+                if let Some(bias) = self.sink_bias.as_ref() {
+                    if t_start == 0 && !scores.is_empty() {
+                        if let Some(b) = bias.get(h) {
+                            scores[0] += *b;
+                        }
+                    }
                 }
                 softmax_inplace(&mut scores);
 
@@ -773,15 +798,13 @@ if let Some(bias) = self.sink_bias.as_ref() {
         };
         let mut cpu_forward = || {
             let mut q = matmul_row_major(&self.wq, x, q_dim, self.d_model);
-            let mut k = matmul_row_major(&self.wk, x, kv_dim, self.d_model);
-            // V projection width is `num_kv_heads * v_head_dim`.
-            let mut v = matmul_row_major(&self.wv, x, self.v_proj_dim(), self.d_model);
-            // QKV projection biases (GPT-OSS `attention_bias = true`),
-            // added to the raw projections before QK-Norm / RoPE.
-            self.apply_qkv_bias(&mut q, &mut k, &mut v);
-            // QK-Norm (Qwen3): per-head RMSNorm on Q and K *before* RoPE.
+            // Q bias (GPT-OSS `attention_bias`) before QK-Norm / RoPE; K and
+            // V biases are applied inside `project_kv`.
+            if let Some(bq) = self.bq.as_ref() {
+                for (qi, bi) in q.iter_mut().zip(bq.iter()) { *qi += bi; }
+            }
+            // QK-Norm (Qwen3): per-head RMSNorm on Q *before* RoPE.
             self.apply_q_norm(&mut q);
-            self.apply_k_norm(&mut k);
             // RoPE rotates only the first `rope_dim` dims of each head
             // (partial rotary on MiMo-V2-Flash; `rope_dim == head_dim`
             // elsewhere ⇒ full rotation).
@@ -789,10 +812,9 @@ if let Some(bias) = self.sink_bias.as_ref() {
                 let s = h * self.head_dim;
                 apply_rope_maybe_scaled(&mut q[s..s + self.rope_dim], pos, self.rope_base, self.rope_yarn.as_ref());
             }
-            for h in 0..self.num_kv_heads {
-                let s = h * self.head_dim;
-                apply_rope_maybe_scaled(&mut k[s..s + self.rope_dim], pos, self.rope_base, self.rope_yarn.as_ref());
-            }
+            // K/V projection (+ bias, QK-Norm, RoPE) is shared with the
+            // speculative KV preview via `project_kv`.
+            let (k, v) = self.project_kv(x, pos);
             kv.append(&k, &v);
             let mut attn_out = cpu_attend(&q, kv);
             // Post-attention output scale (MiMo-V2-Flash 0.707), applied
@@ -1373,6 +1395,16 @@ impl TransformerLayer {
         match self.mla.as_ref() {
             Some(mla) => mla.latent_dim(),
             None => self.attn.kv_dim(),
+        }
+    }
+
+    /// V-cache width this layer needs. MLA stores its latent vector in the
+    /// value slot too (`KvCache::append(&latent, &latent)`), so the V width
+    /// is the latent dim; the standard path uses `num_kv_heads * v_head_dim`.
+    pub fn v_dim(&self) -> usize {
+        match self.mla.as_ref() {
+            Some(mla) => mla.latent_dim(),
+            None => self.attn.v_proj_dim(),
         }
     }
 


### PR DESCRIPTION
## Why

This started as a review of two gists of feedback and grew into a broader pass over the engine. The headline issue: the MLA attention path crashed on the **first** token in the live server/draft flow, so any DeepSeek-V3-style model was effectively unrunnable outside of direct-construction unit tests. Along the way the review turned up a telemetry wiring bug, a dense-execution data race, a couple of crash-on-malformed-input paths, and a large amount of dead code. The README also still read as a Mixtral-only project even though the engine now supports eight architectures.

## Confirmed bug fixes

- **MLA KV-cache panic (the big one).** `fresh_kv_caches` sized MLA layers with the standard `attn.kv_dim()` instead of the latent width, so the very first MLA token hit a `copy_from_slice` width mismatch and panicked. Caches are now sized per layer via a new `TransformerLayer::v_dim()` (latent_dim for MLA), and draft preview KV is MLA-aware. Added an end-to-end regression test (`mla_model_steps_through_fresh_kv_caches`) that fails before the fix and passes after.
- **Draft V-projection / RoPE.** Rewrote `advance_preview_kv` on a shared `project_kv()` helper, fixing a V-width crash and a RoPE off-by-one on the speculative preview path.
- **Compile break.** A stray brace in `cpu_attend` meant the binary did not build; the library-only check masked it because most modules only compile through the binary.
- **Dense shared-buffer race.** Added `dense_exec_lock` around `matmul`/`swiglu`/`softmax`/`kv_attend`, plus `d_model` bounds checks on both expert builders.
- **f32 to f16 downcast.** Vectorized the readback downcast using `half`'s SIMD conversion (gist #2.1).
- **Fuzz-test overflow.** `fuzz_probe` and `fuzz_strip` overflowed their length generator at `trial=2` in debug builds, so they aborted before exercising the parser at all. Switched to `wrapping_mul` so they now actually fuzz.

## Wiring fix

Engine telemetry (locality/speculator hits, SSD stall) was never reaching Prometheus because `Engine::with_metrics` was never called and the HTTP server held a separate `Metrics`. Both sides now share one `Metrics`, so the registry sees the engine counters.

## Dead code

Removed roughly 45 unused public accessors, consts, and fields across `batch_scheduler`, `block_pool`, `buffer_pool`, `engine`, `expert_cache`, `io_provider`, `multi_layer_cache`, `router`, `session`, and `tensor_header`, including the orphaned `EngineCore.kv_cache` field whose only setter was already gone. The documented live features (idle eviction, speculation clamp, pressure ladder, session KV persistence) stay wired internally; only the unused accessors on top were removed. Truly-dead warnings dropped from ~49 to 25.

## README

Reframed the project from Mixtral-centric to multi-architecture: a new "Supported model families" section covering all eight families (Mixtral, Qwen3 / Qwen3-MoE, DeepSeek-V3 with MLA, MiMo-V2-Flash, GPT-OSS, Mistral Small 3, Phi-4), with Mixtral kept as the canonical streamed example. Also fixed stale references to removed methods/fields and a couple of renamed section anchors.

## Review notes

- Most of the gist feedback was already addressed in the current code; the only genuinely outstanding item was the f32 to f16 downcast.
- The `SessionMeta.block_manager` paged-KV path is still unwired (its setter was never called). Fully wiring it is a feature project and is intentionally left out of scope here.

## Verification

`cargo check --bins` is clean (EXIT 0) and the full binary test suite passes at **411 passed / 0 failed**. Note that `cargo check --lib` only compiles two modules; the meaningful checks are the `--bins` variants. The io_uring paths are Linux-gated and were not compiled on this macOS host.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced support for Multi-Head Latent Attention (MLA) models with improved KV cache handling
  * Generalized documentation for broader Mixture-of-Experts (MoE) model families beyond Mixtral

* **Bug Fixes**
  * Fixed metrics sharing between engine and server components
  * Improved GPU operation synchronization for dense computations
  * Corrected KV cache sizing for MLA-based layers

* **Documentation**
  * Updated README with clarified KV cache behavior, page-aligned buffer descriptions, and speculative execution details
  * Enhanced explanations of sparse MoE execution across multiple model architectures

* **Chores**
  * Streamlined internal APIs by removing redundant accessor methods

<!-- end of auto-generated comment: release notes by coderabbit.ai -->