### PR TITLE
Streaming Tiers 1–4: beat the cache-fraction wall (skew residency, packed I/O, pre-gate, governor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,14 @@ Our latest endurance tests demonstrate the engine's ability to maintain stable p
   - [6. Expert deduplication via alias map (`--alias-map`)](#6-expert-deduplication-via-alias-map---alias-map)
   - [7. Predictive architecture (`S ∪ L ∪ M` speculative I/O)](#7-predictive-architecture-s--l--m-speculative-io)
   - [How to combine them](#how-to-combine-them)
+- [Defeating the cache-fraction wall (streaming Tiers 1–4)](#defeating-the-cache-fraction-wall-streaming-tiers-14)
+  - [The wall](#the-wall)
+  - [Benchmark workload harness (`--workload`)](#benchmark-workload-harness---workload)
+  - [Tier 1 — skew-aware static residency](#tier-1--skew-aware-static-residency)
+  - [Tier 2 — packed expert storage + coalesced vectored reads](#tier-2--packed-expert-storage--coalesced-vectored-reads)
+  - [Tier 3 — per-layer pre-gate (cross-layer prefetch)](#tier-3--per-layer-pre-gate-cross-layer-prefetch)
+  - [Tier 4 — adaptive prefetch governor + cost-aware eviction](#tier-4--adaptive-prefetch-governor--cost-aware-eviction)
+  - [Putting it together](#putting-it-together)
 - [3-tier heterogeneous memory cache (SSD → RAM → VRAM)](#3-tier-heterogeneous-memory-cache-ssd--ram--vram)
   - [`monitor` subcommand](#monitor-subcommand)
 - [Limitations / next steps](#limitations--next-steps)
@@ -1158,6 +1166,29 @@ speculator_top_k       = 0      # 0 ⇒ inherit `model.top_k`
 affinity_enabled       = false  # turn on per-layer expert-affinity + UTH-spatial folds
 affinity_neighbors_k   = 4      # co-fired neighbours to fold in per seed
 affinity_decay_epoch   = 100000 # cumulative observations before a decay right-shift
+
+# Streaming Tiers 1/3/4 (off by default; defaults stream as before).
+# See "Defeating the cache-fraction wall" for the full story.
+prefetch_governor              = false  # Tier 4: throttle low-value speculation
+prefetch_precision_floor       = 0.05   # governor precision floor / EWMA seed, [0,1]
+prefetch_contention_weight     = 1.0    # governor backoff per in-flight foreground read
+cost_aware_eviction            = false  # Tier 4: evict coldest heat score, not strict LRU
+pregate_enabled                = false  # Tier 3: layer-L→L+1 next-layer prefetch
+static_residency_fraction      = 0.0    # Tier 1: pin hottest fraction of the namespace
+static_residency_warmup_tokens = 0      # tokens observed before deriving the online hot set
+# static_residency_profile     = "hot.json"  # seed the hot set from a --profile-out dump
+```
+
+The packed-storage knobs (Tier 2) live under `[storage]`:
+
+```toml
+[storage]
+# Read every expert from one packed blob (built by the `repack`
+# subcommand) instead of one file per expert; adjacent experts coalesce
+# into a single vectored preadv. Both must be set together, or both unset
+# (default, one-file-per-expert layout).
+# packed_blob     = "./experts.blob"
+# packed_manifest = "./experts.blob.manifest.json"
 ```
 
 The defaults (everything off) reproduce the legacy Markov-only
@@ -1166,7 +1197,8 @@ the prefetch union and lights up the corresponding Prometheus
 counters on `/metrics`. The schema is validated at startup
 (`config.rs`) and rejects nonsensical settings, `locality_window
 == 0`, `locality_threshold_pct` outside `(0, 1]`, `speculator_top_k >
-num_experts`, etc.
+num_experts`, `static_residency_fraction` outside `[0, 1]`, a
+`packed_blob` without its `packed_manifest`, etc.
 
 #### Real-transformer pipeline
 
@@ -1595,6 +1627,22 @@ micro-expert-router gen-data
   --block-align <BYTES>      O_DIRECT alignment (default 4096)
   --dtype <DTYPE>            f32 | f16 | int8 | q4k | q4_0 | q8_0 (default f32)
 
+micro-expert-router repack    # Tier 2: build a packed expert blob + manifest
+  --data-dir <PATH>          Source dir of expert_<id>.bin (default ./data)
+  --out-blob <PATH>          Output blob (all expert payloads concatenated)
+  --out-manifest <PATH>      Output manifest (default <out-blob>.manifest.json)
+  --num-experts <N>          Experts to pack, ids 0..N (default 64)
+  --expert-size <BYTES>      Bytes per expert; must match the source files
+  --block-align <BYTES>      O_DIRECT alignment, must match gen-data (default 4096)
+  --no-direct                Disable O_DIRECT while reading sources (tmpfs/macOS/CI)
+  --num-experts-per-layer <N>  Layer-qualified source naming, if used
+  --profile <PATH>           Routing-frequency profile (from run --profile-out)
+                              to order experts hottest-first; unobserved
+                              experts appended numerically.
+  --order <PATH>             Explicit physical layout: a file of expert ids
+                              (one per line or a JSON array). Overrides
+                              --profile; only the listed experts are packed.
+
 micro-expert-router run
   --data-dir <PATH>          Directory with expert_<id>.bin files
                               (auto-loads metadata.json if present).
@@ -1702,6 +1750,56 @@ micro-expert-router run
                               layer+1..=layer+pipeline_depth ahead (hides
                               SSD latency behind compute). Unset = flat
                               single-namespace benchmark (no look-ahead).
+
+  # Streaming Tiers 1-4 (all off by default; defaults stream as before).
+  # See "Defeating the cache-fraction wall" below for the full story.
+  --static-residency-fraction <F>  Tier 1. Pin the hottest F of the expert
+                              namespace permanently in RAM so a skewed
+                              workload can exceed the bare cache-fraction
+                              hit ceiling. 0.0 (default) disables it.
+  --static-residency-warmup-tokens <N>  Tokens to observe before deriving
+                              the online hot set (ignored when a profile
+                              is supplied). Default 0.
+  --static-residency-profile <PATH>  JSON popularity profile ({"<id>":count},
+                              e.g. from --profile-out) to pin the hot set
+                              from token 0 with no warmup.
+  --profile-out <PATH>       Write the observed expert id->count routing
+                              profile at shutdown (feed back into
+                              --static-residency-profile or `repack`).
+  --pregate                  Tier 3. Train an online layer-L->L+1 conditional
+                              map and drive high-precision next-layer
+                              prefetch (multi-layer / replay path).
+  --prefetch-governor        Tier 4. Throttle speculative prefetches by
+                              measured precision (consumed/completed) and
+                              foreground-read contention, so low-value
+                              speculation can't crowd out foreground misses.
+  --prefetch-precision-floor <F>  Precision floor / optimistic EWMA seed for
+                              the governor, in [0,1] (default 0.05).
+  --prefetch-contention-weight <F>  Per-outstanding-foreground-read multiplier
+                              on the governor's admission threshold
+                              (default 1.0; higher = backs off harder).
+  --cost-aware-eviction      Tier 4. Evict the coldest resident by decaying
+                              heat score instead of strict LRU.
+  --packed-blob <PATH>       Tier 2. Read every expert from this single
+                              packed blob (built by `repack`) instead of
+                              one file per expert. Requires --packed-manifest.
+                              Physically-adjacent experts coalesce into one
+                              vectored preadv. Falls back to the per-file
+                              path when unset.
+  --packed-manifest <PATH>   JSON manifest (id->offset,len) for --packed-blob.
+
+  # Benchmark workload selector (so the tiers above are falsifiable).
+  --workload <KIND>          synthetic (default; uniform-i.i.d., hit rate
+                              pinned to the cache fraction) | skewed (Zipf
+                              popularity + Markov correlation) | replay
+                              (stream experts from a JSONL routing trace).
+  --zipf-s <F>               Zipf exponent for --workload skewed (default
+                              1.0; larger = more skew).
+  --workload-correlation <F>  Markov stay-probability for --workload skewed,
+                              in [0,1] (default 0.0; temporal correlation
+                              the predictors can exploit).
+  --replay-trace <PATH>      JSONL routing trace to replay with
+                              --workload replay (the --trace-out format).
 
   # Multi-drive striping:
   --data-dir <DIR1,DIR2...> Comma-separated list of mountpoints shards
@@ -2742,7 +2840,207 @@ you can verify the energy-saving paths actually engaged.
 
 ---
 
-## 3-tier heterogeneous memory cache (SSD → RAM → VRAM)
+## Defeating the cache-fraction wall (streaming Tiers 1–4)
+
+### The wall
+
+On a real SSD-streaming run the headline number is the **hit rate**: the
+fraction of routed experts already resident in the RAM cache. The whole
+point of the project is to push that number *above* the cache fraction so
+the SSD tier buys you more than the RAM you paid for. The failure mode the
+engine kept hitting is that the hit rate tracks the cache fraction almost
+exactly — 50 % of experts cached ⇒ ~50 % hit rate — and the predictive
+prefetcher (`S ∪ L ∪ M`) does nothing to lift it.
+
+**This is not a prefetcher bug. It is information-theoretic.** The legacy
+benchmark feeds `synth_hidden_state(t)` = `splitmix64(t, seed)`: every
+token is an **independent, uniform** random vector, so the routed experts
+are i.i.d. uniform over the pool. Under a uniform-i.i.d. access stream the
+optimal hit rate of *any* cache of capacity `c` over `N` experts is exactly
+`c / N`, and **no predictor can beat it** — there is no temporal locality,
+no correlation, and no signal in the hidden state to exploit. Worse, a
+speculator firing at chance accuracy (`top_k / N`) pours junk prefetches
+into a saturated disk queue, inflating the foreground-miss latency (in the
+Mixtral run, p50 read climbed from 120 ms to 405 ms — a 3.4× self-inflicted
+penalty). The "wall" is the diagonal `hit ≈ cache_fraction`, and on a
+memoryless workload the diagonal is the ceiling.
+
+Real MoE traces are **not** memoryless — they are Zipf-skewed (a few
+experts carry most of the routing mass) and Markov-correlated (the active
+expert set drifts slowly within a topic). The four tiers below exploit
+exactly those two properties, and a new **workload harness** makes them
+falsifiable on synthetic data without a GPU or real weights.
+
+Every tier is **opt-in**; with all the new knobs at their defaults the
+engine streams bit-for-bit as before.
+
+### Benchmark workload harness (`--workload`)
+
+So the streaming tiers can be measured (and so the wall can be *seen*), the
+`run` loop grows a workload selector:
+
+```bash
+# Legacy memoryless benchmark — hit rate pinned to the cache fraction.
+micro-expert-router run --data-dir ./data --workload synthetic ...
+
+# Zipf-skewed + Markov-correlated stream (the realistic case).
+micro-expert-router run --data-dir ./data \
+    --workload skewed --zipf-s 1.2 --workload-correlation 0.6 ...
+
+# Replay a captured routing trace (the `--trace-out` JSONL format).
+micro-expert-router run --data-dir ./data \
+    --workload replay --replay-trace ./trace.jsonl ...
+```
+
+* `--workload synthetic` (default) is the original uniform-i.i.d. stream —
+  unchanged, so existing numbers reproduce exactly.
+* `--workload skewed` draws each token's experts from a **Zipf** popularity
+  law (`--zipf-s`, larger ⇒ more skew) and then, with probability
+  `--workload-correlation`, re-uses experts from the previous token (a
+  first-order Markov stay), modelling topical drift.
+* `--workload replay` streams the experts from a JSONL routing trace, so a
+  capture from a real model can drive the cache simulator directly.
+
+On a skewed stream at 50 % cache, the engine clears ~90 % hit rate versus
+the ~50 % wall on the memoryless stream — the headroom the tiers below are
+designed to capture.
+
+### Tier 1 — skew-aware static residency
+
+Zipf skew means a small hot set is responsible for most routing. Tier 1
+pins that hot set in RAM permanently, so the popular experts are read **at
+most once** instead of being churned by the LRU under cold-expert pressure.
+
+```bash
+# Derive the hot set ONLINE: observe `warmup_tokens`, then pin the top
+# `fraction` of the namespace by observed routing frequency.
+micro-expert-router run ... \
+    --static-residency-fraction 0.10 \
+    --static-residency-warmup-tokens 512
+
+# …or seed it from a profile captured on a previous run:
+micro-expert-router run ... --profile-out hot.json          # capture
+micro-expert-router run ... --static-residency-profile hot.json  # reuse
+```
+
+The pin set is applied once (CAS-latched) and reuses the existing
+`ExpertCache` pin machinery, so a pinned expert is simply never chosen as an
+eviction victim. `--profile-out` writes the observed `id → count` map at
+shutdown; feeding it back via `--static-residency-profile` pins the hot set
+from token 0 with no warmup. Config equivalents live under `[predictive]`
+(`static_residency_fraction`, `static_residency_warmup_tokens`,
+`static_residency_profile`).
+
+### Tier 2 — packed expert storage + coalesced vectored reads
+
+The default storage layout is **one file per expert** (`expert_<id>.bin`).
+On a low-hit-rate stream that means a cascade of `open(2)`s and fd-cache
+thrash, and a token that misses on `K` experts issues `K` independent
+`pread`s the NVMe can only partially overlap. Tier 2 repacks every expert
+into a single **blob** (one block-aligned `expert_size` slot each) with a
+JSON manifest (`id → offset,len`), and the read path coalesces
+**physically-adjacent** experts into one vectored `preadv(2)` that scatters
+straight into the per-expert buffers — one syscall, one seek, full device
+queue depth.
+
+```bash
+# Build the blob + manifest. Order experts hottest-first from a profile so
+# the popular set is contiguous (and so co-fetched experts coalesce):
+micro-expert-router repack \
+    --data-dir ./data --out-blob ./experts.blob \
+    --num-experts 256 --expert-size 99090432 \
+    --profile hot.json            # or --order ids.txt, or numeric default
+
+# Point the engine at it (or set [storage] packed_blob / packed_manifest):
+micro-expert-router run ... \
+    --packed-blob ./experts.blob \
+    --packed-manifest ./experts.blob.manifest.json
+```
+
+The coalesced path keeps the full fault-tolerance contract: a singleton
+run, an oversized iovec batch, or any short/failed `preadv` falls back to
+the per-expert retry + circuit-breaker path, so byte-for-byte results are
+identical to the one-file layout (an integration test asserts exactly this).
+With neither knob set the engine uses the per-file path unchanged.
+
+### Tier 3 — per-layer pre-gate (cross-layer prefetch)
+
+Within one forward pass the MoE layers route **in order**, and the set of
+experts a layer picks is correlated with the next layer's pick. Tier 3
+learns that conditional online — a `layer L routed set → layer L+1 experts`
+map — and issues a **high-precision** prefetch for the next layer's likely
+experts the moment layer `L` routes, hiding the `L+1` miss behind the `L`
+compute. It runs on the multi-layer `moe_step` path (`--num-layers > 1` or
+the real-transformer/replay path), not the flat single-namespace benchmark.
+
+```bash
+micro-expert-router run ... --pregate          # [predictive] pregate_enabled
+```
+
+The run summary gains a `pregate:` line reporting the predictor's running
+accuracy (intersection of prediction with the actual next-layer routed set).
+
+### Tier 4 — adaptive prefetch governor + cost-aware eviction
+
+Tier 4 is the antidote to the self-inflicted latency the wall section
+describes. Two mechanisms:
+
+* **Adaptive prefetch governor** (`--prefetch-governor`). Tracks an EWMA of
+  prefetch **precision** (speculative reads later consumed by a hit ÷ reads
+  completed) and the disk's saturation, and **throttles speculative
+  admission** when precision is low or the queue is hot — so junk prefetches
+  stop crowding out foreground misses. Tunable via
+  `--prefetch-precision-floor` and `--prefetch-contention-weight`
+  (`[predictive] prefetch_precision_floor`, `prefetch_contention_weight`).
+* **Cost-aware eviction** (`--cost-aware-eviction`). Replaces plain LRU with
+  a decaying per-expert heat score, so the victim is the expert least likely
+  to be needed soon rather than merely the least-recently-used
+  (`[predictive] cost_aware_eviction`).
+
+The run summary gains a `governor:` line reporting precision, prefetch
+admit/throttle counts, and used/completed. On the memoryless wall workload
+the governor correctly throttles ~all speculation (it has no value to add);
+on a skewed workload it admits the prefetches that actually land.
+
+### Putting it together
+
+A realistic streaming preset on a skewed/real workload:
+
+```bash
+# 1. Capture a hot-set profile on a warmup run.
+micro-expert-router run --data-dir ./data --workload skewed \
+    --zipf-s 1.2 --workload-correlation 0.6 --tokens 2000 --profile-out hot.json
+
+# 2. Repack hottest-first so the popular set is contiguous.
+micro-expert-router repack --data-dir ./data --out-blob ./experts.blob \
+    --num-experts 256 --expert-size 99090432 --profile hot.json
+
+# 3. Stream with every tier engaged.
+micro-expert-router run --data-dir ./data \
+    --workload skewed --zipf-s 1.2 --workload-correlation 0.6 \
+    --packed-blob ./experts.blob --packed-manifest ./experts.blob.manifest.json \
+    --static-residency-profile hot.json \
+    --pregate --prefetch-governor --cost-aware-eviction
+```
+
+…and the `serve`-time equivalent in `config.toml`:
+
+```toml
+[storage]
+packed_blob     = "./experts.blob"
+packed_manifest = "./experts.blob.manifest.json"
+
+[predictive]
+static_residency_fraction      = 0.10
+static_residency_warmup_tokens = 512
+pregate_enabled                = true
+prefetch_governor              = true
+cost_aware_eviction            = true
+```
+
+---
+
+
 
 The legacy 2-tier `SSD → RAM` substrate is bit-for-bit unchanged when
 `[gpu_cache] enabled = false` (the default). With `enabled = true`,
@@ -2816,8 +3114,21 @@ The streaming GGUF reader, the Unified Tensor Header (U.T.H.) format,
 and the primary/shadow `BufferPool` (with the batched
 `IoUringStorage::read_experts_batch_fixed_promote` fast path) are all
 shipped and on by default, see the *Energy Efficiency Features*
-section above for the user-facing details. The genuinely open items
-are:
+section above for the user-facing details. The streaming **Tiers 1–4**
+(skew-aware static residency, packed storage + coalesced `preadv`,
+per-layer pre-gate, and the prefetch governor + cost-aware eviction)
+plus the `--workload` harness are likewise shipped, all opt-in, see
+[Defeating the cache-fraction wall](#defeating-the-cache-fraction-wall-streaming-tiers-14).
+The genuinely open items are:
+
+- **Tier 3 pre-gate is exercised only on the multi-layer path.** The
+  per-layer pre-gate learns a layer-L→L+1 conditional, so it only
+  contributes on the real-transformer / trace-replay path (or
+  `--num-layers > 1`); the flat single-namespace benchmark has no
+  next-layer to predict, and the module is currently covered by unit
+  tests rather than an end-to-end run. The skewed-workload hit-rate
+  figures quoted above are cache-simulator results, not full-model
+  inference numbers.
 
 - **GPU / alternative math backend.** The per-expert SwiGLU FFN runs
   through **`candle-core`**. The default build is CPU-only (no

--- a/config.toml
+++ b/config.toml
@@ -141,6 +141,17 @@ partial_load_fraction = 1.0
 # permanently in the LRU cache so it is never evicted by cold experts.
 # 0 (default) disables frequency-based pinning.
 pin_after_observations = 0
+# --- Tier 2: packed expert storage (opt-in) -------------------------------
+# Read every expert from one packed blob (built by the `repack` subcommand)
+# instead of one file per expert. The engine then uses a single shared fd
+# and coalesces physically-adjacent experts into one vectored `preadv`,
+# raising effective queue depth and cutting per-miss open()/syscall cost.
+# Leave both unset (default) for the original one-file-per-expert layout.
+# Build the blob with, e.g.:
+#   micro-expert-router repack --data-dir ./data --out-blob ./experts.blob \
+#       --num-experts 256 --expert-size 99090432 --profile hot.json
+# packed_blob = "./experts.blob"
+# packed_manifest = "./experts.blob.manifest.json"
 
 [tokenizer]
 # Path to a HuggingFace `tokenizer.json` (e.g. the one shipped with

--- a/config.toml
+++ b/config.toml
@@ -229,6 +229,62 @@ speculator_hidden_dim = 128
 # Top-K experts pulled from the speculator each routing step. 0 ⇒
 # inherit `model.top_k`.
 speculator_top_k = 0
+# -- Per-layer expert-affinity arm (co-occurrence prefetch) ----------
+# Tracks which experts co-fire inside the same MoE layer and folds
+# their co-fired + disk-adjacent neighbours into the prefetch union.
+# Only effective on the layer-qualified `moe_step` path.
+affinity_enabled = false
+# Co-fired neighbours pulled per high-confidence seed.
+affinity_neighbors_k = 4
+# Cumulative observations between background decay sweeps of the
+# co-occurrence counters (larger = slower aging).
+affinity_decay_epoch = 100000
+
+# -- Tier 4: adaptive prefetch governor ------------------------------
+# Throttle speculative prefetches by measured precision (consumed /
+# completed) and foreground-read contention, so low-value speculation
+# can't inflate the latency of the foreground misses that actually
+# block token generation. This is the highest-leverage knob on a
+# bandwidth-bound SSD (a saturated NVMe queue inflates foreground miss
+# latency several-fold). Off by default (legacy unbounded admission).
+prefetch_governor = false
+# Precision floor / optimistic EWMA seed for the governor, in [0, 1].
+# The governor never lets the effective precision multiplier fall
+# below this, so a cold predictor still gets a small admission budget.
+prefetch_precision_floor = 0.05
+# Per-outstanding-foreground-read multiplier on the governor's
+# admission threshold. Higher ⇒ speculation backs off harder while
+# real misses are in flight.
+prefetch_contention_weight = 1.0
+
+# -- Tier 4: cost-aware eviction -------------------------------------
+# Evict the coldest resident by decaying heat score instead of strict
+# LRU, so a genuinely hot expert that briefly fell to the LRU tail is
+# not dumped ahead of a one-shot cold expert. Off by default (LRU).
+cost_aware_eviction = false
+
+# -- Tier 3: per-layer pre-gate predictor ----------------------------
+# Train an online conditional map from one layer's routed expert set
+# to the next layer's experts and drive high-precision next-layer
+# prefetch from it (real-transformer / trace-replay path). Off by
+# default.
+pregate_enabled = false
+
+# -- Tier 1: skew-aware static residency -----------------------------
+# Pin the hottest `fraction` of the expert namespace permanently in
+# the RAM cache so a *skewed* routing distribution can exceed the bare
+# cache-capacity hit-rate ceiling (the "C/E wall"). 0.0 (default)
+# disables it; a value in (0, 1] pins ceil(fraction * num_experts)
+# experts. Has no benefit on a uniform-i.i.d. workload.
+static_residency_fraction = 0.0
+# Tokens to observe before deriving the *online* hot set from live
+# route counts. Ignored when `static_residency_profile` is set.
+static_residency_warmup_tokens = 0
+# Optional path to an offline popularity profile ({ "<id>": <count> }
+# JSON, e.g. from a previous run's `--profile-out`). When set, its
+# hottest `fraction` is pinned at startup for an immediately warm
+# cache instead of deriving the hot set online.
+# static_residency_profile = "hot_experts.json"
 
 # 3-tier heterogeneous memory cache (SSD → RAM → VRAM).
 #

--- a/rust-engine/src/config.rs
+++ b/rust-engine/src/config.rs
@@ -514,6 +514,29 @@ pub struct PredictiveConfig {
     /// speculator/Markov look-ahead untouched.
     #[serde(default)]
     pub pregate_enabled: bool,
+
+    /// **Tier 1 — static residency.** Fraction of the global expert
+    /// namespace to pin permanently in the RAM cache (the hottest
+    /// experts). `0.0` (default) disables the feature; a value in
+    /// `(0, 1]` pins `ceil(fraction × num_experts)` experts. Clamped to
+    /// `[0, 1]`.
+    #[serde(default)]
+    pub static_residency_fraction: f64,
+
+    /// Tokens to observe before deriving the *online* static-residency
+    /// hot set from live route counts. Ignored when
+    /// `static_residency_profile` is set (an offline profile is applied
+    /// immediately, with no warmup).
+    #[serde(default)]
+    pub static_residency_warmup_tokens: u64,
+
+    /// Optional path to an offline expert-popularity profile
+    /// (`{ "<id>": <count> }` JSON, e.g. from a previous run's
+    /// `--profile-out`). When present, its hottest `fraction` is pinned
+    /// at startup for an immediately warm cache. `None` derives the hot
+    /// set online instead.
+    #[serde(default)]
+    pub static_residency_profile: Option<String>,
 }
 
 fn default_prefetch_precision_floor() -> f64 { 0.05 }
@@ -542,6 +565,9 @@ impl Default for PredictiveConfig {
             prefetch_contention_weight: default_prefetch_contention_weight(),
             cost_aware_eviction: false,
             pregate_enabled: false,
+            static_residency_fraction: 0.0,
+            static_residency_warmup_tokens: 0,
+            static_residency_profile: None,
         }
     }
 }
@@ -762,6 +788,12 @@ impl Config {
             return Err(ConfigError::Invalid(format!(
                 "storage.partial_load_fraction ({}) must be in [0.1, 1.0]",
                 self.storage.partial_load_fraction
+            )));
+        }
+        if !(0.0..=1.0).contains(&self.predictive.static_residency_fraction) {
+            return Err(ConfigError::Invalid(format!(
+                "predictive.static_residency_fraction ({}) must be in [0.0, 1.0]",
+                self.predictive.static_residency_fraction
             )));
         }
         // [gpu_cache] validation — only meaningful when enabled.

--- a/rust-engine/src/config.rs
+++ b/rust-engine/src/config.rs
@@ -831,6 +831,18 @@ impl Config {
                 self.predictive.static_residency_fraction
             )));
         }
+        if !(0.0..=1.0).contains(&self.predictive.prefetch_precision_floor) {
+            return Err(ConfigError::Invalid(format!(
+                "predictive.prefetch_precision_floor ({}) must be in [0.0, 1.0]",
+                self.predictive.prefetch_precision_floor
+            )));
+        }
+        if self.predictive.prefetch_contention_weight < 0.0 {
+            return Err(ConfigError::Invalid(format!(
+                "predictive.prefetch_contention_weight ({}) must be >= 0.0",
+                self.predictive.prefetch_contention_weight
+            )));
+        }
         // [gpu_cache] validation — only meaningful when enabled.
         if self.gpu_cache.enabled {
             if !(0.0..=1.0).contains(&self.gpu_cache.vram_anchor_ratio) {
@@ -1358,6 +1370,20 @@ mod tests {
         let mut c = minimal_cfg();
         c.predictive.speculator_enabled = true;
         c.predictive.speculator_top_k = 9999;
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn predictive_rejects_out_of_range_precision_floor() {
+        let mut c = minimal_cfg();
+        c.predictive.prefetch_precision_floor = 1.5;
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn predictive_rejects_negative_contention_weight() {
+        let mut c = minimal_cfg();
+        c.predictive.prefetch_contention_weight = -0.1;
         assert!(c.validate().is_err());
     }
 }

--- a/rust-engine/src/config.rs
+++ b/rust-engine/src/config.rs
@@ -475,7 +475,49 @@ pub struct PredictiveConfig {
     /// distribution shifts and prevents `u32::MAX` saturation.
     #[serde(default = "default_affinity_decay_epoch")]
     pub affinity_decay_epoch: u64,
+
+    /// **Tier 4 — adaptive prefetch governor.** Master switch for the
+    /// [`crate::prefetch_governor::PrefetchGovernor`]. When `true`,
+    /// speculative prefetches are admitted only when their expected
+    /// value (predicted score × measured precision) beats a bar that
+    /// rises with the number of foreground (token-blocking) misses
+    /// queued for the device. `false` (default) preserves the legacy
+    /// unbounded admission behaviour. This is the highest-leverage knob
+    /// on a bandwidth-bound SSD: it stops low-precision speculation from
+    /// inflating the latency of the foreground misses that actually
+    /// block token generation.
+    #[serde(default)]
+    pub prefetch_governor: bool,
+    /// Precision floor / optimistic EWMA seed for the governor, in
+    /// `[0, 1]`. Only consulted when `prefetch_governor = true`.
+    #[serde(default = "default_prefetch_precision_floor")]
+    pub prefetch_precision_floor: f64,
+    /// Per-outstanding-foreground-read multiplier the governor applies
+    /// to its admission threshold. Higher ⇒ speculation backs off harder
+    /// while real misses are in flight.
+    #[serde(default = "default_prefetch_contention_weight")]
+    pub prefetch_contention_weight: f64,
+
+    /// **Tier 4 — cost-aware eviction.** When `true`, the RAM expert
+    /// cache evicts the non-pinned resident with the lowest decaying
+    /// heat score rather than the strict LRU victim, so a genuinely hot
+    /// expert that briefly fell to the LRU tail is not dumped ahead of a
+    /// one-shot cold expert. `false` (default) keeps pure LRU eviction.
+    #[serde(default)]
+    pub cost_aware_eviction: bool,
+
+    /// **Tier 3 — per-layer pre-gate predictor.** When `true`, the
+    /// engine trains an online conditional map from one layer's routed
+    /// set to the next layer's experts and uses it to drive
+    /// high-precision next-layer prefetch on the real-transformer /
+    /// trace-replay path. `false` (default) leaves the existing
+    /// speculator/Markov look-ahead untouched.
+    #[serde(default)]
+    pub pregate_enabled: bool,
 }
+
+fn default_prefetch_precision_floor() -> f64 { 0.05 }
+fn default_prefetch_contention_weight() -> f64 { 1.0 }
 
 fn default_locality_window() -> usize { 256 }
 fn default_locality_threshold() -> f32 { 0.10 }
@@ -495,6 +537,11 @@ impl Default for PredictiveConfig {
             affinity_enabled: false,
             affinity_neighbors_k: default_affinity_neighbors_k(),
             affinity_decay_epoch: default_affinity_decay_epoch(),
+            prefetch_governor: false,
+            prefetch_precision_floor: default_prefetch_precision_floor(),
+            prefetch_contention_weight: default_prefetch_contention_weight(),
+            cost_aware_eviction: false,
+            pregate_enabled: false,
         }
     }
 }

--- a/rust-engine/src/config.rs
+++ b/rust-engine/src/config.rs
@@ -218,6 +218,22 @@ pub struct StorageConfigToml {
     /// evicted by cold experts. `0` (default) disables pinning.
     #[serde(default = "default_pin_after_observations")]
     pub pin_after_observations: u64,
+
+    /// **Tier 2 — packed expert storage.** Path to a single packed blob
+    /// file containing every expert payload back-to-back (one block-aligned
+    /// `expert_size` slot each), produced by the `repack` subcommand. When
+    /// set (together with [`Self::packed_manifest`]) the engine reads all
+    /// experts from this one fd and coalesces physically-adjacent experts
+    /// into single vectored `preadv` syscalls. `None` (default) keeps the
+    /// one-file-per-expert layout bit-for-bit.
+    #[serde(default)]
+    pub packed_blob: Option<PathBuf>,
+
+    /// **Tier 2.** Path to the JSON manifest (`id -> offset,len`) that
+    /// accompanies [`Self::packed_blob`]. Required when `packed_blob` is
+    /// set; ignored otherwise.
+    #[serde(default)]
+    pub packed_manifest: Option<PathBuf>,
 }
 
 fn default_partial_load_fraction() -> f64 { 1.0 }
@@ -790,6 +806,25 @@ impl Config {
                 self.storage.partial_load_fraction
             )));
         }
+        // Tier 2 packed storage: the blob and its manifest must be set
+        // together — one without the other is a misconfiguration.
+        match (&self.storage.packed_blob, &self.storage.packed_manifest) {
+            (Some(_), None) => {
+                return Err(ConfigError::Invalid(
+                    "storage.packed_blob is set but storage.packed_manifest is missing; \
+                     both are required to enable the packed layout"
+                        .into(),
+                ));
+            }
+            (None, Some(_)) => {
+                return Err(ConfigError::Invalid(
+                    "storage.packed_manifest is set but storage.packed_blob is missing; \
+                     both are required to enable the packed layout"
+                        .into(),
+                ));
+            }
+            _ => {}
+        }
         if !(0.0..=1.0).contains(&self.predictive.static_residency_fraction) {
             return Err(ConfigError::Invalid(format!(
                 "predictive.static_residency_fraction ({}) must be in [0.0, 1.0]",
@@ -1156,6 +1191,8 @@ mod tests {
                 predict_min_prob: 0.0,
                 partial_load_fraction: 1.0,
                 pin_after_observations: 0,
+                packed_blob: None,
+                packed_manifest: None,
             },
             tokenizer: TokenizerConfig::default(),
             real_transformer: RealTransformerConfig::default(),

--- a/rust-engine/src/engine.rs
+++ b/rust-engine/src/engine.rs
@@ -926,6 +926,13 @@ pub struct EngineOptions {
     /// trace-replay path. `false` (the default) leaves the existing
     /// speculator/Markov look-ahead untouched.
     pub pregate_enabled: bool,
+    /// **Tier 1 — route-profile collection.** When `true`, the engine
+    /// always bumps per-expert `route_observations` (even when neither
+    /// frequency pinning nor online static residency would otherwise
+    /// need them) so a run can emit a popularity profile via
+    /// `--profile-out`. `false` (the default) keeps the per-token bump
+    /// free when no consumer needs the counts.
+    pub collect_route_profile: bool,
 }
 
 /// Default semaphore ceiling for `Engine::spawn_prefetch`. Matches a
@@ -969,6 +976,7 @@ impl Default for EngineOptions {
             prefetch_contention_weight: 1.0,
             cost_aware_eviction: false,
             pregate_enabled: false,
+            collect_route_profile: false,
         }
     }
 }
@@ -1185,6 +1193,13 @@ pub(crate) struct EngineSpeculation {
     /// lifetime; dropping it stops the worker. `None` when the
     /// affinity arm is disabled.
     pub(super) affinity_decay: Option<DecayWorkerHandle>,
+    /// Tier 1 — **static residency** controller. When present, the
+    /// engine pins the hottest `fraction` of experts permanently in the
+    /// RAM cache (from an offline profile at startup, or an online hot
+    /// set derived from [`Self::route_observations`] after a warmup
+    /// window) so a skewed routing distribution can exceed the bare
+    /// cache-capacity hit-rate ceiling. `None` disables the feature.
+    pub(super) static_residency: Option<crate::residency::StaticResidencyState>,
 }
 
 /// Observability: latency histograms, cumulative timing atomics,
@@ -1346,6 +1361,7 @@ impl EngineSpeculation {
             affinity: None,
             affinity_neighbors_k: 0,
             affinity_decay: None,
+            static_residency: None,
         }
     }
 }
@@ -1827,6 +1843,110 @@ impl Engine {
         self
     }
 
+    /// Tier 1 — install the **static residency** controller. `fraction`
+    /// is the share of the global expert namespace to pin permanently
+    /// (`<= 0.0` disables the feature and leaves the engine unchanged).
+    /// When `profile` is `Some`, its hot set is pinned at the first
+    /// token with no warmup; when `None`, the engine derives the hot set
+    /// online from [`Self::route_observations`] after `warmup_tokens`
+    /// tokens. The pin budget is sized against the router's expert
+    /// namespace so it is a true fraction of *all* experts.
+    pub fn with_static_residency(
+        mut self,
+        fraction: f64,
+        warmup_tokens: u64,
+        profile: Option<crate::residency::ResidencyProfile>,
+    ) -> Self {
+        if fraction <= 0.0 {
+            return self;
+        }
+        let namespace = self.core.router.num_experts() as usize;
+        self.speculation.static_residency = Some(crate::residency::StaticResidencyState::new(
+            fraction.min(1.0),
+            warmup_tokens,
+            namespace,
+            profile,
+        ));
+        self
+    }
+
+    /// Whether the static-residency controller still needs
+    /// `route_observations` populated this token — true only while an
+    /// *online* (profile-less) controller is configured and has not yet
+    /// pinned its hot set. Keeps the per-token observation bump free
+    /// when the feature is off or already applied.
+    fn static_residency_needs_counts(&self) -> bool {
+        self.speculation
+            .static_residency
+            .as_ref()
+            .map(|sr| sr.is_online() && !sr.applied.load(Ordering::Acquire))
+            .unwrap_or(false)
+    }
+
+    /// Build a [`ResidencyProfile`] snapshot from the live
+    /// `route_observations` counters. Cheap relaxed reads — the counts
+    /// are advisory, so a torn-but-consistent snapshot is acceptable.
+    fn snapshot_route_profile(&self) -> crate::residency::ResidencyProfile {
+        let mut counts = HashMap::new();
+        for entry in self.speculation.route_observations.iter() {
+            counts.insert(*entry.key(), entry.value().load(Ordering::Relaxed));
+        }
+        crate::residency::ResidencyProfile::from_counts(counts)
+    }
+
+    /// Dump the engine's live route-observation profile to `path` as
+    /// JSON (`{ "<id>": <count> }`). Used by the `--profile-out` flag so
+    /// a run can emit its own hot-set profile for a later
+    /// `--static-residency-profile` warm start.
+    pub fn dump_route_profile(&self, path: &std::path::Path) -> std::io::Result<()> {
+        self.snapshot_route_profile().dump_json(path)
+    }
+
+    /// Apply the static-residency hot set exactly once, when ready. For
+    /// a profile-seeded controller this fires on the first token; for an
+    /// online controller it waits until `token_idx >= warmup_tokens` and
+    /// then derives the hot set from the accumulated route observations.
+    /// The pin is latched behind a compare-and-swap so concurrent
+    /// per-token calls apply it a single time.
+    fn maybe_apply_static_residency(&self, token_idx: u64) {
+        let Some(sr) = self.speculation.static_residency.as_ref() else {
+            return;
+        };
+        if sr.applied.load(Ordering::Acquire) {
+            return;
+        }
+        let hot = if let Some(profile) = sr.profile.as_ref() {
+            profile.hot_set(sr.fraction, sr.namespace)
+        } else {
+            if token_idx < sr.warmup_tokens {
+                return;
+            }
+            self.snapshot_route_profile()
+                .hot_set(sr.fraction, sr.namespace)
+        };
+        if hot.is_empty() {
+            return;
+        }
+        // Latch: exactly one caller transitions false -> true and pins.
+        if sr
+            .applied
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+        for id in &hot {
+            self.core.cache.pin(*id);
+        }
+        info!(
+            pinned = hot.len(),
+            fraction = sr.fraction,
+            source = if sr.profile.is_some() { "profile" } else { "online" },
+            warmup_tokens = sr.warmup_tokens,
+            "static residency: pinned hot expert set"
+        );
+    }
+
     /// Wire a Prometheus metrics sink. The engine will mirror its
     /// telemetry counters (locality / speculator hits & misses, SSD
     /// stall) into the metrics registry alongside its own atomics.
@@ -1903,9 +2023,18 @@ impl Engine {
 
         // Frequency-based pinning: bump observation counts and ask the
         // cache to pin any id that crossed the threshold this token.
-        if self.core.options.pin_after_observations > 0 {
+        // Also bump (without pinning) when an online static-residency
+        // controller still needs route counts to derive its hot set, or
+        // when the run is collecting a popularity profile for export.
+        if self.core.options.pin_after_observations > 0
+            || self.core.options.collect_route_profile
+            || self.static_residency_needs_counts()
+        {
             self.bump_route_observations(&target);
         }
+        // Tier 1: pin the static-residency hot set once it is ready
+        // (immediately for a profile seed, post-warmup for online).
+        self.maybe_apply_static_residency(token_idx);
 
         // 1) Make sure every required expert is resident.
         //
@@ -3462,10 +3591,17 @@ if let Some(gpu) = me.core.gpu_cache.as_ref() {
         // online against the gate's actual top-K decision.
         let m_speculator = self.speculator_predict_and_train(x, &target, Some(layer));
 
-        // Frequency-based pinning: same logic as `generate`.
-        if self.core.options.pin_after_observations > 0 {
+        // Frequency-based pinning: same logic as `generate`. Also bump
+        // (without pinning) for an online static-residency controller or
+        // when collecting a popularity profile for export.
+        if self.core.options.pin_after_observations > 0
+            || self.core.options.collect_route_profile
+            || self.static_residency_needs_counts()
+        {
             self.bump_route_observations(&target);
         }
+        // Tier 1: pin the static-residency hot set once it is ready.
+        self.maybe_apply_static_residency(token_idx);
 
         // **Speculative I/O union-fetch (S ∪ L ∪ M), issued
         // concurrently with the target-miss fetches.** Fire the
@@ -5066,6 +5202,128 @@ mod tests {
         assert_eq!(affinity.affinity(1, 0, 1), 3, "co-fired three times");
         // No leakage into layer 0's matrix.
         assert!(affinity.neighbors(0, 0, 2).is_empty(), "layer 0 must be untouched");
+    }
+
+    /// **Tier 1 — online static residency.** With no seed profile the
+    /// engine must derive its hot set from the live route observations
+    /// after the warmup window and pin exactly `ceil(fraction × N)`
+    /// experts — the most-frequently routed ones — exactly once.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn static_residency_online_pins_hottest_after_warmup() {
+        let dir = TempDir::new("static-residency-online");
+        let total_experts: u32 = 8;
+        let d_model = 16usize;
+        let d_ff = 32usize;
+        let seed: u64 = 0x5EED_1234_u64;
+
+        let weight_bytes = crate::inference::expert_weight_bytes(d_model, d_ff);
+        let block_align = 4096usize;
+        let expert_size = weight_bytes.div_ceil(block_align) * block_align;
+        generate_synthetic_experts(&dir.path, total_experts, expert_size, d_model, d_ff)
+            .expect("generate synthetic experts");
+
+        let storage = Arc::new(
+            NvmeStorage::new(StorageConfig {
+                base_path: dir.path.clone(),
+                expert_size,
+                block_align,
+                use_direct_io: false,
+                num_experts_per_layer: None,
+            })
+            .expect("storage init"),
+        );
+        storage.warmup_fds(0..total_experts).expect("pre-open fds");
+
+        let pool = BufferPool::new(total_experts as usize + 2, expert_size, block_align);
+        let cache = Arc::new(MultiLayerExpertCache::single_layer(total_experts as usize));
+        let router = Router::Markov(Arc::new(TopKRouter::new(total_experts, 2, seed)));
+        let predictor = Arc::new(PredictiveLoader::new(total_experts, 2, 0.05, seed));
+
+        // fraction 0.25 of 8 experts ⇒ pin the 2 hottest. Warm up 4 tokens.
+        let engine = Arc::new(
+            Engine::new(
+                cache.clone(),
+                pool,
+                storage,
+                router,
+                predictor,
+                ModelShape { d_model, d_ff, hidden_seed: seed },
+            )
+            .with_static_residency(0.25, /*warmup_tokens=*/ 4, /*profile=*/ None),
+        );
+
+        let hidden = crate::inference::synth_hidden_state(0, d_model, seed);
+        // Skewed stream: experts {2,5} fire every token; a rotating cold
+        // expert fires once each so {2,5} are unambiguously hottest.
+        for t in 0..8u64 {
+            let cold = 6 + (t % 2) as u32; // 6 or 7, never as hot as {2,5}
+            let _ = engine.moe_step(t, /*layer=*/ 0, &hidden, &[2, 5, cold]).await;
+        }
+
+        // After warmup the hot set must be pinned exactly once.
+        assert_eq!(cache.pinned_count(), 2, "ceil(0.25*8)=2 experts pinned");
+        assert_eq!(cache.pinned_ids(), vec![2, 5], "the two hottest experts");
+    }
+
+    /// **Tier 1 — profile-seeded static residency.** With an offline
+    /// popularity profile the hot set is pinned at the first token with
+    /// no warmup, independent of the live routing stream.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn static_residency_profile_pins_immediately() {
+        let dir = TempDir::new("static-residency-profile");
+        let total_experts: u32 = 8;
+        let d_model = 16usize;
+        let d_ff = 32usize;
+        let seed: u64 = 0x5EED_ABCD_u64;
+
+        let weight_bytes = crate::inference::expert_weight_bytes(d_model, d_ff);
+        let block_align = 4096usize;
+        let expert_size = weight_bytes.div_ceil(block_align) * block_align;
+        generate_synthetic_experts(&dir.path, total_experts, expert_size, d_model, d_ff)
+            .expect("generate synthetic experts");
+
+        let storage = Arc::new(
+            NvmeStorage::new(StorageConfig {
+                base_path: dir.path.clone(),
+                expert_size,
+                block_align,
+                use_direct_io: false,
+                num_experts_per_layer: None,
+            })
+            .expect("storage init"),
+        );
+        storage.warmup_fds(0..total_experts).expect("pre-open fds");
+
+        let pool = BufferPool::new(total_experts as usize + 2, expert_size, block_align);
+        let cache = Arc::new(MultiLayerExpertCache::single_layer(total_experts as usize));
+        let router = Router::Markov(Arc::new(TopKRouter::new(total_experts, 2, seed)));
+        let predictor = Arc::new(PredictiveLoader::new(total_experts, 2, 0.05, seed));
+
+        // Profile makes experts 0 and 3 hottest regardless of the stream.
+        let mut counts = std::collections::HashMap::new();
+        counts.insert(0u32, 1000u64);
+        counts.insert(3u32, 900u64);
+        counts.insert(1u32, 5u64);
+        let profile = crate::residency::ResidencyProfile::from_counts(counts);
+
+        let engine = Arc::new(
+            Engine::new(
+                cache.clone(),
+                pool,
+                storage,
+                router,
+                predictor,
+                ModelShape { d_model, d_ff, hidden_seed: seed },
+            )
+            .with_static_residency(0.25, /*warmup_tokens=*/ 100, Some(profile)),
+        );
+
+        let hidden = crate::inference::synth_hidden_state(0, d_model, seed);
+        // A single token suffices — the seed profile ignores warmup.
+        let _ = engine.moe_step(0, /*layer=*/ 0, &hidden, &[5, 6]).await;
+
+        assert_eq!(cache.pinned_count(), 2, "ceil(0.25*8)=2 experts pinned");
+        assert_eq!(cache.pinned_ids(), vec![0, 3], "profile's two hottest experts");
     }
 
     /// **Layer-scoped speculator accuracy.** On the `moe_step` path the

--- a/rust-engine/src/engine.rs
+++ b/rust-engine/src/engine.rs
@@ -810,6 +810,13 @@ pub(crate) struct Counters {
     /// `EngineReport::prefetch_dropped_pool_starved` and
     /// `mer_prefetch_dropped_pool_starved_total`.
     prefetch_dropped_pool_starved: AtomicU64,
+    /// **Tier 4.** Speculative prefetches the adaptive
+    /// [`crate::prefetch_governor::PrefetchGovernor`] declined to admit
+    /// because their expected value did not clear the contention-scaled
+    /// bar. Always `0` when the governor is disabled (the default), so
+    /// legacy telemetry is unchanged. Surfaced via
+    /// `EngineReport::prefetch_dropped_governor`.
+    prefetch_dropped_governor: AtomicU64,
     /// Tokens for which the neural speculator (M arm) was silently
     /// disabled because the hidden-state width didn't match the
     /// speculator's `d_model`. A persistent non-zero rate means the
@@ -887,6 +894,38 @@ pub struct EngineOptions {
     /// concurrent prefetches under steady-state load (gist feedback
     /// #1.3). Values less than `1` are clamped to `1` at use.
     pub max_fetch_yields: usize,
+    /// **Tier 4 — adaptive prefetch governor.** When `true`, every
+    /// speculative prefetch is admitted by
+    /// [`crate::prefetch_governor::PrefetchGovernor`], which throttles
+    /// speculation as measured prefetch precision falls or as foreground
+    /// (token-blocking) reads queue up for the device. `false` (the
+    /// default) preserves the legacy unbounded-admission behaviour
+    /// exactly. This is the highest-leverage knob on a bandwidth-bound
+    /// SSD: it stops low-precision speculation from inflating the latency
+    /// of the foreground misses that actually block token generation.
+    pub prefetch_governor: bool,
+    /// Precision floor (and optimistic EWMA seed lower bound) for the
+    /// prefetch governor, in `[0, 1]`. Only consulted when
+    /// `prefetch_governor` is set.
+    pub prefetch_precision_floor: f64,
+    /// Per-outstanding-foreground-read multiplier the prefetch governor
+    /// applies to its admission threshold. Higher values make
+    /// speculation back off harder while real misses are in flight.
+    pub prefetch_contention_weight: f64,
+    /// **Tier 4 — cost-aware eviction.** When `true`, the RAM expert
+    /// cache evicts the non-pinned resident with the lowest *decaying
+    /// heat score* (frequency of use, aged over time) rather than the
+    /// strict LRU victim, so a genuinely hot expert that briefly fell to
+    /// the LRU tail is not dumped ahead of a one-shot cold expert.
+    /// `false` (the default) keeps pure-LRU + binary pin-set eviction.
+    pub cost_aware_eviction: bool,
+    /// **Tier 3 — per-layer pre-gate predictor.** When `true`, the
+    /// engine trains an online conditional map from one layer's routed
+    /// expert set to the *next* layer's experts and uses it to drive
+    /// high-precision next-layer prefetch on the real-transformer /
+    /// trace-replay path. `false` (the default) leaves the existing
+    /// speculator/Markov look-ahead untouched.
+    pub pregate_enabled: bool,
 }
 
 /// Default semaphore ceiling for `Engine::spawn_prefetch`. Matches a
@@ -925,6 +964,11 @@ impl Default for EngineOptions {
             use_qmm_for_q4: true,
             max_concurrent_prefetches: DEFAULT_MAX_CONCURRENT_PREFETCHES,
             max_fetch_yields: DEFAULT_MAX_FETCH_YIELDS,
+            prefetch_governor: false,
+            prefetch_precision_floor: 0.05,
+            prefetch_contention_weight: 1.0,
+            cost_aware_eviction: false,
+            pregate_enabled: false,
         }
     }
 }
@@ -1002,6 +1046,14 @@ pub(crate) struct EngineCore {
     /// `BackendBox::Cpu` automatically if no GPU is available, so this
     /// field is always installed (see gist Phase 3, CHANGE 3).
     pub(super) backend: Arc<crate::backend::BackendBox>,
+    /// **Tier 4 — adaptive prefetch admission controller.** Always
+    /// present; constructed in the transparent pass-through state unless
+    /// [`EngineOptions::prefetch_governor`] is set, in which case it
+    /// gates every `spawn_prefetch` admission on measured prefetch
+    /// precision and foreground-read contention. Lock-free, so the
+    /// per-prefetch `admit` check and the per-hit precision feedback add
+    /// only a handful of relaxed atomic ops to the hot path.
+    pub(super) governor: Arc<crate::prefetch_governor::PrefetchGovernor>,
 }
 
 /// Predictive-routing state: aliasing & frequency-based pinning,
@@ -1238,6 +1290,17 @@ impl EngineCore {
                 .max_concurrent_prefetches
                 .min(pool_headroom.saturating_sub(1))
         };
+        let governor = Arc::new(crate::prefetch_governor::PrefetchGovernor::new(
+            options.prefetch_governor,
+            crate::prefetch_governor::GovernorConfig {
+                precision_floor: options.prefetch_precision_floor,
+                contention_weight: options.prefetch_contention_weight,
+                ..crate::prefetch_governor::GovernorConfig::default()
+            },
+        ));
+        // Tier 4: flip the RAM cache into cost-aware (lowest-heat)
+        // eviction when requested. Off by default ⇒ pure LRU.
+        cache.set_cost_aware(options.cost_aware_eviction);
         Self {
             cache,
             pool,
@@ -1256,6 +1319,7 @@ impl EngineCore {
             backend: Arc::new(crate::backend::BackendBox::Cpu(
                 crate::backend::CandleBackend::new(),
             )),
+            governor,
         }
     }
 }
@@ -1809,6 +1873,10 @@ impl Engine {
         token_idx: u64,
     ) -> Result<CycleStats, ExpertReadError> {
         let cycle_start = Instant::now();
+        // Tier 4: fold the previous token's prefetch precision window
+        // into the governor's EWMA before this token issues any new
+        // speculative reads. No-op when the governor is disabled.
+        self.core.governor.refresh();
         // Compute the residual-stream hidden state up front. The
         // production `Router::Linear` path needs it to compute the
         // gate's softmax logits; the legacy `Router::Markov` path
@@ -1882,6 +1950,16 @@ impl Engine {
                 // promotion only on the threshold crossing, and only if
                 // the expert is not already resident in the GPU cache.
                 let new_hits = r.record_hit();
+                // Tier 4 precision feedback: the first hit on a
+                // shadow-backed resident means a speculative prefetch
+                // paid off (it was consumed before eviction). Credit the
+                // governor so its precision EWMA tracks reality, and bump
+                // the (previously dead) `prefetch_used` counter so the
+                // run summary can report end-to-end prefetch precision.
+                if new_hits == 1 && r.is_shadow_backed() {
+                    self.metrics.counters.prefetch_used.fetch_add(1, Ordering::Relaxed);
+                    self.core.governor.record_used();
+                }
                 if let (Some(gpu), Some(tx)) = (
                     self.core.gpu_cache.as_ref(),
                     self.core.gpu_promotion_tx.as_ref(),
@@ -2435,7 +2513,14 @@ impl Engine {
             }
         }
         let mut buf = self.core.pool.acquire().await;
-        match self.core.storage.read_expert(id, &mut buf).await {
+        // Tier 4: mark this as a foreground (token-blocking) read for the
+        // duration of the device I/O so the governor throttles
+        // speculation that would otherwise queue ahead of it. No-op when
+        // the governor is disabled.
+        self.core.governor.begin_foreground();
+        let read_result = self.core.storage.read_expert(id, &mut buf).await;
+        self.core.governor.end_foreground();
+        match read_result {
             Ok(_) => {
                 let io_us = io_start.elapsed().as_micros() as u64;
                 let _ = self.metrics.io_hist.lock().record(io_us.max(1));
@@ -2490,6 +2575,21 @@ impl Engine {
         // fine: the post-spawn `contains` re-check and the singleflight
         // entry below stay authoritative.
         if self.core.cache.contains(id) || self.core.in_flight.contains_key(&id) {
+            return;
+        }
+        // **Tier 4 admission gate.** Before spending a semaphore permit
+        // (or any device bandwidth), ask the adaptive governor whether
+        // this speculative read is worth issuing *right now*, given its
+        // predicted score `p`, the recently-measured prefetch precision,
+        // and how many foreground (token-blocking) misses are currently
+        // competing for the SSD. A disabled governor always admits, so
+        // the legacy unbounded behaviour is preserved bit-for-bit.
+        if !self.core.governor.admit(p) {
+            self.metrics
+                .counters
+                .prefetch_dropped_governor
+                .fetch_add(1, Ordering::Relaxed);
+            debug!(expert = id, score = p, "governor throttled speculative prefetch");
             return;
         }
         // Speculative prefetches are *bounded*: each spawn must hold
@@ -2611,6 +2711,12 @@ impl Engine {
             match me.core.storage.read_expert(id, &mut buf).await {
                 Ok(_) => {
                     me.metrics.counters.prefetch_completed.fetch_add(1, Ordering::Relaxed);
+                    // Tier 4: a speculative read landed in the cache. This
+                    // is the precision *denominator*; the matching
+                    // numerator (`record_used`) fires if/when a hit later
+                    // consumes this shadow-backed resident. No-op when the
+                    // governor is disabled.
+                    me.core.governor.record_completed();
                     me.metrics.counters
                         .bytes_read
                         .fetch_add(buf.len() as u64, Ordering::Relaxed);
@@ -3322,6 +3428,10 @@ if let Some(gpu) = me.core.gpu_cache.as_ref() {
         experts: &[u32],
     ) -> Vec<HiddenState> {
         let cycle_start = Instant::now();
+        // Tier 4: fold the previous step's prefetch precision window into
+        // the governor's EWMA before issuing this step's speculation.
+        // No-op when the governor is disabled.
+        self.core.governor.refresh();
         // Resolve aliases up front so the cache + predictor only ever
         // see canonical expert ids (mirrors `generate`).
         let target: Vec<u32> = experts.iter().map(|&id| self.resolve_alias(id)).collect();
@@ -3433,6 +3543,13 @@ if let Some(gpu) = me.core.gpu_cache.as_ref() {
             if let Some(r) = self.core.cache.get(id) {
                 self.metrics.counters.hits.fetch_add(1, Ordering::Relaxed);
                 let new_hits = r.record_hit();
+                // Tier 4 precision feedback (mirrors `generate`): a
+                // first hit on a shadow-backed resident is a prefetch
+                // that paid off. No-op when the governor is disabled.
+                if new_hits == 1 && r.is_shadow_backed() {
+                    self.metrics.counters.prefetch_used.fetch_add(1, Ordering::Relaxed);
+                    self.core.governor.record_used();
+                }
                 if let (Some(gpu), Some(tx)) = (
                     self.core.gpu_cache.as_ref(),
                     self.core.gpu_promotion_tx.as_ref(),
@@ -3879,6 +3996,16 @@ if let Some(gpu) = me.core.gpu_cache.as_ref() {
                 .as_ref()
                 .map(|g| g.lru_len())
                 .unwrap_or(0),
+            prefetch_used: self.metrics.counters.prefetch_used.load(Ordering::Relaxed),
+            prefetch_dropped_governor: self
+                .metrics
+                .counters
+                .prefetch_dropped_governor
+                .load(Ordering::Relaxed),
+            governor_enabled: self.core.governor.is_enabled(),
+            governor_precision: self.core.governor.precision(),
+            governor_admitted: self.core.governor.decisions().0,
+            governor_throttled: self.core.governor.decisions().1,
         }
     }
 
@@ -3956,6 +4083,27 @@ if let Some(gpu) = me.core.gpu_cache.as_ref() {
                 if r.speculator_enabled { "on" } else { "off" },
                 r.predictive.speculator_accuracy * 100.0,
                 r.predictive.ssd_stall_us as f64 / 1000.0,
+            );
+        }
+        // Tier 4 governor line — only emitted when the adaptive
+        // prefetch governor is enabled, so the legacy summary shape is
+        // untouched for existing runs/tests.
+        if r.governor_enabled {
+            let precision_pct = r.governor_precision * 100.0;
+            let admit_total = r.governor_admitted + r.governor_throttled;
+            let admit_rate = if admit_total == 0 {
+                0.0
+            } else {
+                r.governor_admitted as f64 / admit_total as f64 * 100.0
+            };
+            info!(
+                "governor:      on  precision={:.2}%  prefetch_used={}/{}  admitted={} throttled={} ({:.1}% admit)",
+                precision_pct,
+                r.prefetch_used,
+                r.prefetch_completed,
+                r.governor_admitted,
+                r.governor_throttled,
+                admit_rate,
             );
         }
         info!("=======================================================");
@@ -4072,6 +4220,25 @@ pub struct EngineReport {
     pub gpu_anchor_count: usize,
     /// Number of experts in the VRAM LRU (cold-edge) region.
     pub gpu_lru_count: usize,
+    /// **Tier 4.** Speculative prefetches that landed in cache and were
+    /// then consumed by a hit before eviction (precision numerator).
+    /// Previously always `0` (the counter was dead); now wired on both
+    /// the `generate` and `moe_step` hit paths.
+    pub prefetch_used: u64,
+    /// **Tier 4.** Speculative prefetches the adaptive governor declined
+    /// to admit. `0` when the governor is disabled (the default).
+    pub prefetch_dropped_governor: u64,
+    /// **Tier 4.** Whether the adaptive prefetch governor is enabled.
+    pub governor_enabled: bool,
+    /// **Tier 4.** Current governor precision EWMA (consumed / completed),
+    /// in `[0, 1]`. Meaningless when `governor_enabled` is `false`.
+    pub governor_precision: f64,
+    /// **Tier 4.** Cumulative speculative prefetches the governor
+    /// admitted.
+    pub governor_admitted: u64,
+    /// **Tier 4.** Cumulative speculative prefetches the governor
+    /// throttled (declined).
+    pub governor_throttled: u64,
 }
 
 #[cfg(test)]

--- a/rust-engine/src/engine.rs
+++ b/rust-engine/src/engine.rs
@@ -1123,6 +1123,11 @@ pub(crate) struct EngineSpeculation {
     /// `fetch_add` in steady state, so concurrent `moe_step` calls
     /// from batched requests no longer serialize on one writer lock.
     pub(super) route_observations: DashMap<u32, AtomicU64>,
+    /// Engine-owned monotonic token counter for route-observation bumps.
+    /// Online static-residency warmup gates on this instead of the
+    /// caller-supplied `token_idx`, which can be per-stream or reused on
+    /// `moe_step`.
+    pub(super) route_observation_tokens: AtomicU64,
     /// Two-deep Markov history (`last` + `last_last`) behind a single
     /// mutex — see [`MarkovRing`] for why the entries share one lock.
     pub(super) markov_ring: parking_lot::Mutex<MarkovRing>,
@@ -1137,6 +1142,9 @@ pub(crate) struct EngineSpeculation {
     /// reconciliation. Diff'd against the current hot set so we only
     /// `pin`/`unpin` ids that actually changed status.
     pub(super) locality_pinned: parking_lot::Mutex<HashSet<u32>>,
+    /// Expert ids pinned by static residency. Locality reconciliation must
+    /// not unpin these ids when they leave the sliding-window hot set.
+    pub(super) static_pinned: parking_lot::Mutex<HashSet<u32>>,
     /// Heat threshold for [`Self::locality`]. Mirrors
     /// [`LocalityMonitor::DEFAULT_THRESHOLD_PCT`] when not overridden.
     pub(super) locality_threshold_pct: f32,
@@ -1351,9 +1359,11 @@ impl EngineSpeculation {
             alias_map: None,
             alias_redirects: AtomicU64::new(0),
             route_observations: DashMap::new(),
+            route_observation_tokens: AtomicU64::new(0),
             markov_ring: parking_lot::Mutex::new(MarkovRing::default()),
             locality: None,
             locality_pinned: parking_lot::Mutex::new(HashSet::new()),
+            static_pinned: parking_lot::Mutex::new(HashSet::new()),
             locality_threshold_pct: LocalityMonitor::DEFAULT_THRESHOLD_PCT,
             locality_hits: AtomicU64::new(0),
             locality_misses: AtomicU64::new(0),
@@ -1920,11 +1930,12 @@ impl Engine {
 
     /// Apply the static-residency hot set exactly once, when ready. For
     /// a profile-seeded controller this fires on the first token; for an
-    /// online controller it waits until `token_idx >= warmup_tokens` and
-    /// then derives the hot set from the accumulated route observations.
+    /// online controller it waits until the engine has bumped route
+    /// observations for `warmup_tokens` tokens, then derives the hot set
+    /// from the accumulated route observations.
     /// The pin is latched behind a compare-and-swap so concurrent
     /// per-token calls apply it a single time.
-    fn maybe_apply_static_residency(&self, token_idx: u64) {
+    fn maybe_apply_static_residency(&self) {
         let Some(sr) = self.speculation.static_residency.as_ref() else {
             return;
         };
@@ -1934,7 +1945,12 @@ impl Engine {
         let hot = if let Some(profile) = sr.profile.as_ref() {
             profile.hot_set(sr.fraction, sr.namespace)
         } else {
-            if token_idx < sr.warmup_tokens {
+            if self
+                .speculation
+                .route_observation_tokens
+                .load(Ordering::Acquire)
+                < sr.warmup_tokens
+            {
                 return;
             }
             self.snapshot_route_profile()
@@ -1953,6 +1969,10 @@ impl Engine {
         }
         for id in &hot {
             self.core.cache.pin(*id);
+        }
+        {
+            let mut static_pinned = self.speculation.static_pinned.lock();
+            static_pinned.extend(hot.iter().copied());
         }
         info!(
             pinned = hot.len(),
@@ -1984,6 +2004,14 @@ impl Engine {
             }
         }
         id
+    }
+
+    #[inline]
+    fn credit_prefetch_use(&self, resident: &Arc<ExpertResident>, new_hits: u64) {
+        if new_hits == 1 && resident.is_shadow_backed() {
+            self.metrics.counters.prefetch_used.fetch_add(1, Ordering::Relaxed);
+            self.core.governor.record_used();
+        }
     }
 
     /// Total number of distinct experts the engine's router can
@@ -2050,7 +2078,7 @@ impl Engine {
         }
         // Tier 1: pin the static-residency hot set once it is ready
         // (immediately for a profile seed, post-warmup for online).
-        self.maybe_apply_static_residency(token_idx);
+        self.maybe_apply_static_residency();
 
         // 1) Make sure every required expert is resident.
         //
@@ -2101,10 +2129,7 @@ impl Engine {
                 // governor so its precision EWMA tracks reality, and bump
                 // the (previously dead) `prefetch_used` counter so the
                 // run summary can report end-to-end prefetch precision.
-                if new_hits == 1 && r.is_shadow_backed() {
-                    self.metrics.counters.prefetch_used.fetch_add(1, Ordering::Relaxed);
-                    self.core.governor.record_used();
-                }
+                self.credit_prefetch_use(&r, new_hits);
                 if let (Some(gpu), Some(tx)) = (
                     self.core.gpu_cache.as_ref(),
                     self.core.gpu_promotion_tx.as_ref(),
@@ -2208,6 +2233,8 @@ impl Engine {
             // fetch task (a bug, not an I/O failure), preserving the
             // pre-concurrency panic-propagation semantics for that case.
             let r = h.await.expect("expert fetch task panicked")?;
+            let new_hits = r.record_hit();
+            self.credit_prefetch_use(&r, new_hits);
             // We still account the per-call `stats.bytes_read` here
             // for the synthetic-benchmark accumulator (it tracks
             // logical bytes consumed, not bytes actually pulled
@@ -2662,9 +2689,8 @@ impl Engine {
         // duration of the device I/O so the governor throttles
         // speculation that would otherwise queue ahead of it. No-op when
         // the governor is disabled.
-        self.core.governor.begin_foreground();
+        let _fg = self.core.governor.foreground_guard();
         let read_result = self.core.storage.read_expert(id, &mut buf).await;
-        self.core.governor.end_foreground();
         match read_result {
             Ok(_) => {
                 let io_us = io_start.elapsed().as_micros() as u64;
@@ -3051,6 +3077,9 @@ if let Some(gpu) = me.core.gpu_cache.as_ref() {
     /// previous value makes the threshold crossing exact: precisely
     /// one caller observes `prev + 1 == threshold` and issues the pin.
     fn bump_route_observations(&self, target: &[u32]) {
+        self.speculation
+            .route_observation_tokens
+            .fetch_add(1, Ordering::Release);
         let threshold = self.core.options.pin_after_observations;
         for &id in target {
             let prev = if let Some(counter) = self.speculation.route_observations.get(&id) {
@@ -3140,7 +3169,10 @@ if let Some(gpu) = me.core.gpu_cache.as_ref() {
         }
         for &id in prev.iter() {
             if !new_hot.contains(&id) {
-                self.core.cache.unpin(id);
+                let is_static_pinned = self.speculation.static_pinned.lock().contains(&id);
+                if !is_static_pinned {
+                    self.core.cache.unpin(id);
+                }
             }
         }
         let len = new_hot.len();
@@ -3635,7 +3667,7 @@ if let Some(gpu) = me.core.gpu_cache.as_ref() {
             self.bump_route_observations(&target);
         }
         // Tier 1: pin the static-residency hot set once it is ready.
-        self.maybe_apply_static_residency(token_idx);
+        self.maybe_apply_static_residency();
 
         // **Speculative I/O union-fetch (S ∪ L ∪ M), issued
         // concurrently with the target-miss fetches.** Fire the
@@ -3723,10 +3755,7 @@ if let Some(gpu) = me.core.gpu_cache.as_ref() {
                 // Tier 4 precision feedback (mirrors `generate`): a
                 // first hit on a shadow-backed resident is a prefetch
                 // that paid off. No-op when the governor is disabled.
-                if new_hits == 1 && r.is_shadow_backed() {
-                    self.metrics.counters.prefetch_used.fetch_add(1, Ordering::Relaxed);
-                    self.core.governor.record_used();
-                }
+                self.credit_prefetch_use(&r, new_hits);
                 if let (Some(gpu), Some(tx)) = (
                     self.core.gpu_cache.as_ref(),
                     self.core.gpu_promotion_tx.as_ref(),
@@ -3792,6 +3821,8 @@ if let Some(gpu) = me.core.gpu_cache.as_ref() {
             // re-raise so the supervising scheduler can restart us.
             match h.await.expect("expert fetch task panicked") {
                 Ok(r) => {
+                    let new_hits = r.record_hit();
+                    self.credit_prefetch_use(&r, new_hits);
                     // `bytes_read` is already bumped inside
                     // `fetch_once` on the actual leader path, so we
                     // don't double-count here. Followers that
@@ -5336,14 +5367,109 @@ mod tests {
         let hidden = crate::inference::synth_hidden_state(0, d_model, seed);
         // Skewed stream: experts {2,5} fire every token; a rotating cold
         // expert fires once each so {2,5} are unambiguously hottest.
-        for t in 0..8u64 {
+        // Reuse token_idx=0 on every call to prove online warmup is driven
+        // by the engine-owned observation counter, not the caller seed.
+        for t in 0..3u64 {
             let cold = 6 + (t % 2) as u32; // 6 or 7, never as hot as {2,5}
-            let _ = engine.moe_step(t, /*layer=*/ 0, &hidden, &[2, 5, cold]).await;
+            let _ = engine.moe_step(0, /*layer=*/ 0, &hidden, &[2, 5, cold]).await;
+        }
+        assert_eq!(cache.pinned_count(), 0, "warmup should not fire before 4 bumps");
+        for t in 3..8u64 {
+            let cold = 6 + (t % 2) as u32;
+            let _ = engine.moe_step(0, /*layer=*/ 0, &hidden, &[2, 5, cold]).await;
         }
 
         // After warmup the hot set must be pinned exactly once.
         assert_eq!(cache.pinned_count(), 2, "ceil(0.25*8)=2 experts pinned");
         assert_eq!(cache.pinned_ids(), vec![2, 5], "the two hottest experts");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn static_residency_pin_survives_locality_unpin() {
+        let dir = TempDir::new("static-locality-pin");
+        let total_experts: u32 = 4;
+        let d_model = 16usize;
+        let d_ff = 32usize;
+        let seed: u64 = 0x51A7_1C_u64;
+        let engine = build_engine(
+            &dir.path,
+            total_experts,
+            d_model,
+            d_ff,
+            /*cache_slots=*/ 4,
+            /*top_k=*/ 1,
+            /*predict_fanout=*/ 1,
+            seed,
+        );
+        let profile = crate::residency::ResidencyProfile::from_counts(HashMap::from([
+            (0, 10),
+            (1, 1),
+            (2, 1),
+            (3, 1),
+        ]));
+        let engine = {
+            let cache = engine.core.cache.clone();
+            let pool = engine.core.pool.clone();
+            let storage = engine.core.storage.clone();
+            let router = engine.core.router.clone();
+            let predictor = engine.core.predictor.clone();
+            let shape = engine.core.shape;
+            let monitor = Arc::new(LocalityMonitor::new(total_experts, /*window=*/ 2));
+            Arc::new(
+                Engine::new(cache, pool, storage, router, predictor, shape)
+                    .with_static_residency(0.25, /*warmup_tokens=*/ 100, Some(profile))
+                    .with_locality_monitor(monitor, 0.5),
+            )
+        };
+
+        engine.maybe_apply_static_residency();
+        assert!(
+            engine.core.cache.pinned_ids().contains(&0),
+            "static residency pins expert 0"
+        );
+
+        engine.locality_observe_and_reconcile(&[0]);
+        assert!(
+            engine.core.cache.pinned_ids().contains(&0),
+            "locality also sees expert 0 hot"
+        );
+        engine.locality_observe_and_reconcile(&[1]);
+        engine.locality_observe_and_reconcile(&[1]);
+
+        assert!(
+            engine.core.cache.pinned_ids().contains(&0),
+            "locality must not unpin an expert pinned by static residency"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn credit_prefetch_use_counts_shadow_resident_once() {
+        let dir = TempDir::new("prefetch-use-credit");
+        let engine = build_engine(
+            &dir.path,
+            /*num_experts=*/ 2,
+            /*d_model=*/ 16,
+            /*d_ff=*/ 32,
+            /*cache_slots=*/ 2,
+            /*top_k=*/ 1,
+            /*predict_fanout=*/ 1,
+            0xC0FF_EE_u64,
+        );
+        let shadow_pool = BufferPool::new_with_shadow(1, 1, 4096, 4096);
+        let buf = shadow_pool.try_acquire_shadow().expect("shadow buffer");
+        let resident = Arc::new(ExpertResident::new(0, buf));
+        assert!(resident.is_shadow_backed());
+
+        let first = resident.record_hit();
+        engine.credit_prefetch_use(&resident, first);
+        let second = resident.record_hit();
+        engine.credit_prefetch_use(&resident, second);
+
+        assert_eq!(
+            engine.metrics.counters.prefetch_used.load(Ordering::Relaxed),
+            1,
+            "only the first consumption of a shadow-backed resident is credited"
+        );
     }
 
     /// **Tier 1 — profile-seeded static residency.** With an offline

--- a/rust-engine/src/engine.rs
+++ b/rust-engine/src/engine.rs
@@ -1200,6 +1200,12 @@ pub(crate) struct EngineSpeculation {
     /// window) so a skewed routing distribution can exceed the bare
     /// cache-capacity hit-rate ceiling. `None` disables the feature.
     pub(super) static_residency: Option<crate::residency::StaticResidencyState>,
+    /// Tier 3 — **per-layer pre-gate** predictor. When present, every
+    /// `moe_step` records the layer-to-layer routing transition and
+    /// prefetches the predicted next-layer experts (a high-precision
+    /// signal conditioned on the previous layer's actual routing).
+    /// `None` disables the feature.
+    pub(super) pregate: Option<Arc<crate::pregate::PerLayerPreGate>>,
 }
 
 /// Observability: latency histograms, cumulative timing atomics,
@@ -1362,6 +1368,7 @@ impl EngineSpeculation {
             affinity_neighbors_k: 0,
             affinity_decay: None,
             static_residency: None,
+            pregate: None,
         }
     }
 }
@@ -1867,6 +1874,15 @@ impl Engine {
             namespace,
             profile,
         ));
+        self
+    }
+
+    /// Tier 3 — install the **per-layer pre-gate** predictor. Once set,
+    /// every `moe_step` records the layer-to-layer routing transition
+    /// and prefetches the predicted next-layer experts. `top_n` bounds
+    /// how many next-layer experts are prefetched per step.
+    pub fn with_pregate(mut self, pregate: Arc<crate::pregate::PerLayerPreGate>) -> Self {
+        self.speculation.pregate = Some(pregate);
         self
     }
 
@@ -3311,6 +3327,24 @@ if let Some(gpu) = me.core.gpu_cache.as_ref() {
         }
     }
 
+    /// Tier 3 — drive the per-layer pre-gate. Records this layer's
+    /// routing transition into the conditional map and prefetches the
+    /// experts it predicts for the *next* layer. A disabled pre-gate
+    /// (`None`) makes this a no-op, preserving legacy behaviour.
+    fn pregate_prefetch(self: &Arc<Self>, layer: u32, target: &[u32]) {
+        let Some(pregate) = self.speculation.pregate.as_ref() else {
+            return;
+        };
+        let predicted = pregate.observe_and_predict(layer, target);
+        for id in predicted {
+            // Resolve aliases defensively (idempotent) so deduplicated
+            // experts share the canonical resident copy, then issue the
+            // speculative read with the pre-gate's high confidence tag.
+            let id = self.resolve_alias(id);
+            self.spawn_prefetch(id, crate::pregate::PREGATE_PREFETCH_PROB);
+        }
+    }
+
     /// Prefetch every id in the union `S ∪ L ∪ M` (plus the optional
     /// affinity/spatial neighbour fold) that isn't already resident —
     /// the **speculative I/O union-fetch** described in the design spec.
@@ -3653,6 +3687,13 @@ if let Some(gpu) = me.core.gpu_cache.as_ref() {
         // submit their reads now, so they overlap this layer's compute
         // and the next layer finds them already resident.
         self.speculate_layer_ahead(x, layer);
+
+        // **Tier 3 pre-gate look-ahead.** Record this layer's routing
+        // transition and prefetch the predicted next-layer experts — a
+        // high-precision signal conditioned on the previous layer's
+        // *actual* routing, complementing the hidden-state speculation
+        // above. No-op when the pre-gate is disabled.
+        self.pregate_prefetch(layer, &target);
 
         // Concurrent miss fetches; hits resolved inline.
         let io_wait_start = Instant::now();
@@ -4142,6 +4183,25 @@ if let Some(gpu) = me.core.gpu_cache.as_ref() {
             governor_precision: self.core.governor.precision(),
             governor_admitted: self.core.governor.decisions().0,
             governor_throttled: self.core.governor.decisions().1,
+            pregate_enabled: self.speculation.pregate.is_some(),
+            pregate_accuracy: self
+                .speculation
+                .pregate
+                .as_ref()
+                .map(|pg| pg.accuracy())
+                .unwrap_or(0.0),
+            pregate_hits: self
+                .speculation
+                .pregate
+                .as_ref()
+                .map(|pg| pg.stats().0)
+                .unwrap_or(0),
+            pregate_misses: self
+                .speculation
+                .pregate
+                .as_ref()
+                .map(|pg| pg.stats().1)
+                .unwrap_or(0),
         }
     }
 
@@ -4240,6 +4300,16 @@ if let Some(gpu) = me.core.gpu_cache.as_ref() {
                 r.governor_admitted,
                 r.governor_throttled,
                 admit_rate,
+            );
+        }
+        // Tier 3 pre-gate line — only when the per-layer pre-gate is
+        // enabled, keeping the legacy summary shape otherwise.
+        if r.pregate_enabled {
+            info!(
+                "pregate:       on  accuracy={:.2}%  predictions={}/{} (hit/total)",
+                r.pregate_accuracy * 100.0,
+                r.pregate_hits,
+                r.pregate_hits + r.pregate_misses,
             );
         }
         info!("=======================================================");
@@ -4375,6 +4445,17 @@ pub struct EngineReport {
     /// **Tier 4.** Cumulative speculative prefetches the governor
     /// throttled (declined).
     pub governor_throttled: u64,
+    /// **Tier 3.** Whether the per-layer pre-gate predictor is enabled.
+    pub pregate_enabled: bool,
+    /// **Tier 3.** Fraction of scored pre-gate predictions that
+    /// intersected the actually-routed next-layer set, in `[0, 1]`.
+    /// `0.0` when the pre-gate is disabled or nothing was scored yet.
+    pub pregate_accuracy: f64,
+    /// **Tier 3.** Pre-gate predictions that intersected the actual
+    /// next-layer routed set.
+    pub pregate_hits: u64,
+    /// **Tier 3.** Pre-gate predictions that missed.
+    pub pregate_misses: u64,
 }
 
 #[cfg(test)]

--- a/rust-engine/src/expert_cache.rs
+++ b/rust-engine/src/expert_cache.rs
@@ -19,8 +19,21 @@ use lru::LruCache;
 use parking_lot::Mutex;
 use std::collections::{HashMap, HashSet};
 use std::num::NonZeroUsize;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
+
+/// Pack/unpack an `f64` heat score into the bits of an `AtomicU64` so it
+/// can be read and updated without a lock. The cost-aware eviction
+/// scorer tolerates the occasional torn update from a racing reader —
+/// the score is a heuristic, not an invariant.
+#[inline]
+fn load_heat_f64(a: &AtomicU64) -> f64 {
+    f64::from_bits(a.load(Ordering::Relaxed))
+}
+#[inline]
+fn store_heat_f64(a: &AtomicU64, v: f64) {
+    a.store(v.to_bits(), Ordering::Relaxed);
+}
 
 /// One resident expert: id + the bytes loaded from the SSD.
 ///
@@ -50,6 +63,18 @@ pub struct ExpertResident {
     /// on-disk bytes are slightly short (≤ one block/page) of the
     /// derived expected size.
     q4_0_padded: StdMutex<Option<(usize, Arc<[u8]>)>>,
+    /// **Tier 4 cost-aware eviction.** Decaying heat score: bumped by
+    /// `+1` on every cache hit and exponentially decayed by the number
+    /// of intervening insertions (cache-pressure events). Only
+    /// maintained when the owning [`ExpertCache`] has cost-aware
+    /// eviction enabled; otherwise it stays at its initial value and is
+    /// never read. Stored as `f64` bits behind an `AtomicU64` so the
+    /// lock-free hit path can update it.
+    heat_bits: AtomicU64,
+    /// Insertion epoch (a logical cache-pressure clock) at which this
+    /// resident's heat was last refreshed. Paired with `heat_bits` to
+    /// apply lazy exponential decay.
+    heat_last_epoch: AtomicU64,
 }
 
 impl ExpertResident {
@@ -73,6 +98,8 @@ impl ExpertResident {
             payload_offset,
             hits: AtomicU64::new(0),
             q4_0_padded: StdMutex::new(None),
+            heat_bits: AtomicU64::new(0.0f64.to_bits()),
+            heat_last_epoch: AtomicU64::new(0),
         }
     }
 
@@ -84,6 +111,33 @@ impl ExpertResident {
     #[inline]
     pub fn record_hit(&self) -> u64 {
         self.hits.fetch_add(1, Ordering::Relaxed) + 1
+    }
+
+    /// **Tier 4 cost-aware eviction.** Refresh this resident's decaying
+    /// heat score for an access at logical insertion-`epoch`: decay the
+    /// stored heat by `decay^(epoch − last_epoch)`, add `1.0` for this
+    /// access, and stamp `epoch`. `decay ∈ (0, 1]`; `epoch` is the
+    /// owning cache's monotonic insertion counter, so an expert reused
+    /// every few insertions keeps a high score while one untouched
+    /// across many insertions fades toward zero. Approximate under
+    /// concurrent access (heat is a heuristic), never a correctness
+    /// hazard.
+    #[inline]
+    pub fn bump_heat(&self, epoch: u64, decay: f64) {
+        let prev = self.heat_last_epoch.swap(epoch, Ordering::Relaxed);
+        let dt = epoch.saturating_sub(prev).min(4096) as i32;
+        let decayed = load_heat_f64(&self.heat_bits) * decay.powi(dt);
+        store_heat_f64(&self.heat_bits, decayed + 1.0);
+    }
+
+    /// Current heat score decayed forward to `epoch` (read-only; does
+    /// not mutate the stored score). Used by the cost-aware victim
+    /// scorer to compare residents at a single point in logical time.
+    #[inline]
+    pub fn decayed_heat(&self, epoch: u64, decay: f64) -> f64 {
+        let last = self.heat_last_epoch.load(Ordering::Relaxed);
+        let dt = epoch.saturating_sub(last).min(4096) as i32;
+        load_heat_f64(&self.heat_bits) * decay.powi(dt)
     }
 
     /// Whether this resident's bytes live in a **shadow** (Buffer B)
@@ -165,7 +219,25 @@ pub struct ExpertCache {
     /// (see [`crate::engine::Engine`] / `pin_after_observations`).
     pinned: Mutex<HashSet<u32>>,
     capacity: usize,
+    /// **Tier 4 — cost-aware eviction.** When `true`, [`Self::insert`]'s
+    /// pre-eviction and [`Self::evict_lru`] choose the lowest decaying
+    /// **heat** resident rather than the strict LRU victim, and
+    /// [`Self::get`] maintains each resident's heat score on hit. When
+    /// `false` (the default) the cache is a pure LRU and the heat
+    /// machinery is completely inert, so legacy behaviour is preserved
+    /// bit-for-bit. Interior-mutable so the engine can flip it on a
+    /// shared `Arc<ExpertCache>` after construction.
+    cost_aware: AtomicBool,
+    /// Logical cache-pressure clock: incremented once per insertion.
+    /// Drives the exponential decay of resident heat scores.
+    epoch: AtomicU64,
 }
+
+/// Per-insertion decay factor applied to resident heat scores in
+/// cost-aware mode. `0.98` gives heat a half-life of ~34 insertions, so
+/// an expert needs to keep getting hit to stay resident — long enough to
+/// ride out a brief lull, short enough to release genuinely cold experts.
+const COST_AWARE_HEAT_DECAY: f64 = 0.98;
 
 impl ExpertCache {
     pub fn new(capacity: usize) -> Self {
@@ -174,6 +246,8 @@ impl ExpertCache {
             inner: Mutex::new(LruCache::new(cap)),
             pinned: Mutex::new(HashSet::new()),
             capacity,
+            cost_aware: AtomicBool::new(false),
+            epoch: AtomicU64::new(0),
         }
     }
 
@@ -181,9 +255,30 @@ impl ExpertCache {
         self.capacity
     }
 
-    /// Look up an expert. Updates LRU recency on hit.
+    /// Enable or disable **Tier 4 cost-aware eviction** on this cache.
+    /// Cheap and idempotent; safe to call on a shared `Arc<ExpertCache>`
+    /// at startup. No-op effect on the hot path while `false`.
+    pub fn set_cost_aware(&self, on: bool) {
+        self.cost_aware.store(on, Ordering::Relaxed);
+    }
+
+    /// Whether cost-aware eviction is currently enabled.
+    #[inline]
+    pub fn is_cost_aware(&self) -> bool {
+        self.cost_aware.load(Ordering::Relaxed)
+    }
+
+    /// Look up an expert. Updates LRU recency on hit, and (in cost-aware
+    /// mode) refreshes the resident's decaying heat score.
     pub fn get(&self, id: u32) -> Option<Arc<ExpertResident>> {
-        self.inner.lock().get(&id).cloned()
+        let resident = self.inner.lock().get(&id).cloned();
+        if let Some(r) = resident.as_ref() {
+            if self.is_cost_aware() {
+                let epoch = self.epoch.load(Ordering::Relaxed);
+                r.bump_heat(epoch, COST_AWARE_HEAT_DECAY);
+            }
+        }
+        resident
     }
 
     /// Peek without changing recency. Useful for the predictive loader to
@@ -214,27 +309,36 @@ impl ExpertCache {
         // then silently evict the LRU entry — which may be pinned.
         let pinned = self.pinned.lock();
         let mut guard = self.inner.lock();
+        // Tier 4: every insertion is one tick of the cache-pressure
+        // clock that ages resident heat scores. Cheap; only meaningful
+        // when cost-aware mode is enabled.
+        let cost_aware = self.is_cost_aware();
+        let epoch = if cost_aware {
+            self.epoch.fetch_add(1, Ordering::Relaxed) + 1
+        } else {
+            0
+        };
         let mut pre_evicted = None;
         if guard.len() >= self.capacity && guard.peek(&id).is_none() {
-            // Walk LRU order (`iter()` yields most-recently-used
-            // first, so the *last* item is the LRU) and pop the first
-            // non-pinned entry.
-            let id_order: Vec<u32> = guard.iter().map(|(k, _)| *k).collect();
-            for &cand in id_order.iter().rev() {
-                if !pinned.contains(&cand) {
-                    if let Some(v) = guard.pop(&cand) {
-                        pre_evicted = Some(v);
-                        break;
-                    }
+            // Pick the victim under the active policy: strict LRU by
+            // default, or the lowest decaying-heat resident in
+            // cost-aware mode.
+            match self.select_victim_id(&guard, &pinned) {
+                Some(victim) => pre_evicted = guard.pop(&victim),
+                None => {
+                    // Cache is full *and* every resident expert is
+                    // pinned. We must refuse the insert: calling `push`
+                    // here would evict a pinned id (LruCache has no
+                    // pinning concept).
+                    return Err(resident);
                 }
             }
-            if pre_evicted.is_none() {
-                // Cache is full *and* every resident expert is
-                // pinned. We must refuse the insert: calling `push`
-                // here would evict a pinned id (LruCache has no
-                // pinning concept).
-                return Err(resident);
-            }
+        }
+        // Tier 4: seed the freshly-loaded resident's heat for *this*
+        // access so it isn't the instant next eviction victim (which
+        // would thrash the very expert we just paid an SSD read for).
+        if cost_aware {
+            resident.bump_heat(epoch, COST_AWARE_HEAT_DECAY);
         }
         // `LruCache::push` returns the (k, v) pair that was evicted, if any.
         // With the pre-eviction above we never hit a second eviction
@@ -242,6 +346,47 @@ impl ExpertCache {
         // value — which is fine to surface as "evicted" too.
         let push_evicted = guard.push(id, resident).map(|(_, v)| v);
         Ok(push_evicted.or(pre_evicted))
+    }
+
+    /// Choose the id to evict from `guard` under the active policy.
+    /// Returns the least-recently-used non-pinned id by default, or the
+    /// resident with the lowest decaying **heat** in cost-aware mode.
+    /// Ties resolve toward the more-LRU candidate. `None` when every
+    /// resident is pinned.
+    fn select_victim_id(
+        &self,
+        guard: &LruCache<u32, Arc<ExpertResident>>,
+        pinned: &HashSet<u32>,
+    ) -> Option<u32> {
+        if self.is_cost_aware() {
+            let epoch = self.epoch.load(Ordering::Relaxed);
+            // `iter()` yields most-recently-used first, so iterating in
+            // order and replacing on `score <= best` makes the more-LRU
+            // candidate win heat ties.
+            let mut best: Option<(u32, f64)> = None;
+            for (k, v) in guard.iter() {
+                if pinned.contains(k) {
+                    continue;
+                }
+                let score = v.decayed_heat(epoch, COST_AWARE_HEAT_DECAY);
+                let replace = match best {
+                    None => true,
+                    Some((_, bs)) => score <= bs,
+                };
+                if replace {
+                    best = Some((*k, score));
+                }
+            }
+            best.map(|(k, _)| k)
+        } else {
+            // Strict LRU: `iter()` is MRU-first, so the last non-pinned
+            // id is the least-recently-used non-pinned victim.
+            guard
+                .iter()
+                .map(|(k, _)| *k)
+                .filter(|k| !pinned.contains(k))
+                .last()
+        }
     }
 
     /// Number of resident experts currently in the cache.
@@ -257,24 +402,16 @@ impl ExpertCache {
     /// `None`, meaning there is no room to evict.
     pub fn evict_lru(&self) -> Option<Arc<ExpertResident>> {
         let pinned = self.pinned.lock();
-        if pinned.is_empty() {
-            // Fast path: no pinning, just pop LRU.
+        if pinned.is_empty() && !self.is_cost_aware() {
+            // Fast path: no pinning and pure LRU, just pop LRU.
             return self.inner.lock().pop_lru().map(|(_, v)| v);
         }
-        // Walk LRU order from least-recent to most-recent and pop the
-        // first non-pinned entry.
+        // Otherwise defer to the policy-aware victim selector (strict
+        // LRU, or lowest decaying heat in cost-aware mode), skipping
+        // pinned residents.
         let mut guard = self.inner.lock();
-        // Collect ids in reverse-recency order. `LruCache::iter` yields
-        // most-recently-used first, so the *last* item is the LRU.
-        let id_order: Vec<u32> = guard.iter().map(|(k, _)| *k).collect();
-        for &id in id_order.iter().rev() {
-            if !pinned.contains(&id) {
-                if let Some(v) = guard.pop(&id) {
-                    return Some(v);
-                }
-            }
-        }
-        None
+        let victim = self.select_victim_id(&guard, &pinned)?;
+        guard.pop(&victim)
     }
 
     /// Pop the least-recently-used entry that is **shadow-backed**
@@ -812,6 +949,92 @@ mod tests {
         cache.pin(0);
         cache.pin(1);
         assert!(cache.evict_lru().is_none());
+    }
+
+    #[test]
+    fn cost_aware_evicts_coldest_not_lru() {
+        // Scenario where strict LRU and cost-aware eviction diverge: the
+        // *least-recently-used* resident is also the *hottest*. Cost-aware
+        // mode must keep the hot expert and evict the cold newcomer.
+        let pool = BufferPool::new(4, 4096, 4096);
+        let cache = ExpertCache::new(2);
+        cache.set_cost_aware(true);
+        // A (id 0) is loaded and then hit many times → high heat. The
+        // hits make it most-recently-used for now.
+        let _ = cache.insert(make(0, &pool)).map_err(|_| panic!("insert failed"));
+        for _ in 0..10 {
+            let _ = cache.get(0);
+        }
+        // B (id 1) is loaded cold. Now A is the LRU (B is MRU) but A is
+        // far hotter than B.
+        let _ = cache.insert(make(1, &pool)).map_err(|_| panic!("insert failed"));
+        // Inserting C evicts a victim: cost-aware keeps hot A, drops cold B.
+        let evicted = match cache.insert(make(2, &pool)) {
+            Ok(Some(e)) => e,
+            other => panic!("expected an eviction, got ok={}", other.is_ok()),
+        };
+        assert_eq!(
+            evicted.id, 1,
+            "cost-aware eviction should drop the cold expert (1), not the hot LRU (0)"
+        );
+        assert!(cache.contains(0));
+        assert!(!cache.contains(1));
+        assert!(cache.contains(2));
+    }
+
+    #[test]
+    fn cost_aware_disabled_is_pure_lru() {
+        // The same access pattern as `cost_aware_evicts_coldest_not_lru`,
+        // but with cost-aware mode OFF (the default), must reproduce the
+        // legacy strict-LRU outcome: the hot-but-LRU expert is evicted.
+        let pool = BufferPool::new(4, 4096, 4096);
+        let cache = ExpertCache::new(2);
+        let _ = cache.insert(make(0, &pool)).map_err(|_| panic!("insert failed"));
+        for _ in 0..10 {
+            let _ = cache.get(0);
+        }
+        let _ = cache.insert(make(1, &pool)).map_err(|_| panic!("insert failed"));
+        // 0 is MRU after the hits, then 1 is inserted → 1 MRU, 0 LRU.
+        let evicted = match cache.insert(make(2, &pool)) {
+            Ok(Some(e)) => e,
+            other => panic!("expected an eviction, got ok={}", other.is_ok()),
+        };
+        assert_eq!(evicted.id, 0, "pure LRU should evict the least-recently-used expert (0)");
+        assert!(!cache.contains(0));
+        assert!(cache.contains(1));
+        assert!(cache.contains(2));
+    }
+
+    #[test]
+    fn cost_aware_heat_decays_releasing_stale_hot() {
+        // An expert that was hot long ago but has gone cold must
+        // eventually become the eviction victim as its heat decays under
+        // sustained churn from other experts.
+        let pool = BufferPool::new(8, 4096, 4096);
+        let cache = ExpertCache::new(2);
+        cache.set_cost_aware(true);
+        // Make expert 0 very hot, then never touch it again.
+        let _ = cache.insert(make(0, &pool)).map_err(|_| panic!("insert failed"));
+        for _ in 0..20 {
+            let _ = cache.get(0);
+        }
+        // Churn many distinct cold experts through the other slot. Each
+        // insertion ages expert 0's heat; after enough churn its decayed
+        // heat falls below a freshly-loaded expert's seed and it is
+        // finally evicted.
+        let mut zero_evicted = false;
+        for id in 1..400u32 {
+            if let Ok(Some(ev)) = cache.insert(make(id, &pool)) {
+                if ev.id == 0 {
+                    zero_evicted = true;
+                    break;
+                }
+            }
+        }
+        assert!(
+            zero_evicted,
+            "stale-hot expert 0 should eventually be released once its heat decays"
+        );
     }
 
     #[test]

--- a/rust-engine/src/io_provider.rs
+++ b/rust-engine/src/io_provider.rs
@@ -45,6 +45,7 @@ use std::fs::{File, OpenOptions};
 use std::io;
 use std::num::NonZeroUsize;
 use std::os::unix::fs::FileExt;
+use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::Arc;
@@ -463,6 +464,13 @@ pub struct NvmeStorage {
     /// keeps a one-element vector. Eagerly sized at construction so
     /// the hot path is a plain index load, no `RwLock` access.
     drive_breakers: Vec<Arc<DriveBreakerState>>,
+    /// **Tier 2.** Optional packed-blob layout. When attached via
+    /// [`NvmeStorage::with_packed_blob`], every expert is read from a
+    /// single shared blob fd at the manifest-recorded offset, and
+    /// [`Self::read_experts_batch`] coalesces physically-adjacent
+    /// experts into one vectored `preadv`. `None` (default) keeps the
+    /// original one-file-per-expert path bit-for-bit.
+    packed: Option<Arc<crate::packed_storage::PackedBlob>>,
 }
 
 impl NvmeStorage {
@@ -485,6 +493,7 @@ impl NvmeStorage {
             manifest: None,
             breakers: RwLock::new(HashMap::new()),
             drive_breakers: vec![Arc::new(DriveBreakerState::default())],
+            packed: None,
         })
     }
 
@@ -561,6 +570,33 @@ impl NvmeStorage {
     /// indexing — the legacy per-fetch resolution path is used.
     pub fn manifest(&self) -> Option<&Arc<Manifest>> {
         self.manifest.as_ref()
+    }
+
+    /// **Tier 2.** Attach a packed blob (single-file layout + manifest)
+    /// produced by the `repack` CLI subcommand. Once attached, every
+    /// `read_expert*` call sources bytes from the shared blob fd at the
+    /// expert's recorded offset, and [`Self::read_experts_batch`]
+    /// coalesces adjacent experts into one vectored `preadv`.
+    ///
+    /// Builder-style: returns `self` for chaining at construction
+    /// (`NvmeStorage::new(cfg)?.with_packed_blob(blob)`).
+    pub fn with_packed_blob(
+        mut self,
+        blob: Arc<crate::packed_storage::PackedBlob>,
+    ) -> Self {
+        self.packed = Some(blob);
+        self
+    }
+
+    /// The packed blob attached via [`Self::with_packed_blob`], if any.
+    #[allow(dead_code)] // public accessor; engine uses `is_packed()` on the hot path.
+    pub fn packed(&self) -> Option<&Arc<crate::packed_storage::PackedBlob>> {
+        self.packed.as_ref()
+    }
+
+    /// Whether this storage is serving experts from a packed blob.
+    pub fn is_packed(&self) -> bool {
+        self.packed.is_some()
     }
 
     /// Number of drives this storage is striped across. `1` for the
@@ -1024,6 +1060,29 @@ impl NvmeStorage {
     /// on success — short reads are surfaced as an `UnexpectedEof` error).
     pub async fn read_expert(&self, expert_id: u32, buf: &mut PooledBuffer) -> io::Result<usize> {
         debug_assert_eq!(buf.len(), self.cfg.expert_size);
+        // Tier 2 packed path: source the bytes from the shared blob fd at
+        // the expert's recorded offset. The fault-tolerant retry +
+        // circuit-breaker wrapper is reused unchanged — only the (file,
+        // offset) pair differs from the per-file path.
+        if let Some(packed) = &self.packed {
+            let entry = packed.entry(expert_id).ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::NotFound,
+                    format!("expert {expert_id} is not present in the packed blob manifest"),
+                )
+            })?;
+            let file = packed.file().clone();
+            let dst_len = buf.len();
+            let n = tokio::task::block_in_place(|| {
+                self.read_at_with_retries(
+                    &file,
+                    expert_id,
+                    entry.offset,
+                    &mut buf.as_mut_slice()[..dst_len],
+                )
+            })?;
+            return Ok(n);
+        }
         // Note: the breaker fast-fail used to live here for symmetry
         // with `read_at_with_retries`, but that bypassed the
         // half-open probe gate (a tripped breaker could never reach
@@ -1072,6 +1131,12 @@ impl NvmeStorage {
         );
         if ids.is_empty() {
             return Ok(0);
+        }
+        // Tier 2 packed path: coalesce physically-adjacent experts into
+        // single vectored `preadv` syscalls. Distinct ids ⇒ disjoint
+        // destination buffers, so the scatter is sound.
+        if self.packed.is_some() {
+            return self.read_experts_batch_packed(ids, bufs).await;
         }
         // Resolve all fds before donating the worker — `fd_for` takes a
         // (rare) write lock the first time it sees an id, and we don't
@@ -1148,7 +1213,172 @@ impl NvmeStorage {
         Ok(total)
     }
 
-    /// Partial-column read: load only the listed input-feature columns
+    /// **Tier 2.** Packed-blob sibling of [`Self::read_experts_batch`].
+    ///
+    /// Resolves every requested expert to its `(offset, len)` slot in the
+    /// shared blob, groups physically-adjacent slots into contiguous runs
+    /// (see [`crate::packed_storage::coalesce_runs`]), and issues **one
+    /// `preadv(2)` per run** that scatters the bytes straight into the
+    /// per-expert [`PooledBuffer`]s. A run of `K` adjacent experts thus
+    /// costs a single vectored syscall at full device queue depth instead
+    /// of `K` independent `pread`s.
+    ///
+    /// Robustness: a singleton run, an oversized iovec batch, or any
+    /// `preadv` error / short read falls back to the ordinary
+    /// per-expert [`Self::read_at_with_retries`] path, so the circuit
+    /// breaker, retry budget and short-read accounting behave exactly as
+    /// on the one-file-per-expert path.
+    #[allow(dead_code)] // reached via `read_experts_batch` (batched-miss path).
+    async fn read_experts_batch_packed(
+        &self,
+        ids: &[u32],
+        bufs: &mut [&mut PooledBuffer],
+    ) -> io::Result<usize> {
+        let packed = self
+            .packed
+            .as_ref()
+            .expect("read_experts_batch_packed called without a packed blob");
+        let expert_size = self.cfg.expert_size;
+
+        // Resolve slots and capture the (disjoint) destination pointers.
+        // Distinct ids ⇒ distinct slots ⇒ disjoint buffers, so the raw
+        // pointers never alias and reconstructing `&mut [u8]` from them
+        // inside the blocking closure is sound.
+        let mut requested: Vec<(u32, usize, crate::packed_storage::PackedEntry)> =
+            Vec::with_capacity(ids.len());
+        for (idx, &id) in ids.iter().enumerate() {
+            let entry = packed.entry(id).ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::NotFound,
+                    format!("expert {id} is not present in the packed blob manifest"),
+                )
+            })?;
+            requested.push((id, idx, entry));
+        }
+        let mut dst: Vec<(*mut u8, usize)> = Vec::with_capacity(bufs.len());
+        for buf in bufs.iter_mut() {
+            let b: &mut PooledBuffer = &mut *buf;
+            debug_assert_eq!(b.len(), expert_size);
+            let s = b.as_mut_slice();
+            dst.push((s.as_mut_ptr(), s.len()));
+        }
+
+        let runs = crate::packed_storage::coalesce_runs(requested);
+        let file = packed.file().clone();
+
+        let total = tokio::task::block_in_place(|| -> io::Result<usize> {
+            let mut total = 0usize;
+            for run in &runs {
+                total += self.read_run(&file, run, &dst)?;
+            }
+            Ok(total)
+        })?;
+        Ok(total)
+    }
+
+    /// Read a single coalesced run into its destination buffers.
+    ///
+    /// Multi-member runs go through one vectored `preadv`; singletons and
+    /// any failed/short `preadv` fall back to the per-expert
+    /// fault-tolerant path. `dst[i]` is the `(ptr, len)` of the caller's
+    /// `i`-th request buffer.
+    #[allow(dead_code)] // reached via `read_experts_batch_packed`.
+    fn read_run(
+        &self,
+        file: &File,
+        run: &crate::packed_storage::ContiguousRun,
+        dst: &[(*mut u8, usize)],
+    ) -> io::Result<usize> {
+        // Singleton (or, defensively, an oversized iovec batch): per-expert
+        // path. `IOV_MAX` is 1024 on Linux / macOS; top-k miss sets are
+        // orders of magnitude smaller, so the cap is never hit in practice.
+        const IOV_MAX_SAFE: usize = 512;
+        if run.members.len() == 1 || run.members.len() > IOV_MAX_SAFE {
+            let mut total = 0usize;
+            for &(id, idx) in &run.members {
+                let (ptr, len) = dst[idx];
+                // SAFETY: disjoint per-expert buffer, valid for `len`
+                // bytes for the duration of this call.
+                let slice = unsafe { std::slice::from_raw_parts_mut(ptr, len) };
+                let off = self.packed_offset(id);
+                total += self.read_at_with_retries(file, id, off, slice)?;
+            }
+            return Ok(total);
+        }
+
+        // Multi-member contiguous run: one vectored read.
+        let iovecs: Vec<libc::iovec> = run
+            .members
+            .iter()
+            .map(|&(_, idx)| {
+                let (ptr, len) = dst[idx];
+                libc::iovec {
+                    iov_base: ptr as *mut libc::c_void,
+                    iov_len: len,
+                }
+            })
+            .collect();
+        let want = run.total_len as usize;
+        // SAFETY: `iovecs` point into the caller's disjoint, live
+        // destination buffers; `file` is a valid open fd; the run is
+        // physically contiguous starting at `start_offset`.
+        let n = unsafe {
+            libc::preadv(
+                file.as_raw_fd(),
+                iovecs.as_ptr(),
+                iovecs.len() as libc::c_int,
+                run.start_offset as libc::off_t,
+            )
+        };
+        if n >= 0 && n as usize == want {
+            // Full coalesced read: credit each member's breaker.
+            for &(id, _) in &run.members {
+                self.note_read_success(id);
+            }
+            return Ok(want);
+        }
+        // Short or failed preadv — fall back to independent, fully
+        // fault-tolerant per-expert reads so a single bad slot can't wedge
+        // the whole run and the retry/breaker accounting is preserved.
+        if n < 0 {
+            let err = io::Error::last_os_error();
+            tracing::warn!(
+                error = %err,
+                run_start = run.start_offset,
+                members = run.members.len(),
+                "coalesced preadv failed; falling back to per-expert reads"
+            );
+        } else {
+            tracing::warn!(
+                got = n,
+                want,
+                run_start = run.start_offset,
+                members = run.members.len(),
+                "coalesced preadv short read; falling back to per-expert reads"
+            );
+        }
+        let mut total = 0usize;
+        for &(id, idx) in &run.members {
+            let (ptr, len) = dst[idx];
+            // SAFETY: see the singleton branch above.
+            let slice = unsafe { std::slice::from_raw_parts_mut(ptr, len) };
+            let off = self.packed_offset(id);
+            total += self.read_at_with_retries(file, id, off, slice)?;
+        }
+        Ok(total)
+    }
+
+    /// Blob offset of a packed expert id. Panics only if called without a
+    /// packed blob attached (an internal invariant of the packed read
+    /// paths), and returns `0` for an id missing from the manifest — the
+    /// subsequent read then surfaces the bounds error.
+    fn packed_offset(&self, id: u32) -> u64 {
+        self.packed
+            .as_ref()
+            .and_then(|p| p.entry(id))
+            .map(|e| e.offset)
+            .unwrap_or(0)
+    }
     /// of an expert's `gate_proj` and `up_proj` plus the full `down_proj`,
     /// packed into `buf` in the layout consumed by
     /// [`crate::inference::OwnedExpertWeights::from_bytes_partial`]:
@@ -1247,8 +1477,53 @@ impl NvmeStorage {
 
 }
 
+/// **Tier 2.** Build a packed blob + manifest from a source storage.
+///
+/// Reads each expert in `order` from `source` (which may be a plain
+/// one-file-per-expert [`NvmeStorage`], honouring its path resolution and
+/// fault-tolerant retries) and writes the payloads back-to-back into
+/// `blob_path`, one uniform `expert_size` slot each. Emits the JSON
+/// [`crate::packed_storage::PackedManifest`] to `manifest_path`.
+///
+/// `order` defines the **physical layout**: experts that the engine tends to
+/// fetch together (a routing-frequency hot set, or a co-firing affinity
+/// ordering) should be adjacent so the steady-state read path can coalesce
+/// them into a single `preadv`. Returns the manifest it wrote.
+pub async fn pack_experts(
+    source: &NvmeStorage,
+    pool: &crate::buffer_pool::BufferPool,
+    order: &[u32],
+    blob_path: &Path,
+    manifest_path: &Path,
+) -> io::Result<crate::packed_storage::PackedManifest> {
+    use std::io::Write;
+    let expert_size = source.cfg.expert_size;
+    let block_align = source.cfg.block_align;
+    let blob = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(blob_path)?;
+    let mut writer = std::io::BufWriter::with_capacity(8 * 1024 * 1024, blob);
+    for &id in order {
+        let mut buf = pool.acquire().await;
+        debug_assert_eq!(buf.len(), expert_size);
+        source.read_expert(id, &mut buf).await?;
+        writer.write_all(buf.as_slice())?;
+    }
+    writer.flush()?;
+    writer.into_inner().map_err(|e| e.into_error())?.sync_all()?;
+    let manifest = crate::packed_storage::PackedManifest::uniform(
+        order.to_vec(),
+        expert_size as u64,
+        block_align as u64,
+    );
+    manifest.write_to(manifest_path)?;
+    Ok(manifest)
+}
+
 #[cfg(target_os = "linux")]
-fn open_expert_file(path: &Path, direct: bool) -> io::Result<File> {
+pub(crate) fn open_expert_file(path: &Path, direct: bool) -> io::Result<File> {
     let mut opts = OpenOptions::new();
     opts.read(true);
     if direct {
@@ -1276,7 +1551,7 @@ fn open_expert_file(path: &Path, direct: bool) -> io::Result<File> {
 }
 
 #[cfg(not(target_os = "linux"))]
-fn open_expert_file(path: &Path, _direct: bool) -> io::Result<File> {
+pub(crate) fn open_expert_file(path: &Path, _direct: bool) -> io::Result<File> {
     OpenOptions::new().read(true).open(path)
 }
 
@@ -2105,7 +2380,93 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    /// The bounded fd cache must (a) keep at most `max_open_files`
+    /// **Tier 2.** A packed blob must return byte-identical payloads to the
+    /// one-file-per-expert path for both single (`read_expert`) and
+    /// coalesced (`read_experts_batch`) reads — including a shuffled
+    /// request that exercises the offset sort, a contiguous run serviced
+    /// by one `preadv`, and an isolated slot serviced by the singleton
+    /// fallback.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn packed_blob_reads_match_per_file_including_coalesce() {
+        let dir = tempdir("packed");
+        let num_experts = 6u32;
+        let d_model = 8usize;
+        let d_ff = 16usize;
+        let block = 4096usize;
+        let weight_bytes = crate::inference::expert_weight_bytes(d_model, d_ff);
+        let expert_size = weight_bytes.div_ceil(block) * block;
+        generate_synthetic_experts(&dir, num_experts, expert_size, d_model, d_ff).unwrap();
+
+        let cfg = StorageConfig {
+            base_path: dir.clone(),
+            expert_size,
+            block_align: block,
+            use_direct_io: false,
+            num_experts_per_layer: None,
+        };
+        let source = NvmeStorage::new(cfg.clone()).unwrap();
+        let pool = BufferPool::new(num_experts as usize * 2 + 4, expert_size, block);
+
+        // Reference bytes via the per-file path.
+        let mut ref_bufs: Vec<Vec<u8>> = Vec::with_capacity(num_experts as usize);
+        for id in 0..num_experts {
+            let mut b = pool.acquire().await;
+            source.read_expert(id, &mut b).await.unwrap();
+            ref_bufs.push(b.as_slice().to_vec());
+        }
+
+        // Pack experts in id order, then open a packed storage over the blob.
+        let order: Vec<u32> = (0..num_experts).collect();
+        let blob_path = dir.join("experts.blob");
+        let manifest_path = dir.join("experts.manifest.json");
+        let manifest = pack_experts(&source, &pool, &order, &blob_path, &manifest_path)
+            .await
+            .unwrap();
+        assert_eq!(manifest.len(), num_experts as usize);
+        assert_eq!(manifest.entries[&3].offset, 3 * expert_size as u64);
+
+        let blob =
+            crate::packed_storage::PackedBlob::open(&blob_path, &manifest_path, false).unwrap();
+        let packed = NvmeStorage::new(cfg).unwrap().with_packed_blob(Arc::new(blob));
+        assert!(packed.is_packed());
+
+        // Single packed reads match the per-file bytes.
+        for id in 0..num_experts {
+            let mut b = pool.acquire().await;
+            packed.read_expert(id, &mut b).await.unwrap();
+            assert_eq!(
+                b.as_slice(),
+                ref_bufs[id as usize].as_slice(),
+                "single packed read mismatch on expert {id}"
+            );
+        }
+
+        // Coalesced batch: {0,1,2} is a contiguous run (one preadv) and {5}
+        // is isolated (singleton fallback). The request is shuffled so the
+        // offset sort is exercised; results must land in request order.
+        let ids = vec![2u32, 0, 1, 5];
+        let mut bufs: Vec<_> = Vec::with_capacity(ids.len());
+        for _ in &ids {
+            bufs.push(pool.acquire().await);
+        }
+        let mut buf_refs: Vec<&mut crate::buffer_pool::PooledBuffer> =
+            bufs.iter_mut().collect();
+        let total = packed
+            .read_experts_batch(&ids, &mut buf_refs)
+            .await
+            .unwrap();
+        assert_eq!(total, expert_size * ids.len());
+        for (slot, &id) in ids.iter().enumerate() {
+            assert_eq!(
+                bufs[slot].as_slice(),
+                ref_bufs[id as usize].as_slice(),
+                "coalesced read mismatch: expert {id} in request slot {slot}"
+            );
+        }
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     /// descriptors resident, evicting the least-recently-used when a
     /// new expert is opened, and (b) still return correct bytes for an
     /// expert whose fd was evicted (it is simply re-opened on demand).

--- a/rust-engine/src/io_provider.rs
+++ b/rust-engine/src/io_provider.rs
@@ -1505,7 +1505,16 @@ pub async fn pack_experts(
         .truncate(true)
         .open(blob_path)?;
     let mut writer = std::io::BufWriter::with_capacity(8 * 1024 * 1024, blob);
+    // Reject duplicate ids: the manifest collapses entries by key while the
+    // blob writes every slot, so a repeated id yields a malformed layout.
+    let mut seen = std::collections::HashSet::with_capacity(order.len());
     for &id in order {
+        if !seen.insert(id) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("duplicate expert id {id} in packed order"),
+            ));
+        }
         let mut buf = pool.acquire().await;
         debug_assert_eq!(buf.len(), expert_size);
         source.read_expert(id, &mut buf).await?;
@@ -2915,5 +2924,37 @@ mod tests {
             HardwareFailure::ExpertUnavailable { expert_id, .. } => assert_eq!(expert_id, 7),
             _ => panic!("wrong variant"),
         }
+    }
+
+    /// `pack_experts` rejects a duplicate id in the requested order rather
+    /// than writing a malformed blob whose manifest collapses by key.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn pack_experts_rejects_duplicate_order() {
+        let dir = tempdir("packed-dup");
+        let num_experts = 3u32;
+        let d_model = 8usize;
+        let d_ff = 16usize;
+        let block = 4096usize;
+        let weight_bytes = crate::inference::expert_weight_bytes(d_model, d_ff);
+        let expert_size = weight_bytes.div_ceil(block) * block;
+        generate_synthetic_experts(&dir, num_experts, expert_size, d_model, d_ff).unwrap();
+
+        let cfg = StorageConfig {
+            base_path: dir.clone(),
+            expert_size,
+            block_align: block,
+            use_direct_io: false,
+            num_experts_per_layer: None,
+        };
+        let source = NvmeStorage::new(cfg).unwrap();
+        let pool = BufferPool::new(num_experts as usize * 2 + 4, expert_size, block);
+        let blob_path = dir.join("dup.blob");
+        let manifest_path = dir.join("dup.manifest.json");
+
+        let err = pack_experts(&source, &pool, &[0, 1, 1], &blob_path, &manifest_path)
+            .await
+            .unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -45,6 +45,7 @@ mod multi_layer_cache;
 mod numa;
 mod parallel;
 mod prefetch_governor;
+mod pregate;
 mod residency;
 mod router;
 mod rpc;
@@ -1362,6 +1363,16 @@ async fn cmd_serve(config_path: PathBuf) -> Result<(), Box<dyn std::error::Error
             profile,
         );
     }
+    // Tier 3 — per-layer pre-gate. Predict + prefetch the next layer's
+    // experts from the current layer's routed set on the multi-layer
+    // `moe_step` path.
+    if cfg.predictive.pregate_enabled {
+        let pregate = Arc::new(crate::pregate::PerLayerPreGate::new(
+            cfg.model.num_layers.max(1),
+            cfg.model.top_k,
+        ));
+        engine_builder = engine_builder.with_pregate(pregate);
+    }
     // Phase 2: optional VRAM (GPU) expert cache (3-tier hierarchy
     // SSD → RAM → VRAM). When `[gpu_cache].enabled = false` (default)
     // the engine retains its historical 2-tier posture.
@@ -2237,6 +2248,24 @@ async fn cmd_run(mut args: RunArgs, startup_pinned: bool) -> Result<(), Box<dyn 
                 args.static_residency_warmup_tokens,
                 profile,
             );
+        }
+        // Tier 3 — per-layer pre-gate. Predict (and prefetch) the next
+        // layer's experts from the current layer's routed set. Only
+        // effective on the multi-layer `moe_step` path; warn when no
+        // layer geometry is configured so it can't actually fire.
+        if args.pregate {
+            if args.num_layers <= 1 {
+                warn!(
+                    "--pregate has no effect with --num-layers 1: the pre-gate predicts \
+                     the *next* layer's experts, so it needs a multi-layer geometry \
+                     (set --num-layers > 1, typically with --gate-weights / a real model)."
+                );
+            }
+            let pregate = Arc::new(crate::pregate::PerLayerPreGate::new(
+                args.num_layers.max(1) as usize,
+                args.top_k,
+            ));
+            base = base.with_pregate(pregate);
         }
         // Optional alias map (Change 6: expert deduplication).
         match args.alias_map_path.as_ref() {

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -45,6 +45,7 @@ mod multi_layer_cache;
 mod numa;
 mod parallel;
 mod prefetch_governor;
+mod residency;
 mod router;
 mod rpc;
 mod sampling;
@@ -379,6 +380,26 @@ enum Cmd {
         /// next-layer prefetch from it. Off by default.
         #[arg(long)]
         pregate: bool,
+        /// **Tier 1 — static residency.** Fraction of the global expert
+        /// namespace to pin permanently in RAM (the hottest experts), in
+        /// `(0, 1]`. `0.0` (default) disables it. Lifts the hit-rate
+        /// ceiling above the bare cache fraction on a *skewed* workload.
+        #[arg(long, default_value_t = 0.0)]
+        static_residency_fraction: f64,
+        /// Tokens to observe before deriving the online static-residency
+        /// hot set (ignored when `--static-residency-profile` is given).
+        #[arg(long, default_value_t = 0)]
+        static_residency_warmup_tokens: u64,
+        /// Path to an offline expert-popularity profile JSON
+        /// (`{ "<id>": <count> }`) to seed static residency at startup.
+        /// When omitted, the hot set is derived online.
+        #[arg(long)]
+        static_residency_profile: Option<String>,
+        /// Write the run's accumulated route-observation profile to this
+        /// JSON path at shutdown (consumable by
+        /// `--static-residency-profile` on a later run).
+        #[arg(long)]
+        profile_out: Option<String>,
         /// Number of transformer layers, used to size the affinity
         /// matrix. `1` (default) is the single-namespace synthetic
         /// benchmark.
@@ -637,6 +658,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     prefetch_contention_weight,
                     cost_aware_eviction,
                     pregate,
+                    static_residency_fraction,
+                    static_residency_warmup_tokens,
+                    static_residency_profile,
+                    profile_out,
                     num_layers,
                     num_experts_per_layer,
                 } = cli.cmd
@@ -689,6 +714,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         prefetch_contention_weight,
                         cost_aware_eviction,
                         pregate,
+                        static_residency_fraction,
+                        static_residency_warmup_tokens,
+                        static_residency_profile,
+                        profile_out,
                         num_layers,
                         num_experts_per_layer,
                         },
@@ -1221,6 +1250,7 @@ async fn cmd_serve(config_path: PathBuf) -> Result<(), Box<dyn std::error::Error
             prefetch_contention_weight: cfg.predictive.prefetch_contention_weight,
             cost_aware_eviction: cfg.predictive.cost_aware_eviction,
             pregate_enabled: cfg.predictive.pregate_enabled,
+            collect_route_profile: false,
         },
     );
     // Apply the configured look-ahead pipeline depth (`[storage]
@@ -1278,6 +1308,28 @@ async fn cmd_serve(config_path: PathBuf) -> Result<(), Box<dyn std::error::Error
             affinity,
             cfg.predictive.affinity_neighbors_k,
             cfg.predictive.affinity_decay_epoch,
+        );
+    }
+    // Tier 1 — static residency. Pin the hottest `fraction` of experts
+    // permanently (from an offline profile when `static_residency_profile`
+    // is set, else online after the warmup window).
+    if cfg.predictive.static_residency_fraction > 0.0 {
+        let profile = match cfg.predictive.static_residency_profile.as_ref() {
+            Some(path) => {
+                let p = crate::residency::ResidencyProfile::load_json(std::path::Path::new(path))?;
+                info!(
+                    path = %path,
+                    experts = p.len(),
+                    "loaded static-residency popularity profile"
+                );
+                Some(p)
+            }
+            None => None,
+        };
+        engine_builder = engine_builder.with_static_residency(
+            cfg.predictive.static_residency_fraction,
+            cfg.predictive.static_residency_warmup_tokens,
+            profile,
         );
     }
     // Phase 2: optional VRAM (GPU) expert cache (3-tier hierarchy
@@ -1699,6 +1751,10 @@ struct RunArgs {
     prefetch_contention_weight: f64,
     cost_aware_eviction: bool,
     pregate: bool,
+    static_residency_fraction: f64,
+    static_residency_warmup_tokens: u64,
+    static_residency_profile: Option<String>,
+    profile_out: Option<String>,
     num_layers: u32,
     num_experts_per_layer: Option<u32>,
 }
@@ -2048,6 +2104,7 @@ async fn cmd_run(mut args: RunArgs, startup_pinned: bool) -> Result<(), Box<dyn 
                 prefetch_contention_weight: args.prefetch_contention_weight,
                 cost_aware_eviction: args.cost_aware_eviction,
                 pregate_enabled: args.pregate,
+                collect_route_profile: args.profile_out.is_some(),
             },
         );
         if let Some(gpu_cache) = args.gpu_expert_cache.clone() {
@@ -2121,6 +2178,30 @@ async fn cmd_run(mut args: RunArgs, startup_pinned: bool) -> Result<(), Box<dyn 
                 affinity,
                 args.affinity_neighbors_k,
                 args.affinity_decay_epoch,
+            );
+        }
+        // Tier 1 — static residency. Pin the hottest `fraction` of the
+        // expert namespace permanently. With `--static-residency-profile`
+        // the hot set comes from an offline popularity profile (warm at
+        // startup); otherwise it is derived online from route counts after
+        // `--static-residency-warmup-tokens`.
+        if args.static_residency_fraction > 0.0 {
+            let profile = match args.static_residency_profile.as_ref() {
+                Some(path) => {
+                    let p = crate::residency::ResidencyProfile::load_json(std::path::Path::new(path))?;
+                    info!(
+                        path = %path,
+                        experts = p.len(),
+                        "loaded static-residency popularity profile"
+                    );
+                    Some(p)
+                }
+                None => None,
+            };
+            base = base.with_static_residency(
+                args.static_residency_fraction,
+                args.static_residency_warmup_tokens,
+                profile,
             );
         }
         // Optional alias map (Change 6: expert deduplication).
@@ -2259,6 +2340,15 @@ async fn cmd_run(mut args: RunArgs, startup_pinned: bool) -> Result<(), Box<dyn 
     // Flush the trace before returning so the JSONL file is complete.
     if let Some(tw) = trace_writer.as_ref() {
         tw.flush();
+    }
+
+    // Tier 1 — emit the accumulated expert-popularity profile so a later
+    // run can warm-start static residency with `--static-residency-profile`.
+    if let Some(path) = args.profile_out.as_ref() {
+        match engine.dump_route_profile(std::path::Path::new(path)) {
+            Ok(()) => info!(path = %path, "wrote route-observation profile"),
+            Err(e) => warn!(path = %path, error = %e, "failed to write route profile"),
+        }
     }
 
     Ok(())

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -54,6 +54,7 @@ mod session;
 mod tensor_header;
 mod tokenizer;
 mod transformer;
+mod workload;
 #[cfg(feature = "tui")]
 mod tui;
 
@@ -400,6 +401,27 @@ enum Cmd {
         /// `--static-residency-profile` on a later run).
         #[arg(long)]
         profile_out: Option<String>,
+        /// **Benchmark workload.** `synthetic` (default) keeps the legacy
+        /// uniform-i.i.d. stream (the engine/gate routes its own hidden
+        /// state); `skewed` drives `moe_step` from a Zipf-popular,
+        /// Markov-correlated expert generator (so static residency and
+        /// the predictors are exercisable); `replay` replays a recorded
+        /// JSONL routing trace via `--replay-trace`.
+        #[arg(long, default_value = "synthetic")]
+        workload: String,
+        /// Zipf exponent for `--workload skewed` (larger ⇒ more skew;
+        /// `1.0` ≈ classic Zipf, `0.0` ≈ uniform).
+        #[arg(long, default_value_t = 1.1)]
+        zipf_s: f64,
+        /// Markov stay-probability for `--workload skewed`, in `[0, 1]`:
+        /// the chance a token reuses the previous token's expert set
+        /// (temporal correlation the predictors can exploit).
+        #[arg(long, default_value_t = 0.0)]
+        workload_correlation: f64,
+        /// JSONL routing trace to replay with `--workload replay` (the
+        /// `--trace-out` format).
+        #[arg(long)]
+        replay_trace: Option<String>,
         /// Number of transformer layers, used to size the affinity
         /// matrix. `1` (default) is the single-namespace synthetic
         /// benchmark.
@@ -662,6 +684,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     static_residency_warmup_tokens,
                     static_residency_profile,
                     profile_out,
+                    workload,
+                    zipf_s,
+                    workload_correlation,
+                    replay_trace,
                     num_layers,
                     num_experts_per_layer,
                 } = cli.cmd
@@ -718,6 +744,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         static_residency_warmup_tokens,
                         static_residency_profile,
                         profile_out,
+                        workload,
+                        zipf_s,
+                        workload_correlation,
+                        replay_trace,
                         num_layers,
                         num_experts_per_layer,
                         },
@@ -1755,6 +1785,10 @@ struct RunArgs {
     static_residency_warmup_tokens: u64,
     static_residency_profile: Option<String>,
     profile_out: Option<String>,
+    workload: String,
+    zipf_s: f64,
+    workload_correlation: f64,
+    replay_trace: Option<String>,
     num_layers: u32,
     num_experts_per_layer: Option<u32>,
 }
@@ -2274,28 +2308,96 @@ async fn cmd_run(mut args: RunArgs, startup_pinned: bool) -> Result<(), Box<dyn 
         None => None,
     };
 
+    // Benchmark workload selection (Tier 1/3 falsifiability). `synthetic`
+    // keeps the legacy uniform-i.i.d. stream; `skewed`/`replay` drive
+    // `moe_step` with an explicit, structured expert set so the
+    // skew-aware and correlation-aware machinery is exercisable.
+    let workload = crate::workload::Workload::from_str_opt(&args.workload).ok_or_else(|| {
+        format!(
+            "--workload: unknown value {:?} (use 'synthetic', 'skewed', or 'replay')",
+            args.workload
+        )
+    })?;
+    let mut skewed_stream = if workload == crate::workload::Workload::Skewed {
+        info!(
+            zipf_s = args.zipf_s,
+            correlation = args.workload_correlation,
+            top_k = args.top_k,
+            "workload: skewed (Zipf popularity + Markov correlation)"
+        );
+        Some(crate::workload::SkewedStream::new(
+            args.num_experts,
+            args.top_k,
+            args.zipf_s,
+            args.workload_correlation,
+            args.seed,
+        ))
+    } else {
+        None
+    };
+    let mut replay_stream = if workload == crate::workload::Workload::Replay {
+        let path = args
+            .replay_trace
+            .as_ref()
+            .ok_or("--workload replay requires --replay-trace <path>")?;
+        let stream = crate::workload::ReplayStream::load(std::path::Path::new(path))?;
+        if stream.is_empty() {
+            return Err(format!("--replay-trace {path}: no usable routing records").into());
+        }
+        info!(path = %path, records = stream.len(), "workload: replay JSONL routing trace");
+        Some(stream)
+    } else {
+        None
+    };
+
     for t in 0..args.tokens {
         let start = Instant::now();
-        let stats = if let Some(gate) = gate.as_ref() {
-            // Real gating-network path. Hidden state is the same
-            // synthetic activation `Engine::generate` would have used,
-            // so the only difference relative to the legacy path is
-            // *which* experts are selected.
-            let hidden = crate::inference::synth_hidden_state(t, args.d_model, args.seed);
-            let dec = gate.route(&hidden);
-            let pre_hits = engine.report().hits;
-            let pre_misses = engine.report().misses;
-            let pre_bytes = engine.report().bytes_read;
-            let _ = engine.moe_step(t, 0, &hidden, &dec.experts).await;
-            let post = engine.report();
-            crate::engine::CycleStats {
-                hits: post.hits.saturating_sub(pre_hits),
-                misses: post.misses.saturating_sub(pre_misses),
-                prefetch_hits: 0,
-                bytes_read: post.bytes_read.saturating_sub(pre_bytes),
+        let stats = match workload {
+            // Structured workloads: drive `moe_step` with the harness's
+            // explicit expert set and measure the engine-counter delta.
+            crate::workload::Workload::Skewed | crate::workload::Workload::Replay => {
+                let experts: Vec<u32> = match workload {
+                    crate::workload::Workload::Skewed => {
+                        skewed_stream.as_mut().expect("skewed stream").next_experts()
+                    }
+                    _ => replay_stream
+                        .as_mut()
+                        .expect("replay stream")
+                        .next_experts()
+                        .expect("replay stream non-empty"),
+                };
+                let hidden = crate::inference::synth_hidden_state(t, args.d_model, args.seed);
+                let pre = engine.report();
+                let _ = engine.moe_step(t, 0, &hidden, &experts).await;
+                let post = engine.report();
+                crate::engine::CycleStats {
+                    hits: post.hits.saturating_sub(pre.hits),
+                    misses: post.misses.saturating_sub(pre.misses),
+                    prefetch_hits: 0,
+                    bytes_read: post.bytes_read.saturating_sub(pre.bytes_read),
+                }
             }
-        } else {
-            engine.generate(t).await?
+            crate::workload::Workload::Synthetic => {
+                if let Some(gate) = gate.as_ref() {
+                    // Real gating-network path. Hidden state is the same
+                    // synthetic activation `Engine::generate` would have
+                    // used, so the only difference relative to the legacy
+                    // path is *which* experts are selected.
+                    let hidden = crate::inference::synth_hidden_state(t, args.d_model, args.seed);
+                    let dec = gate.route(&hidden);
+                    let pre = engine.report();
+                    let _ = engine.moe_step(t, 0, &hidden, &dec.experts).await;
+                    let post = engine.report();
+                    crate::engine::CycleStats {
+                        hits: post.hits.saturating_sub(pre.hits),
+                        misses: post.misses.saturating_sub(pre.misses),
+                        prefetch_hits: 0,
+                        bytes_read: post.bytes_read.saturating_sub(pre.bytes_read),
+                    }
+                } else {
+                    engine.generate(t).await?
+                }
+            }
         };
         let elapsed = start.elapsed();
         let throughput = if elapsed.as_secs_f64() > 0.0 {

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -44,6 +44,7 @@ mod model;
 mod multi_layer_cache;
 mod numa;
 mod parallel;
+mod prefetch_governor;
 mod router;
 mod rpc;
 mod sampling;
@@ -349,6 +350,35 @@ enum Cmd {
         /// cumulative observations (with `--affinity`).
         #[arg(long, default_value_t = 10_000)]
         affinity_decay_epoch: u64,
+        /// **Tier 4 — adaptive prefetch governor.** Throttle speculative
+        /// prefetches by measured precision (consumed / completed) and
+        /// foreground-read contention, so low-value speculation can't
+        /// inflate the latency of the foreground misses that actually
+        /// block token generation. Off by default (legacy unbounded
+        /// admission). This is the highest-leverage knob on a
+        /// bandwidth-bound SSD.
+        #[arg(long)]
+        prefetch_governor: bool,
+        /// Precision floor / optimistic EWMA seed for the governor, in
+        /// `[0, 1]` (with `--prefetch-governor`).
+        #[arg(long, default_value_t = 0.05)]
+        prefetch_precision_floor: f64,
+        /// Per-outstanding-foreground-read multiplier on the governor's
+        /// admission threshold (with `--prefetch-governor`). Higher ⇒
+        /// speculation backs off harder while real misses are in flight.
+        #[arg(long, default_value_t = 1.0)]
+        prefetch_contention_weight: f64,
+        /// **Tier 4 — cost-aware eviction.** Evict the coldest resident
+        /// by decaying heat score instead of strict LRU, so a hot expert
+        /// that briefly fell to the LRU tail isn't dumped ahead of a
+        /// one-shot cold expert. Off by default (pure LRU).
+        #[arg(long)]
+        cost_aware_eviction: bool,
+        /// **Tier 3 — per-layer pre-gate predictor.** Train an online
+        /// layer-L→L+1 conditional map and drive high-precision
+        /// next-layer prefetch from it. Off by default.
+        #[arg(long)]
+        pregate: bool,
         /// Number of transformer layers, used to size the affinity
         /// matrix. `1` (default) is the single-namespace synthetic
         /// benchmark.
@@ -602,6 +632,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     affinity,
                     affinity_neighbors_k,
                     affinity_decay_epoch,
+                    prefetch_governor,
+                    prefetch_precision_floor,
+                    prefetch_contention_weight,
+                    cost_aware_eviction,
+                    pregate,
                     num_layers,
                     num_experts_per_layer,
                 } = cli.cmd
@@ -649,6 +684,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         affinity,
                         affinity_neighbors_k,
                         affinity_decay_epoch,
+                        prefetch_governor,
+                        prefetch_precision_floor,
+                        prefetch_contention_weight,
+                        cost_aware_eviction,
+                        pregate,
                         num_layers,
                         num_experts_per_layer,
                         },
@@ -1176,6 +1216,11 @@ async fn cmd_serve(config_path: PathBuf) -> Result<(), Box<dyn std::error::Error
             use_qmm_for_q4: true,
             max_concurrent_prefetches: cfg.real_transformer.max_concurrent_prefetches,
             max_fetch_yields: cfg.real_transformer.max_fetch_yields,
+            prefetch_governor: cfg.predictive.prefetch_governor,
+            prefetch_precision_floor: cfg.predictive.prefetch_precision_floor,
+            prefetch_contention_weight: cfg.predictive.prefetch_contention_weight,
+            cost_aware_eviction: cfg.predictive.cost_aware_eviction,
+            pregate_enabled: cfg.predictive.pregate_enabled,
         },
     );
     // Apply the configured look-ahead pipeline depth (`[storage]
@@ -1649,6 +1694,11 @@ struct RunArgs {
     affinity: bool,
     affinity_neighbors_k: usize,
     affinity_decay_epoch: u64,
+    prefetch_governor: bool,
+    prefetch_precision_floor: f64,
+    prefetch_contention_weight: f64,
+    cost_aware_eviction: bool,
+    pregate: bool,
     num_layers: u32,
     num_experts_per_layer: Option<u32>,
 }
@@ -1993,6 +2043,11 @@ async fn cmd_run(mut args: RunArgs, startup_pinned: bool) -> Result<(), Box<dyn 
                 use_qmm_for_q4: true,
                 max_concurrent_prefetches: 64,
                 max_fetch_yields: crate::engine::DEFAULT_MAX_FETCH_YIELDS,
+                prefetch_governor: args.prefetch_governor,
+                prefetch_precision_floor: args.prefetch_precision_floor,
+                prefetch_contention_weight: args.prefetch_contention_weight,
+                cost_aware_eviction: args.cost_aware_eviction,
+                pregate_enabled: args.pregate,
             },
         );
         if let Some(gpu_cache) = args.gpu_expert_cache.clone() {

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -43,6 +43,7 @@ mod mla;
 mod model;
 mod multi_layer_cache;
 mod numa;
+mod packed_storage;
 mod parallel;
 mod prefetch_governor;
 mod pregate;
@@ -125,6 +126,51 @@ enum Cmd {
         /// byte width of every weight in the generated files.
         #[arg(long, default_value = "f32")]
         dtype: String,
+    },
+
+    /// **Tier 2.** Repack a directory of `expert_<id>.bin` files into a
+    /// single packed blob + JSON manifest for the packed storage layout.
+    /// Experts are written back-to-back (one block-aligned `expert_size`
+    /// slot each) in an order chosen by `--profile` / `--order` so the
+    /// engine can coalesce co-fetched experts into single `preadv`s.
+    Repack {
+        /// Source directory containing `expert_<id>.bin` (or
+        /// `expert_<layer>_<local>.bin` with `--num-experts-per-layer`).
+        #[arg(long, default_value = "./data")]
+        data_dir: PathBuf,
+        /// Output blob path (all expert payloads concatenated).
+        #[arg(long)]
+        out_blob: PathBuf,
+        /// Output manifest path. Defaults to `<out_blob>.manifest.json`.
+        #[arg(long)]
+        out_manifest: Option<PathBuf>,
+        /// Number of experts to pack (ids `0..num_experts`, unless
+        /// `--order` restricts the set).
+        #[arg(long, default_value_t = 64)]
+        num_experts: u32,
+        /// Bytes per expert. Must equal the source files' `expert_size`.
+        #[arg(long, default_value_t = 16 * 1024 * 1024)]
+        expert_size: usize,
+        /// Block alignment (must match `gen-data` / the source files).
+        #[arg(long, default_value_t = 4096)]
+        block_align: usize,
+        /// Disable `O_DIRECT` when reading the source files (needed on
+        /// tmpfs / macOS / CI).
+        #[arg(long)]
+        no_direct: bool,
+        /// Experts per layer for layer-qualified source naming.
+        #[arg(long)]
+        num_experts_per_layer: Option<u32>,
+        /// Order experts hottest-first using a routing-frequency profile
+        /// JSON (as produced by `run --profile-out`). Unobserved experts
+        /// are appended in numeric order. Ignored if `--order` is set.
+        #[arg(long)]
+        profile: Option<PathBuf>,
+        /// Explicit physical layout: a file listing expert ids (one per
+        /// line, or a JSON array). Overrides `--profile`. Only the listed
+        /// experts are packed.
+        #[arg(long)]
+        order: Option<PathBuf>,
     },
 
     /// Run the token-generation simulation against the on-disk experts.
@@ -436,6 +482,16 @@ enum Cmd {
         /// flat single-namespace benchmark (no layer-ahead).
         #[arg(long)]
         num_experts_per_layer: Option<u32>,
+        /// **Tier 2 — packed storage.** Read every expert from this single
+        /// packed blob (produced by the `repack` subcommand) instead of
+        /// one file per expert. Requires `--packed-manifest`. Adjacent
+        /// experts are fetched with coalesced `preadv` syscalls.
+        #[arg(long)]
+        packed_blob: Option<PathBuf>,
+        /// **Tier 2.** JSON manifest (`id -> offset,len`) accompanying
+        /// `--packed-blob`. Required when `--packed-blob` is set.
+        #[arg(long)]
+        packed_manifest: Option<PathBuf>,
     },
 
     /// Convert a GGUF checkpoint (Mixtral-style) into the engine's
@@ -630,6 +686,34 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             block_align,
             dtype,
         } => cmd_gen_data(&data_dir, num_experts, expert_size, d_model, d_ff, block_align, &dtype),
+        Cmd::Repack {
+            data_dir,
+            out_blob,
+            out_manifest,
+            num_experts,
+            expert_size,
+            block_align,
+            no_direct,
+            num_experts_per_layer,
+            profile,
+            order,
+        } => {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()?;
+            rt.block_on(cmd_repack(RepackArgs {
+                data_dir,
+                out_blob,
+                out_manifest,
+                num_experts,
+                expert_size,
+                block_align,
+                no_direct,
+                num_experts_per_layer,
+                profile,
+                order,
+            }))
+        }
         Cmd::Run { .. } => {
             let rt = tokio::runtime::Builder::new_multi_thread()
                 .enable_all()
@@ -691,6 +775,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     replay_trace,
                     num_layers,
                     num_experts_per_layer,
+                    packed_blob,
+                    packed_manifest,
                 } = cli.cmd
                 {
                     let dtype = crate::inference::WeightDtype::from_str_opt(&dtype)
@@ -751,6 +837,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         replay_trace,
                         num_layers,
                         num_experts_per_layer,
+                        packed_blob,
+                        packed_manifest,
                         },
                         startup_pinned,
                     )
@@ -864,6 +952,47 @@ fn install_run_gpu_backend(
             "GpuBackend installed for run benchmark"
         );
         Some(gpu_expert_cache)
+    }
+}
+
+/// **Tier 2.** Attach a packed expert blob to `storage` when both the blob
+/// and its manifest are configured, after validating the manifest's slot
+/// size against the engine's `expert_size`. Returns the storage unchanged
+/// when no packed layout is configured (the default). Shared by the
+/// `serve` and `run` engine-build paths.
+fn maybe_attach_packed_blob(
+    storage: NvmeStorage,
+    packed_blob: Option<&std::path::Path>,
+    packed_manifest: Option<&std::path::Path>,
+    use_direct_io: bool,
+    expert_size: usize,
+) -> Result<NvmeStorage, Box<dyn std::error::Error>> {
+    match (packed_blob, packed_manifest) {
+        (Some(blob_path), Some(manifest_path)) => {
+            let blob = crate::packed_storage::PackedBlob::open(
+                blob_path,
+                manifest_path,
+                use_direct_io,
+            )?;
+            let slot = blob.manifest().expert_size;
+            if slot != expert_size as u64 {
+                return Err(format!(
+                    "packed manifest expert_size ({slot}) != expert_size ({expert_size}); \
+                     re-run `repack` with the matching --expert-size"
+                )
+                .into());
+            }
+            info!(
+                experts = blob.len(),
+                blob = %blob_path.display(),
+                "Tier 2: packed expert blob attached (single-fd reads + coalesced preadv)"
+            );
+            Ok(storage.with_packed_blob(Arc::new(blob)))
+        }
+        (Some(_), None) | (None, Some(_)) => Err(
+            "both packed_blob and packed_manifest must be set to enable the packed layout".into(),
+        ),
+        (None, None) => Ok(storage),
     }
 }
 
@@ -1066,7 +1195,7 @@ async fn cmd_serve(config_path: PathBuf) -> Result<(), Box<dyn std::error::Error
 
     // Wire the multi-layer extractor naming when num_layers > 1, so
     // either `expert_<id>.bin` or `expert_<layer>_<local>.bin` works.
-    let storage = Arc::new(NvmeStorage::new(StorageConfig {
+    let storage = NvmeStorage::new(StorageConfig {
         base_path: cfg.model.data_dir.clone(),
         expert_size: cfg.model.expert_size,
         block_align: cfg.storage.block_align,
@@ -1076,12 +1205,25 @@ async fn cmd_serve(config_path: PathBuf) -> Result<(), Box<dyn std::error::Error
         } else {
             None
         },
-    })?);
+    })?;
+    // Tier 2: attach the packed blob if configured (defaults: no-op).
+    let storage = maybe_attach_packed_blob(
+        storage,
+        cfg.storage.packed_blob.as_deref(),
+        cfg.storage.packed_manifest.as_deref(),
+        !cfg.storage.no_direct,
+        cfg.model.expert_size,
+    )?;
+    let storage = Arc::new(storage);
     // Warm fds across the whole multi-layer namespace (one global id
     // per (layer, local_expert) pair) so the steady-state path never
-    // pays the open() cost.
+    // pays the open() cost. Skipped in packed mode: every expert is
+    // served from the single already-open blob fd, and the per-expert
+    // files may not even exist on disk.
     let total_experts = (cfg.model.num_layers as u32).saturating_mul(cfg.model.num_experts);
-    storage.warmup_fds(0..total_experts)?;
+    if !storage.is_packed() {
+        storage.warmup_fds(0..total_experts)?;
+    }
 
     // Double-buffered pool (Parts 1–2): split the RAM buffers into a
     // **primary** (Buffer A) half that backs the resident LRU plus one
@@ -1747,6 +1889,136 @@ fn cmd_gen_data(
     Ok(())
 }
 
+struct RepackArgs {
+    data_dir: PathBuf,
+    out_blob: PathBuf,
+    out_manifest: Option<PathBuf>,
+    num_experts: u32,
+    expert_size: usize,
+    block_align: usize,
+    no_direct: bool,
+    num_experts_per_layer: Option<u32>,
+    profile: Option<PathBuf>,
+    order: Option<PathBuf>,
+}
+
+/// Parse an explicit `--order` file: either a JSON array of ids or a
+/// newline / whitespace-separated list (blank lines and `#` comments
+/// ignored).
+fn parse_order_file(path: &std::path::Path) -> Result<Vec<u32>, Box<dyn std::error::Error>> {
+    let raw = std::fs::read_to_string(path)?;
+    let trimmed = raw.trim_start();
+    if trimmed.starts_with('[') {
+        let ids: Vec<u32> = serde_json::from_str(trimmed)?;
+        return Ok(ids);
+    }
+    let mut ids = Vec::new();
+    for tok in raw.split(|c: char| c.is_whitespace() || c == ',') {
+        let t = tok.trim();
+        if t.is_empty() || t.starts_with('#') {
+            continue;
+        }
+        ids.push(t.parse::<u32>()?);
+    }
+    Ok(ids)
+}
+
+/// **Tier 2.** Build a packed blob + manifest from a per-expert directory.
+async fn cmd_repack(args: RepackArgs) -> Result<(), Box<dyn std::error::Error>> {
+    if args.block_align == 0 || !args.block_align.is_power_of_two() {
+        return Err(format!(
+            "--block-align ({}) must be a positive power of two",
+            args.block_align
+        )
+        .into());
+    }
+    if args.expert_size % args.block_align != 0 {
+        return Err(format!(
+            "--expert-size ({}) must be a multiple of --block-align ({})",
+            args.expert_size, args.block_align
+        )
+        .into());
+    }
+    if !args.data_dir.is_dir() {
+        return Err(format!("data dir {} does not exist", args.data_dir.display()).into());
+    }
+
+    // Resolve the physical layout order.
+    let order: Vec<u32> = if let Some(order_path) = &args.order {
+        let ids = parse_order_file(order_path)?;
+        if ids.is_empty() {
+            return Err(format!("--order file {} listed no ids", order_path.display()).into());
+        }
+        info!(
+            count = ids.len(),
+            path = %order_path.display(),
+            "repack: using explicit expert order"
+        );
+        ids
+    } else if let Some(profile_path) = &args.profile {
+        let profile = crate::residency::ResidencyProfile::load_json(profile_path)?;
+        // Hottest-first over the whole namespace, then append any expert
+        // the profile never observed so the blob still covers 0..N.
+        let mut ranked = profile.hot_set(1.0, args.num_experts as usize);
+        let seen: std::collections::HashSet<u32> = ranked.iter().copied().collect();
+        for id in 0..args.num_experts {
+            if !seen.contains(&id) {
+                ranked.push(id);
+            }
+        }
+        info!(
+            observed = seen.len(),
+            total = ranked.len(),
+            path = %profile_path.display(),
+            "repack: ordering experts hottest-first from profile"
+        );
+        ranked
+    } else {
+        info!(num_experts = args.num_experts, "repack: using numeric expert order");
+        (0..args.num_experts).collect()
+    };
+
+    let manifest_path = args.out_manifest.clone().unwrap_or_else(|| {
+        let mut p = args.out_blob.clone().into_os_string();
+        p.push(".manifest.json");
+        PathBuf::from(p)
+    });
+
+    let storage = NvmeStorage::new(StorageConfig {
+        base_path: args.data_dir.clone(),
+        expert_size: args.expert_size,
+        block_align: args.block_align,
+        use_direct_io: !args.no_direct,
+        num_experts_per_layer: args.num_experts_per_layer,
+    })?;
+    // One reusable buffer is enough (we read sequentially), but a tiny
+    // pool keeps the acquire/release ergonomics and alignment.
+    let pool = BufferPool::new(2, args.expert_size, args.block_align);
+
+    info!(
+        experts = order.len(),
+        out_blob = %args.out_blob.display(),
+        out_manifest = %manifest_path.display(),
+        "repack: writing packed blob"
+    );
+    let started = Instant::now();
+    let manifest = crate::io_provider::pack_experts(
+        &storage,
+        &pool,
+        &order,
+        &args.out_blob,
+        &manifest_path,
+    )
+    .await?;
+    info!(
+        elapsed_s = started.elapsed().as_secs_f64(),
+        blob_mib = manifest.blob_len() as f64 / (1024.0 * 1024.0),
+        experts = manifest.len(),
+        "repack complete — point [storage] packed_blob / packed_manifest at these files"
+    );
+    Ok(())
+}
+
 struct RunArgs {
     data_dir: PathBuf,
     num_experts: u32,
@@ -1802,6 +2074,8 @@ struct RunArgs {
     replay_trace: Option<String>,
     num_layers: u32,
     num_experts_per_layer: Option<u32>,
+    packed_blob: Option<PathBuf>,
+    packed_manifest: Option<PathBuf>,
 }
 
 async fn cmd_run(mut args: RunArgs, startup_pinned: bool) -> Result<(), Box<dyn std::error::Error>> {
@@ -2026,12 +2300,23 @@ async fn cmd_run(mut args: RunArgs, startup_pinned: bool) -> Result<(), Box<dyn 
         // restrict the speculator head per layer and prefetch ahead.
         num_experts_per_layer: args.num_experts_per_layer,
     };
-    let storage = Arc::new(if data_dirs.len() > 1 {
+    let storage = if data_dirs.len() > 1 {
         NvmeStorage::striped(storage_cfg, data_dirs.clone())?
     } else {
         NvmeStorage::new(storage_cfg)?
-    });
-    storage.warmup_fds(0..args.num_experts)?;
+    };
+    // Tier 2: attach the packed blob if configured (defaults: no-op).
+    let storage = maybe_attach_packed_blob(
+        storage,
+        args.packed_blob.as_deref(),
+        args.packed_manifest.as_deref(),
+        !args.no_direct,
+        args.expert_size,
+    )?;
+    let storage = Arc::new(storage);
+    if !storage.is_packed() {
+        storage.warmup_fds(0..args.num_experts)?;
+    }
 
     let pipeline_depth = args.pipeline_depth.max(1) as usize;
     let prefetch_headroom = if args.no_prefetch || args.predict_fanout == 0 {

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -974,6 +974,8 @@ fn maybe_attach_packed_blob(
                 manifest_path,
                 use_direct_io,
             )?;
+            blob.validate()
+                .map_err(|e| format!("packed blob validation failed: {e}"))?;
             let slot = blob.manifest().expert_size;
             if slot != expert_size as u64 {
                 return Err(format!(
@@ -1913,14 +1915,32 @@ fn parse_order_file(path: &std::path::Path) -> Result<Vec<u32>, Box<dyn std::err
         return Ok(ids);
     }
     let mut ids = Vec::new();
-    for tok in raw.split(|c: char| c.is_whitespace() || c == ',') {
-        let t = tok.trim();
-        if t.is_empty() || t.starts_with('#') {
-            continue;
+    for line in raw.lines() {
+        let without_comment = line.split_once('#').map_or(line, |(body, _)| body);
+        for tok in without_comment.split(|c: char| c.is_whitespace() || c == ',') {
+            let t = tok.trim();
+            if t.is_empty() {
+                continue;
+            }
+            ids.push(t.parse::<u32>()?);
         }
-        ids.push(t.parse::<u32>()?);
     }
     Ok(ids)
+}
+
+fn validate_order(ids: &[u32], num_experts: u32) -> Result<(), String> {
+    let mut seen = std::collections::HashSet::with_capacity(ids.len());
+    for &id in ids {
+        if id >= num_experts {
+            return Err(format!(
+                "--order id {id} is out of range for --num-experts {num_experts}"
+            ));
+        }
+        if !seen.insert(id) {
+            return Err(format!("--order contains duplicate expert id {id}"));
+        }
+    }
+    Ok(())
 }
 
 /// **Tier 2.** Build a packed blob + manifest from a per-expert directory.
@@ -1948,6 +1968,14 @@ async fn cmd_repack(args: RepackArgs) -> Result<(), Box<dyn std::error::Error>> 
         let ids = parse_order_file(order_path)?;
         if ids.is_empty() {
             return Err(format!("--order file {} listed no ids", order_path.display()).into());
+        }
+        validate_order(&ids, args.num_experts)?;
+        let missing = args.num_experts as usize - ids.len();
+        if missing > 0 {
+            warn!(
+                missing,
+                "repack: explicit order omits experts; running/serving in packed mode will hard-error with NotFound if an omitted expert is routed"
+            );
         }
         info!(
             count = ids.len(),
@@ -2670,19 +2698,29 @@ async fn cmd_run(mut args: RunArgs, startup_pinned: bool) -> Result<(), Box<dyn 
             // Structured workloads: drive `moe_step` with the harness's
             // explicit expert set and measure the engine-counter delta.
             crate::workload::Workload::Skewed | crate::workload::Workload::Replay => {
-                let experts: Vec<u32> = match workload {
-                    crate::workload::Workload::Skewed => {
-                        skewed_stream.as_mut().expect("skewed stream").next_experts()
+                let (tok_idx, layer_idx, experts): (u64, u32, Vec<u32>) = match workload {
+                    crate::workload::Workload::Skewed => (
+                        t,
+                        0,
+                        skewed_stream.as_mut().expect("skewed stream").next_experts(),
+                    ),
+                    _ => {
+                        let record = replay_stream
+                            .as_mut()
+                            .expect("replay stream")
+                            .next_record()
+                            .expect("replay stream non-empty");
+                        let layer = u32::try_from(record.layer).map_err(|_| {
+                            format!("replay layer {} does not fit in u32", record.layer)
+                        })?;
+                        (record.token, layer, record.experts)
                     }
-                    _ => replay_stream
-                        .as_mut()
-                        .expect("replay stream")
-                        .next_experts()
-                        .expect("replay stream non-empty"),
                 };
-                let hidden = crate::inference::synth_hidden_state(t, args.d_model, args.seed);
+                let hidden = crate::inference::synth_hidden_state(tok_idx, args.d_model, args.seed);
                 let pre = engine.report();
-                let _ = engine.moe_step(t, 0, &hidden, &experts).await;
+                let _ = engine
+                    .moe_step(tok_idx, layer_idx, &hidden, &experts)
+                    .await;
                 let post = engine.report();
                 crate::engine::CycleStats {
                     hits: post.hits.saturating_sub(pre.hits),
@@ -3518,6 +3556,37 @@ mod tests {
         assert_eq!(parse_gate_layer_index("gate_1.bin.bak"), None);
         assert_eq!(parse_gate_layer_index("rms_moe_1.bin"), None);
         assert_eq!(parse_gate_layer_index("gate.bin"), None);
+    }
+
+    #[test]
+    fn parse_order_file_strips_inline_comments() {
+        let path = tempdir_unique("order-inline-comments.txt");
+        std::fs::write(
+            &path,
+            "# full-line comment\n12  # hot expert\n3,4\n8 9\n",
+        )
+        .unwrap();
+        let ids = parse_order_file(&path).unwrap();
+        assert_eq!(ids, vec![12, 3, 4, 8, 9]);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn repack_order_validation_rejects_duplicate_ids() {
+        let err = validate_order(&[0, 1, 1], 4).unwrap_err();
+        assert!(err.contains("duplicate expert id 1"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn repack_order_validation_rejects_out_of_range_ids() {
+        let err = validate_order(&[0, 4], 4).unwrap_err();
+        assert!(err.contains("out of range"), "unexpected error: {err}");
+        assert!(err.contains("4"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn repack_order_validation_allows_subsets() {
+        assert!(validate_order(&[0, 2], 4).is_ok());
     }
 
     #[test]

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -2799,10 +2799,10 @@ async fn cmd_run(mut args: RunArgs, startup_pinned: bool) -> Result<(), Box<dyn 
     // Tier 1 — emit the accumulated expert-popularity profile so a later
     // run can warm-start static residency with `--static-residency-profile`.
     if let Some(path) = args.profile_out.as_ref() {
-        match engine.dump_route_profile(std::path::Path::new(path)) {
-            Ok(()) => info!(path = %path, "wrote route-observation profile"),
-            Err(e) => warn!(path = %path, error = %e, "failed to write route profile"),
-        }
+        engine
+            .dump_route_profile(std::path::Path::new(path))
+            .map_err(|e| format!("failed to write route profile {}: {e}", path))?;
+        info!(path = %path, "wrote route-observation profile");
     }
 
     Ok(())

--- a/rust-engine/src/multi_layer_cache.rs
+++ b/rust-engine/src/multi_layer_cache.rs
@@ -172,6 +172,16 @@ impl MultiLayerExpertCache {
         self.caches[self.layer_idx(id)].unpin(id);
     }
 
+    /// **Tier 4 — cost-aware eviction.** Enable or disable the
+    /// lowest-heat eviction policy across every per-layer cache. No-op
+    /// effect until at least one layer fills; off by default so the
+    /// engine preserves pure-LRU behaviour unless asked.
+    pub fn set_cost_aware(&self, on: bool) {
+        for c in &self.caches {
+            c.set_cost_aware(on);
+        }
+    }
+
     /// Pop a least-recently-used non-pinned entry. With multiple
     /// layers, evicts from the layer whose per-layer LRU has the most
     /// residents (so we relieve the most-pressured layer first); ties

--- a/rust-engine/src/multi_layer_cache.rs
+++ b/rust-engine/src/multi_layer_cache.rs
@@ -248,6 +248,14 @@ impl MultiLayerExpertCache {
         self.caches.iter().map(|c| c.pinned_count()).sum()
     }
 
+    /// Snapshot of all pinned ids across every per-layer cache, sorted
+    /// ascending (diagnostics / tests).
+    pub fn pinned_ids(&self) -> Vec<u32> {
+        let mut ids: Vec<u32> = self.caches.iter().flat_map(|c| c.pinned_ids()).collect();
+        ids.sort_unstable();
+        ids
+    }
+
     pub fn resident_ids(&self) -> Vec<u32> {
         let mut ids = Vec::with_capacity(self.len());
         for c in &self.caches {

--- a/rust-engine/src/packed_storage.rs
+++ b/rust-engine/src/packed_storage.rs
@@ -1,0 +1,352 @@
+//! **Tier 2 — packed expert storage (single-blob layout + coalesced reads).**
+//!
+//! The default [`crate::io_provider::NvmeStorage`] keeps **one file per
+//! expert** (`expert_<id>.bin`). That layout is simple and robust, but it has
+//! two structural costs on the SSD-streaming hot path:
+//!
+//! 1. **One fd per distinct expert.** A low-hit-rate run streams thousands of
+//!    distinct experts past the bounded fd cache, so every miss can pay an
+//!    `open(2)` syscall and thrash the descriptor LRU.
+//! 2. **No read coalescing.** When a single token misses on `K` experts the
+//!    engine issues `K` independent `pread(2)`s. Even dispatched concurrently
+//!    the NVMe can only overlap them up to its queue depth, and each one is a
+//!    separate command with its own submission overhead.
+//!
+//! The **packed layout** concatenates every expert payload into a single blob
+//! file, each occupying one block-aligned `expert_size` slot, in an order
+//! chosen *offline* (by routing-frequency profile or co-firing affinity — see
+//! the `repack` CLI subcommand). A small JSON [`PackedManifest`] records each
+//! expert's byte `(offset, len)` within the blob.
+//!
+//! Two wins fall out:
+//!
+//! * **One fd for everything.** All reads target the same blob descriptor — no
+//!   per-expert `open()`, no fd-cache pressure.
+//! * **Coalesced vectored reads.** Experts placed in adjacent slots are
+//!   physically contiguous, so a run of them can be fetched in a **single
+//!   `preadv(2)`** that scatters straight into the per-expert
+//!   [`crate::buffer_pool::PooledBuffer`]s — one syscall, one seek, full
+//!   device queue depth — instead of `K` separate reads. See
+//!   [`NvmeStorage::read_experts_batch`](crate::io_provider::NvmeStorage::read_experts_batch).
+//!
+//! The whole layer is **opt-in**: with no `[storage] packed_blob` configured
+//! the engine uses the original one-file-per-expert path bit-for-bit.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs::File;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use crate::io_provider::open_expert_file;
+
+/// One expert's byte location within the packed blob.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct PackedEntry {
+    /// Byte offset of the expert's payload from the start of the blob.
+    /// Always a multiple of [`PackedManifest::block_align`].
+    pub offset: u64,
+    /// Number of payload bytes. Equal to [`PackedManifest::expert_size`]
+    /// for the uniform-slot layout the engine produces.
+    pub len: u64,
+}
+
+/// On-disk index mapping every expert id to its `(offset, len)` slot in a
+/// single packed blob. Serialised as JSON beside the blob (the `repack`
+/// subcommand emits both; the engine loads them via [`PackedBlob::open`]).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PackedManifest {
+    /// Block alignment every offset and slot is padded to (matches
+    /// `StorageConfig::block_align`, typically 4096). Guarantees each
+    /// slot start is `O_DIRECT`-safe.
+    pub block_align: u64,
+    /// Uniform padded slot size for each expert, in bytes. Equal to
+    /// `StorageConfig::expert_size`; the engine asserts the two agree at
+    /// wiring time so a packed read fills a whole `PooledBuffer`.
+    pub expert_size: u64,
+    /// `id -> (offset, len)`.
+    pub entries: HashMap<u32, PackedEntry>,
+    /// Expert ids in ascending blob-offset order. Persisted so a re-pack
+    /// or a human can inspect / reproduce the chosen physical layout.
+    pub order: Vec<u32>,
+}
+
+impl PackedManifest {
+    /// Build a manifest for `order` (the physical layout, front to back)
+    /// with a uniform `expert_size` slot per expert. Offsets are assigned
+    /// densely: slot `i` lives at `i * expert_size`.
+    pub fn uniform(order: Vec<u32>, expert_size: u64, block_align: u64) -> Self {
+        let mut entries = HashMap::with_capacity(order.len());
+        for (i, &id) in order.iter().enumerate() {
+            entries.insert(
+                id,
+                PackedEntry {
+                    offset: i as u64 * expert_size,
+                    len: expert_size,
+                },
+            );
+        }
+        Self {
+            block_align,
+            expert_size,
+            entries,
+            order,
+        }
+    }
+
+    /// Total number of expert slots in the blob.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether the manifest indexes no experts.
+    #[allow(dead_code)] // public API symmetry with `len`.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Expected blob length in bytes (last slot end). `0` for an empty
+    /// manifest.
+    pub fn blob_len(&self) -> u64 {
+        self.entries
+            .values()
+            .map(|e| e.offset + e.len)
+            .max()
+            .unwrap_or(0)
+    }
+
+    /// Serialise to pretty JSON.
+    pub fn to_json(&self) -> serde_json::Result<String> {
+        serde_json::to_string_pretty(self)
+    }
+
+    /// Parse from JSON.
+    pub fn from_json(s: &str) -> serde_json::Result<Self> {
+        serde_json::from_str(s)
+    }
+
+    /// Write the manifest to `path` as JSON.
+    pub fn write_to(&self, path: &Path) -> io::Result<()> {
+        let json = self
+            .to_json()
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        std::fs::write(path, json)
+    }
+
+    /// Load a manifest from a JSON file at `path`.
+    pub fn load_from(path: &Path) -> io::Result<Self> {
+        let raw = std::fs::read_to_string(path)?;
+        Self::from_json(&raw).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+    }
+}
+
+/// An opened packed blob: the shared blob file descriptor plus its
+/// [`PackedManifest`]. Cheap to clone into background prefetch tasks via the
+/// `Arc<File>` handle.
+#[derive(Debug)]
+pub struct PackedBlob {
+    file: Arc<File>,
+    manifest: PackedManifest,
+    blob_path: PathBuf,
+}
+
+impl PackedBlob {
+    /// Open the blob at `blob_path` and load its manifest from
+    /// `manifest_path`. `use_direct_io` mirrors the engine's
+    /// `StorageConfig::use_direct_io` so the packed path honours the same
+    /// page-cache-bypass policy as the per-file path.
+    pub fn open(blob_path: &Path, manifest_path: &Path, use_direct_io: bool) -> io::Result<Self> {
+        let manifest = PackedManifest::load_from(manifest_path)?;
+        let file = open_expert_file(blob_path, use_direct_io)?;
+        Ok(Self {
+            file: Arc::new(file),
+            manifest,
+            blob_path: blob_path.to_path_buf(),
+        })
+    }
+
+    /// The shared blob file descriptor.
+    pub fn file(&self) -> &Arc<File> {
+        &self.file
+    }
+
+    /// The blob's manifest.
+    pub fn manifest(&self) -> &PackedManifest {
+        &self.manifest
+    }
+
+    /// Look up an expert's slot, if it is packed in this blob.
+    pub fn entry(&self, id: u32) -> Option<PackedEntry> {
+        self.manifest.entries.get(&id).copied()
+    }
+
+    /// Whether `id` is present in this blob.
+    #[allow(dead_code)] // public lookup API; used by external callers / tests.
+    pub fn contains(&self, id: u32) -> bool {
+        self.manifest.entries.contains_key(&id)
+    }
+
+    /// Number of experts packed in this blob.
+    pub fn len(&self) -> usize {
+        self.manifest.len()
+    }
+
+    /// Whether the blob is empty.
+    #[allow(dead_code)] // public API symmetry with `len`.
+    pub fn is_empty(&self) -> bool {
+        self.manifest.is_empty()
+    }
+
+    /// Filesystem path of the blob (for diagnostics).
+    #[allow(dead_code)] // surfaced for diagnostics / external callers.
+    pub fn path(&self) -> &Path {
+        &self.blob_path
+    }
+}
+
+/// A maximal run of experts whose blob slots are physically contiguous, i.e.
+/// `slot[i+1].offset == slot[i].offset + slot[i].len`. A run can be fetched
+/// with a single coalesced `preadv`.
+///
+/// `members` lists the experts in ascending-offset order; each tuple is the
+/// expert id and the index into the caller's original request slice (so the
+/// scattered bytes land in the right destination buffer).
+#[derive(Debug, Clone)]
+#[allow(dead_code)] // produced by `coalesce_runs` on the batched packed-read path.
+pub struct ContiguousRun {
+    /// Byte offset of the run's first slot in the blob.
+    pub start_offset: u64,
+    /// Total bytes the run spans (sum of member lens).
+    pub total_len: u64,
+    /// `(expert_id, original_request_index)` in ascending-offset order.
+    pub members: Vec<(u32, usize)>,
+}
+
+/// Group a set of requested experts into maximal contiguous runs over their
+/// packed-blob slots.
+///
+/// `requested` is `(expert_id, original_index, entry)`. The result is sorted
+/// by `start_offset`; each [`ContiguousRun`] holds the members that a single
+/// `preadv` can satisfy. Experts with no adjacent neighbour come back as
+/// singleton runs, which the caller services with the ordinary per-expert
+/// fault-tolerant read.
+#[allow(dead_code)] // entry point of the batched packed-read path (see io_provider).
+pub fn coalesce_runs(mut requested: Vec<(u32, usize, PackedEntry)>) -> Vec<ContiguousRun> {
+    if requested.is_empty() {
+        return Vec::new();
+    }
+    requested.sort_by_key(|(_, _, e)| e.offset);
+
+    let mut runs: Vec<ContiguousRun> = Vec::new();
+    let mut cur = ContiguousRun {
+        start_offset: requested[0].2.offset,
+        total_len: requested[0].2.len,
+        members: vec![(requested[0].0, requested[0].1)],
+    };
+    let mut cur_end = requested[0].2.offset + requested[0].2.len;
+
+    for (id, idx, entry) in requested.into_iter().skip(1) {
+        if entry.offset == cur_end {
+            // Physically adjacent — extend the current run.
+            cur.total_len += entry.len;
+            cur.members.push((id, idx));
+            cur_end = entry.offset + entry.len;
+        } else {
+            // Gap (or duplicate offset) — close the run and start a new one.
+            runs.push(std::mem::replace(
+                &mut cur,
+                ContiguousRun {
+                    start_offset: entry.offset,
+                    total_len: entry.len,
+                    members: vec![(id, idx)],
+                },
+            ));
+            cur_end = entry.offset + entry.len;
+        }
+    }
+    runs.push(cur);
+    runs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(offset: u64, len: u64) -> PackedEntry {
+        PackedEntry { offset, len }
+    }
+
+    #[test]
+    fn uniform_manifest_assigns_dense_offsets() {
+        let m = PackedManifest::uniform(vec![7, 3, 9], 4096, 4096);
+        assert_eq!(m.entries[&7].offset, 0);
+        assert_eq!(m.entries[&3].offset, 4096);
+        assert_eq!(m.entries[&9].offset, 8192);
+        assert_eq!(m.entries[&7].len, 4096);
+        assert_eq!(m.blob_len(), 3 * 4096);
+        assert_eq!(m.order, vec![7, 3, 9]);
+    }
+
+    #[test]
+    fn manifest_json_round_trips() {
+        let m = PackedManifest::uniform(vec![0, 1, 2, 5], 2 * 1024 * 1024, 4096);
+        let json = m.to_json().unwrap();
+        let back = PackedManifest::from_json(&json).unwrap();
+        assert_eq!(back.expert_size, m.expert_size);
+        assert_eq!(back.block_align, m.block_align);
+        assert_eq!(back.order, m.order);
+        for id in [0u32, 1, 2, 5] {
+            assert_eq!(back.entries[&id].offset, m.entries[&id].offset);
+            assert_eq!(back.entries[&id].len, m.entries[&id].len);
+        }
+    }
+
+    #[test]
+    fn coalesce_merges_only_adjacent_slots() {
+        // Slots: id10@0, id11@100, id12@200 are contiguous (len 100);
+        // id20@500 is isolated.
+        let req = vec![
+            (12u32, 0usize, entry(200, 100)),
+            (10u32, 1usize, entry(0, 100)),
+            (20u32, 2usize, entry(500, 100)),
+            (11u32, 3usize, entry(100, 100)),
+        ];
+        let runs = coalesce_runs(req);
+        assert_eq!(runs.len(), 2, "one 3-wide run + one singleton");
+
+        let big = &runs[0];
+        assert_eq!(big.start_offset, 0);
+        assert_eq!(big.total_len, 300);
+        assert_eq!(
+            big.members,
+            vec![(10, 1), (11, 3), (12, 0)],
+            "members carry original request indices in offset order"
+        );
+
+        let small = &runs[1];
+        assert_eq!(small.start_offset, 500);
+        assert_eq!(small.total_len, 100);
+        assert_eq!(small.members, vec![(20, 2)]);
+    }
+
+    #[test]
+    fn coalesce_handles_gap_then_resume() {
+        // 0..100 and 100..200 contiguous, gap, then 4096..4196 alone.
+        let req = vec![
+            (1u32, 0usize, entry(0, 100)),
+            (2u32, 1usize, entry(100, 100)),
+            (3u32, 2usize, entry(4096, 100)),
+        ];
+        let runs = coalesce_runs(req);
+        assert_eq!(runs.len(), 2);
+        assert_eq!(runs[0].members.len(), 2);
+        assert_eq!(runs[1].members.len(), 1);
+        assert_eq!(runs[1].start_offset, 4096);
+    }
+
+    #[test]
+    fn coalesce_empty_is_empty() {
+        assert!(coalesce_runs(Vec::new()).is_empty());
+    }
+}

--- a/rust-engine/src/packed_storage.rs
+++ b/rust-engine/src/packed_storage.rs
@@ -116,6 +116,32 @@ impl PackedManifest {
             .unwrap_or(0)
     }
 
+    /// Validate that each manifest entry matches the uniform-slot layout used
+    /// by the packed read path.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.entries.is_empty() {
+            return Ok(());
+        }
+        if self.expert_size == 0 {
+            return Err("packed manifest expert_size must be non-zero".to_string());
+        }
+        for (&id, entry) in &self.entries {
+            if entry.len != self.expert_size {
+                return Err(format!(
+                    "packed manifest entry for expert {id} has len {} but expert_size is {}",
+                    entry.len, self.expert_size
+                ));
+            }
+            if entry.offset % self.expert_size != 0 {
+                return Err(format!(
+                    "packed manifest entry for expert {id} has offset {} which is not a multiple of expert_size {}",
+                    entry.offset, self.expert_size
+                ));
+            }
+        }
+        Ok(())
+    }
+
     /// Serialise to pretty JSON.
     pub fn to_json(&self) -> serde_json::Result<String> {
         serde_json::to_string_pretty(self)
@@ -203,6 +229,26 @@ impl PackedBlob {
     pub fn path(&self) -> &Path {
         &self.blob_path
     }
+
+    /// Validate manifest invariants and ensure the blob file is long enough
+    /// for the manifest's declared slots.
+    pub fn validate(&self) -> io::Result<()> {
+        self.manifest
+            .validate()
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        let actual_len = self.file.metadata()?.len();
+        let expected_len = self.manifest.blob_len();
+        if actual_len < expected_len {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "packed blob {} is truncated: length {actual_len} bytes but manifest requires {expected_len} bytes",
+                    self.blob_path.display()
+                ),
+            ));
+        }
+        Ok(())
+    }
 }
 
 /// A maximal run of experts whose blob slots are physically contiguous, i.e.
@@ -286,6 +332,30 @@ mod tests {
         assert_eq!(m.entries[&7].len, 4096);
         assert_eq!(m.blob_len(), 3 * 4096);
         assert_eq!(m.order, vec![7, 3, 9]);
+    }
+
+    #[test]
+    fn packed_manifest_validate_accepts_uniform_slots() {
+        let m = PackedManifest::uniform(vec![7, 3, 9], 4096, 4096);
+        assert!(m.validate().is_ok());
+    }
+
+    #[test]
+    fn packed_manifest_validate_rejects_len_mismatch() {
+        let mut m = PackedManifest::uniform(vec![7, 3], 4096, 4096);
+        m.entries.get_mut(&3).unwrap().len = 2048;
+        let err = m.validate().unwrap_err();
+        assert!(err.contains("expert 3"), "unexpected error: {err}");
+        assert!(err.contains("len 2048"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn packed_manifest_validate_rejects_unaligned_offset() {
+        let mut m = PackedManifest::uniform(vec![7, 3], 4096, 4096);
+        m.entries.get_mut(&3).unwrap().offset = 512;
+        let err = m.validate().unwrap_err();
+        assert!(err.contains("expert 3"), "unexpected error: {err}");
+        assert!(err.contains("offset 512"), "unexpected error: {err}");
     }
 
     #[test]

--- a/rust-engine/src/packed_storage.rs
+++ b/rust-engine/src/packed_storage.rs
@@ -185,11 +185,15 @@ impl PackedBlob {
     pub fn open(blob_path: &Path, manifest_path: &Path, use_direct_io: bool) -> io::Result<Self> {
         let manifest = PackedManifest::load_from(manifest_path)?;
         let file = open_expert_file(blob_path, use_direct_io)?;
-        Ok(Self {
+        let blob = Self {
             file: Arc::new(file),
             manifest,
             blob_path: blob_path.to_path_buf(),
-        })
+        };
+        // Reject malformed/stale manifests at open time so direct callers
+        // (not just the attach path) never drive wrong offsets into reads.
+        blob.validate()?;
+        Ok(blob)
     }
 
     /// The shared blob file descriptor.
@@ -418,5 +422,22 @@ mod tests {
     #[test]
     fn coalesce_empty_is_empty() {
         assert!(coalesce_runs(Vec::new()).is_empty());
+    }
+
+    #[test]
+    fn open_rejects_truncated_blob() {
+        let dir = std::env::temp_dir();
+        let pid = std::process::id();
+        let blob_path = dir.join(format!("trunc_{pid}.blob"));
+        let manifest_path = dir.join(format!("trunc_{pid}.manifest.json"));
+        // Manifest declares two 4096-byte slots (blob_len = 8192) but the
+        // blob file holds only one slot's worth of bytes.
+        let m = PackedManifest::uniform(vec![0, 1], 4096, 4096);
+        m.write_to(&manifest_path).unwrap();
+        std::fs::write(&blob_path, vec![0u8; 4096]).unwrap();
+        let err = PackedBlob::open(&blob_path, &manifest_path, false).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        let _ = std::fs::remove_file(&blob_path);
+        let _ = std::fs::remove_file(&manifest_path);
     }
 }

--- a/rust-engine/src/prefetch_governor.rs
+++ b/rust-engine/src/prefetch_governor.rs
@@ -111,6 +111,25 @@ pub struct PrefetchGovernor {
     admitted: AtomicU64,
 }
 
+/// RAII token for foreground-read accounting. Dropping the guard always
+/// balances the corresponding [`PrefetchGovernor::begin_foreground`] call.
+pub struct ForegroundGuard<'a> {
+    governor: &'a PrefetchGovernor,
+}
+
+impl<'a> ForegroundGuard<'a> {
+    fn new(governor: &'a PrefetchGovernor) -> Self {
+        governor.begin_foreground();
+        Self { governor }
+    }
+}
+
+impl Drop for ForegroundGuard<'_> {
+    fn drop(&mut self) {
+        self.governor.end_foreground();
+    }
+}
+
 impl PrefetchGovernor {
     /// Construct a governor. When `enabled` is `false` the controller is
     /// a transparent pass-through: [`Self::admit`] always returns `true`
@@ -196,6 +215,14 @@ impl PrefetchGovernor {
         if self.enabled {
             self.foreground_inflight.fetch_sub(1, Ordering::Relaxed);
         }
+    }
+
+    /// Begin foreground-read accounting and return a guard that ends it
+    /// on drop. Preserves the disabled-governor no-op semantics of the
+    /// explicit begin/end methods.
+    #[inline]
+    pub fn foreground_guard(&self) -> ForegroundGuard<'_> {
+        ForegroundGuard::new(self)
     }
 
     /// Record that a speculative read landed (became resident).
@@ -329,6 +356,24 @@ mod tests {
         g.end_foreground();
         g.end_foreground();
         assert!(g.admit(0.3));
+    }
+
+    #[test]
+    fn foreground_guard_releases_on_drop() {
+        let g = PrefetchGovernor::new(true, GovernorConfig::default());
+        let before = g.foreground_inflight();
+        {
+            let _guard = g.foreground_guard();
+            assert_eq!(g.foreground_inflight(), before + 1);
+        }
+        assert_eq!(g.foreground_inflight(), before);
+
+        let disabled = PrefetchGovernor::disabled();
+        {
+            let _guard = disabled.foreground_guard();
+            assert_eq!(disabled.foreground_inflight(), 0);
+        }
+        assert_eq!(disabled.foreground_inflight(), 0);
     }
 
     #[test]

--- a/rust-engine/src/prefetch_governor.rs
+++ b/rust-engine/src/prefetch_governor.rs
@@ -1,0 +1,362 @@
+//! Adaptive, self-regulating prefetch admission controller.
+//!
+//! ## Why this exists
+//!
+//! The legacy speculative-I/O path admits every predicted expert that
+//! clears a *static* probability threshold and can grab a semaphore
+//! permit. On a structureless or weakly-correlated workload the
+//! predictors degrade to ~chance accuracy, yet the engine keeps issuing
+//! the same volume of speculative reads. Those reads are not free: on a
+//! bandwidth-bound SSD they **queue ahead of foreground cache misses**,
+//! inflating the latency of the reads that actually block token
+//! generation. Field data from a Mixtral-8x7B run made this concrete —
+//! with ~9k speculative reads at ~0.8 % precision the foreground miss
+//! p50 rose from ~120 ms (no speculation) to ~405 ms (3.4x), while hit
+//! rate barely moved.
+//!
+//! The [`PrefetchGovernor`] closes the loop: it continuously measures
+//!
+//! * **precision** — the fraction of completed prefetches that were
+//!   actually consumed before eviction (an EWMA), and
+//! * **contention** — how many foreground (blocking) reads are in
+//!   flight right now,
+//!
+//! and admits a speculative read only when its *expected value* beats
+//! the *expected contention cost*. When the predictors are paying off
+//! and the disk is idle it admits liberally; when precision collapses or
+//! real misses are queued it throttles toward zero, handing the scarce
+//! I/O bandwidth back to the foreground path.
+//!
+//! The controller is **opt-in** (`EngineOptions::prefetch_governor`,
+//! default `false`) so existing deployments and benchmarks are
+//! bit-for-bit unchanged until they enable it.
+
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+
+/// Pack/unpack an `f64` into the bits of an `AtomicU64` so the EWMA can
+/// be read on the hot admission path with a single relaxed load.
+#[inline]
+fn load_f64(a: &AtomicU64) -> f64 {
+    f64::from_bits(a.load(Ordering::Relaxed))
+}
+#[inline]
+fn store_f64(a: &AtomicU64, v: f64) {
+    a.store(v.to_bits(), Ordering::Relaxed);
+}
+
+/// Tunables for [`PrefetchGovernor`]. All values have safe, conservative
+/// defaults; the engine fills these from [`EngineOptions`].
+#[derive(Clone, Copy, Debug)]
+pub struct GovernorConfig {
+    /// EWMA smoothing factor for the measured precision signal, in
+    /// `(0, 1]`. Higher reacts faster to distribution shift; lower is
+    /// steadier. `0.2` blends roughly the last ~5 measurement windows.
+    pub precision_alpha: f64,
+    /// Floor applied to the precision EWMA when scoring admissions, so a
+    /// transient run of wasted prefetches can't latch the controller at
+    /// exactly zero and starve it of the future hits that would let it
+    /// recover. Also the value the EWMA is seeded with.
+    pub precision_floor: f64,
+    /// Per-outstanding-foreground-read multiplier on the admission
+    /// threshold. With `contention_weight = 1.0`, one in-flight
+    /// foreground miss doubles the bar a speculative read must clear,
+    /// two triple it, and so on.
+    pub contention_weight: f64,
+    /// Base admission threshold the (probability x precision) product is
+    /// compared against when the disk is otherwise idle.
+    pub base_threshold: f64,
+}
+
+impl Default for GovernorConfig {
+    fn default() -> Self {
+        Self {
+            precision_alpha: 0.2,
+            precision_floor: 0.05,
+            contention_weight: 1.0,
+            base_threshold: 0.02,
+        }
+    }
+}
+
+/// Lock-free adaptive prefetch admission controller. Cheap to share
+/// behind an `Arc`: every field is a single atomic and the hot
+/// [`Self::admit`] path performs only relaxed loads.
+#[derive(Debug)]
+pub struct PrefetchGovernor {
+    enabled: bool,
+    precision_alpha: f64,
+    precision_floor: f64,
+    contention_weight: f64,
+    base_threshold: f64,
+
+    /// EWMA of recent prefetch precision (consumed / completed), in
+    /// `[0, 1]`. Read on the admission hot path.
+    precision_ewma: AtomicU64,
+
+    /// Gauge of foreground (blocking) reads currently in flight. A
+    /// speculative read admitted while this is non-zero is directly
+    /// competing with a token-blocking miss for device bandwidth.
+    foreground_inflight: AtomicI64,
+
+    /// Rolling within-window counters folded into the EWMA by
+    /// [`Self::refresh`]. `completed` counts prefetch reads that landed;
+    /// `used` counts those that were consumed by a subsequent hit before
+    /// eviction.
+    window_completed: AtomicU64,
+    window_used: AtomicU64,
+
+    /// Telemetry: prefetches the governor declined to admit.
+    throttled: AtomicU64,
+    /// Telemetry: prefetches the governor admitted.
+    admitted: AtomicU64,
+}
+
+impl PrefetchGovernor {
+    /// Construct a governor. When `enabled` is `false` the controller is
+    /// a transparent pass-through: [`Self::admit`] always returns `true`
+    /// and the accounting hooks are no-ops, so the legacy unbounded
+    /// behaviour is preserved exactly.
+    pub fn new(enabled: bool, cfg: GovernorConfig) -> Self {
+        let floor = cfg.precision_floor.clamp(0.0, 1.0);
+        let g = Self {
+            enabled,
+            precision_alpha: cfg.precision_alpha.clamp(1e-3, 1.0),
+            precision_floor: floor,
+            contention_weight: cfg.contention_weight.max(0.0),
+            base_threshold: cfg.base_threshold.max(0.0),
+            precision_ewma: AtomicU64::new(0),
+            foreground_inflight: AtomicI64::new(0),
+            window_completed: AtomicU64::new(0),
+            window_used: AtomicU64::new(0),
+            throttled: AtomicU64::new(0),
+            admitted: AtomicU64::new(0),
+        };
+        // Seed the EWMA optimistically at `max(floor, 0.5)` so a freshly
+        // started engine gives speculation a fair chance to prove itself
+        // before the measured signal takes over.
+        store_f64(&g.precision_ewma, floor.max(0.5));
+        g
+    }
+
+    /// A disabled pass-through governor (no gating, no accounting).
+    pub fn disabled() -> Self {
+        Self::new(false, GovernorConfig::default())
+    }
+
+    #[inline]
+    pub fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    /// Decide whether a speculative read for an expert predicted with
+    /// probability/score `prob` should be admitted *right now*.
+    ///
+    /// Returns `true` unconditionally when the governor is disabled.
+    /// Otherwise admits iff
+    ///
+    /// ```text
+    ///   prob * max(precision_ewma, floor)
+    ///       >= base_threshold * (1 + contention_weight * foreground_inflight)
+    /// ```
+    ///
+    /// i.e. the expected value of the speculation (its probability scaled
+    /// by how often speculation has recently paid off) must clear a bar
+    /// that rises with the number of foreground misses currently
+    /// competing for the device.
+    #[inline]
+    pub fn admit(&self, prob: f64) -> bool {
+        if !self.enabled {
+            return true;
+        }
+        let precision = load_f64(&self.precision_ewma).max(self.precision_floor);
+        let inflight = self.foreground_inflight.load(Ordering::Relaxed).max(0) as f64;
+        let value = prob.max(0.0) * precision;
+        let bar = self.base_threshold * (1.0 + self.contention_weight * inflight);
+        let ok = value >= bar;
+        if ok {
+            self.admitted.fetch_add(1, Ordering::Relaxed);
+        } else {
+            self.throttled.fetch_add(1, Ordering::Relaxed);
+        }
+        ok
+    }
+
+    /// RAII-free gauge bump: a foreground (blocking) read has started.
+    /// Pair with [`Self::end_foreground`]. No-op when disabled.
+    #[inline]
+    pub fn begin_foreground(&self) {
+        if self.enabled {
+            self.foreground_inflight.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    /// A foreground read has finished. No-op when disabled.
+    #[inline]
+    pub fn end_foreground(&self) {
+        if self.enabled {
+            self.foreground_inflight.fetch_sub(1, Ordering::Relaxed);
+        }
+    }
+
+    /// Record that a speculative read landed (became resident).
+    #[inline]
+    pub fn record_completed(&self) {
+        if self.enabled {
+            self.window_completed.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    /// Record that a previously-prefetched expert was consumed by a hit
+    /// before it was evicted — i.e. the speculation paid off.
+    #[inline]
+    pub fn record_used(&self) {
+        if self.enabled {
+            self.window_used.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    /// Fold the current measurement window into the precision EWMA and
+    /// reset the window. Cheap enough to call once per token. When no
+    /// prefetches completed in the window the EWMA is left untouched
+    /// (no signal → no update), which keeps the controller stable during
+    /// cache-resident bursts.
+    pub fn refresh(&self) {
+        if !self.enabled {
+            return;
+        }
+        let completed = self.window_completed.swap(0, Ordering::Relaxed);
+        if completed == 0 {
+            // No completions ⇒ don't drag the EWMA toward 0 for an idle
+            // window; just clear any stray `used` credits.
+            self.window_used.store(0, Ordering::Relaxed);
+            return;
+        }
+        let used = self.window_used.swap(0, Ordering::Relaxed).min(completed);
+        let sample = used as f64 / completed as f64;
+        let prev = load_f64(&self.precision_ewma);
+        let next = prev + self.precision_alpha * (sample - prev);
+        store_f64(&self.precision_ewma, next.clamp(0.0, 1.0));
+    }
+
+    /// Current precision EWMA (for telemetry / the run summary).
+    pub fn precision(&self) -> f64 {
+        load_f64(&self.precision_ewma)
+    }
+
+    /// Current foreground-read gauge (for telemetry).
+    pub fn foreground_inflight(&self) -> i64 {
+        self.foreground_inflight.load(Ordering::Relaxed)
+    }
+
+    /// `(admitted, throttled)` admission decisions so far.
+    pub fn decisions(&self) -> (u64, u64) {
+        (
+            self.admitted.load(Ordering::Relaxed),
+            self.throttled.load(Ordering::Relaxed),
+        )
+    }
+}
+
+impl Default for PrefetchGovernor {
+    fn default() -> Self {
+        Self::disabled()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disabled_governor_admits_everything() {
+        let g = PrefetchGovernor::disabled();
+        assert!(g.admit(0.0));
+        assert!(g.admit(1.0));
+        // Accounting hooks are inert.
+        g.begin_foreground();
+        g.record_completed();
+        g.refresh();
+        assert!(g.admit(0.0));
+    }
+
+    #[test]
+    fn high_precision_idle_disk_admits() {
+        let g = PrefetchGovernor::new(true, GovernorConfig::default());
+        // Seeded optimistic; a confident prediction on an idle disk is
+        // admitted.
+        assert!(g.admit(0.9));
+    }
+
+    #[test]
+    fn collapsed_precision_throttles_even_when_idle() {
+        let g = PrefetchGovernor::new(true, GovernorConfig::default());
+        // Many windows of completed-but-never-used reads drive the
+        // precision EWMA down to its floor.
+        for _ in 0..40 {
+            for _ in 0..10 {
+                g.record_completed();
+            }
+            g.refresh();
+        }
+        // At the floor (0.05) a moderate 0.3-probability prediction's
+        // expected value (0.015) no longer clears even the idle bar
+        // (base_threshold 0.02), so it is declined.
+        assert!(!g.admit(0.3));
+        // A near-certain prediction (0.9 * 0.05 = 0.045) still gets
+        // through — the governor throttles junk, not signal.
+        assert!(g.admit(0.9));
+    }
+
+    #[test]
+    fn foreground_contention_raises_the_bar() {
+        let cfg = GovernorConfig {
+            // Isolate the contention term from the precision term.
+            precision_floor: 1.0,
+            base_threshold: 0.2,
+            contention_weight: 1.0,
+            ..GovernorConfig::default()
+        };
+        let g = PrefetchGovernor::new(true, cfg);
+        store_f64(&g.precision_ewma, 1.0);
+        // Idle disk: prob 0.3 clears the 0.2 bar.
+        assert!(g.admit(0.3));
+        // Two foreground misses in flight ⇒ bar = 0.2 * 3 = 0.6.
+        g.begin_foreground();
+        g.begin_foreground();
+        assert!(!g.admit(0.3));
+        // A near-certain prediction still gets through.
+        assert!(g.admit(0.9));
+        g.end_foreground();
+        g.end_foreground();
+        assert!(g.admit(0.3));
+    }
+
+    #[test]
+    fn precision_recovers_when_prefetches_get_used() {
+        let g = PrefetchGovernor::new(true, GovernorConfig::default());
+        for _ in 0..100 {
+            g.record_completed();
+        }
+        g.refresh(); // precision drops (0 used / 100 completed)
+        let low = g.precision();
+        // Now a window where every completion is consumed.
+        for _ in 0..100 {
+            g.record_completed();
+            g.record_used();
+        }
+        g.refresh();
+        assert!(g.precision() > low);
+    }
+
+    #[test]
+    fn used_is_clamped_to_completed() {
+        let g = PrefetchGovernor::new(true, GovernorConfig::default());
+        g.record_completed();
+        g.record_used();
+        g.record_used();
+        g.record_used();
+        // Should not panic or exceed 1.0.
+        g.refresh();
+        assert!(g.precision() <= 1.0);
+    }
+}

--- a/rust-engine/src/pregate.rs
+++ b/rust-engine/src/pregate.rs
@@ -1,0 +1,258 @@
+//! Tier 3 — per-layer **pre-gate** predictor.
+//!
+//! ## Idea
+//!
+//! In a real transformer the engine sees one MoE layer's routed expert
+//! set strictly *before* the next layer's — `forward` walks layers
+//! `0, 1, 2, …` in order, calling [`crate::engine::Engine::moe_step`]
+//! once per MoE layer. The experts a layer routes to are highly
+//! predictive of the *next* layer's routed set (consecutive layers
+//! operate on the same residual stream), so we can learn an online
+//! conditional map
+//!
+//! ```text
+//!   P(expert b routed in layer L+1 | expert a routed in layer L)
+//! ```
+//!
+//! and, the moment layer `L` routes, prefetch layer `L+1`'s likely
+//! experts from the SSD so their bytes land in RAM *while layer `L` is
+//! still computing*. Unlike the speculative arms that fire on a single
+//! hidden state, this is a **high-precision** signal: it conditions on
+//! the actual routing decision of the immediately preceding layer.
+//!
+//! ## Mechanism
+//!
+//! A per-source-expert frequency table is maintained for every layer
+//! transition `L → L+1`. Each `moe_step` call:
+//!   1. records the transition from the previously-seen layer's routed
+//!      set to the current one (when they are consecutive), and
+//!   2. predicts the *next* layer's experts from the current routed set,
+//!      returning them for the engine to prefetch.
+//!
+//! The whole feature is gated behind `pregate_enabled`; when off the
+//! engine never constructs a [`PerLayerPreGate`] and behaves exactly as
+//! before.
+//!
+//! ## Concurrency
+//!
+//! The "previous layer" link uses a single slot, which is exact for
+//! sequential decoding (the benchmark and single-stream serving). Under
+//! heavily-batched concurrent decoding the slot can occasionally link
+//! layers from different in-flight positions; because every prediction
+//! only drives *speculative* prefetch (wrong guesses waste bandwidth the
+//! Tier 4 governor can throttle, never correctness), this is acceptable
+//! and self-correcting as the frequency tables converge.
+
+use dashmap::DashMap;
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Predicted-confidence score attached to pre-gate prefetches. High by
+/// design — the prediction conditions on the previous layer's actual
+/// routing — so the Tier 4 governor admits it ahead of the low-value
+/// single-hidden-state speculation.
+pub const PREGATE_PREFETCH_PROB: f64 = 0.9;
+
+/// Per-source frequency table over next-layer targets.
+type TargetTable = Mutex<HashMap<u32, u64>>;
+
+/// Online layer-to-layer conditional expert predictor. See the module
+/// docs for the model.
+#[derive(Debug)]
+pub struct PerLayerPreGate {
+    /// `transitions[L]` maps a source expert routed in layer `L` to a
+    /// frequency table over the experts routed in layer `L+1`. Indexed
+    /// by source layer; the final layer has no successor so its slot is
+    /// never written.
+    transitions: Vec<DashMap<u32, TargetTable>>,
+    /// Number of next-layer experts to predict / prefetch per step.
+    top_n: usize,
+    /// Previous `moe_step`'s `(layer, routed_set, predicted_next)`. Used
+    /// to (a) link consecutive layers for transition recording and (b)
+    /// score the previous prediction against the now-known actual set.
+    last: Mutex<Option<LastStep>>,
+    /// Predictions that intersected the actually-routed next set.
+    hits: AtomicU64,
+    /// Predictions that missed.
+    misses: AtomicU64,
+}
+
+#[derive(Debug, Clone)]
+struct LastStep {
+    layer: u32,
+    routed: Vec<u32>,
+    predicted_next: Vec<u32>,
+}
+
+impl PerLayerPreGate {
+    /// Build a pre-gate over `num_layers` MoE layers predicting `top_n`
+    /// experts per transition. `top_n` is clamped to at least 1.
+    pub fn new(num_layers: usize, top_n: usize) -> Self {
+        let layers = num_layers.max(1);
+        let transitions = (0..layers).map(|_| DashMap::new()).collect();
+        Self {
+            transitions,
+            top_n: top_n.max(1),
+            last: Mutex::new(None),
+            hits: AtomicU64::new(0),
+            misses: AtomicU64::new(0),
+        }
+    }
+
+    /// Record the transition into `routed` at `layer` (from the
+    /// previously-observed layer, when consecutive), score the prior
+    /// prediction, and return the predicted expert set for layer
+    /// `layer + 1` so the caller can prefetch it. Returns an empty
+    /// vector until the relevant transition table has been seen at least
+    /// once.
+    pub fn observe_and_predict(&self, layer: u32, routed: &[u32]) -> Vec<u32> {
+        {
+            let mut last = self.last.lock();
+            if let Some(prev) = last.as_ref() {
+                // Only link strictly-consecutive layers.
+                if layer == prev.layer.wrapping_add(1) {
+                    self.record_transition(prev.layer, &prev.routed, routed);
+                    self.score_prediction(&prev.predicted_next, routed);
+                }
+            }
+            // Defer storing `last` until the prediction is computed so the
+            // borrow of `routed` is unambiguous; we update it below.
+            drop(last);
+        }
+
+        let predicted = self.predict(layer, routed);
+
+        let mut last = self.last.lock();
+        *last = Some(LastStep {
+            layer,
+            routed: routed.to_vec(),
+            predicted_next: predicted.clone(),
+        });
+        predicted
+    }
+
+    /// Record `source_set` (layer `src_layer`) → `target_set`
+    /// (layer `src_layer + 1`) co-occurrences.
+    fn record_transition(&self, src_layer: u32, source_set: &[u32], target_set: &[u32]) {
+        let Some(layer_map) = self.transitions.get(src_layer as usize) else {
+            return;
+        };
+        for &a in source_set {
+            let entry = layer_map.entry(a).or_default();
+            let mut table = entry.lock();
+            for &b in target_set {
+                *table.entry(b).or_insert(0) += 1;
+            }
+        }
+    }
+
+    /// Predict layer `layer + 1`'s experts from the current routed set by
+    /// summing each source expert's learned target frequencies and
+    /// taking the `top_n` highest.
+    fn predict(&self, layer: u32, routed: &[u32]) -> Vec<u32> {
+        let Some(layer_map) = self.transitions.get(layer as usize) else {
+            return Vec::new();
+        };
+        let mut scores: HashMap<u32, u64> = HashMap::new();
+        for &a in routed {
+            if let Some(entry) = layer_map.get(&a) {
+                let table = entry.lock();
+                for (&b, &c) in table.iter() {
+                    *scores.entry(b).or_insert(0) += c;
+                }
+            }
+        }
+        if scores.is_empty() {
+            return Vec::new();
+        }
+        let mut ranked: Vec<(u32, u64)> = scores.into_iter().collect();
+        // Highest score first; ties break by ascending id for determinism.
+        ranked.sort_unstable_by(|x, y| y.1.cmp(&x.1).then(x.0.cmp(&y.0)));
+        ranked.truncate(self.top_n);
+        ranked.into_iter().map(|(id, _)| id).collect()
+    }
+
+    /// Update hit/miss telemetry for a prediction against the actual set.
+    fn score_prediction(&self, predicted: &[u32], actual: &[u32]) {
+        if predicted.is_empty() {
+            return;
+        }
+        let intersects = predicted.iter().any(|p| actual.contains(p));
+        if intersects {
+            self.hits.fetch_add(1, Ordering::Relaxed);
+        } else {
+            self.misses.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    /// `(hits, misses)` for the predictions scored so far.
+    pub fn stats(&self) -> (u64, u64) {
+        (self.hits.load(Ordering::Relaxed), self.misses.load(Ordering::Relaxed))
+    }
+
+    /// Fraction of scored predictions that intersected the actual
+    /// next-layer set, in `[0, 1]`. `0.0` when nothing has been scored.
+    pub fn accuracy(&self) -> f64 {
+        let (h, m) = self.stats();
+        let total = h + m;
+        if total == 0 {
+            0.0
+        } else {
+            h as f64 / total as f64
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn learns_and_predicts_consecutive_layer_transition() {
+        // 3 MoE layers, predict up to 2 next-layer experts.
+        let pg = PerLayerPreGate::new(3, 2);
+
+        // First forward pass: layer0 {0,1} -> layer1 {10,11} -> layer2 {20}.
+        // No predictions yet (tables empty), but transitions are recorded.
+        assert!(pg.observe_and_predict(0, &[0, 1]).is_empty());
+        assert!(pg.observe_and_predict(1, &[10, 11]).is_empty());
+        assert!(pg.observe_and_predict(2, &[20]).is_empty());
+
+        // Reset the consecutive-layer link by starting a fresh pass at
+        // layer 0 — the second pass routes the same way.
+        let p0 = pg.observe_and_predict(0, &[0, 1]);
+        // Now layer 0's routed set {0,1} should predict layer 1's {10,11}.
+        let mut got = p0.clone();
+        got.sort_unstable();
+        assert_eq!(got, vec![10, 11], "layer0 set predicts layer1 experts");
+
+        let p1 = pg.observe_and_predict(1, &[10, 11]);
+        assert_eq!(p1, vec![20], "layer1 set predicts layer2 experts");
+    }
+
+    #[test]
+    fn non_consecutive_calls_do_not_record() {
+        let pg = PerLayerPreGate::new(4, 2);
+        // Jump from layer 0 to layer 2 (a non-consecutive link): nothing
+        // should be learned for transition 0->1.
+        pg.observe_and_predict(0, &[1, 2]);
+        pg.observe_and_predict(2, &[5, 6]);
+        // Re-routing layer 0 the same way yields no prediction.
+        assert!(pg.observe_and_predict(0, &[1, 2]).is_empty());
+    }
+
+    #[test]
+    fn accuracy_tracks_prediction_quality() {
+        let pg = PerLayerPreGate::new(2, 2);
+        // Train 0->1: {0} -> {9}.
+        pg.observe_and_predict(0, &[0]);
+        pg.observe_and_predict(1, &[9]);
+        // Second pass: predict {9} from {0}; actual next is {9} ⇒ hit.
+        pg.observe_and_predict(0, &[0]);
+        pg.observe_and_predict(1, &[9]);
+        let (hits, misses) = pg.stats();
+        assert_eq!((hits, misses), (1, 0), "one correctly-scored prediction");
+        assert!((pg.accuracy() - 1.0).abs() < 1e-9);
+    }
+}

--- a/rust-engine/src/residency.rs
+++ b/rust-engine/src/residency.rs
@@ -1,0 +1,226 @@
+//! Tier 1 — skew-aware **static residency**.
+//!
+//! ## Why this exists
+//!
+//! With a uniform-i.i.d. access stream the best any cache can do is a
+//! hit rate equal to its capacity fraction (the "C/E wall"): every
+//! expert is equally likely, so holding `c` of `e` experts hits `c/e` of
+//! the time. Real MoE routing is **not** uniform, though — a handful of
+//! experts are activated far more often than the rest. Static residency
+//! exploits that skew directly: it permanently pins the hottest
+//! `fraction` of experts into the RAM cache so they are *never* streamed
+//! from the SSD again, lifting the achievable hit rate above the bare
+//! capacity fraction.
+//!
+//! Two sources of the hot set are supported:
+//!
+//! * an **offline popularity profile** (`id → count` JSON, e.g. produced
+//!   by a previous run's `--profile-out`), applied at startup for an
+//!   immediate warm cache, or
+//! * an **online** hot set derived from the engine's own
+//!   `route_observations` after a warmup window.
+//!
+//! The whole feature is opt-in (`static_residency_fraction == 0.0`
+//! disables it), so default deployments are unchanged.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::atomic::AtomicBool;
+
+/// An expert-popularity profile: global expert id → observation count.
+///
+/// Serialised as a flat JSON object with string keys (`{"0": 1234,
+/// "5": 42, ...}`) so it round-trips through `serde_json` without a
+/// custom map-key codec and stays human-inspectable.
+#[derive(Debug, Clone, Default)]
+pub struct ResidencyProfile {
+    counts: HashMap<u32, u64>,
+}
+
+impl ResidencyProfile {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn from_counts(counts: HashMap<u32, u64>) -> Self {
+        Self { counts }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.counts.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.counts.len()
+    }
+
+    /// Observation count for `id` (0 when unseen).
+    pub fn get(&self, id: u32) -> u64 {
+        self.counts.get(&id).copied().unwrap_or(0)
+    }
+
+    /// Record one activation of `id`.
+    pub fn observe(&mut self, id: u32) {
+        *self.counts.entry(id).or_insert(0) += 1;
+    }
+
+    /// Load a profile from a JSON object `{ "<id>": <count>, ... }`.
+    pub fn load_json(path: &Path) -> std::io::Result<Self> {
+        let raw = std::fs::read_to_string(path)?;
+        let string_keyed: HashMap<String, u64> = serde_json::from_str(&raw)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        let mut counts = HashMap::with_capacity(string_keyed.len());
+        for (k, v) in string_keyed {
+            let id: u32 = k
+                .parse()
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+            counts.insert(id, v);
+        }
+        Ok(Self { counts })
+    }
+
+    /// Serialise to a JSON object `{ "<id>": <count>, ... }`. Keys are
+    /// emitted in ascending id order so successive dumps diff cleanly.
+    pub fn dump_json(&self, path: &Path) -> std::io::Result<()> {
+        let mut ordered: Vec<(u32, u64)> = self.counts.iter().map(|(k, v)| (*k, *v)).collect();
+        ordered.sort_unstable_by_key(|(k, _)| *k);
+        // Build an order-preserving string map for a stable on-disk form.
+        let mut buf = String::from("{");
+        for (i, (id, count)) in ordered.iter().enumerate() {
+            if i > 0 {
+                buf.push(',');
+            }
+            buf.push_str(&format!("\"{id}\":{count}"));
+        }
+        buf.push('}');
+        std::fs::write(path, buf)
+    }
+
+    /// The hottest `ceil(fraction × namespace)` expert ids, most-popular
+    /// first. Ties break by ascending id for determinism. `fraction` is
+    /// clamped to `[0, 1]`; `namespace` is the total expert count used to
+    /// size the pin budget (so the budget is a fraction of *all* experts,
+    /// not just the observed ones).
+    pub fn hot_set(&self, fraction: f64, namespace: usize) -> Vec<u32> {
+        let frac = fraction.clamp(0.0, 1.0);
+        if frac == 0.0 || namespace == 0 || self.counts.is_empty() {
+            return Vec::new();
+        }
+        let budget = ((namespace as f64) * frac).ceil() as usize;
+        if budget == 0 {
+            return Vec::new();
+        }
+        let mut ranked: Vec<(u32, u64)> = self.counts.iter().map(|(k, v)| (*k, *v)).collect();
+        // Sort by count desc, then id asc. Experts never observed are not
+        // in the map and are correctly excluded.
+        ranked.sort_unstable_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+        ranked.truncate(budget);
+        ranked.into_iter().map(|(id, _)| id).collect()
+    }
+}
+
+/// Engine-side controller state for static residency. Held behind an
+/// `Option` on the speculation struct; `None` means the feature is off.
+#[derive(Debug)]
+pub struct StaticResidencyState {
+    /// Fraction of the global expert namespace to pin (`(0, 1]`).
+    pub fraction: f64,
+    /// Tokens to observe before deriving an *online* hot set. Ignored
+    /// when a seed `profile` is supplied (that is applied immediately).
+    pub warmup_tokens: u64,
+    /// Total expert count, used to size the pin budget.
+    pub namespace: usize,
+    /// Optional offline seed profile. When `Some`, its hot set is pinned
+    /// at the first opportunity with no warmup; when `None`, the hot set
+    /// is derived online from the engine's `route_observations`.
+    pub profile: Option<ResidencyProfile>,
+    /// One-shot latch: set once the hot set has been pinned so the
+    /// engine applies it exactly once.
+    pub applied: AtomicBool,
+}
+
+impl StaticResidencyState {
+    pub fn new(
+        fraction: f64,
+        warmup_tokens: u64,
+        namespace: usize,
+        profile: Option<ResidencyProfile>,
+    ) -> Self {
+        Self {
+            fraction,
+            warmup_tokens,
+            namespace,
+            profile,
+            applied: AtomicBool::new(false),
+        }
+    }
+
+    /// Whether this controller derives its hot set online (no seed
+    /// profile), and therefore needs `route_observations` populated.
+    pub fn is_online(&self) -> bool {
+        self.profile.is_none()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hot_set_picks_top_fraction_by_count() {
+        let mut p = ResidencyProfile::new();
+        // ids 0..10, counts increasing with id.
+        for id in 0..10u32 {
+            for _ in 0..=id {
+                p.observe(id);
+            }
+        }
+        // 20% of a 10-expert namespace = 2 experts: the two hottest (9, 8).
+        let hot = p.hot_set(0.2, 10);
+        assert_eq!(hot, vec![9, 8]);
+    }
+
+    #[test]
+    fn hot_set_zero_fraction_is_empty() {
+        let mut p = ResidencyProfile::new();
+        p.observe(1);
+        assert!(p.hot_set(0.0, 100).is_empty());
+    }
+
+    #[test]
+    fn hot_set_ceils_budget() {
+        let mut p = ResidencyProfile::new();
+        for id in 0..3u32 {
+            p.observe(id);
+        }
+        // ceil(0.1 * 3) = 1.
+        assert_eq!(p.hot_set(0.1, 3).len(), 1);
+    }
+
+    #[test]
+    fn hot_set_breaks_ties_by_ascending_id() {
+        let mut p = ResidencyProfile::new();
+        // All equal counts → tie broken by id, so the lowest ids win.
+        for id in [7u32, 3, 9, 1] {
+            p.observe(id);
+        }
+        let hot = p.hot_set(0.5, 4); // ceil(0.5*4)=2
+        assert_eq!(hot, vec![1, 3]);
+    }
+
+    #[test]
+    fn json_round_trips() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("residency_test_{}.json", std::process::id()));
+        let mut p = ResidencyProfile::new();
+        p.observe(5);
+        p.observe(5);
+        p.observe(42);
+        p.dump_json(&path).unwrap();
+        let loaded = ResidencyProfile::load_json(&path).unwrap();
+        assert_eq!(loaded.get(5), 2);
+        assert_eq!(loaded.get(42), 1);
+        assert_eq!(loaded.get(0), 0);
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/rust-engine/src/residency.rs
+++ b/rust-engine/src/residency.rs
@@ -110,7 +110,18 @@ impl ResidencyProfile {
         if budget == 0 {
             return Vec::new();
         }
-        let mut ranked: Vec<(u32, u64)> = self.counts.iter().map(|(k, v)| (*k, *v)).collect();
+        // Exclude ids outside the active namespace: a stale/offline profile
+        // from a different model can reference ids >= namespace that would
+        // otherwise waste hot-set slots on experts the router can't address.
+        let mut ranked: Vec<(u32, u64)> = self
+            .counts
+            .iter()
+            .filter(|(id, _)| (**id as usize) < namespace)
+            .map(|(k, v)| (*k, *v))
+            .collect();
+        if ranked.is_empty() {
+            return Vec::new();
+        }
         // Sort by count desc, then id asc. Experts never observed are not
         // in the map and are correctly excluded.
         ranked.sort_unstable_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
@@ -195,6 +206,24 @@ mod tests {
         }
         // ceil(0.1 * 3) = 1.
         assert_eq!(p.hot_set(0.1, 3).len(), 1);
+    }
+
+    #[test]
+    fn hot_set_excludes_ids_outside_namespace() {
+        let mut p = ResidencyProfile::new();
+        // A stale id from a larger model dominates the counts but must not
+        // be pinned: it is outside the active 8-expert namespace.
+        for _ in 0..100 {
+            p.observe(99);
+        }
+        for _ in 0..5 {
+            p.observe(2);
+        }
+        for _ in 0..3 {
+            p.observe(5);
+        }
+        // namespace = 8, budget = ceil(0.25 * 8) = 2.
+        assert_eq!(p.hot_set(0.25, 8), vec![2, 5]);
     }
 
     #[test]

--- a/rust-engine/src/server.rs
+++ b/rust-engine/src/server.rs
@@ -1499,6 +1499,8 @@ mod tests {
                 predict_min_prob: 0.05,
                 partial_load_fraction: 1.0,
                 pin_after_observations: 0,
+                packed_blob: None,
+                packed_manifest: None,
             },
             tokenizer: crate::config::TokenizerConfig::default(),
             real_transformer: crate::config::RealTransformerConfig::default(),

--- a/rust-engine/src/workload.rs
+++ b/rust-engine/src/workload.rs
@@ -210,7 +210,18 @@ impl ReplayStream {
             if let Some(arr) = value.get("experts").and_then(|e| e.as_array()) {
                 let experts: Vec<u32> = arr
                     .iter()
-                    .filter_map(|x| x.as_u64().map(|n| n as u32))
+                    .filter_map(|x| x.as_u64())
+                    .filter_map(|n| {
+                        if n > u32::MAX as u64 {
+                            tracing::warn!(
+                                expert_id = n,
+                                "replay trace expert id exceeds u32::MAX; skipping"
+                            );
+                            None
+                        } else {
+                            Some(n as u32)
+                        }
+                    })
                     .collect();
                 if !experts.is_empty() {
                     records.push(ReplayRecord {
@@ -358,6 +369,19 @@ mod tests {
         assert_eq!(third.experts, vec![5]);
         // Cycles back to the start.
         assert_eq!(r.next_experts(), Some(vec![3, 7]));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn replay_skips_expert_ids_exceeding_u32() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("replay_overflow_{}.jsonl", std::process::id()));
+        // 4294967296 == u32::MAX + 1; a silent `as u32` cast would truncate
+        // it to 0, so the guard must drop it instead.
+        std::fs::write(&path, "{\"experts\":[5,4294967296,7]}\n").unwrap();
+        let mut r = ReplayStream::load(&path).unwrap();
+        let rec = r.next_record().unwrap();
+        assert_eq!(rec.experts, vec![5, 7]);
         let _ = std::fs::remove_file(&path);
     }
 }

--- a/rust-engine/src/workload.rs
+++ b/rust-engine/src/workload.rs
@@ -1,0 +1,325 @@
+//! Workload harness for the streaming benchmark.
+//!
+//! The default `synthetic` benchmark feeds the engine a fresh
+//! `splitmix64` hidden state per token, so the realised routing stream
+//! is effectively uniform-i.i.d.: every expert is equally likely and
+//! independent of history. On such a stream the best any cache can do is
+//! a hit rate equal to its capacity fraction (the "C/E wall"), and a
+//! predictor cannot beat chance — which is exactly why the speculative
+//! arms look inert on it.
+//!
+//! Real MoE routing is neither uniform nor memoryless: a handful of
+//! experts are activated far more often than the rest (popularity
+//! **skew**), and consecutive tokens reuse overlapping expert sets
+//! (temporal **correlation**). This module synthesises streams with
+//! both properties so the skew-aware (Tier 1 static residency) and
+//! correlation-aware (Markov / affinity / Tier 3 pre-gate) machinery is
+//! actually *falsifiable*:
+//!
+//! * [`Workload::Skewed`] — a Zipf popularity distribution over experts
+//!   plus a tunable Markov "stay" probability for temporal correlation.
+//! * [`Workload::Replay`] — replays a recorded JSONL routing trace (the
+//!   `--trace-out` format), so a real model's routing can drive the
+//!   cache/predictor harness offline.
+
+use std::path::Path;
+
+/// Which benchmark workload `cmd_run` should drive the engine with.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Workload {
+    /// Legacy behaviour: the engine routes its own per-token synthetic
+    /// hidden state (uniform-i.i.d.), or the `--gate-weights` gate does.
+    Synthetic,
+    /// Zipf popularity + Markov temporal correlation, generated here and
+    /// fed to `moe_step` as an explicit expert set.
+    Skewed,
+    /// Replay an external JSONL routing trace through `moe_step`.
+    Replay,
+}
+
+impl Workload {
+    pub fn from_str_opt(s: &str) -> Option<Self> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "synthetic" | "synth" | "uniform" => Some(Self::Synthetic),
+            "skewed" | "skew" | "zipf" => Some(Self::Skewed),
+            "replay" | "trace" => Some(Self::Replay),
+            _ => None,
+        }
+    }
+}
+
+/// SplitMix64 — the same tiny deterministic PRNG the synthetic hidden
+/// state uses, so workloads are reproducible from a seed.
+#[inline]
+fn splitmix64(state: &mut u64) -> u64 {
+    *state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    let mut z = *state;
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
+}
+
+/// Uniform `f64` in `[0, 1)` with 53 bits of entropy.
+#[inline]
+fn next_unit(state: &mut u64) -> f64 {
+    (splitmix64(state) >> 11) as f64 / ((1u64 << 53) as f64)
+}
+
+/// A Zipf-popular, optionally Markov-correlated stream of top-K expert
+/// sets. Deterministic given its seed.
+#[derive(Debug)]
+pub struct SkewedStream {
+    top_k: usize,
+    /// Probability a token *reuses* the previous token's expert set
+    /// (temporal correlation). `0.0` ⇒ i.i.d. draws from the Zipf law.
+    rho: f64,
+    /// Rank → expert id permutation. Decouples "popularity rank" from
+    /// the raw id so the hot set isn't trivially `{0, 1, 2, ...}` (which
+    /// could accidentally coincide with on-disk layout).
+    rank_to_id: Vec<u32>,
+    /// Cumulative distribution over ranks (`cdf[r]` = P(rank <= r)).
+    cdf: Vec<f64>,
+    state: u64,
+    prev: Vec<u32>,
+}
+
+impl SkewedStream {
+    /// Build a stream over `num_experts` drawing `top_k` distinct
+    /// experts per token. `zipf_s` is the Zipf exponent (larger ⇒ more
+    /// skew; `1.0` is classic Zipf, `0.0` is uniform). `correlation` is
+    /// the Markov stay-probability in `[0, 1]`.
+    pub fn new(num_experts: u32, top_k: usize, zipf_s: f64, correlation: f64, seed: u64) -> Self {
+        let n = num_experts.max(1) as usize;
+        let k = top_k.clamp(1, n);
+        let s = zipf_s.max(0.0);
+
+        // Zipf weights w_r = 1 / (r+1)^s over ranks r = 0..n, normalised
+        // into a CDF for inverse-transform sampling.
+        let mut weights = Vec::with_capacity(n);
+        let mut total = 0.0f64;
+        for r in 0..n {
+            let w = 1.0 / ((r as f64) + 1.0).powf(s);
+            total += w;
+            weights.push(w);
+        }
+        let mut cdf = Vec::with_capacity(n);
+        let mut acc = 0.0f64;
+        for w in &weights {
+            acc += w / total;
+            cdf.push(acc);
+        }
+        if let Some(last) = cdf.last_mut() {
+            *last = 1.0; // guard against fp drift so the search never falls off the end
+        }
+
+        // Deterministic Fisher-Yates shuffle of expert ids → rank map.
+        let mut perm_state = seed ^ 0xD1B5_4A32_D192_ED03;
+        let mut rank_to_id: Vec<u32> = (0..num_experts.max(1)).collect();
+        for i in (1..rank_to_id.len()).rev() {
+            let j = (splitmix64(&mut perm_state) % (i as u64 + 1)) as usize;
+            rank_to_id.swap(i, j);
+        }
+
+        Self {
+            top_k: k,
+            rho: correlation.clamp(0.0, 1.0),
+            rank_to_id,
+            cdf,
+            state: seed.wrapping_add(0x1234_5678),
+            prev: Vec::new(),
+        }
+    }
+
+    /// Map a uniform `u in [0,1)` to a rank via binary search on the CDF.
+    fn sample_rank(&self, u: f64) -> usize {
+        match self
+            .cdf
+            .binary_search_by(|p| p.partial_cmp(&u).unwrap_or(std::cmp::Ordering::Less))
+        {
+            Ok(i) => i,
+            Err(i) => i.min(self.cdf.len().saturating_sub(1)),
+        }
+    }
+
+    /// Produce the next token's top-K expert set.
+    pub fn next_experts(&mut self) -> Vec<u32> {
+        // Temporal correlation: with probability `rho`, reuse the
+        // previous token's set verbatim (a Markov "stay").
+        if !self.prev.is_empty() && next_unit(&mut self.state) < self.rho {
+            return self.prev.clone();
+        }
+        let mut chosen: Vec<u32> = Vec::with_capacity(self.top_k);
+        let guard_max = self.top_k.saturating_mul(64).max(64);
+        let mut guard = 0;
+        while chosen.len() < self.top_k && guard < guard_max {
+            let u = next_unit(&mut self.state);
+            let rank = self.sample_rank(u);
+            let id = self.rank_to_id[rank];
+            if !chosen.contains(&id) {
+                chosen.push(id);
+            }
+            guard += 1;
+        }
+        // Degenerate fallback (tiny namespaces / pathological draws):
+        // top up deterministically so the set is always full.
+        let mut r = 0usize;
+        while chosen.len() < self.top_k && r < self.rank_to_id.len() {
+            let id = self.rank_to_id[r];
+            if !chosen.contains(&id) {
+                chosen.push(id);
+            }
+            r += 1;
+        }
+        self.prev = chosen.clone();
+        chosen
+    }
+}
+
+/// Replays the `experts` arrays of a recorded JSONL routing trace (the
+/// `--trace-out` format). Cycles back to the start when exhausted so a
+/// short trace can drive an arbitrarily long benchmark.
+#[derive(Debug)]
+pub struct ReplayStream {
+    records: Vec<Vec<u32>>,
+    idx: usize,
+}
+
+impl ReplayStream {
+    /// Load every `{"experts":[...]}` record from `path`, in file order.
+    pub fn load(path: &Path) -> std::io::Result<Self> {
+        let text = std::fs::read_to_string(path)?;
+        let mut records = Vec::new();
+        for line in text.lines() {
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            let value: serde_json::Value = serde_json::from_str(line)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+            if let Some(arr) = value.get("experts").and_then(|e| e.as_array()) {
+                let experts: Vec<u32> = arr
+                    .iter()
+                    .filter_map(|x| x.as_u64().map(|n| n as u32))
+                    .collect();
+                if !experts.is_empty() {
+                    records.push(experts);
+                }
+            }
+        }
+        Ok(Self { records, idx: 0 })
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.records.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.records.len()
+    }
+
+    /// Next expert set, cycling through the trace. `None` only when the
+    /// trace contained no usable records.
+    pub fn next_experts(&mut self) -> Option<Vec<u32>> {
+        if self.records.is_empty() {
+            return None;
+        }
+        let rec = self.records[self.idx % self.records.len()].clone();
+        self.idx += 1;
+        Some(rec)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn workload_parses_aliases() {
+        assert_eq!(Workload::from_str_opt("synthetic"), Some(Workload::Synthetic));
+        assert_eq!(Workload::from_str_opt("ZIPF"), Some(Workload::Skewed));
+        assert_eq!(Workload::from_str_opt(" replay "), Some(Workload::Replay));
+        assert_eq!(Workload::from_str_opt("nope"), None);
+    }
+
+    #[test]
+    fn skewed_stream_is_actually_skewed() {
+        let n = 64u32;
+        let mut s = SkewedStream::new(n, 2, /*zipf_s=*/ 1.2, /*correlation=*/ 0.0, 0xABCD);
+        let mut counts: HashMap<u32, u64> = HashMap::new();
+        for _ in 0..20_000 {
+            for id in s.next_experts() {
+                *counts.entry(id).or_insert(0) += 1;
+            }
+        }
+        // The most popular rank (rank 0) must dominate the median expert
+        // by a wide margin under a Zipf law.
+        let hottest_id = s.rank_to_id[0];
+        let hottest = *counts.get(&hottest_id).unwrap_or(&0);
+        let mut all: Vec<u64> = counts.values().copied().collect();
+        all.sort_unstable();
+        let median = all[all.len() / 2];
+        assert!(
+            hottest > median * 5,
+            "Zipf hot expert ({hottest}) should dwarf the median ({median})"
+        );
+    }
+
+    #[test]
+    fn skewed_top_set_is_distinct_and_full() {
+        let mut s = SkewedStream::new(32, 4, 1.0, 0.0, 7);
+        for _ in 0..1000 {
+            let e = s.next_experts();
+            assert_eq!(e.len(), 4, "always top_k experts");
+            let mut uniq = e.clone();
+            uniq.sort_unstable();
+            uniq.dedup();
+            assert_eq!(uniq.len(), e.len(), "experts within a token are distinct");
+        }
+    }
+
+    #[test]
+    fn correlation_increases_consecutive_overlap() {
+        // High stay-probability ⇒ many consecutive tokens are identical;
+        // zero correlation ⇒ far fewer exact repeats.
+        let count_repeats = |rho: f64| {
+            let mut s = SkewedStream::new(128, 2, 0.8, rho, 99);
+            let mut prev = s.next_experts();
+            let mut repeats = 0;
+            for _ in 0..5000 {
+                let cur = s.next_experts();
+                if cur == prev {
+                    repeats += 1;
+                }
+                prev = cur;
+            }
+            repeats
+        };
+        let correlated = count_repeats(0.9);
+        let independent = count_repeats(0.0);
+        assert!(
+            correlated > independent * 3,
+            "rho=0.9 ({correlated} repeats) must be far more correlated than rho=0 ({independent})"
+        );
+    }
+
+    #[test]
+    fn replay_round_trips_a_small_trace() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("replay_test_{}.jsonl", std::process::id()));
+        std::fs::write(
+            &path,
+            "{\"token\":0,\"layer\":0,\"experts\":[3,7]}\n\
+             \n\
+             {\"token\":1,\"layer\":0,\"experts\":[1,4,9]}\n",
+        )
+        .unwrap();
+        let mut r = ReplayStream::load(&path).unwrap();
+        assert_eq!(r.len(), 2);
+        assert_eq!(r.next_experts(), Some(vec![3, 7]));
+        assert_eq!(r.next_experts(), Some(vec![1, 4, 9]));
+        // Cycles back to the start.
+        assert_eq!(r.next_experts(), Some(vec![3, 7]));
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/rust-engine/src/workload.rs
+++ b/rust-engine/src/workload.rs
@@ -175,20 +175,29 @@ impl SkewedStream {
     }
 }
 
-/// Replays the `experts` arrays of a recorded JSONL routing trace (the
-/// `--trace-out` format). Cycles back to the start when exhausted so a
-/// short trace can drive an arbitrarily long benchmark.
+/// One replayed routing record from a JSONL trace.
+#[derive(Debug, Clone)]
+pub struct ReplayRecord {
+    pub token: u64,
+    pub layer: usize,
+    pub experts: Vec<u32>,
+}
+
+/// Replays recorded JSONL routing trace records (the `--trace-out` format).
+/// Cycles back to the start when exhausted so a short trace can drive an
+/// arbitrarily long benchmark.
 #[derive(Debug)]
 pub struct ReplayStream {
-    records: Vec<Vec<u32>>,
+    records: Vec<ReplayRecord>,
     idx: usize,
 }
 
 impl ReplayStream {
-    /// Load every `{"experts":[...]}` record from `path`, in file order.
+    /// Load every usable `{"experts":[...]}` record from `path`, in file order.
     pub fn load(path: &Path) -> std::io::Result<Self> {
         let text = std::fs::read_to_string(path)?;
         let mut records = Vec::new();
+        let mut record_index = 0u64;
         for line in text.lines() {
             let line = line.trim();
             if line.is_empty() {
@@ -196,13 +205,25 @@ impl ReplayStream {
             }
             let value: serde_json::Value = serde_json::from_str(line)
                 .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+            let default_token = record_index;
+            record_index += 1;
             if let Some(arr) = value.get("experts").and_then(|e| e.as_array()) {
                 let experts: Vec<u32> = arr
                     .iter()
                     .filter_map(|x| x.as_u64().map(|n| n as u32))
                     .collect();
                 if !experts.is_empty() {
-                    records.push(experts);
+                    records.push(ReplayRecord {
+                        token: value
+                            .get("token")
+                            .and_then(|t| t.as_u64())
+                            .unwrap_or(default_token),
+                        layer: value
+                            .get("layer")
+                            .and_then(|l| l.as_u64())
+                            .unwrap_or(0) as usize,
+                        experts,
+                    });
                 }
             }
         }
@@ -217,15 +238,22 @@ impl ReplayStream {
         self.records.len()
     }
 
-    /// Next expert set, cycling through the trace. `None` only when the
+    /// Next replay record, cycling through the trace. `None` only when the
     /// trace contained no usable records.
-    pub fn next_experts(&mut self) -> Option<Vec<u32>> {
+    pub fn next_record(&mut self) -> Option<ReplayRecord> {
         if self.records.is_empty() {
             return None;
         }
         let rec = self.records[self.idx % self.records.len()].clone();
         self.idx += 1;
         Some(rec)
+    }
+
+    /// Next expert set, cycling through the trace. `None` only when the
+    /// trace contained no usable records.
+    #[allow(dead_code)]
+    pub fn next_experts(&mut self) -> Option<Vec<u32>> {
+        self.next_record().map(|record| record.experts)
     }
 }
 
@@ -309,15 +337,25 @@ mod tests {
         let path = dir.join(format!("replay_test_{}.jsonl", std::process::id()));
         std::fs::write(
             &path,
-            "{\"token\":0,\"layer\":0,\"experts\":[3,7]}\n\
-             \n\
-             {\"token\":1,\"layer\":0,\"experts\":[1,4,9]}\n",
+            "{\"token\":10,\"layer\":2,\"experts\":[3,7]}\n\
+             {\"token\":11,\"layer\":3,\"experts\":[1,4,9]}\n\
+             {\"experts\":[5]}\n",
         )
         .unwrap();
         let mut r = ReplayStream::load(&path).unwrap();
-        assert_eq!(r.len(), 2);
-        assert_eq!(r.next_experts(), Some(vec![3, 7]));
-        assert_eq!(r.next_experts(), Some(vec![1, 4, 9]));
+        assert_eq!(r.len(), 3);
+        let first = r.next_record().unwrap();
+        assert_eq!(first.token, 10);
+        assert_eq!(first.layer, 2);
+        assert_eq!(first.experts, vec![3, 7]);
+        let second = r.next_record().unwrap();
+        assert_eq!(second.token, 11);
+        assert_eq!(second.layer, 3);
+        assert_eq!(second.experts, vec![1, 4, 9]);
+        let third = r.next_record().unwrap();
+        assert_eq!(third.token, 2);
+        assert_eq!(third.layer, 0);
+        assert_eq!(third.experts, vec![5]);
         // Cycles back to the start.
         assert_eq!(r.next_experts(), Some(vec![3, 7]));
         let _ = std::fs::remove_file(&path);


### PR DESCRIPTION
## The problem

On the Mixtral 8x7B run, hit rate tracked the cache fraction almost exactly — 128/256 slots (50%) → **57.7% hit rate** — so streaming from SSD bought nothing over the RAM we paid for. The predictors were inert (locality 0.00%, speculator 0.82% ≈ random `2/256`).

**Root cause (information-theoretic, not a bug):** the benchmark feeds `synth_hidden_state(t) = splitmix64(t, seed)` — every token is an **independent, uniform** random vector. Under a uniform‑i.i.d. access stream the optimal hit rate of *any* cache of capacity `c` over `N` experts is exactly `c/N`, and **no predictor can beat the diagonal**. Worse, chance-accuracy speculation floods a saturated NVMe queue and inflates foreground-miss latency (p50 read 120 ms → 405 ms). Real MoE traces are Zipf-skewed + Markov-correlated; these tiers exploit exactly those two properties.

Every tier is **opt-in**. With defaults unchanged the engine streams bit-for-bit as before (446 tests pass, 1 ignored).

## What's in this PR

| Tier | What | Knobs |
|---|---|---|
| **Harness** | `--workload synthetic\|skewed\|replay` so Tiers 1/3 are falsifiable (Zipf popularity + Markov correlation; or replay a `--trace-out` JSONL). Skewed @ 50% cache ≈ 90% hit vs ~50% wall. | `--workload`, `--zipf-s`, `--workload-correlation`, `--replay-trace` |
| **Tier 1** | Skew-aware **static residency** — pin the hottest fraction (online-derived after warmup, or from a profile) so popular experts are read at most once. | `--static-residency-fraction/-warmup-tokens/-profile`, `--profile-out` |
| **Tier 2** | **Packed expert storage** — one blob + JSON manifest; physically-adjacent experts coalesce into a single vectored `preadv(2)`. New `repack` subcommand. Falls back to per-file retry/breaker path on any short/failed read (byte-identical; integration-tested). | `repack`, `--packed-blob`, `--packed-manifest`, `[storage]` |
| **Tier 3** | Per-layer **pre-gate** — online layer‑L→L+1 conditional drives high-precision next-layer prefetch (multi-layer / replay path). | `--pregate` |
| **Tier 4** | Adaptive **prefetch governor** (throttles low-precision speculation under disk contention — the antidote to the self-inflicted latency above) + **cost-aware eviction** (decaying heat score vs strict LRU). | `--prefetch-governor`, `--prefetch-precision-floor`, `--prefetch-contention-weight`, `--cost-aware-eviction` |

New modules: `residency.rs`, `workload.rs`, `pregate.rs`, `packed_storage.rs`, `prefetch_governor.rs`. Telemetry: gated `governor:` and `pregate:` run-summary lines; legacy summary shape untouched when off.

## Validation
- `cargo build --offline` clean; `cargo test --offline --bin micro-expert-router` → **446 passed, 1 ignored**.
- Tier 2 verified end-to-end via the CLI (`repack` → 128 MiB blob; packed run byte-identical, ~90.7% hit on skewed workload).
- All new flag/config/summary-line names cross-checked against the code.

## Docs
README gains a **"Defeating the cache-fraction wall"** section (root-cause + all four tiers + harness), CLI reference entries (run flags + `repack`), serve-time `[predictive]`/`[storage]` blocks, `config.toml` knobs, TOC, and limitations (incl. the note that Tier 3 only contributes on the multi-layer/replay path).

## Caveats
- Skewed-workload hit-rate figures are cache-simulator results, not full-model inference.
- Tier 3 pre-gate is unit-tested; it needs a `--num-layers > 1` / real-model / replay run to exercise end-to-end (the flat single-namespace benchmark has no next layer to predict).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Streaming tiers (1-4) for optimized expert caching and prefetching strategies
  * Packed expert storage for efficient multi-expert reads
  * Adaptive prefetch governor with contention-aware admission throttling
  * Cost-aware eviction based on thermal decay scoring
  * Per-layer pre-gate expert predictor for next-layer prefetching
  * Static residency pinning to keep hot experts memory-resident
  * New `repack` CLI command to prepare packed storage layouts
  * Workload selection modes (synthetic, skewed, replay from traces)

* **Documentation**
  * Comprehensive guide for streaming tier mechanisms and configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->