### PR TITLE
[codex] fix speculator observability tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -924,7 +924,7 @@ Endpoints:
 | method   | path                       | purpose                                            |
 | -------- | -------------------------- | -------------------------------------------------- |
 | `GET`    | `/health`                  | liveness probe (`{"status":"ok"...}`)             |
-| `GET`    | `/metrics`                 | Prometheus text format: cache hit rate, request latency histograms, tokens generated, per-token I/O wait, and, when the predictive arms are enabled, `mer_locality_hits_total`, `mer_locality_misses_total`, `mer_speculator_hits_total`, `mer_speculator_misses_total`, `mer_speculator_accuracy_total`, and the `mer_ssd_stall_seconds` histogram. When `[gpu_cache] enabled = true`, also exports `mer_vram_used_bytes`, `mer_vram_capacity_bytes`, `mer_gpu_cache_hits_total`, `mer_gpu_cache_misses_total`, and `mer_promotions_total` |
+| `GET`    | `/metrics`                 | Prometheus text format: cache hit rate, request latency histograms, tokens generated, per-token I/O wait, and, when the predictive arms are enabled, `mer_locality_hits_total`, `mer_locality_misses_total`, `mer_speculator_hits_total`, `mer_speculator_misses_total`, `mer_speculator_accuracy_total`, `mer_speculator_evaluations_total`, and the `mer_ssd_stall_seconds` histogram. When `[gpu_cache] enabled = true`, also exports `mer_vram_used_bytes`, `mer_vram_capacity_bytes`, `mer_gpu_cache_hits_total`, `mer_gpu_cache_misses_total`, and `mer_promotions_total` |
 | `GET`    | `/v1/admin/health/experts` | JSON snapshot of the 3-tier hierarchy: per-tier hit/miss counters (SSD, RAM, VRAM), VRAM used / capacity bytes, total RAM→VRAM promotions, and engine status fields. Consumed by `micro-expert-router monitor`. |
 | `POST`   | `/v1/admin/evict`          | One-shot reclaim pass on the paged-KV pool's overflow slab. Returns `{"reclaimed_overflow_blocks": N}`. Useful after a transient burst inflated the heap-backed fallback, returns memory to the allocator immediately rather than waiting for the periodic background sweep. |
 | `POST`   | `/v1/completions`          | OpenAI text-completion shape (`prompt`, `max_tokens`...) |
@@ -2775,17 +2775,18 @@ small MLP forward + SGD step per token, plus one ring-buffer
 update) that is far below the energy cost of even a single
 NVMe expert read.
 
-**Telemetry.** The engine maintains four atomic counters
-(`spec_hits`, `spec_misses`, `locality_hits`, `locality_misses`)
-and a cumulative `total_ssd_stall_us`, all readable through
-`Engine::predictive_telemetry()` and exported as Prometheus
+**Telemetry.** The engine maintains speculator prediction precision@K
+counters, speculator top-1 match/evaluation counters, locality
+hit/miss counters, and a cumulative `total_ssd_stall_us`, all readable
+through `Engine::predictive_telemetry()` and exported as Prometheus
 counters / a histogram on `/metrics`:
 
 | Metric | Meaning |
 |---|---|
-| `mer_speculator_hits_total` | Per-token speculator predictions that intersected the gate's actual top-K. |
-| `mer_speculator_misses_total` | Per-token speculator predictions that did not. The ratio is the speculator's running accuracy. |
-| `mer_speculator_accuracy_total` | Tokens for which the speculator's **top-1** prediction matched the gate's actual top-1 routed expert. The primary quality signal called out by the Omniscient Predictive Architecture spec; divide by tokens-generated to read accuracy as a fraction. |
+| `mer_speculator_hits_total` | Predicted expert IDs contained in the gate's actual top-K; numerator of prediction precision@K. |
+| `mer_speculator_misses_total` | Predicted expert IDs not contained in the gate's actual top-K; with hits, forms the prediction precision@K denominator. |
+| `mer_speculator_accuracy_total` | Tokens for which the speculator's **top-1** prediction matched the gate's actual top-1 routed expert; numerator for top-1 accuracy. |
+| `mer_speculator_evaluations_total` | Valid top-1 speculator evaluations, whether or not the prediction matched; denominator for top-1 accuracy. |
 | `mer_locality_hits_total` | Routed experts that were already in the locality monitor's hot set at routing time (would-be cache miss avoided by pinning). |
 | `mer_locality_misses_total` | Routed experts that were not. |
 | `mer_ssd_stall_seconds` | Histogram of cumulative SSD critical-path stall time per token, the wall-clock window the engine spent blocked waiting for cache-miss reads to land. The headline number the L / M arms aim to drive down. |

