### PR TITLE
audit neural speculator wiring

### DIFF
--- a/rust-engine/src/engine.rs
+++ b/rust-engine/src/engine.rs
@@ -4315,10 +4315,11 @@ if let Some(gpu) = me.core.gpu_cache.as_ref() {
         // summary shape so older diff-on-output tests stay valid.
         if r.locality_enabled || r.speculator_enabled {
             info!(
-                "predictive:    locality={} (hit_rate={:.2}%)  speculator={} (accuracy={:.2}%)  ssd_stall={:.1}ms",
+                "predictive:    locality={} (hit_rate={:.2}%)  speculator={} (top1={:.2}% topk_overlap={:.2}%)  ssd_stall={:.1}ms",
                 if r.locality_enabled { "on" } else { "off" },
                 r.predictive.locality_hit_rate * 100.0,
                 if r.speculator_enabled { "on" } else { "off" },
+                r.predictive.speculator_top1_accuracy * 100.0,
                 r.predictive.speculator_accuracy * 100.0,
                 r.predictive.ssd_stall_us as f64 / 1000.0,
             );
@@ -4620,6 +4621,24 @@ mod tests {
             predictor,
             ModelShape { d_model, d_ff, hidden_seed: seed },
         ))
+    }
+
+    fn rebuild_with_speculator(
+        base: &Arc<Engine>,
+        spec: Arc<NeuralSpeculator>,
+        top_k: usize,
+    ) -> Arc<Engine> {
+        Arc::new(
+            Engine::new(
+                base.core.cache.clone(),
+                base.core.pool.clone(),
+                base.core.storage.clone(),
+                base.core.router.clone(),
+                base.core.predictor.clone(),
+                base.core.shape,
+            )
+            .with_speculator(spec, top_k),
+        )
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -4968,6 +4987,58 @@ mod tests {
             tele
         );
         assert!(tele.speculator_accuracy >= 0.0 && tele.speculator_accuracy <= 1.0);
+    }
+
+    #[test]
+    fn speculator_prediction_is_recorded_before_current_sample_training() {
+        let dir = TempDir::new("spec-before-train");
+        let num_experts: u32 = 4;
+        let d_model = 4usize;
+        let d_ff = 8usize;
+        let seed = 0xB4E0_1ABE;
+        let base = build_engine(&dir.path, num_experts, d_model, d_ff, 4, 1, 1, seed);
+        let spec = Arc::new(NeuralSpeculator::new(d_model, 16, num_experts, seed));
+        let hidden = vec![1.0f32, -0.5, 0.25, -0.125];
+
+        for _ in 0..400 {
+            spec.train_step(&hidden, &[0], 0.1);
+        }
+        assert_eq!(spec.predict_topk(&hidden, 1), vec![0]);
+
+        let engine = rebuild_with_speculator(&base, spec, 1);
+        let preds = engine.speculator_predict_and_train(&hidden, &[1], None);
+        assert_eq!(
+            preds,
+            vec![0],
+            "prediction should use weights from before the current target is queued"
+        );
+
+        let tele = engine.predictive_telemetry();
+        assert_eq!(tele.speculator_top1_matches, 0);
+        assert_eq!(tele.speculator_top1_total, 1);
+        assert_eq!(tele.speculator_hits, 0);
+        assert_eq!(tele.speculator_misses, 1);
+    }
+
+    #[test]
+    fn speculator_dmodel_mismatch_returns_empty_and_counts_disabled() {
+        let dir = TempDir::new("spec-dmodel-mismatch");
+        let num_experts: u32 = 4;
+        let d_model = 4usize;
+        let d_ff = 8usize;
+        let seed = 0xD15A_B1ED;
+        let base = build_engine(&dir.path, num_experts, d_model, d_ff, 4, 1, 1, seed);
+        let spec = Arc::new(NeuralSpeculator::new(d_model + 1, 16, num_experts, seed));
+        let engine = rebuild_with_speculator(&base, spec, 1);
+
+        let preds = engine.speculator_predict_and_train(&[0.0f32; 4], &[0], None);
+        assert!(preds.is_empty());
+
+        let report = engine.report();
+        assert_eq!(report.speculator_dmodel_mismatch, 1);
+        let tele = engine.predictive_telemetry();
+        assert_eq!(tele.speculator_top1_total, 0);
+        assert_eq!(tele.speculator_hits + tele.speculator_misses, 0);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/rust-engine/src/metrics.rs
+++ b/rust-engine/src/metrics.rs
@@ -279,7 +279,7 @@ impl Metrics {
         self.inner.io_wait_seconds.observe(seconds);
     }
 
-    /// Record speculator accuracy: `hits` predictions that overlapped
+    /// Record speculator top-K overlap: `hits` predictions that overlapped
     /// the gate's top-K and `misses` that did not. Either may be zero.
     pub fn record_speculator(&self, hits: u64, misses: u64) {
         if hits > 0 {

--- a/rust-engine/src/router.rs
+++ b/rust-engine/src/router.rs
@@ -1569,7 +1569,7 @@ impl NeuralSpeculator {
             std::thread::Builder::new()
                 .name("mer-speculator-train".to_string())
                 .spawn(move || speculator_training_loop(weak, rx))
-                .ok(); // Failing to spawn is non-fatal; fall back to in-line train.
+                .ok(); // Failing to spawn is non-fatal; queued samples will drop.
             tx
         });
     }
@@ -2506,6 +2506,81 @@ mod tests {
         let preds = s.predict_topk(&x, 2);
         assert!(preds.contains(&2), "preds={preds:?}");
         assert!(preds.contains(&3), "preds={preds:?}");
+    }
+
+    #[test]
+    fn speculator_learns_hidden_derived_labels_above_random() {
+        let d_model = 8usize;
+        let num_experts = 4u32;
+        let s = NeuralSpeculator::new(d_model, 32, num_experts, 0x1EAF);
+        let samples: Vec<(Vec<f32>, u32)> = (0..num_experts)
+            .map(|id| {
+                let mut x = vec![-0.5f32; d_model];
+                x[id as usize] = 1.0;
+                x[id as usize + num_experts as usize] =
+                    if id % 2 == 0 { 0.25 } else { -0.25 };
+                (x, id)
+            })
+            .collect();
+
+        for _ in 0..500 {
+            for (x, target) in &samples {
+                s.train_step(x, &[*target], 0.05);
+            }
+        }
+
+        let correct = samples
+            .iter()
+            .filter(|(x, target)| s.predict_topk(x, 1).first() == Some(target))
+            .count();
+        let accuracy = correct as f32 / samples.len() as f32;
+        assert!(
+            accuracy >= 0.75,
+            "hidden-derived labels should be learnable well above random: {correct}/{}",
+            samples.len()
+        );
+    }
+
+    #[test]
+    fn speculator_uncorrelated_labels_remain_near_random() {
+        let num_experts = 4u32;
+        let s = NeuralSpeculator::new(4, 16, num_experts, 0xC0117E);
+        let x = vec![0.5f32, -0.25, 0.125, -0.75];
+
+        for _ in 0..400 {
+            for target in 0..num_experts {
+                s.train_step(&x, &[target], 0.05);
+            }
+        }
+
+        let pred = s.predict_topk(&x, 1);
+        assert_eq!(pred.len(), 1);
+        let correct = (0..num_experts).filter(|&target| target == pred[0]).count();
+        let accuracy = correct as f32 / num_experts as f32;
+        assert!(
+            accuracy <= (1.0 / num_experts as f32) + f32::EPSILON,
+            "constant hidden state carries no label signal; got accuracy={accuracy}"
+        );
+    }
+
+    #[test]
+    fn speculator_training_worker_consumes_samples_and_advances_steps() {
+        let s = std::sync::Arc::new(NeuralSpeculator::new(4, 8, 4, 0x57E9));
+        s.spawn_training_worker();
+        let x = vec![0.25f32, -0.5, 0.75, 1.0];
+        for _ in 0..16 {
+            s.queue_train(&x, &[2], 0.1);
+        }
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        while s.train_steps.load(Ordering::Relaxed) == 0 && std::time::Instant::now() < deadline {
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+
+        assert!(
+            s.train_steps.load(Ordering::Relaxed) > 0,
+            "background worker should consume queued samples"
+        );
     }
 
     #[test]


### PR DESCRIPTION
The reporting change fixes the misleading CLI summary by separating top1 from topk_overlap.