### PR TITLE
QA: fix latent bugs, harden numerics, wire telemetry, prune dead code

### DIFF
--- a/rust-engine/src/batch_scheduler.rs
+++ b/rust-engine/src/batch_scheduler.rs
@@ -1147,7 +1147,6 @@ mod tests {
     use super::*;
     use crate::buffer_pool::BufferPool;
     use crate::engine::{Engine, EngineOptions, ModelShape};
-    use crate::expert_cache::ExpertCache;
     use crate::multi_layer_cache::MultiLayerExpertCache;
     use crate::io_provider::{generate_synthetic_experts, NvmeStorage, StorageConfig};
     use crate::model::{RealModel, RealModelConfig};

--- a/rust-engine/src/draft.rs
+++ b/rust-engine/src/draft.rs
@@ -443,7 +443,6 @@ impl RealModel {
 mod tests {
     use super::*;
     use crate::engine::{EngineOptions, ModelShape};
-    use crate::expert_cache::ExpertCache;
     use crate::multi_layer_cache::MultiLayerExpertCache;
     use crate::buffer_pool::BufferPool;
     use crate::io_provider::{NvmeStorage, StorageConfig};

--- a/rust-engine/src/engine.rs
+++ b/rust-engine/src/engine.rs
@@ -34,7 +34,6 @@ use crate::router::{
 };
 use dashmap::DashMap;
 use hdrhistogram::Histogram;
-use parking_lot::Mutex;
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -4133,8 +4132,6 @@ if let Some(gpu) = me.core.gpu_cache.as_ref() {
             tokens_processed: tokens,
             avg_io_wait_us,
             avg_compute_us,
-            total_io_wait_us,
-            total_cycle_us,
             pct_time_io,
             io_only: self.core.options.io_only,
             pinned_count: self.core.cache.pinned_count(),
@@ -4233,6 +4230,11 @@ if let Some(gpu) = me.core.gpu_cache.as_ref() {
                 .as_ref()
                 .map(|pg| pg.stats().1)
                 .unwrap_or(0),
+            singleflight_followers: self
+                .metrics
+                .counters
+                .singleflight_followers
+                .load(Ordering::Relaxed),
         }
     }
 
@@ -4269,6 +4271,15 @@ if let Some(gpu) = me.core.gpu_cache.as_ref() {
             r.io_count,
             r.bytes_read as f64 / (1024.0 * 1024.0)
         );
+        // SSD read de-duplication win — only emitted when singleflight
+        // coalescing actually saved a read, so the legacy summary shape is
+        // preserved for runs/tests that never contend on the same expert.
+        if r.singleflight_followers > 0 {
+            info!(
+                "dedup:         {} concurrent reads coalesced onto in-flight leaders",
+                r.singleflight_followers
+            );
+        }
         info!(
             "i/o latency:   p50={}us  p95={}us  p99={}us",
             r.io_p50_us, r.io_p95_us, r.io_p99_us
@@ -4343,6 +4354,30 @@ if let Some(gpu) = me.core.gpu_cache.as_ref() {
                 r.pregate_hits + r.pregate_misses,
             );
         }
+        // Health diagnostics — only emitted when something actually
+        // degraded, so the legacy summary shape is preserved for clean
+        // runs. These counters are otherwise only legible via the
+        // Prometheus exporter; surfacing them here makes a problem run
+        // self-explanatory from the CLI summary alone.
+        let prefetch_dropped = r.prefetch_dropped_concurrency
+            + r.prefetch_dropped_pool_starved
+            + r.prefetch_dropped_governor;
+        if prefetch_dropped > 0
+            || r.gpu_cpu_fallbacks > 0
+            || r.speculator_dmodel_mismatch > 0
+            || r.expert_read_failures > 0
+        {
+            info!(
+                "diagnostics:   prefetch_dropped={} (concurrency={} pool_starved={} governor={})  gpu_cpu_fallbacks={}  speculator_dmodel_mismatch={}  expert_read_failures={}",
+                prefetch_dropped,
+                r.prefetch_dropped_concurrency,
+                r.prefetch_dropped_pool_starved,
+                r.prefetch_dropped_governor,
+                r.gpu_cpu_fallbacks,
+                r.speculator_dmodel_mismatch,
+                r.expert_read_failures,
+            );
+        }
         info!("=======================================================");
     }
 }
@@ -4379,13 +4414,9 @@ pub struct EngineReport {
     /// Mean per-token compute (FFN forward, or XOR-digest under
     /// `--io-only`), in microseconds.
     pub avg_compute_us: f64,
-    /// Sum of per-token critical-path I/O wait (microseconds).
-    pub total_io_wait_us: u64,
-    /// Sum of per-token cycle time (microseconds).
-    pub total_cycle_us: u64,
-    /// `total_io_wait_us / total_cycle_us * 100` — the headline "what
-    /// fraction of token time was the engine waiting on SSD?" number
-    /// the gist asks the run summary to print.
+    /// Total per-token critical-path I/O wait as a percentage of total
+    /// token cycle time — the headline "what fraction of token time was
+    /// the engine waiting on SSD?" number the run summary prints.
     pub pct_time_io: f64,
     /// Whether this run was executed in `--io-only` mode (FFN skipped).
     pub io_only: bool,
@@ -4487,6 +4518,11 @@ pub struct EngineReport {
     pub pregate_hits: u64,
     /// **Tier 3.** Pre-gate predictions that missed.
     pub pregate_misses: u64,
+    /// Concurrent `fetch_with_retry` callers that piggy-backed on an
+    /// in-flight leader's read (or a just-published resident) instead of
+    /// issuing their own (Phase 1 — SSD read de-duplication). Each one
+    /// maps directly to one disk read that was avoided.
+    pub singleflight_followers: u64,
 }
 
 #[cfg(test)]
@@ -4501,7 +4537,6 @@ mod tests {
     //! Engine::generate loop" gap closed.
     use super::*;
     use crate::buffer_pool::BufferPool;
-    use crate::expert_cache::ExpertCache;
     use crate::io_provider::{generate_synthetic_experts, NvmeStorage, StorageConfig};
     use crate::router::{PredictiveLoader, TopKRouter};
     use std::path::PathBuf;

--- a/rust-engine/src/expert_cache.rs
+++ b/rust-engine/src/expert_cache.rs
@@ -187,27 +187,6 @@ impl ExpertResident {
         *guard = Some((need, cached.clone()));
         Some(cached)
     }
-
-    /// Raw buffer bytes, including any U.T.H. prefix. Used by paths
-    /// that need the literal on-disk image (e.g. the cache-integrity
-    /// verifier, the dump tools).
-    #[allow(dead_code)]
-    pub fn raw(&self) -> &[u8] {
-        self.buffer.as_slice()
-    }
-
-    /// Parsed Unified Tensor Header, if one is present at the start of
-    /// the buffer. Returns `None` for legacy files (and for the
-    /// synthetic-expert fixtures, which deliberately omit the header).
-    ///
-    /// This is a cold-path accessor (used by dump/diagnostic tools);
-    /// the header is re-probed here rather than stored to keep the
-    /// resident struct small.
-    #[allow(dead_code)]
-    pub fn header(&self) -> Option<TensorHeader> {
-        let raw = self.buffer.as_slice();
-        TensorHeader::strip(raw, DEFAULT_BLOCK_ALIGN).0
-    }
 }
 
 /// Thread-safe fixed-capacity LRU cache of resident experts.

--- a/rust-engine/src/io_provider.rs
+++ b/rust-engine/src/io_provider.rs
@@ -1370,14 +1370,17 @@ impl NvmeStorage {
 
     /// Blob offset of a packed expert id. Panics only if called without a
     /// packed blob attached (an internal invariant of the packed read
-    /// paths), and returns `0` for an id missing from the manifest — the
-    /// subsequent read then surfaces the bounds error.
+    /// paths). For an id missing from the manifest — which the callers
+    /// already rule out by resolving every entry up front in
+    /// `read_experts_batch_packed` — it returns `u64::MAX` so the
+    /// subsequent `pread` fails loudly instead of silently aliasing the
+    /// first expert's bytes at offset `0`.
     fn packed_offset(&self, id: u32) -> u64 {
         self.packed
             .as_ref()
             .and_then(|p| p.entry(id))
             .map(|e| e.offset)
-            .unwrap_or(0)
+            .unwrap_or(u64::MAX)
     }
     /// of an expert's `gate_proj` and `up_proj` plus the full `down_proj`,
     /// packed into `buf` in the layout consumed by

--- a/rust-engine/src/mla.rs
+++ b/rust-engine/src/mla.rs
@@ -52,6 +52,13 @@ fn softmax_inplace(scores: &mut [f32]) {
         return;
     }
     let max = scores.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+    // Fully-masked row (every score `-inf`): fall back to a uniform
+    // distribution rather than propagating `NaN`s from `(-inf) - (-inf)`.
+    if !max.is_finite() {
+        let uniform = 1.0 / scores.len() as f32;
+        scores.iter_mut().for_each(|s| *s = uniform);
+        return;
+    }
     let mut sum = 0.0f32;
     for s in scores.iter_mut() {
         *s = (*s - max).exp();
@@ -369,6 +376,19 @@ pub fn dequant_fp8_e4m3_blockwise(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn softmax_all_neg_inf_is_uniform() {
+        // A fully-masked row must degrade to a uniform distribution rather
+        // than propagating NaNs from `(-inf) - (-inf)`.
+        let mut scores = vec![f32::NEG_INFINITY; 3];
+        softmax_inplace(&mut scores);
+        let expected = 1.0 / 3.0;
+        assert!(
+            scores.iter().all(|&s| (s - expected).abs() < 1e-6),
+            "got {scores:?}"
+        );
+    }
 
     /// Build a small, deterministic MLA block for shape/behaviour tests.
     fn tiny_mla(q_lora_rank: usize) -> MultiHeadLatentAttention {

--- a/rust-engine/src/mla.rs
+++ b/rust-engine/src/mla.rs
@@ -51,10 +51,20 @@ fn softmax_inplace(scores: &mut [f32]) {
     if scores.is_empty() {
         return;
     }
-    let max = scores.iter().copied().fold(f32::NEG_INFINITY, f32::max);
-    // Fully-masked row (every score `-inf`): fall back to a uniform
-    // distribution rather than propagating `NaN`s from `(-inf) - (-inf)`.
-    if !max.is_finite() {
+    let mut max = f32::NEG_INFINITY;
+    let mut saw_nan = false;
+    for &s in scores.iter() {
+        if s.is_nan() {
+            saw_nan = true;
+        } else if s > max {
+            max = s;
+        }
+    }
+    // Non-finite fallback: a stray `NaN`, a `+inf`, or a fully-masked row
+    // (every score `-inf`, leaving `max == -inf`) cannot yield a meaningful
+    // distribution, so emit a uniform distribution rather than letting NaN
+    // propagate downstream.
+    if saw_nan || !max.is_finite() {
         let uniform = 1.0 / scores.len() as f32;
         scores.iter_mut().for_each(|s| *s = uniform);
         return;
@@ -386,6 +396,22 @@ mod tests {
         let expected = 1.0 / 3.0;
         assert!(
             scores.iter().all(|&s| (s - expected).abs() < 1e-6),
+            "got {scores:?}"
+        );
+    }
+
+    #[test]
+    fn softmax_mixed_nan_is_uniform() {
+        // A stray NaN with an otherwise-finite max must not poison the row.
+        // The previous `!max.is_finite()` guard missed this because
+        // `f32::max` ignores NaN, leaving a finite max.
+        let mut scores = vec![0.0, f32::NAN, 1.0];
+        softmax_inplace(&mut scores);
+        let expected = 1.0 / 3.0;
+        assert!(
+            scores
+                .iter()
+                .all(|&s| s.is_finite() && (s - expected).abs() < 1e-6),
             "got {scores:?}"
         );
     }

--- a/rust-engine/src/model.rs
+++ b/rust-engine/src/model.rs
@@ -305,6 +305,14 @@ impl RealModelConfig {
                     f
                 ));
             }
+            if self.rope_dim() == 0 {
+                return Err(format!(
+                    "partial_rotary_factor ({}) with head_dim ({}) rounds the RoPE width down \
+                     to zero, which would silently disable rotary embeddings; raise \
+                     partial_rotary_factor or head_dim",
+                    f, self.head_dim
+                ));
+            }
         }
         if let Some(v) = adv.v_head_dim {
             if v == 0 || v > self.head_dim {
@@ -1368,7 +1376,7 @@ if let Ok(sv) = s.tensor(&scale_name) {
                 maybe!(&naming.k_proj_bias(l), kv_dim, |v| {
                     model.layers[l].attn.bk = Some(v);
                 });
-                maybe!(&naming.v_proj_bias(l), kv_dim, |v| {
+                maybe!(&naming.v_proj_bias(l), v_proj_dim, |v| {
                     model.layers[l].attn.bv = Some(v);
                 });
                 maybe!(&naming.o_proj_bias(l), d_model, |v| {
@@ -2063,7 +2071,6 @@ mod tests {
     use super::*;
     use crate::buffer_pool::BufferPool;
     use crate::engine::{Engine, EngineOptions, ModelShape};
-    use crate::expert_cache::ExpertCache;
     use crate::multi_layer_cache::MultiLayerExpertCache;
     use crate::io_provider::{generate_synthetic_experts, NvmeStorage, StorageConfig};
     use crate::router::{PredictiveLoader, TopKRouter};
@@ -2104,6 +2111,20 @@ mod tests {
         let mut c = RealModelConfig::tiny();
         c.top_k = 99;
         assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_zero_rope_dim() {
+        // A `partial_rotary_factor` in (0, 1] that nonetheless rounds the
+        // RoPE width down to zero must be rejected — otherwise rotary
+        // embeddings are silently disabled for the whole model.
+        let mut c = RealModelConfig::tiny(); // head_dim = 8
+        c.advanced.partial_rotary_factor = Some(0.1); // floor(8*0.1) = 0
+        assert_eq!(c.rope_dim(), 0);
+        assert!(c.validate().is_err());
+        // A factor that leaves a non-zero even width still validates.
+        c.advanced.partial_rotary_factor = Some(0.5); // floor(8*0.5) = 4
+        assert!(c.validate().is_ok());
     }
 
     #[test]
@@ -2537,6 +2558,68 @@ mod tests {
         let lm = &model.lm_head.weights;
         let first = lm[0];
         assert!(lm.iter().any(|&x| x != first), "lm_head should remain seeded, not constant");
+    }
+
+    /// Regression: a checkpoint with `attention_bias = true` AND an
+    /// asymmetric V head (`v_head_dim != head_dim`, MiMo-V2-Flash style)
+    /// ships a `v_proj.bias` of length `num_kv_heads * v_head_dim`
+    /// (`v_proj_dim`), NOT `num_kv_heads * head_dim` (`kv_dim`). The loader
+    /// must size the V-bias expectation by `v_proj_dim`; otherwise the
+    /// size-checked `find_f32` silently drops the tensor and the bias is
+    /// lost.
+    #[test]
+    fn from_safetensors_loads_asymmetric_v_proj_bias() {
+        use safetensors::tensor::{Dtype, TensorView};
+        use safetensors::serialize_to_file;
+        let mut adv = AdvancedConfig::default();
+        adv.attention_bias = true;
+        adv.v_head_dim = Some(2); // V uses 2 while Q/K use head_dim = 4
+        let cfg = RealModelConfig {
+            vocab_size: 8,
+            d_model: 8, // = num_heads * head_dim (Mixtral tie)
+            d_ff: 8,
+            num_heads: 2,
+            num_kv_heads: 2,
+            head_dim: 4,
+            num_layers: 1,
+            num_experts: 2,
+            top_k: 1,
+            rope_base: 10_000.0,
+            rms_eps: 1e-6,
+            window_size: None,
+            architecture: Architecture::Mixtral,
+            first_k_dense_replace: 0,
+            advanced: adv,
+        };
+        let kv_dim = cfg.num_kv_heads * cfg.head_dim; // 8
+        let v_proj_dim = cfg.num_kv_heads * cfg.v_head_dim(); // 4
+        assert_ne!(kv_dim, v_proj_dim, "test requires an asymmetric V head");
+
+        let bv = vec![0.375f32; v_proj_dim];
+        let to_bytes = |v: &[f32]| -> Vec<u8> {
+            let mut out = Vec::with_capacity(v.len() * 4);
+            for &x in v {
+                out.extend_from_slice(&x.to_le_bytes());
+            }
+            out
+        };
+        let bv_bytes = to_bytes(&bv);
+        let dir = TempDir::new("safetensors_vbias");
+        let tensors: Vec<(String, TensorView)> = vec![(
+            "model.layers.0.self_attn.v_proj.bias".to_string(),
+            TensorView::new(Dtype::F32, vec![v_proj_dim], &bv_bytes).unwrap(),
+        )];
+        let out_path = dir.path.join("model.safetensors");
+        serialize_to_file(tensors, &None, &out_path).unwrap();
+
+        let model = RealModel::from_safetensors(cfg.clone(), &dir.path, 1).unwrap();
+        let bv_loaded = model.layers[0]
+            .attn
+            .bv
+            .as_ref()
+            .expect("v_proj.bias must load for an asymmetric V head (was sized by kv_dim)");
+        assert_eq!(bv_loaded.len(), v_proj_dim);
+        assert!(bv_loaded.iter().all(|&x| x == 0.375));
     }
 
     /// Phi-4 (`phi3`) ships a single fused `qkv_proj` tensor. The loader

--- a/rust-engine/src/pregate.rs
+++ b/rust-engine/src/pregate.rs
@@ -108,10 +108,13 @@ impl PerLayerPreGate {
     /// once.
     pub fn observe_and_predict(&self, layer: u32, routed: &[u32]) -> Vec<u32> {
         {
-            let mut last = self.last.lock();
+            let last = self.last.lock();
             if let Some(prev) = last.as_ref() {
-                // Only link strictly-consecutive layers.
-                if layer == prev.layer.wrapping_add(1) {
+                // Only link strictly-consecutive layers. Guard against the
+                // `u32::MAX` sentinel wrapping back to `0` and falsely
+                // linking an unrelated first layer onto a stale final-layer
+                // observation.
+                if prev.layer != u32::MAX && layer == prev.layer.wrapping_add(1) {
                     self.record_transition(prev.layer, &prev.routed, routed);
                     self.score_prediction(&prev.predicted_next, routed);
                 }

--- a/rust-engine/src/server.rs
+++ b/rust-engine/src/server.rs
@@ -1457,7 +1457,6 @@ mod tests {
     use super::*;
     use crate::buffer_pool::BufferPool;
     use crate::engine::{Engine, EngineOptions, ModelShape};
-    use crate::expert_cache::ExpertCache;
     use crate::multi_layer_cache::MultiLayerExpertCache;
     use crate::io_provider::{generate_synthetic_experts, NvmeStorage, StorageConfig};
     use crate::router::{PredictiveLoader, TopKRouter};

--- a/rust-engine/src/transformer.rs
+++ b/rust-engine/src/transformer.rs
@@ -1440,16 +1440,20 @@ pub fn softmax_inplace(v: &mut [f32]) {
     if v.is_empty() {
         return;
     }
-    let mut max = v[0];
+    let mut max = f32::NEG_INFINITY;
+    let mut saw_nan = false;
     for &x in v.iter() {
-        if x > max {
+        if x.is_nan() {
+            saw_nan = true;
+        } else if x > max {
             max = x;
         }
     }
-    // Fully-masked or otherwise non-finite input (every logit `-inf`, or a
-    // stray `NaN`): emit a uniform distribution instead of letting the
-    // `x - max` subtraction produce `NaN`s that then propagate downstream.
-    if !max.is_finite() {
+    // Non-finite fallback: a stray `NaN`, a `+inf`, or a fully-masked row
+    // (every logit `-inf`, leaving `max == -inf`) cannot yield a meaningful
+    // distribution, so emit a uniform distribution rather than letting the
+    // `x - max` subtraction produce `NaN`s that propagate downstream.
+    if saw_nan || !max.is_finite() {
         let uniform = 1.0 / v.len() as f32;
         v.iter_mut().for_each(|x| *x = uniform);
         return;
@@ -1763,6 +1767,22 @@ mod tests {
         let mut v = vec![f32::NEG_INFINITY; 4];
         softmax_inplace(&mut v);
         assert!(v.iter().all(|&x| (x - 0.25).abs() < 1e-6), "got {v:?}");
+        let sum: f32 = v.iter().sum();
+        assert!((sum - 1.0).abs() < 1e-6, "softmax sum={sum}");
+    }
+
+    #[test]
+    fn softmax_mixed_nan_is_uniform() {
+        // A stray NaN that is NOT at index 0 must not poison the row. The
+        // previous `!max.is_finite()` guard missed this because the running
+        // max ignores NaN, leaving a finite max.
+        let mut v = vec![0.0, f32::NAN, 1.0, -1.0];
+        softmax_inplace(&mut v);
+        let expected = 0.25;
+        assert!(
+            v.iter().all(|&x| x.is_finite() && (x - expected).abs() < 1e-6),
+            "got {v:?}"
+        );
         let sum: f32 = v.iter().sum();
         assert!((sum - 1.0).abs() < 1e-6, "softmax sum={sum}");
     }

--- a/rust-engine/src/transformer.rs
+++ b/rust-engine/src/transformer.rs
@@ -1446,6 +1446,14 @@ pub fn softmax_inplace(v: &mut [f32]) {
             max = x;
         }
     }
+    // Fully-masked or otherwise non-finite input (every logit `-inf`, or a
+    // stray `NaN`): emit a uniform distribution instead of letting the
+    // `x - max` subtraction produce `NaN`s that then propagate downstream.
+    if !max.is_finite() {
+        let uniform = 1.0 / v.len() as f32;
+        v.iter_mut().for_each(|x| *x = uniform);
+        return;
+    }
     let mut sum = 0.0f32;
     for x in v.iter_mut() {
         *x = (*x - max).exp();
@@ -1745,6 +1753,18 @@ mod tests {
         let mut v: Vec<f32> = Vec::new();
         softmax_inplace(&mut v);
         assert!(v.is_empty());
+    }
+
+    #[test]
+    fn softmax_all_neg_inf_is_uniform() {
+        // A fully-masked attention row (every score `-inf`) must not
+        // produce NaNs: `(-inf) - (-inf)` is NaN and would poison the
+        // whole distribution. We fall back to a uniform distribution.
+        let mut v = vec![f32::NEG_INFINITY; 4];
+        softmax_inplace(&mut v);
+        assert!(v.iter().all(|&x| (x - 0.25).abs() < 1e-6), "got {v:?}");
+        let sum: f32 = v.iter().sum();
+        assert!((sum - 1.0).abs() < 1e-6, "softmax sum={sum}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A QA pass over the codebase following the large prefetch/skew/cluster/pregate refactor (PR #116) and older PRs. Each finding was verified individually before fixing. The change set is intentionally **focused and conservative** — it fixes real, demonstrable issues and wires up telemetry that was already being collected, while deliberately leaving ~80 platform-gated / feature-gated scaffolding warnings (AVX/AMX kernels, NUMA, io_uring, etc.) untouched since they are live on other targets.

`cargo test`: **466 unit + 4 concurrency-stress pass.** Net unique `--all-targets` warnings **89 → 81**, none newly introduced.

## Bugs / correctness

- **`model.rs` — V projection bias loaded with the wrong size (latent data-loss bug).** The `v_proj.bias` tensor was loaded against the `kv_dim` (`num_kv_heads * head_dim`) expectation, but its real length is `v_proj_dim` (`num_kv_heads * v_head_dim`). For an **asymmetric-V** checkpoint (`v_head_dim != head_dim`, e.g. MiMo-V2-Flash) with `attention_bias = true`, the size-checked `find_f32` helper **silently dropped the bias**, degrading output with no error. Fixed to use the already-computed `v_proj_dim`. **Added a regression test** that fails without the fix.

## Numerical hardening

- **`transformer.rs` / `mla.rs` `softmax_inplace` — NaN on a fully-masked row.** A row that is entirely `-inf` (e.g. fully masked attention) computed `(-inf) - (-inf) = NaN`. Both now fall back to a uniform distribution when the row max is non-finite. **Tests added for both.**
- **`model.rs` `validate` — zero-width RoPE.** A `partial_rotary_factor` that rounds the rotary width down to `0` would silently disable rotary embeddings. Now rejected at validation time. **Test added.**
- **`pregate.rs`** — guard the consecutive-layer link against the `u32::MAX` sentinel wrapping around to `0`.
- **`io_provider.rs` `packed_offset`** — return `u64::MAX` (forcing a loud read error) instead of `0` (which would silently alias expert 0's bytes) for an id missing from the packed manifest.

## Telemetry (collected but never surfaced)

- Surface **`singleflight_followers`** (redundant SSD reads avoided via request coalescing) through `EngineReport` and the run summary.
- Surface the **prefetch-drop / gpu-cpu-fallback / speculator-mismatch / expert-read-failure** health counters as a conditional summary line.

Both summary additions are **gated** so the legacy summary shape is preserved on clean runs and only appears when there is something to report.

## Dead code

- Remove redundant `EngineReport::{total_io_wait_us, total_cycle_us}` (never read; derivable from the per-token average + token count).
- Remove orphaned `ExpertResident::{raw, header}` (zero callers, referenced a non-existent dump tool).
- Remove an unused `parking_lot::Mutex` import and an unnecessary `mut`.
- Remove 5 unused `ExpertCache` test-module imports.

## Notes / scope

- Platform- and feature-gated dead-code warnings (AVX/AMX kernels, NUMA Linux fns, io_uring) were **left in place** — they are live on x86_64/Linux and removing them would break those targets.
- Several flagged items were investigated and **rejected as false positives** (e.g. speculator training helpers that are reached via the prod train queue, `ExpertCache` pin/unpin helpers used in prod or `#[allow]`-ed test-only).

🤖 Generated with QA audit pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed softmax numeric stability when processing fully-masked rows to prevent NaN propagation
  * Corrected attention bias tensor size calculation during model loading for asymmetric configurations
  * Improved error handling for missing expert data with explicit failure signaling

* **New Features**
  * Added SSD read deduplication telemetry to engine reporting
  * Enhanced engine health diagnostics with aggregated degradation signal monitoring

* **Validation**
  * Stricter model configuration validation to prevent silent feature disabling

* **Tests**
  * Expanded test coverage for numeric stability edge cases and model loading scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->