--- a/deploy/grafana/dashboard.json
+++ b/deploy/grafana/dashboard.json
@@ -30,7 +30,7 @@
       "type": "graph",
       "title": "Tokens / sec",
       "datasource": "Prometheus",
-      "targets": [{ "expr": "rate(mer_tokens_total[1m])" }],
+      "targets": [{ "expr": "rate(mer_tokens_generated_total[1m])" }],
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 }
     },
     {
@@ -65,7 +65,7 @@
       "title": "Speculator top-1 accuracy",
       "datasource": "Prometheus",
       "targets": [{
-        "expr": "rate(mer_speculator_accuracy_total[5m]) / rate(mer_speculator_total[5m])"
+        "expr": "rate(mer_speculator_accuracy_total[5m]) / clamp_min(rate(mer_speculator_evaluations_total[5m]), 1e-9)"
       }],
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 }
     },

--- a/rust-engine/src/engine.rs
+++ b/rust-engine/src/engine.rs
@@ -738,9 +738,12 @@ pub struct PredictiveTelemetry {
     pub speculator_hits: u64,
     pub speculator_misses: u64,
     /// `speculator_hits / (speculator_hits + speculator_misses)`, or
-    /// `0.0` when neither has fired. This is the **top-K overlap**
-    /// accuracy and is preserved for backwards compatibility — the
-    /// design spec's "speculator accuracy" is the top-1 metric below.
+    /// `0.0` when neither has fired. Hits are predicted expert IDs
+    /// contained in the gate's actual top-K; misses are predicted
+    /// expert IDs not contained in the gate's actual top-K. The ratio
+    /// is prediction precision@K. The field name is preserved for
+    /// backwards compatibility — the design spec's "speculator
+    /// accuracy" is the top-1 metric below.
     pub speculator_accuracy: f64,
     /// Cumulative count of tokens for which the speculator's **top-1**
     /// prediction matched the gate's actual top-1 routed expert.
@@ -1172,10 +1175,11 @@ pub(crate) struct EngineSpeculation {
     /// out are staler, so the per-layer fanout is tapered with distance to
     /// keep low-confidence far-layer reads from flooding the SSD.
     pub(super) pipeline_depth: u32,
-    /// Cumulative speculator hit count (predictions that intersected
-    /// the gate's actual top-K).
+    /// Cumulative speculator hit count: predicted expert IDs contained
+    /// in the gate's actual top-K.
     pub(super) spec_hits: AtomicU64,
-    /// Cumulative speculator miss count.
+    /// Cumulative speculator miss count: predicted expert IDs not
+    /// contained in the gate's actual top-K.
     pub(super) spec_misses: AtomicU64,
     /// Cumulative count of tokens for which the speculator's **top-1**
     /// prediction matched the gate's actual top-1 routed expert.
@@ -3237,6 +3241,9 @@ if let Some(gpu) = me.core.gpu_cache.as_ref() {
             }
             _ => spec.predict_topk(x, self.speculation.speculator_topk),
         };
+        // Prediction precision@K components: hits are predicted expert
+        // IDs contained in the gate's actual top-K, misses are
+        // predicted expert IDs outside that top-K.
         let target_set: HashSet<u32> = target.iter().copied().collect();
         let mut hits: u64 = 0;
         for &p in &preds {
@@ -4315,7 +4322,7 @@ if let Some(gpu) = me.core.gpu_cache.as_ref() {
         // summary shape so older diff-on-output tests stay valid.
         if r.locality_enabled || r.speculator_enabled {
             info!(
-                "predictive:    locality={} (hit_rate={:.2}%)  speculator={} (top1={:.2}% topk_overlap={:.2}%)  ssd_stall={:.1}ms",
+                "predictive:    locality={} (hit_rate={:.2}%)  speculator={} (top1={:.2}% precision_at_k={:.2}%)  ssd_stall={:.1}ms",
                 if r.locality_enabled { "on" } else { "off" },
                 r.predictive.locality_hit_rate * 100.0,
                 if r.speculator_enabled { "on" } else { "off" },
@@ -5004,14 +5011,28 @@ mod tests {
             spec.train_step(&hidden, &[0], 0.1);
         }
         assert_eq!(spec.predict_topk(&hidden, 1), vec![0]);
+        let train_steps_before = spec.train_steps_for_test();
 
-        let engine = rebuild_with_speculator(&base, spec, 1);
-        let preds = engine.speculator_predict_and_train(&hidden, &[1], None);
+        let ((engine, preds), queued) =
+            NeuralSpeculator::capture_queued_train_for_test(&spec, || {
+                let engine = rebuild_with_speculator(&base, spec.clone(), 1);
+                let preds = engine.speculator_predict_and_train(&hidden, &[1], None);
+                (engine, preds)
+            });
         assert_eq!(
             preds,
             vec![0],
             "prediction should use weights from before the current target is queued"
         );
+        assert_eq!(
+            spec.train_steps_for_test(),
+            train_steps_before,
+            "current sample must not be trained synchronously on the caller thread"
+        );
+        assert_eq!(spec.predict_topk(&hidden, 1), vec![0]);
+        assert_eq!(queued.x, hidden);
+        assert_eq!(queued.actual_top_k, vec![1]);
+        assert_eq!(queued.lr, NeuralSpeculator::DEFAULT_LR);
 
         let tele = engine.predictive_telemetry();
         assert_eq!(tele.speculator_top1_matches, 0);
@@ -5029,7 +5050,19 @@ mod tests {
         let seed = 0xD15A_B1ED;
         let base = build_engine(&dir.path, num_experts, d_model, d_ff, 4, 1, 1, seed);
         let spec = Arc::new(NeuralSpeculator::new(d_model + 1, 16, num_experts, seed));
-        let engine = rebuild_with_speculator(&base, spec, 1);
+        let metrics = Metrics::new();
+        let engine = Arc::new(
+            Engine::new(
+                base.core.cache.clone(),
+                base.core.pool.clone(),
+                base.core.storage.clone(),
+                base.core.router.clone(),
+                base.core.predictor.clone(),
+                base.core.shape,
+            )
+            .with_metrics(metrics.clone())
+            .with_speculator(spec, 1),
+        );
 
         let preds = engine.speculator_predict_and_train(&[0.0f32; 4], &[0], None);
         assert!(preds.is_empty());
@@ -5039,6 +5072,11 @@ mod tests {
         let tele = engine.predictive_telemetry();
         assert_eq!(tele.speculator_top1_total, 0);
         assert_eq!(tele.speculator_hits + tele.speculator_misses, 0);
+        let prom = String::from_utf8(metrics.render().unwrap()).unwrap();
+        assert!(
+            prom.contains("mer_speculator_evaluations_total 0"),
+            "d_model mismatch must not count as a valid top-1 evaluation:\n{prom}"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/rust-engine/src/metrics.rs
+++ b/rust-engine/src/metrics.rs
@@ -33,9 +33,11 @@ struct MetricsInner {
     pub cache_hits_total: Counter,
     pub cache_misses_total: Counter,
     pub io_wait_seconds: Histogram,
-    /// Speculator predictions that intersected the gate's actual top-K.
+    /// Predicted expert IDs contained in the gate's actual top-K
+    /// (prediction precision@K numerator).
     pub speculator_hits_total: Counter,
-    /// Speculator predictions that did **not** intersect the gate's actual top-K.
+    /// Predicted expert IDs not contained in the gate's actual top-K
+    /// (prediction precision@K denominator component).
     pub speculator_misses_total: Counter,
     /// Tokens for which the speculator's **top-1** prediction matched
     /// the actual top-1 routed expert. The "Omniscient Predictive
@@ -43,6 +45,9 @@ struct MetricsInner {
     /// `mer_speculator_accuracy_total` and uses it as the primary
     /// quality signal for the predictive controller.
     pub speculator_accuracy_total: Counter,
+    /// Valid top-1 speculator evaluations, whether or not the
+    /// prediction matched. Denominator for top-1 accuracy.
+    pub speculator_evaluations_total: Counter,
     /// Activations whose chosen expert was already in the locality
     /// monitor's hot set at the time of routing.
     pub locality_hits_total: Counter,
@@ -145,13 +150,13 @@ impl Metrics {
         .expect("metric registration: mer_io_wait_seconds");
         let speculator_hits_total = register_counter_with_registry!(
             "mer_speculator_hits_total",
-            "Neural speculator predictions that intersected the gate's chosen top-K.",
+            "Neural speculator predicted expert IDs contained in the gate's actual top-K; numerator of prediction precision@K.",
             registry
         )
         .expect("metric registration: mer_speculator_hits_total");
         let speculator_misses_total = register_counter_with_registry!(
             "mer_speculator_misses_total",
-            "Neural speculator predictions that did NOT intersect the gate's chosen top-K.",
+            "Neural speculator predicted expert IDs not contained in the gate's actual top-K; with hits, forms the prediction precision@K denominator.",
             registry
         )
         .expect("metric registration: mer_speculator_misses_total");
@@ -161,6 +166,12 @@ impl Metrics {
             registry
         )
         .expect("metric registration: mer_speculator_accuracy_total");
+        let speculator_evaluations_total = register_counter_with_registry!(
+            "mer_speculator_evaluations_total",
+            "Valid neural speculator top-1 evaluations, whether or not the prediction matched.",
+            registry
+        )
+        .expect("metric registration: mer_speculator_evaluations_total");
         let locality_hits_total = register_counter_with_registry!(
             "mer_locality_hits_total",
             "Routed activations whose chosen expert was in the locality monitor's hot set.",
@@ -242,6 +253,7 @@ impl Metrics {
                 speculator_hits_total,
                 speculator_misses_total,
                 speculator_accuracy_total,
+                speculator_evaluations_total,
                 locality_hits_total,
                 locality_misses_total,
                 ssd_stall_seconds,
@@ -279,8 +291,10 @@ impl Metrics {
         self.inner.io_wait_seconds.observe(seconds);
     }
 
-    /// Record speculator top-K overlap: `hits` predictions that overlapped
-    /// the gate's top-K and `misses` that did not. Either may be zero.
+    /// Record speculator prediction precision@K components: `hits`
+    /// predicted expert IDs contained in the gate's actual top-K and
+    /// `misses` predicted expert IDs not contained in that top-K.
+    /// Either may be zero; `hits / (hits + misses)` is precision@K.
     pub fn record_speculator(&self, hits: u64, misses: u64) {
         if hits > 0 {
             self.inner.speculator_hits_total.inc_by(hits as f64);
@@ -293,12 +307,12 @@ impl Metrics {
     /// Record one token's worth of **top-1** speculator accuracy.
     /// Pass `1` if the speculator's highest-logit expert matched the
     /// gate's actual top-1 routed expert for this token, `0` otherwise.
-    /// Increments `mer_speculator_accuracy_total` by `top1_match`.
+    /// Increments `mer_speculator_evaluations_total` once per call and
+    /// `mer_speculator_accuracy_total` only on a match.
     pub fn record_speculator_top1(&self, top1_match: u64) {
-        if top1_match > 0 {
-            self.inner
-                .speculator_accuracy_total
-                .inc_by(top1_match as f64);
+        self.inner.speculator_evaluations_total.inc();
+        if top1_match == 1 {
+            self.inner.speculator_accuracy_total.inc();
         }
     }
 
@@ -394,6 +408,7 @@ mod tests {
         m.record_io_wait(0.002);
         m.record_speculator(7, 3);
         m.record_speculator_top1(1);
+        m.record_speculator_top1(0);
         m.record_locality(5, 2);
         m.record_ssd_stall(0.0005);
         m.record_gpu_cache(2, 1);
@@ -414,6 +429,7 @@ mod tests {
             "mer_speculator_hits_total",
             "mer_speculator_misses_total",
             "mer_speculator_accuracy_total",
+            "mer_speculator_evaluations_total",
             "mer_locality_hits_total",
             "mer_locality_misses_total",
             "mer_ssd_stall_seconds",
@@ -428,6 +444,8 @@ mod tests {
         ] {
             assert!(body.contains(name), "metric {name} missing from /metrics body:\n{body}");
         }
+        assert_metric_value(&body, "mer_speculator_accuracy_total", 1.0);
+        assert_metric_value(&body, "mer_speculator_evaluations_total", 2.0);
         // The label we recorded must show up in the rendered text.
         assert!(body.contains("/v1/completions"));
     }
@@ -439,5 +457,22 @@ mod tests {
         let body = String::from_utf8(m.render().unwrap()).unwrap();
         // Counters should still be exported (with value 0).
         assert!(body.contains("mer_cache_hits_total"));
+    }
+
+    fn assert_metric_value(body: &str, name: &str, expected: f64) {
+        let line = body
+            .lines()
+            .find(|line| line.starts_with(name))
+            .unwrap_or_else(|| panic!("metric {name} missing from /metrics body:\n{body}"));
+        let value: f64 = line
+            .split_whitespace()
+            .nth(1)
+            .unwrap_or_else(|| panic!("metric {name} line missing value: {line}"))
+            .parse()
+            .unwrap_or_else(|_| panic!("metric {name} line has non-numeric value: {line}"));
+        assert!(
+            (value - expected).abs() < f64::EPSILON,
+            "metric {name} expected {expected}, got {value} in line {line}"
+        );
     }
 }

--- a/rust-engine/src/router.rs
+++ b/rust-engine/src/router.rs
@@ -1082,6 +1082,14 @@ struct TrainSample {
     lr: f32,
 }
 
+#[cfg(test)]
+#[derive(Debug, PartialEq)]
+pub(crate) struct QueuedTrainSampleForTest {
+    pub x: Vec<f32>,
+    pub actual_top_k: Vec<u32>,
+    pub lr: f32,
+}
+
 struct SpeculatorWeights {
     /// `[hidden, d_model]` row-major.
     w1: Vec<f32>,
@@ -1595,6 +1603,35 @@ impl NeuralSpeculator {
             // contain useful gradient signal).
             let _ = tx.try_send(sample);
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn train_steps_for_test(&self) -> u64 {
+        self.train_steps.load(Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn capture_queued_train_for_test<R>(
+        spec: &std::sync::Arc<Self>,
+        f: impl FnOnce() -> R,
+    ) -> (R, QueuedTrainSampleForTest) {
+        let (tx, rx) = std::sync::mpsc::sync_channel::<TrainSample>(1);
+        if spec.train_queue.set(tx).is_err() {
+            panic!("test training queue must be installed before spawning the worker");
+        }
+
+        let result = f();
+        let sample = rx
+            .try_recv()
+            .expect("current sample should be submitted to the training queue");
+        (
+            result,
+            QueuedTrainSampleForTest {
+                x: sample.x,
+                actual_top_k: sample.actual_top_k,
+                lr: sample.lr,
+            },
+        )
     }
 }
 
@@ -2543,23 +2580,49 @@ mod tests {
 
     #[test]
     fn speculator_uncorrelated_labels_remain_near_random() {
-        let num_experts = 4u32;
-        let s = NeuralSpeculator::new(4, 16, num_experts, 0xC0117E);
-        let x = vec![0.5f32, -0.25, 0.125, -0.75];
+        use rand::Rng;
 
-        for _ in 0..400 {
-            for target in 0..num_experts {
-                s.train_step(&x, &[target], 0.05);
+        let d_model = 8usize;
+        let num_experts = 8u32;
+        let train_len = 2_048usize;
+        let heldout_len = 2_048usize;
+        let s = NeuralSpeculator::new(d_model, 16, num_experts, 0xC011_7E);
+
+        let mut train_x_rng = StdRng::seed_from_u64(0xA11C_E5EED);
+        let mut train_label_rng = StdRng::seed_from_u64(0x1A8E_15EED);
+        let train: Vec<(Vec<f32>, u32)> = (0..train_len)
+            .map(|_| {
+                let x = (0..d_model)
+                    .map(|_| train_x_rng.gen_range(-1.0f32..1.0))
+                    .collect();
+                let label = train_label_rng.gen_range(0..num_experts);
+                (x, label)
+            })
+            .collect();
+
+        for _ in 0..3 {
+            for (x, target) in &train {
+                s.train_step(x, &[*target], 0.05);
             }
         }
 
-        let pred = s.predict_topk(&x, 1);
-        assert_eq!(pred.len(), 1);
-        let correct = (0..num_experts).filter(|&target| target == pred[0]).count();
-        let accuracy = correct as f32 / num_experts as f32;
+        let mut heldout_x_rng = StdRng::seed_from_u64(0x5E1F_1E55);
+        let mut heldout_label_rng = StdRng::seed_from_u64(0xBADC_0FFE);
+        let correct = (0..heldout_len)
+            .filter(|_| {
+                let x: Vec<f32> = (0..d_model)
+                    .map(|_| heldout_x_rng.gen_range(-1.0f32..1.0))
+                    .collect();
+                let label = heldout_label_rng.gen_range(0..num_experts);
+                s.predict_topk(&x, 1).first() == Some(&label)
+            })
+            .count();
+        let accuracy = correct as f32 / heldout_len as f32;
+        let random = 1.0 / num_experts as f32;
+        let tolerance = 0.06;
         assert!(
-            accuracy <= (1.0 / num_experts as f32) + f32::EPSILON,
-            "constant hidden state carries no label signal; got accuracy={accuracy}"
+            (random - tolerance..=random + tolerance).contains(&accuracy),
+            "held-out labels are independent of hidden states; accuracy should stay near random ({random}), got {accuracy} ({correct}/{heldout_len})"
         );
     }
 


### PR DESCRIPTION
## Summary

- Add `mer_speculator_evaluations_total` as the Prometheus denominator for valid top-1 speculator evaluations.
- Fix Grafana top-1 accuracy and tokens/sec queries.
- Clarify speculator top-K hit/miss terminology as prediction precision@K while preserving existing field/counter names.
- Replace the tautological uncorrelated-label test with a seeded train/held-out control and strengthen the before-training queue-only test.

## Behavior

This is scoped to observability, dashboard expressions, comments/labels, and tests. It does not change the speculator algorithm, learning parameters, routing, prefetch policy, or inference behavior.

## Validation

- `cargo test metrics::tests::render_includes_all_metric_names` passed.
- `cargo test router::tests::speculator_uncorrelated_labels_remain_near_random` passed.
- Repeated uncorrelated-label test 10 consecutive times: passed.
- `cargo test -q speculator` passed.
- `cargo test` passed: 491 unit tests passed, 1 ignored; concurrency stress integration tests passed; doc-tests passed.
- `cargo test --test concurrency_stress` passed: 4 passed.
- `cargo test --doc` passed: 0 doctests.
- `git diff --check` passed.
- `python3 -m json.tool deploy/grafana/dashboard.json` passed.
- `cargo fmt --check` was run and failed on pre-existing rustfmt drift across unrelated files; the patch was kept narrowly scoped and did not reformat unrelated modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded observability docs to include additional predictive and GPU cache metrics exposed on the metrics endpoint.
  * Clarified how speculator telemetry is measured, including precision@K-style hit/miss and evaluation counters.

* **Bug Fixes**
  * Updated the Grafana “Tokens / sec” panel to use the current throughput metric.
  * Improved the speculator accuracy calculation to avoid divide-by-zero edge cases and show more stable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->