### PR TITLE
[codex] Fix MoE config validation and test isolation

### DIFF
--- a/rust-engine/Cargo.lock
+++ b/rust-engine/Cargo.lock
@@ -2009,6 +2009,7 @@ dependencies = [
  "libc",
  "lru",
  "matrixmultiply",
+ "once_cell",
  "parking_lot",
  "pollster",
  "prometheus",

--- a/rust-engine/Cargo.toml
+++ b/rust-engine/Cargo.toml
@@ -40,6 +40,7 @@ prometheus = { version = "0.13", default-features = false }
 # Sync primitive for the LRU + buffer pool. parking_lot is faster and not async,
 # which is exactly what we want around a short critical section.
 parking_lot = "0.12"
+once_cell = "1"
 
 # Persistent, work-stealing thread pool for the architecture-agnostic
 # dense-compute kernels (`matmul_row_major`, per-expert `gate_up_swiglu`

--- a/rust-engine/src/architecture.rs
+++ b/rust-engine/src/architecture.rs
@@ -688,6 +688,8 @@ pub enum ArchitectureError {
     UnknownArchitecture { model_type: String, architectures: Vec<String> },
     /// A required hyperparameter was missing or the wrong type.
     MissingField(&'static str),
+    /// A recognised hyperparameter had an unsupported value or shape.
+    InvalidField(String),
 }
 
 impl std::fmt::Display for ArchitectureError {
@@ -705,6 +707,7 @@ impl std::fmt::Display for ArchitectureError {
             Self::MissingField(name) => {
                 write!(f, "config.json is missing required field `{name}`")
             }
+            Self::InvalidField(message) => write!(f, "invalid config.json field: {message}"),
         }
     }
 }
@@ -1079,6 +1082,35 @@ impl HfConfig {
             .or_else(|| get("num_experts").and_then(as_usize))
             .or_else(|| get("n_routed_experts").and_then(as_usize));
 
+        let first_k_dense_replace =
+            if let Some(first_k_dense_replace) = get("first_k_dense_replace").and_then(as_usize) {
+                Some(first_k_dense_replace)
+            } else if let Some(arr) = get("moe_layer_freq").and_then(|v| v.as_array()) {
+                // MiMo-V2-Flash has no `first_k_dense_replace`; it marks
+                // dense vs MoE layers via `moe_layer_freq` (0 = dense FFN,
+                // 1 = MoE). MER models this as a contiguous dense prefix,
+                // so reject interleaved dense layers instead of silently
+                // mapping them to MoE.
+                let leading_dense = arr.iter().take_while(|e| e.as_u64() == Some(0)).count();
+                let mut seen_moe = false;
+                for (i, e) in arr.iter().enumerate() {
+                    match e.as_u64() {
+                        Some(1) => seen_moe = true,
+                        Some(0) if seen_moe => {
+                            return Err(ArchitectureError::InvalidField(format!(
+                                "moe_layer_freq contains non-leading zero at index {i}; \
+                                 MER only supports a contiguous dense prefix \
+                                 (first_k_dense_replace), not interleaved dense layers"
+                            )));
+                        }
+                        _ => {}
+                    }
+                }
+                Some(leading_dense)
+            } else {
+                None
+            };
+
         Ok(HfConfig {
             architecture,
             model_type: if top_model_type.is_empty() {
@@ -1103,17 +1135,7 @@ impl HfConfig {
             num_routed_experts,
             num_experts_per_tok: get("num_experts_per_tok").and_then(as_usize),
             num_shared_experts: get("n_shared_experts").and_then(as_usize),
-            first_k_dense_replace: get("first_k_dense_replace")
-                .and_then(as_usize)
-                // MiMo-V2-Flash has no `first_k_dense_replace`; it marks
-                // dense vs MoE layers via `moe_layer_freq` (0 = dense FFN,
-                // 1 = MoE). Layer 0 is dense, so the number of leading dense
-                // layers is the count of leading zeros in that array.
-                .or_else(|| {
-                    get("moe_layer_freq").and_then(|v| v.as_array()).map(|arr| {
-                        arr.iter().take_while(|e| e.as_u64() == Some(0)).count()
-                    })
-                }),
+            first_k_dense_replace,
             scoring_func: get("scoring_func").and_then(|v| v.as_str().map(String::from)),
             topk_method: get("topk_method").and_then(|v| v.as_str().map(String::from)),
             n_group: get("n_group").and_then(as_usize),
@@ -2002,5 +2024,21 @@ mod tests {
         }"#;
         let cfg = HfConfig::from_json_str(json).unwrap();
         assert_eq!(cfg.first_k_dense_replace, Some(0));
+    }
+
+    #[test]
+    fn moe_layer_freq_rejects_non_leading_zero() {
+        let json = r#"{
+            "architectures": ["MiMoV2FlashForCausalLM"],
+            "model_type": "mimo_v2_flash",
+            "hidden_size": 4096, "num_hidden_layers": 6,
+            "num_attention_heads": 64, "vocab_size": 152576,
+            "moe_layer_freq": [0, 1, 1, 0, 1, 1]
+        }"#;
+        let err = HfConfig::from_json_str(json).unwrap_err();
+        assert!(
+            err.to_string().contains("non-leading zero"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/rust-engine/src/expert_cache.rs
+++ b/rust-engine/src/expert_cache.rs
@@ -16,11 +16,12 @@ use crate::buffer_pool::PooledBuffer;
 use crate::gguf_loader::DEFAULT_BLOCK_ALIGN;
 use crate::tensor_header::TensorHeader;
 use lru::LruCache;
+use once_cell::sync::OnceCell;
 use parking_lot::Mutex;
 use std::collections::{HashMap, HashSet};
 use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex as StdMutex};
+use std::sync::Arc;
 
 /// Pack/unpack an `f64` heat score into the bits of an `AtomicU64` so it
 /// can be read and updated without a lock. The cost-aware eviction
@@ -62,7 +63,7 @@ pub struct ExpertResident {
     /// Cached once-per-resident Q4_0 zero-padded payload used when the
     /// on-disk bytes are slightly short (≤ one block/page) of the
     /// derived expected size.
-    q4_0_padded: StdMutex<Option<(usize, Arc<[u8]>)>>,
+    q4_0_padded: OnceCell<(usize, Arc<[u8]>)>,
     /// **Tier 4 cost-aware eviction.** Decaying heat score: bumped by
     /// `+1` on every cache hit and exponentially decayed by the number
     /// of intervening insertions (cache-pressure events). Only
@@ -97,7 +98,7 @@ impl ExpertResident {
             buffer,
             payload_offset,
             hits: AtomicU64::new(0),
-            q4_0_padded: StdMutex::new(None),
+            q4_0_padded: OnceCell::new(),
             heat_bits: AtomicU64::new(0.0f64.to_bits()),
             heat_last_epoch: AtomicU64::new(0),
         }
@@ -163,7 +164,7 @@ impl ExpertResident {
 
     /// Return a cached zero-padded Q4_0 payload when the resident is at
     /// most `tolerance` bytes short of `need`. The padded allocation is
-    /// created at most once per `need` for this resident.
+    /// created at most once for this resident.
     pub fn q4_0_padded_payload(&self, need: usize, tolerance: usize) -> Option<Arc<[u8]>> {
         let data = self.data();
         if data.len() >= need {
@@ -174,18 +175,13 @@ impl ExpertResident {
             return None;
         }
 
-        let mut guard = self.q4_0_padded.lock().expect("q4_0_padded poisoned");
-        if let Some((cached_need, cached)) = guard.as_ref() {
-            if *cached_need == need {
-                return Some(cached.clone());
-            }
-        }
-        let mut padded = Vec::with_capacity(need);
-        padded.extend_from_slice(data);
-        padded.resize(need, 0);
-        let cached: Arc<[u8]> = Arc::from(padded.into_boxed_slice());
-        *guard = Some((need, cached.clone()));
-        Some(cached)
+        let (cached_need, cached) = self.q4_0_padded.get_or_init(|| {
+            let mut padded = Vec::with_capacity(need);
+            padded.extend_from_slice(data);
+            padded.resize(need, 0);
+            (need, Arc::from(padded.into_boxed_slice()))
+        });
+        (*cached_need == need).then(|| cached.clone())
     }
 }
 

--- a/rust-engine/src/parallel.rs
+++ b/rust-engine/src/parallel.rs
@@ -238,6 +238,10 @@ where
 mod tests {
     use super::*;
 
+    fn build_test_pool(threads: usize) -> rayon::ThreadPool {
+        rayon::ThreadPoolBuilder::new().num_threads(threads).build().unwrap()
+    }
+
     /// Reference row-major mat-vec used as the parity oracle.
     fn serial_matvec(w: &[f32], x: &[f32], rows: usize, cols: usize) -> Vec<f32> {
         (0..rows)
@@ -264,10 +268,11 @@ mod tests {
     fn matches_serial_across_sizes() {
         // Span the inline path (tiny), the boundary, and the fanned-out
         // path (large) to exercise both branches and the chunk seam.
+        let pool = build_test_pool(4);
         for &(rows, cols) in &[(1usize, 1usize), (3, 5), (64, 64), (1024, 512), (4096, 256)] {
             let w: Vec<f32> = (0..rows * cols).map(|i| ((i % 17) as f32) * 0.01 - 0.5).collect();
             let x: Vec<f32> = (0..cols).map(|i| ((i % 13) as f32) * 0.1 - 0.3).collect();
-            let got = par_matvec(&w, &x, rows, cols);
+            let got = pool.install(|| par_matvec(&w, &x, rows, cols));
             let want = serial_matvec(&w, &x, rows, cols);
             assert_eq!(got.len(), want.len());
             for (g, e) in got.iter().zip(want.iter()) {
@@ -283,11 +288,14 @@ mod tests {
         // index, so any double-write or skipped row would corrupt it.
         let rows = 1000usize;
         let mut out = vec![usize::MAX; rows];
-        // Force the parallel path regardless of arithmetic width.
-        par_row_chunks(&mut out, MIN_TOTAL_FOR_PARALLEL, |row_start, chunk| {
-            for (i, slot) in chunk.iter_mut().enumerate() {
-                *slot = row_start + i;
-            }
+        let pool = build_test_pool(4);
+        pool.install(|| {
+            // Force the parallel path regardless of arithmetic width.
+            par_row_chunks(&mut out, MIN_TOTAL_FOR_PARALLEL, |row_start, chunk| {
+                for (i, slot) in chunk.iter_mut().enumerate() {
+                    *slot = row_start + i;
+                }
+            });
         });
         for (i, v) in out.iter().enumerate() {
             assert_eq!(*v, i, "row {i} was not written exactly once");
@@ -302,10 +310,13 @@ mod tests {
         // 1` capture would make it `FnMut`, which `par_row_chunks`
         // rejects). A single row must take the inline path: one call.
         let calls = AtomicUsize::new(0);
-        par_row_chunks(&mut out, 1_000_000, |row_start, chunk| {
-            calls.fetch_add(1, Ordering::Relaxed);
-            assert_eq!(row_start, 0);
-            chunk[0] = 42;
+        let pool = build_test_pool(4);
+        pool.install(|| {
+            par_row_chunks(&mut out, 1_000_000, |row_start, chunk| {
+                calls.fetch_add(1, Ordering::Relaxed);
+                assert_eq!(row_start, 0);
+                chunk[0] = 42;
+            });
         });
         assert_eq!(calls.load(Ordering::Relaxed), 1);
         assert_eq!(out[0], 42);

--- a/rust-engine/src/workload.rs
+++ b/rust-engine/src/workload.rs
@@ -134,7 +134,7 @@ impl SkewedStream {
     fn sample_rank(&self, u: f64) -> usize {
         match self
             .cdf
-            .binary_search_by(|p| p.partial_cmp(&u).unwrap_or(std::cmp::Ordering::Less))
+            .binary_search_by(|p| p.total_cmp(&u))
         {
             Ok(i) => i,
             Err(i) => i.min(self.cdf.len().saturating_sub(1)),
@@ -340,6 +340,16 @@ mod tests {
             correlated > independent * 3,
             "rho=0.9 ({correlated} repeats) must be far more correlated than rho=0 ({independent})"
         );
+    }
+
+    #[test]
+    fn sample_rank_handles_nan_cdf_entry() {
+        let mut s = SkewedStream::new(8, 1, 1.0, 0.0, 11);
+        s.cdf[3] = f64::NAN;
+
+        let rank = s.sample_rank(0.5);
+
+        assert!(rank < s.cdf.len(), "rank {rank} should stay within the CDF");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Reject interleaved `moe_layer_freq` dense markers instead of silently treating later dense layers as MoE
- Use `f64::total_cmp` for skewed workload CDF binary search and cover NaN CDF entries
- Replace the Q4_0 padded payload mutex with a write-once `OnceCell`
- Move `parallel.rs` tests onto isolated local Rayon pools

## Validation

- `cargo test --manifest-path rust-engine/Cargo.toml --no-default-features`
- `cargo test --manifest-path rust-engine/Cargo.toml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration validation so invalid architecture settings are now rejected with clearer error messages.
  * Fixed handling of model layer patterns to prevent ambiguous dense/MoE layouts from being accepted.
  * Made workload sampling deterministic when special numeric values are present.
  * Improved expert cache behavior to avoid unnecessary recomputation and keep results consistent.
  * Strengthened parallel processing tests to better verify behavior across thread pools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->