### PR TITLE
[codex] support mixed GGUF expert projections

### DIFF
--- a/rust-engine/src/engine.rs
+++ b/rust-engine/src/engine.rs
@@ -17,18 +17,18 @@ use crate::aligned_buffer::AlignedBuffer;
 use crate::backend::Backend as _;
 use crate::buffer_pool::BufferPool;
 use crate::expert_cache::{ExpertResident, GpuExpertCache, GpuResident};
-use crate::multi_layer_cache::MultiLayerExpertCache;
 use crate::gating::Router;
 use crate::inference::{
-    combine_outputs, run_inference_bf16, run_inference_f16, run_inference_int8, run_inference_mxfp4,
-    run_inference_q4_0,
-    run_inference_q4_0_qmm, run_inference_q4k, run_inference_q4k_qmm,
-    run_inference_q8_0, run_inference_q8_0_qmm, synth_hidden_state,
-    uniform_scores, ExpertWeightsError, HiddenState,
-    InferenceOutput, WeightDtype, Q4_0_BLOCK_ELEMS, Q4K_BLOCK_ELEMS, Q8_0_BLOCK_ELEMS,
+    combine_outputs, run_inference_bf16, run_inference_f16, run_inference_int8,
+    run_inference_mixed_quant, run_inference_mxfp4, run_inference_q4_0, run_inference_q4_0_qmm,
+    run_inference_q4k, run_inference_q4k_qmm, run_inference_q5k, run_inference_q6k,
+    run_inference_q8_0, run_inference_q8_0_qmm, synth_hidden_state, uniform_scores,
+    ExpertWeightsError, HiddenState, InferenceOutput, WeightDtype, Q4K_BLOCK_ELEMS,
+    Q4_0_BLOCK_ELEMS, Q8_0_BLOCK_ELEMS,
 };
 use crate::io_provider::NvmeStorage;
 use crate::metrics::Metrics;
+use crate::multi_layer_cache::MultiLayerExpertCache;
 use crate::router::{
     DecayWorkerHandle, LayeredExpertAffinity, LocalityMonitor, NeuralSpeculator, PredictiveLoader,
 };
@@ -182,8 +182,16 @@ impl AlignedKvCache {
     ///
     /// Panics if either slice's length differs from `kv_dim`.
     pub fn append(&mut self, k: &[f32], v: &[f32]) -> bool {
-        assert_eq!(k.len(), self.kv_dim, "AlignedKvCache::append: kv_dim mismatch");
-        assert_eq!(v.len(), self.kv_dim, "AlignedKvCache::append: kv_dim mismatch");
+        assert_eq!(
+            k.len(),
+            self.kv_dim,
+            "AlignedKvCache::append: kv_dim mismatch"
+        );
+        assert_eq!(
+            v.len(),
+            self.kv_dim,
+            "AlignedKvCache::append: kv_dim mismatch"
+        );
         let evicted = if self.seq_len == self.window_tokens {
             self.shift_one_left();
             true
@@ -206,7 +214,10 @@ impl AlignedKvCache {
 
     /// Read the i-th cached value.
     pub fn value(&self, i: usize) -> &[f32] {
-        assert!(i < self.seq_len, "AlignedKvCache::value: index out of bounds");
+        assert!(
+            i < self.seq_len,
+            "AlignedKvCache::value: index out of bounds"
+        );
         self.row_floats(self.values.as_slice(), i)
     }
 
@@ -246,10 +257,8 @@ impl AlignedKvCache {
         // in-memory representation of `[f32]` already matches the desired
         // serialized layout. `[f32]` is contiguous, and the produced byte
         // slices cover exactly `row_bytes`.
-        let k_bytes =
-            unsafe { std::slice::from_raw_parts(k.as_ptr() as *const u8, row_bytes) };
-        let v_bytes =
-            unsafe { std::slice::from_raw_parts(v.as_ptr() as *const u8, row_bytes) };
+        let k_bytes = unsafe { std::slice::from_raw_parts(k.as_ptr() as *const u8, row_bytes) };
+        let v_bytes = unsafe { std::slice::from_raw_parts(v.as_ptr() as *const u8, row_bytes) };
         kb.copy_from_slice(k_bytes);
         vb.copy_from_slice(v_bytes);
     }
@@ -276,9 +285,7 @@ impl AlignedKvCache {
             0,
             "row_floats: byte slice pointer must be 4-byte aligned for f32"
         );
-        unsafe {
-            std::slice::from_raw_parts(bytes.as_ptr() as *const f32, self.kv_dim)
-        }
+        unsafe { std::slice::from_raw_parts(bytes.as_ptr() as *const f32, self.kv_dim) }
     }
 
     /// Shift the K/V rows one slot toward index 0. Called by `append`
@@ -341,7 +348,11 @@ pub enum ExpertReadError {
 impl std::fmt::Display for ExpertReadError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ExpertReadError::Io { id, attempts, source } => write!(
+            ExpertReadError::Io {
+                id,
+                attempts,
+                source,
+            } => write!(
                 f,
                 "expert {id} read failed after {attempts} attempts: {source}"
             ),
@@ -447,7 +458,11 @@ pub struct TraceWriter {
     /// Shared with the worker so `flush` can synchronise on a
     /// definite "everything queued so far has been written" point
     /// (used in shutdown paths and tests).
-    flush_signal: Arc<(parking_lot::Mutex<u64>, parking_lot::Condvar, std::sync::atomic::AtomicU64)>,
+    flush_signal: Arc<(
+        parking_lot::Mutex<u64>,
+        parking_lot::Condvar,
+        std::sync::atomic::AtomicU64,
+    )>,
     /// Producer-side high-water mark: the largest sequence number
     /// successfully enqueued onto the channel. Updated *after* a
     /// successful `try_send` so `flush()` never waits on a record the
@@ -644,9 +659,7 @@ impl TraceWriter {
                 // The store uses a CAS-style max so out-of-order
                 // success notifications (rare under contention) can't
                 // walk the HWM backwards.
-                let mut current = self
-                    .producer_hwm
-                    .load(std::sync::atomic::Ordering::Acquire);
+                let mut current = self.producer_hwm.load(std::sync::atomic::Ordering::Acquire);
                 while seq > current {
                     match self.producer_hwm.compare_exchange_weak(
                         current,
@@ -687,9 +700,7 @@ impl TraceWriter {
         // Snapshot the *producer* HWM (not the worker's HWM); the
         // worker's HWM lags the producer and would let `flush` return
         // before the worker has actually drained the latest records.
-        let snapshot = self
-            .producer_hwm
-            .load(std::sync::atomic::Ordering::Acquire);
+        let snapshot = self.producer_hwm.load(std::sync::atomic::Ordering::Acquire);
         if snapshot == 0 {
             return; // nothing ever queued (or every send dropped)
         }
@@ -700,10 +711,7 @@ impl TraceWriter {
             if now >= deadline {
                 break;
             }
-            let _ = self
-                .flush_signal
-                .1
-                .wait_for(&mut guard, deadline - now);
+            let _ = self.flush_signal.1.wait_for(&mut guard, deadline - now);
         }
     }
 }
@@ -1445,9 +1453,7 @@ pub struct Engine {
 fn run_compute_donated<R>(f: impl FnOnce() -> R) -> R {
     use tokio::runtime::{Handle, RuntimeFlavor};
     match Handle::try_current() {
-        Ok(h) if h.runtime_flavor() == RuntimeFlavor::MultiThread => {
-            tokio::task::block_in_place(f)
-        }
+        Ok(h) if h.runtime_flavor() == RuntimeFlavor::MultiThread => tokio::task::block_in_place(f),
         _ => f(),
     }
 }
@@ -1496,16 +1502,13 @@ fn dispatch_expert_forward(
         // Without the feature this is a direct call to the CPU path, so
         // default builds are byte-for-byte unchanged.
         #[cfg(feature = "cuda")]
-        WeightDtype::F32 => {
-            crate::inference::run_inference_gpu(token_idx, r, x, d_model, d_ff)
-        }
+        WeightDtype::F32 => crate::inference::run_inference_gpu(token_idx, r, x, d_model, d_ff),
         #[cfg(not(feature = "cuda"))]
         WeightDtype::F32 => crate::inference::run_inference(token_idx, r, x, d_model, d_ff),
         WeightDtype::F16 => run_inference_f16(token_idx, r, x, d_model, d_ff),
         WeightDtype::Int8 => run_inference_int8(token_idx, r, x, d_model, d_ff),
-        WeightDtype::Q4K if use_qmm
-            && d_model % Q4K_BLOCK_ELEMS == 0
-            && d_ff % Q4K_BLOCK_ELEMS == 0 =>
+        WeightDtype::Q4K
+            if use_qmm && d_model % Q4K_BLOCK_ELEMS == 0 && d_ff % Q4K_BLOCK_ELEMS == 0 =>
         {
             match run_inference_q4k_qmm(token_idx, r, x, d_model, d_ff) {
                 Ok(v) => Ok(v),
@@ -1516,9 +1519,8 @@ fn dispatch_expert_forward(
             }
         }
         WeightDtype::Q4K => run_inference_q4k(token_idx, r, x, d_model, d_ff),
-        WeightDtype::Q4_0 if use_qmm
-            && d_model % Q4_0_BLOCK_ELEMS == 0
-            && d_ff % Q4_0_BLOCK_ELEMS == 0 =>
+        WeightDtype::Q4_0
+            if use_qmm && d_model % Q4_0_BLOCK_ELEMS == 0 && d_ff % Q4_0_BLOCK_ELEMS == 0 =>
         {
             match run_inference_q4_0_qmm(token_idx, r, x, d_model, d_ff) {
                 Ok(v) => Ok(v),
@@ -1529,9 +1531,8 @@ fn dispatch_expert_forward(
             }
         }
         WeightDtype::Q4_0 => run_inference_q4_0(token_idx, r, x, d_model, d_ff),
-        WeightDtype::Q8_0 if use_qmm
-            && d_model % Q8_0_BLOCK_ELEMS == 0
-            && d_ff % Q8_0_BLOCK_ELEMS == 0 =>
+        WeightDtype::Q8_0
+            if use_qmm && d_model % Q8_0_BLOCK_ELEMS == 0 && d_ff % Q8_0_BLOCK_ELEMS == 0 =>
         {
             match run_inference_q8_0_qmm(token_idx, r, x, d_model, d_ff) {
                 Ok(v) => Ok(v),
@@ -1542,8 +1543,11 @@ fn dispatch_expert_forward(
             }
         }
         WeightDtype::Q8_0 => run_inference_q8_0(token_idx, r, x, d_model, d_ff),
+        WeightDtype::Q5K => run_inference_q5k(token_idx, r, x, d_model, d_ff),
+        WeightDtype::Q6K => run_inference_q6k(token_idx, r, x, d_model, d_ff),
         WeightDtype::BF16 => run_inference_bf16(token_idx, r, x, d_model, d_ff),
         WeightDtype::MXFP4 => run_inference_mxfp4(token_idx, r, x, d_model, d_ff),
+        WeightDtype::Mixed => run_inference_mixed_quant(token_idx, r, x, d_model, d_ff),
     }
 }
 
@@ -1560,7 +1564,11 @@ fn summarise_output_like_cpu(token_idx: u64, expert_id: u32, y: &[f32]) -> Infer
         digest ^= v.to_bits() as u64;
         digest = digest.wrapping_mul(FNV_PRIME);
     }
-    InferenceOutput { expert_id, digest, out_norm }
+    InferenceOutput {
+        expert_id,
+        digest,
+        out_norm,
+    }
 }
 
 impl Engine {
@@ -1572,7 +1580,15 @@ impl Engine {
         predictor: Arc<PredictiveLoader>,
         shape: ModelShape,
     ) -> Self {
-        Self::with_options(cache, pool, storage, router, predictor, shape, EngineOptions::default())
+        Self::with_options(
+            cache,
+            pool,
+            storage,
+            router,
+            predictor,
+            shape,
+            EngineOptions::default(),
+        )
     }
 
     pub fn with_options(
@@ -1684,8 +1700,7 @@ impl Engine {
     /// Updates the `mer_vram_used_bytes` Prometheus gauge after every
     /// successful promotion.
     pub fn install_gpu_cache(&mut self, gpu: Arc<GpuExpertCache>) {
-        let (tx, mut rx) =
-            tokio::sync::mpsc::unbounded_channel::<(u32, Arc<ExpertResident>)>();
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<(u32, Arc<ExpertResident>)>();
         let gpu_for_task = gpu.clone();
         let prom_for_task = self.metrics.prom.clone();
         // Snapshot the (immutable) expert dtype so each promoted
@@ -1735,12 +1750,8 @@ impl Engine {
         // automatically when no adapter is present, so this never
         // panics.
         let backend = crate::backend::BackendBox::init_blocking(
-            /* num_layers   = */ 1,
-            /* max_seq_len  = */ 1,
-            /* num_heads    = */ 1,
-            /* num_kv_heads = */ 1,
-            /* head_dim     = */ 1,
-            gpu,
+            /* num_layers   = */ 1, /* max_seq_len  = */ 1, /* num_heads    = */ 1,
+            /* num_kv_heads = */ 1, /* head_dim     = */ 1, gpu,
         );
         self.core.backend = Arc::new(backend);
     }
@@ -1762,8 +1773,7 @@ impl Engine {
         &mut self,
         gpu: Arc<GpuExpertCache>,
     ) -> tokio::sync::mpsc::UnboundedReceiver<(u32, Arc<ExpertResident>)> {
-        let (tx, rx) =
-            tokio::sync::mpsc::unbounded_channel::<(u32, Arc<ExpertResident>)>();
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<(u32, Arc<ExpertResident>)>();
         self.core.gpu_cache = Some(gpu);
         self.core.gpu_promotion_tx = Some(tx);
         rx
@@ -1795,7 +1805,11 @@ impl Engine {
     /// `moe_step`, reconcile the monitor's hot set with the cache's pin
     /// state — newly hot ids are pinned, ids that fell below the heat
     /// threshold are unpinned.
-    pub fn with_locality_monitor(mut self, monitor: Arc<LocalityMonitor>, threshold_pct: f32) -> Self {
+    pub fn with_locality_monitor(
+        mut self,
+        monitor: Arc<LocalityMonitor>,
+        threshold_pct: f32,
+    ) -> Self {
         self.speculation.locality = Some(monitor);
         // Clamp into a sane range; values outside `[0,1]` make no
         // semantic sense for a "fraction of the window" threshold.
@@ -1980,7 +1994,11 @@ impl Engine {
         info!(
             pinned = hot.len(),
             fraction = sr.fraction,
-            source = if sr.profile.is_some() { "profile" } else { "online" },
+            source = if sr.profile.is_some() {
+                "profile"
+            } else {
+                "online"
+            },
             warmup_tokens = sr.warmup_tokens,
             "static residency: pinned hot expert set"
         );
@@ -2001,7 +2019,9 @@ impl Engine {
         if let Some(m) = &self.speculation.alias_map {
             if let Some(&canon) = m.get(&id) {
                 if canon != id {
-                    self.speculation.alias_redirects.fetch_add(1, Ordering::Relaxed);
+                    self.speculation
+                        .alias_redirects
+                        .fetch_add(1, Ordering::Relaxed);
                     return canon;
                 }
             }
@@ -2012,7 +2032,10 @@ impl Engine {
     #[inline]
     fn credit_prefetch_use(&self, resident: &Arc<ExpertResident>, new_hits: u64) {
         if new_hits == 1 && resident.is_shadow_backed() {
-            self.metrics.counters.prefetch_used.fetch_add(1, Ordering::Relaxed);
+            self.metrics
+                .counters
+                .prefetch_used
+                .fetch_add(1, Ordering::Relaxed);
             self.core.governor.record_used();
         }
     }
@@ -2035,10 +2058,7 @@ impl Engine {
     /// from the top-K mixture), so the only safe degradation is to
     /// surface the error to the caller — the HTTP serving path maps it
     /// to a 500 instead of crashing the process.
-    pub async fn generate(
-        self: &Arc<Self>,
-        token_idx: u64,
-    ) -> Result<CycleStats, ExpertReadError> {
+    pub async fn generate(self: &Arc<Self>, token_idx: u64) -> Result<CycleStats, ExpertReadError> {
         let cycle_start = Instant::now();
         // Tier 4: fold the previous token's prefetch precision window
         // into the governor's EWMA before this token issues any new
@@ -2050,14 +2070,20 @@ impl Engine {
         // ignores it. Either way the value is re-used by the FFN
         // forward pass below, so this is at worst the same single
         // `synth_hidden_state` call the legacy path always made.
-        let hidden: HiddenState =
-            synth_hidden_state(token_idx, self.core.shape.d_model, self.core.shape.hidden_seed);
+        let hidden: HiddenState = synth_hidden_state(
+            token_idx,
+            self.core.shape.d_model,
+            self.core.shape.hidden_seed,
+        );
         let decision = self.core.router.route(&hidden, token_idx);
         let raw_target = decision.experts;
         // Resolve aliases up front so the cache + predictor only ever
         // see canonical expert ids. This is what makes deduplicated
         // experts share one resident copy.
-        let target: Vec<u32> = raw_target.iter().map(|&id| self.resolve_alias(id)).collect();
+        let target: Vec<u32> = raw_target
+            .iter()
+            .map(|&id| self.resolve_alias(id))
+            .collect();
         let mut stats = CycleStats::default();
 
         // Locality monitor: observe the chosen experts and reconcile
@@ -2149,10 +2175,7 @@ impl Engine {
                 stats.misses += 1;
                 debug!(expert = id, "cache miss, fetching from NVMe");
                 let me = self.clone();
-                miss_handles.push((
-                    i,
-                    tokio::spawn(async move { me.fetch(id).await }),
-                ));
+                miss_handles.push((i, tokio::spawn(async move { me.fetch(id).await })));
             }
         }
         // Aggregate VRAM-tier outcome for this routing decision.
@@ -2195,7 +2218,10 @@ impl Engine {
                     .observe_step2(&ring.last_last.ids, &ring.last.ids, &target);
             }
             ring.last_last = ring.last.clone();
-            ring.last = MarkovHistory { ids: target.clone(), layer: None };
+            ring.last = MarkovHistory {
+                ids: target.clone(),
+                layer: None,
+            };
         }
         // Kick off speculative prefetches for the most-recent expert,
         // using the 2nd-order predictor when a prev_prev is available
@@ -2269,7 +2295,9 @@ impl Engine {
         // exports it as its own histogram so future overlapped-fetch
         // refactors can decouple the two without breaking dashboards.
         if io_wait_us > 0 {
-            self.metrics.total_ssd_stall_us.fetch_add(io_wait_us, Ordering::Relaxed);
+            self.metrics
+                .total_ssd_stall_us
+                .fetch_add(io_wait_us, Ordering::Relaxed);
             if let Some(m) = &self.metrics.prom {
                 m.record_ssd_stall(io_wait_us as f64 / 1_000_000.0);
             }
@@ -2294,175 +2322,186 @@ impl Engine {
         //    duration — otherwise the speculative prefetch tasks fired
         //    above can't get a worker to overlap this compute.
         let compute_start = Instant::now();
-        let compute_us = run_compute_donated(|| if self.core.options.io_only {
-            let mut digest: u64 = 0;
-            let mut total_bytes: u64 = 0;
-            for r in &residents {
-                let bytes = r.data();
-                total_bytes += bytes.len() as u64;
-                // XOR every byte. The accumulator is 64 bits wide so we
-                // also rotate per chunk; this prevents a smart compiler
-                // from folding the loop and guarantees every read byte
-                // is observed, the whole point of `--io-only`.
-                let mut acc: u64 = 0;
-                for chunk in bytes.chunks(8) {
-                    // Final chunk may be < 8 bytes; the remaining slots
-                    // in `buf` stay zero. XOR with zero is a no-op, so
-                    // the digest is still deterministic and every
-                    // actually-read byte still contributes.
-                    let mut buf = [0u8; 8];
-                    buf[..chunk.len()].copy_from_slice(chunk);
-                    acc ^= u64::from_le_bytes(buf);
+        let compute_us = run_compute_donated(|| {
+            if self.core.options.io_only {
+                let mut digest: u64 = 0;
+                let mut total_bytes: u64 = 0;
+                for r in &residents {
+                    let bytes = r.data();
+                    total_bytes += bytes.len() as u64;
+                    // XOR every byte. The accumulator is 64 bits wide so we
+                    // also rotate per chunk; this prevents a smart compiler
+                    // from folding the loop and guarantees every read byte
+                    // is observed, the whole point of `--io-only`.
+                    let mut acc: u64 = 0;
+                    for chunk in bytes.chunks(8) {
+                        // Final chunk may be < 8 bytes; the remaining slots
+                        // in `buf` stay zero. XOR with zero is a no-op, so
+                        // the digest is still deterministic and every
+                        // actually-read byte still contributes.
+                        let mut buf = [0u8; 8];
+                        buf[..chunk.len()].copy_from_slice(chunk);
+                        acc ^= u64::from_le_bytes(buf);
+                    }
+                    // `% 63` (deliberately not 64): `rotate_left(0)` and
+                    // `rotate_left(64)` are both no-ops on `u64`. Using 63
+                    // keeps the rotation amount in `0..63` so adjacent
+                    // expert ids actually pick different rotations and
+                    // the per-expert contributions don't collapse.
+                    digest ^= acc.rotate_left((r.id % 63) as u32);
                 }
-                // `% 63` (deliberately not 64): `rotate_left(0)` and
-                // `rotate_left(64)` are both no-ops on `u64`. Using 63
-                // keeps the rotation amount in `0..63` so adjacent
-                // expert ids actually pick different rotations and
-                // the per-expert contributions don't collapse.
-                digest ^= acc.rotate_left((r.id % 63) as u32);
-            }
-            let us = compute_start.elapsed().as_micros() as u64;
-            debug!(
-                token = token_idx,
-                bytes_touched = total_bytes,
-                io_only_digest = digest,
-                "io-only mode: skipped FFN, touched buffer bytes"
-            );
-            us
-        } else {
-            // Real expert FFN forward pass over weights streamed from SSD.
-            // `hidden` is the residual-stream activation already
-            // computed at the top of `generate`; under
-            // `Router::Linear` it is *the same* tensor that drove the
-            // routing decision, so the FFN sees the exact gate
-            // input (the production path), and under `Router::Markov`
-            // it stays the synthetic placeholder the benchmark path
-            // has always used.
-            let x: &HiddenState = &hidden;
-            let mut per_expert_y: Vec<HiddenState> = Vec::with_capacity(residents.len());
-            let mut outputs: Vec<InferenceOutput> = Vec::with_capacity(residents.len());
-            for r in &residents {
-                // ── Phase 3: GPU fast path ────────────────────────────────
-                // CandleBackend::expert_matmul bails unconditionally, so we
-                // always guard behind is_gpu(). A VRAM miss returns Err
-                // and we fall through to the CPU path below. Both F32 and
-                // (block-aligned) Q4_0 experts are eligible — see
-                // `Engine::gpu_eligible_dtype`.
+                let us = compute_start.elapsed().as_micros() as u64;
                 debug!(
-                    expert = r.id,
-                    is_gpu = self.core.backend.is_gpu(),
-                    gpu_eligible_dtype = self.gpu_eligible_dtype(),
-                    "generate GPU fast-path guard"
+                    token = token_idx,
+                    bytes_touched = total_bytes,
+                    io_only_digest = digest,
+                    "io-only mode: skipped FFN, touched buffer bytes"
                 );
-                info!(
-                    is_gpu = self.core.backend.is_gpu(),
-                    gpu_eligible = self.gpu_eligible_dtype(),
-                    "generate GPU fast-path guard check"
-                );
-                let gpu_result = if self.core.backend.is_gpu() && self.gpu_eligible_dtype()
-                {
-                    let mut out_f16 = vec![half::f16::ZERO; self.core.shape.d_model];
-                    let x_f16: Vec<half::f16> =
-                        x.iter().map(|&f| half::f16::from_f32(f)).collect();
-                    let x_view = crate::backend::TensorView {
-                        data: &x_f16,
-                        rows: 1,
-                        cols: self.core.shape.d_model,
-                    };
-                    let mut out_view = crate::backend::TensorViewMut {
-                        data: &mut out_f16,
-                        rows: 1,
-                        cols: self.core.shape.d_model,
-                    };
-                    // `generate` is the synthetic-benchmark path; it has no
-                    // per-layer iteration, so we route everything through
-                    // layer 0 — `expert_matmul` ignores `layer_idx` anyway
-                    // (the trait API takes it only for future logging).
+                us
+            } else {
+                // Real expert FFN forward pass over weights streamed from SSD.
+                // `hidden` is the residual-stream activation already
+                // computed at the top of `generate`; under
+                // `Router::Linear` it is *the same* tensor that drove the
+                // routing decision, so the FFN sees the exact gate
+                // input (the production path), and under `Router::Markov`
+                // it stays the synthetic placeholder the benchmark path
+                // has always used.
+                let x: &HiddenState = &hidden;
+                let mut per_expert_y: Vec<HiddenState> = Vec::with_capacity(residents.len());
+                let mut outputs: Vec<InferenceOutput> = Vec::with_capacity(residents.len());
+                for r in &residents {
+                    // ── Phase 3: GPU fast path ────────────────────────────────
+                    // CandleBackend::expert_matmul bails unconditionally, so we
+                    // always guard behind is_gpu(). A VRAM miss returns Err
+                    // and we fall through to the CPU path below. Both F32 and
+                    // (block-aligned) Q4_0 experts are eligible — see
+                    // `Engine::gpu_eligible_dtype`.
                     debug!(
                         expert = r.id,
                         is_gpu = self.core.backend.is_gpu(),
-                        dtype = ?self.core.options.dtype,
-                        "calling backend.expert_matmul"
+                        gpu_eligible_dtype = self.gpu_eligible_dtype(),
+                        "generate GPU fast-path guard"
                     );
-                    let matmul_res = self.core.backend.expert_matmul(
-                        0,
-                        r.id,
-                        x_view,
-                        self.core.shape.d_model,
-                        self.core.shape.d_ff,
-                        &mut out_view,
-                    );
-                    debug!(
-                        expert = r.id,
+                    info!(
                         is_gpu = self.core.backend.is_gpu(),
-                        dtype = ?self.core.options.dtype,
-                        ok = matmul_res.is_ok(),
-                        "returned from backend.expert_matmul"
+                        gpu_eligible = self.gpu_eligible_dtype(),
+                        "generate GPU fast-path guard check"
                     );
-                    match matmul_res {
-                        Ok(()) => Some(out_f16.iter().map(|h| h.to_f32()).collect::<Vec<f32>>()),
-                        Err(_) => None,
-                    }
-                } else {
-                    None
-                };
-
-                let res = if let Some(gpu_out) = gpu_result {
-                    Ok((
-                        summarise_output_like_cpu(token_idx, r.id, &gpu_out),
-                        gpu_out,
-                    ))
-                } else {
-                    dispatch_expert_forward(
-                        self.core.options.dtype,
-                        self.core.options.use_qmm_for_q4,
-                        token_idx,
-                        r,
-                        x,
-                        self.core.shape.d_model,
-                        self.core.shape.d_ff,
-                    )
-                };
-                match res {
-                    Ok((out, y)) => {
-                        outputs.push(out);
-                        per_expert_y.push(y);
-                    }
-                    Err(e) => {
-                        warn!(
-                            token = token_idx,
+                    let gpu_result = if self.core.backend.is_gpu() && self.gpu_eligible_dtype() {
+                        let mut out_f16 = vec![half::f16::ZERO; self.core.shape.d_model];
+                        let x_f16: Vec<half::f16> =
+                            x.iter().map(|&f| half::f16::from_f32(f)).collect();
+                        let x_view = crate::backend::TensorView {
+                            data: &x_f16,
+                            rows: 1,
+                            cols: self.core.shape.d_model,
+                        };
+                        let mut out_view = crate::backend::TensorViewMut {
+                            data: &mut out_f16,
+                            rows: 1,
+                            cols: self.core.shape.d_model,
+                        };
+                        // `generate` is the synthetic-benchmark path; it has no
+                        // per-layer iteration, so we route everything through
+                        // layer 0 — `expert_matmul` ignores `layer_idx` anyway
+                        // (the trait API takes it only for future logging).
+                        debug!(
                             expert = r.id,
-                            error = %e,
-                            "skipping expert: failed to reinterpret buffer as SwiGLU weights"
+                            is_gpu = self.core.backend.is_gpu(),
+                            dtype = ?self.core.options.dtype,
+                            "calling backend.expert_matmul"
                         );
+                        let matmul_res = self.core.backend.expert_matmul(
+                            0,
+                            r.id,
+                            x_view,
+                            self.core.shape.d_model,
+                            self.core.shape.d_ff,
+                            &mut out_view,
+                        );
+                        debug!(
+                            expert = r.id,
+                            is_gpu = self.core.backend.is_gpu(),
+                            dtype = ?self.core.options.dtype,
+                            ok = matmul_res.is_ok(),
+                            "returned from backend.expert_matmul"
+                        );
+                        match matmul_res {
+                            Ok(()) => {
+                                Some(out_f16.iter().map(|h| h.to_f32()).collect::<Vec<f32>>())
+                            }
+                            Err(_) => None,
+                        }
+                    } else {
+                        None
+                    };
+
+                    let res = if let Some(gpu_out) = gpu_result {
+                        Ok((
+                            summarise_output_like_cpu(token_idx, r.id, &gpu_out),
+                            gpu_out,
+                        ))
+                    } else {
+                        dispatch_expert_forward(
+                            self.core.options.dtype,
+                            self.core.options.use_qmm_for_q4,
+                            token_idx,
+                            r,
+                            x,
+                            self.core.shape.d_model,
+                            self.core.shape.d_ff,
+                        )
+                    };
+                    match res {
+                        Ok((out, y)) => {
+                            outputs.push(out);
+                            per_expert_y.push(y);
+                        }
+                        Err(e) => {
+                            warn!(
+                                token = token_idx,
+                                expert = r.id,
+                                error = %e,
+                                "skipping expert: failed to reinterpret buffer as SwiGLU weights"
+                            );
+                        }
                     }
                 }
+                // Synthetic / benchmark path has no real gating network, so
+                // weight every routed expert uniformly (`1/k`) — that matches
+                // the legacy averaging behaviour bit-for-bit while flowing
+                // through the new softmax-gated combiner signature.
+                let scores = uniform_scores(per_expert_y.len());
+                let combined = combine_outputs(&per_expert_y, &scores);
+                let us = compute_start.elapsed().as_micros() as u64;
+                debug!(
+                    token = token_idx,
+                    d_model = self.core.shape.d_model,
+                    d_ff = self.core.shape.d_ff,
+                    ?outputs,
+                    combined_norm = combined.iter().map(|v| v * v).sum::<f32>().sqrt(),
+                    "FFN forward complete"
+                );
+                us
             }
-            // Synthetic / benchmark path has no real gating network, so
-            // weight every routed expert uniformly (`1/k`) — that matches
-            // the legacy averaging behaviour bit-for-bit while flowing
-            // through the new softmax-gated combiner signature.
-            let scores = uniform_scores(per_expert_y.len());
-            let combined = combine_outputs(&per_expert_y, &scores);
-            let us = compute_start.elapsed().as_micros() as u64;
-            debug!(
-                token = token_idx,
-                d_model = self.core.shape.d_model,
-                d_ff = self.core.shape.d_ff,
-                ?outputs,
-                combined_norm = combined.iter().map(|v| v * v).sum::<f32>().sqrt(),
-                "FFN forward complete"
-            );
-            us
         });
         let _ = self.metrics.compute_hist.lock().record(compute_us.max(1));
-        self.metrics.total_compute_us.fetch_add(compute_us, Ordering::Relaxed);
-        self.metrics.total_io_wait_us.fetch_add(io_wait_us, Ordering::Relaxed);
+        self.metrics
+            .total_compute_us
+            .fetch_add(compute_us, Ordering::Relaxed);
+        self.metrics
+            .total_io_wait_us
+            .fetch_add(io_wait_us, Ordering::Relaxed);
 
         let cycle_us = cycle_start.elapsed().as_micros() as u64;
         let _ = self.metrics.cycle_hist.lock().record(cycle_us.max(1));
-        self.metrics.total_cycle_us.fetch_add(cycle_us, Ordering::Relaxed);
-        self.metrics.tokens_processed.fetch_add(1, Ordering::Relaxed);
+        self.metrics
+            .total_cycle_us
+            .fetch_add(cycle_us, Ordering::Relaxed);
+        self.metrics
+            .tokens_processed
+            .fetch_add(1, Ordering::Relaxed);
 
         Ok(stats)
     }
@@ -2552,14 +2591,18 @@ impl Engine {
                 tokio::pin!(fut);
                 fut.as_mut().enable();
                 if let Some(r) = self.core.cache.get(id) {
-                    self.metrics.counters.singleflight_followers
+                    self.metrics
+                        .counters
+                        .singleflight_followers
                         .fetch_add(1, Ordering::Relaxed);
                     return Ok(r);
                 }
                 if self.core.in_flight.contains_key(&id) {
                     fut.await;
                     if let Some(r) = self.core.cache.get(id) {
-                        self.metrics.counters.singleflight_followers
+                        self.metrics
+                            .counters
+                            .singleflight_followers
                             .fetch_add(1, Ordering::Relaxed);
                         return Ok(r);
                     }
@@ -2600,7 +2643,9 @@ impl Engine {
             // guard still runs on this early return, freeing the slot
             // we installed and waking any followers parked on us.
             if let Some(r) = self.core.cache.get(id) {
-                self.metrics.counters.singleflight_followers
+                self.metrics
+                    .counters
+                    .singleflight_followers
                     .fetch_add(1, Ordering::Relaxed);
                 return Ok(r);
             }
@@ -2660,10 +2705,7 @@ impl Engine {
     /// if the pool is under pressure), issues the read, and either
     /// installs the resident in the cache or surfaces the I/O error
     /// to the retry loop.
-    async fn fetch_once(
-        self: &Arc<Self>,
-        id: u32,
-    ) -> Result<Arc<ExpertResident>, FetchOnceError> {
+    async fn fetch_once(self: &Arc<Self>, id: u32) -> Result<Arc<ExpertResident>, FetchOnceError> {
         let io_start = Instant::now();
         // Acquire-with-eviction: evict an LRU entry if the cache is at
         // capacity (which releases its `PooledBuffer` on `Arc` drop),
@@ -2707,7 +2749,8 @@ impl Engine {
                 // a deduplicated batch of N concurrent fetches must
                 // increase `bytes_read` by exactly one expert's
                 // worth, regardless of which call site issued them.
-                self.metrics.counters
+                self.metrics
+                    .counters
                     .bytes_read
                     .fetch_add(buf.len() as u64, Ordering::Relaxed);
                 let resident = Arc::new(ExpertResident::new(id, buf));
@@ -2763,7 +2806,11 @@ impl Engine {
                 .counters
                 .prefetch_dropped_governor
                 .fetch_add(1, Ordering::Relaxed);
-            debug!(expert = id, score = p, "governor throttled speculative prefetch");
+            debug!(
+                expert = id,
+                score = p,
+                "governor throttled speculative prefetch"
+            );
             return;
         }
         // Speculative prefetches are *bounded*: each spawn must hold
@@ -2781,7 +2828,10 @@ impl Engine {
                     .counters
                     .prefetch_dropped_concurrency
                     .fetch_add(1, Ordering::Relaxed);
-                debug!(expert = id, "skipping prefetch: concurrency ceiling reached");
+                debug!(
+                    expert = id,
+                    "skipping prefetch: concurrency ceiling reached"
+                );
                 return;
             }
         };
@@ -2840,15 +2890,13 @@ impl Engine {
             // load.
             let mut buf = match me.core.pool.try_acquire_shadow() {
                 Some(b) => b,
-                None if me.core.pool.shadow_capacity() == 0 => {
-                    match me.core.pool.try_acquire() {
-                        Some(b) => b,
-                        None => {
-                            me.note_prefetch_dropped_pool_starved(id);
-                            return;
-                        }
+                None if me.core.pool.shadow_capacity() == 0 => match me.core.pool.try_acquire() {
+                    Some(b) => b,
+                    None => {
+                        me.note_prefetch_dropped_pool_starved(id);
+                        return;
                     }
-                }
+                },
                 None => {
                     // **Shadow recycling (Finding 3).** Buffer B is
                     // starved — but its capacity may be parked inside
@@ -2860,19 +2908,15 @@ impl Engine {
                     // If a clone of the resident is still referenced
                     // elsewhere the buffer comes back later — drop
                     // this speculative load, exactly like before.
-                    match me
-                        .core
-                        .cache
-                        .evict_lru_shadow_backed()
-                        .and_then(|victim| {
-                            debug!(
-                                expert = id,
-                                recycled = victim.id,
-                                "shadow pool starved: recycled LRU shadow-backed resident"
-                            );
-                            drop(victim);
-                            me.core.pool.try_acquire_shadow()
-                        }) {
+                    match me.core.cache.evict_lru_shadow_backed().and_then(|victim| {
+                        debug!(
+                            expert = id,
+                            recycled = victim.id,
+                            "shadow pool starved: recycled LRU shadow-backed resident"
+                        );
+                        drop(victim);
+                        me.core.pool.try_acquire_shadow()
+                    }) {
                         Some(b) => b,
                         None => {
                             me.note_prefetch_dropped_pool_starved(id);
@@ -2884,14 +2928,18 @@ impl Engine {
             let started = Instant::now();
             match me.core.storage.read_expert(id, &mut buf).await {
                 Ok(_) => {
-                    me.metrics.counters.prefetch_completed.fetch_add(1, Ordering::Relaxed);
+                    me.metrics
+                        .counters
+                        .prefetch_completed
+                        .fetch_add(1, Ordering::Relaxed);
                     // Tier 4: a speculative read landed in the cache. This
                     // is the precision *denominator*; the matching
                     // numerator (`record_used`) fires if/when a hit later
                     // consumes this shadow-backed resident. No-op when the
                     // governor is disabled.
                     me.core.governor.record_completed();
-                    me.metrics.counters
+                    me.metrics
+                        .counters
                         .bytes_read
                         .fetch_add(buf.len() as u64, Ordering::Relaxed);
                     // **Self-balancing shadow accounting.** We insert the
@@ -2927,15 +2975,16 @@ impl Engine {
                     // of waiting for `promote_after_hits` RAM hits — the
                     // lazy path can leave a predicted expert on the CPU
                     // fallback for its first N activations (one CPU
-// Only attempt eager VRAM promotion when the cache definitely has room;
-// otherwise we would copy ~expert_size bytes into a Vec only to have the
-// non-evicting promotion path immediately reject it.
-if let Some(gpu) = me.core.gpu_cache.as_ref() {
-    let bytes = resident.data().len();
-    if (gpu.used_bytes() as usize).saturating_add(bytes) <= gpu.capacity_bytes() {
-        me.try_promote_resident_to_gpu(&resident);
-    }
-}
+                    // Only attempt eager VRAM promotion when the cache definitely has room;
+                    // otherwise we would copy ~expert_size bytes into a Vec only to have the
+                    // non-evicting promotion path immediately reject it.
+                    if let Some(gpu) = me.core.gpu_cache.as_ref() {
+                        let bytes = resident.data().len();
+                        if (gpu.used_bytes() as usize).saturating_add(bytes) <= gpu.capacity_bytes()
+                        {
+                            me.try_promote_resident_to_gpu(&resident);
+                        }
+                    }
                     debug!(
                         expert = id,
                         prob = p,
@@ -3127,10 +3176,14 @@ if let Some(gpu) = me.core.gpu_cache.as_ref() {
             }
         }
         if hits > 0 {
-            self.speculation.locality_hits.fetch_add(hits, Ordering::Relaxed);
+            self.speculation
+                .locality_hits
+                .fetch_add(hits, Ordering::Relaxed);
         }
         if misses > 0 {
-            self.speculation.locality_misses.fetch_add(misses, Ordering::Relaxed);
+            self.speculation
+                .locality_misses
+                .fetch_add(misses, Ordering::Relaxed);
         }
         if let Some(m) = &self.metrics.prom {
             m.record_locality(hits, misses);
@@ -3253,10 +3306,14 @@ if let Some(gpu) = me.core.gpu_cache.as_ref() {
         }
         let misses = preds.len() as u64 - hits;
         if hits > 0 {
-            self.speculation.spec_hits.fetch_add(hits, Ordering::Relaxed);
+            self.speculation
+                .spec_hits
+                .fetch_add(hits, Ordering::Relaxed);
         }
         if misses > 0 {
-            self.speculation.spec_misses.fetch_add(misses, Ordering::Relaxed);
+            self.speculation
+                .spec_misses
+                .fetch_add(misses, Ordering::Relaxed);
         }
         // Top-1 accuracy: 1 if the speculator's #1 expert matches the
         // gate's #1 expert for this token, 0 otherwise. This is the
@@ -3266,7 +3323,9 @@ if let Some(gpu) = me.core.gpu_cache.as_ref() {
             _ => 0,
         };
         if top1_match > 0 {
-            self.speculation.spec_top1_matches.fetch_add(1, Ordering::Relaxed);
+            self.speculation
+                .spec_top1_matches
+                .fetch_add(1, Ordering::Relaxed);
         }
         // One token observed by the speculator (regardless of match).
         self.speculation.spec_tokens.fetch_add(1, Ordering::Relaxed);
@@ -3524,7 +3583,9 @@ if let Some(gpu) = me.core.gpu_cache.as_ref() {
         affinity: &LayeredExpertAffinity,
         per_layer: u32,
     ) -> Vec<(u32, f32)> {
-        use crate::router::{spatial_neighbors, SPATIAL_CONFIDENCE_THRESHOLD, W_AFFINITY, W_SPATIAL};
+        use crate::router::{
+            spatial_neighbors, SPATIAL_CONFIDENCE_THRESHOLD, W_AFFINITY, W_SPATIAL,
+        };
         let seeds: Vec<u32> = base
             .iter()
             .filter(|(_, s)| *s >= SPATIAL_CONFIDENCE_THRESHOLD)
@@ -3550,14 +3611,8 @@ if let Some(gpu) = me.core.gpu_cache.as_ref() {
                 }
             }
         }
-        let mut out: Vec<(u32, f32)> = combined
-            .into_iter()
-            .filter(|&(_, p)| p > 0.0)
-            .collect();
-        out.sort_by(|a, b| {
-            b.1.total_cmp(&a.1)
-                .then_with(|| a.0.cmp(&b.0))
-        });
+        let mut out: Vec<(u32, f32)> = combined.into_iter().filter(|&(_, p)| p > 0.0).collect();
+        out.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
         out
     }
 
@@ -3809,9 +3864,17 @@ if let Some(gpu) = me.core.gpu_cache.as_ref() {
         // trained) above this token, so we reuse it as the `predicted`
         // column rather than running a second forward.
         if let Some(tw) = self.metrics.trace_writer.read().as_ref() {
-            let predicted: Vec<u32> =
-                m_speculator.iter().map(|&id| self.resolve_alias(id)).collect();
-            tw.write_record(token_idx, layer, &target, &cache_hits_per_expert, &predicted);
+            let predicted: Vec<u32> = m_speculator
+                .iter()
+                .map(|&id| self.resolve_alias(id))
+                .collect();
+            tw.write_record(
+                token_idx,
+                layer,
+                &target,
+                &cache_hits_per_expert,
+                &predicted,
+            );
         }
         let had_misses = !miss_handles.is_empty();
         // Track expert slots whose fetch task failed: we'll drop them
@@ -3841,7 +3904,8 @@ if let Some(gpu) = me.core.gpu_cache.as_ref() {
                 }
                 Err(e) => {
                     let id = target[i];
-                    self.metrics.counters
+                    self.metrics
+                        .counters
                         .expert_read_failures
                         .fetch_add(1, Ordering::Relaxed);
                     warn!(token = token_idx, layer, expert = id, error = %e,
@@ -3862,8 +3926,8 @@ if let Some(gpu) = me.core.gpu_cache.as_ref() {
         // (same semantics as `run_inference` failing for a single
         // expert). The engine itself never panics anymore.
         let _ = failed_experts; // retained for telemetry below
-        // Reconstruct a Vec<Option<Arc<ExpertResident>>> aligned with
-        // `target.len()`; None entries correspond to failed fetches.
+                                // Reconstruct a Vec<Option<Arc<ExpertResident>>> aligned with
+                                // `target.len()`; None entries correspond to failed fetches.
         let residents: Vec<Option<Arc<ExpertResident>>> = residents;
 
         // Run the SwiGLU FFN per expert against the hidden state.
@@ -3894,11 +3958,9 @@ if let Some(gpu) = me.core.gpu_cache.as_ref() {
                 // miss returns Err and we fall through to the CPU path below.
                 // Both F32 and (block-aligned) Q4_0 experts are eligible —
                 // see `Engine::gpu_eligible_dtype`.
-                let gpu_result = if self.core.backend.is_gpu() && self.gpu_eligible_dtype()
-                {
+                let gpu_result = if self.core.backend.is_gpu() && self.gpu_eligible_dtype() {
                     let mut out_f16 = vec![half::f16::ZERO; self.core.shape.d_model];
-                    let x_f16: Vec<half::f16> =
-                        x.iter().map(|&f| half::f16::from_f32(f)).collect();
+                    let x_f16: Vec<half::f16> = x.iter().map(|&f| half::f16::from_f32(f)).collect();
                     let x_view = crate::backend::TensorView {
                         data: &x_f16,
                         rows: 1,
@@ -3985,10 +4047,16 @@ if let Some(gpu) = me.core.gpu_cache.as_ref() {
         });
         let compute_us = compute_start.elapsed().as_micros() as u64;
         let _ = self.metrics.compute_hist.lock().record(compute_us.max(1));
-        self.metrics.total_compute_us.fetch_add(compute_us, Ordering::Relaxed);
-        self.metrics.total_io_wait_us.fetch_add(io_wait_us, Ordering::Relaxed);
+        self.metrics
+            .total_compute_us
+            .fetch_add(compute_us, Ordering::Relaxed);
+        self.metrics
+            .total_io_wait_us
+            .fetch_add(io_wait_us, Ordering::Relaxed);
         if io_wait_us > 0 {
-            self.metrics.total_ssd_stall_us.fetch_add(io_wait_us, Ordering::Relaxed);
+            self.metrics
+                .total_ssd_stall_us
+                .fetch_add(io_wait_us, Ordering::Relaxed);
             if let Some(m) = &self.metrics.prom {
                 m.record_ssd_stall(io_wait_us as f64 / 1_000_000.0);
             }
@@ -4018,16 +4086,25 @@ if let Some(gpu) = me.core.gpu_cache.as_ref() {
                     } else {
                         &[]
                     };
-                self.core.predictor.observe_step2(pp, &ring.last.ids, &target);
+                self.core
+                    .predictor
+                    .observe_step2(pp, &ring.last.ids, &target);
             }
             ring.last_last = ring.last.clone();
-            ring.last = MarkovHistory { ids: target.clone(), layer: Some(layer) };
+            ring.last = MarkovHistory {
+                ids: target.clone(),
+                layer: Some(layer),
+            };
         }
 
         let cycle_us = cycle_start.elapsed().as_micros() as u64;
         let _ = self.metrics.cycle_hist.lock().record(cycle_us.max(1));
-        self.metrics.total_cycle_us.fetch_add(cycle_us, Ordering::Relaxed);
-        self.metrics.tokens_processed.fetch_add(1, Ordering::Relaxed);
+        self.metrics
+            .total_cycle_us
+            .fetch_add(cycle_us, Ordering::Relaxed);
+        self.metrics
+            .tokens_processed
+            .fetch_add(1, Ordering::Relaxed);
 
         per_expert_y
     }
@@ -4076,9 +4153,9 @@ if let Some(gpu) = me.core.gpu_cache.as_ref() {
         let mut handles = Vec::with_capacity(unique.len());
         for id in unique {
             let me = self.clone();
-            handles.push(tokio::spawn(async move {
-                (id, me.fetch_with_retry(id).await)
-            }));
+            handles.push(tokio::spawn(
+                async move { (id, me.fetch_with_retry(id).await) },
+            ));
         }
         for h in handles {
             match h.await {
@@ -4106,8 +4183,16 @@ if let Some(gpu) = me.core.gpu_cache.as_ref() {
         let total_io_wait_us = self.metrics.total_io_wait_us.load(Ordering::Relaxed);
         let total_compute_us = self.metrics.total_compute_us.load(Ordering::Relaxed);
         let total_cycle_us = self.metrics.total_cycle_us.load(Ordering::Relaxed);
-        let avg_io_wait_us = if tokens == 0 { 0.0 } else { total_io_wait_us as f64 / tokens as f64 };
-        let avg_compute_us = if tokens == 0 { 0.0 } else { total_compute_us as f64 / tokens as f64 };
+        let avg_io_wait_us = if tokens == 0 {
+            0.0
+        } else {
+            total_io_wait_us as f64 / tokens as f64
+        };
+        let avg_compute_us = if tokens == 0 {
+            0.0
+        } else {
+            total_compute_us as f64 / tokens as f64
+        };
         let pct_time_io = if total_cycle_us == 0 {
             0.0
         } else {
@@ -4116,7 +4201,11 @@ if let Some(gpu) = me.core.gpu_cache.as_ref() {
         EngineReport {
             hits: self.metrics.counters.hits.load(Ordering::Relaxed),
             misses: self.metrics.counters.misses.load(Ordering::Relaxed),
-            prefetch_completed: self.metrics.counters.prefetch_completed.load(Ordering::Relaxed),
+            prefetch_completed: self
+                .metrics
+                .counters
+                .prefetch_completed
+                .load(Ordering::Relaxed),
             bytes_read: self.metrics.counters.bytes_read.load(Ordering::Relaxed),
             cycle_p50_us: cycle.value_at_quantile(0.50),
             cycle_p95_us: cycle.value_at_quantile(0.95),
@@ -4148,7 +4237,11 @@ if let Some(gpu) = me.core.gpu_cache.as_ref() {
             predictive: self.predictive_telemetry(),
             locality_enabled: self.speculation.locality.is_some(),
             speculator_enabled: self.speculation.speculator.is_some(),
-            expert_read_failures: self.metrics.counters.expert_read_failures.load(Ordering::Relaxed),
+            expert_read_failures: self
+                .metrics
+                .counters
+                .expert_read_failures
+                .load(Ordering::Relaxed),
             prefetch_dropped_concurrency: self
                 .metrics
                 .counters
@@ -4164,7 +4257,11 @@ if let Some(gpu) = me.core.gpu_cache.as_ref() {
                 .counters
                 .speculator_dmodel_mismatch
                 .load(Ordering::Relaxed),
-            gpu_cpu_fallbacks: self.metrics.counters.gpu_cpu_fallbacks.load(Ordering::Relaxed),
+            gpu_cpu_fallbacks: self
+                .metrics
+                .counters
+                .gpu_cpu_fallbacks
+                .load(Ordering::Relaxed),
             gpu_cache_enabled: self.core.gpu_cache.is_some(),
             vram_used_bytes: self
                 .core
@@ -4184,12 +4281,7 @@ if let Some(gpu) = me.core.gpu_cache.as_ref() {
                 .as_ref()
                 .map(|g| g.promotions())
                 .unwrap_or(0),
-            gpu_cache_hits: self
-                .core
-                .gpu_cache
-                .as_ref()
-                .map(|g| g.hits())
-                .unwrap_or(0),
+            gpu_cache_hits: self.core.gpu_cache.as_ref().map(|g| g.hits()).unwrap_or(0),
             gpu_cache_misses: self
                 .core
                 .gpu_cache
@@ -4296,7 +4388,11 @@ if let Some(gpu) = me.core.gpu_cache.as_ref() {
             r.compute_p50_us,
             r.compute_p95_us,
             r.compute_p99_us,
-            if r.io_only { "io-only XOR digest, FFN skipped" } else { "SwiGLU FFN per token" }
+            if r.io_only {
+                "io-only XOR digest, FFN skipped"
+            } else {
+                "SwiGLU FFN per token"
+            }
         );
         info!(
             "cycle latency: p50={}us  p95={}us  p99={}us  max={}us",
@@ -4618,7 +4714,12 @@ mod tests {
         let pool = BufferPool::new(pool_slots, expert_size, block_align);
         let cache = Arc::new(MultiLayerExpertCache::single_layer(cache_slots));
         let router = Router::Markov(Arc::new(TopKRouter::new(num_experts, top_k, seed)));
-        let predictor = Arc::new(PredictiveLoader::new(num_experts, predict_fanout, 0.05, seed));
+        let predictor = Arc::new(PredictiveLoader::new(
+            num_experts,
+            predict_fanout,
+            0.05,
+            seed,
+        ));
 
         Arc::new(Engine::new(
             cache,
@@ -4626,7 +4727,11 @@ mod tests {
             storage,
             router,
             predictor,
-            ModelShape { d_model, d_ff, hidden_seed: seed },
+            ModelShape {
+                d_model,
+                d_ff,
+                hidden_seed: seed,
+            },
         ))
     }
 
@@ -4691,9 +4796,18 @@ mod tests {
         // The first token always misses (cold cache); after that the
         // cache + prefetcher should eventually start serving experts
         // from RAM rather than disk.
-        assert!(total_hits > 0, "expected at least some cache hits across {tokens} tokens");
-        assert!(total_misses > 0, "expected at least some cache misses across {tokens} tokens");
-        assert!(total_bytes > 0, "expected the engine to read bytes from the SSD");
+        assert!(
+            total_hits > 0,
+            "expected at least some cache hits across {tokens} tokens"
+        );
+        assert!(
+            total_misses > 0,
+            "expected at least some cache misses across {tokens} tokens"
+        );
+        assert!(
+            total_bytes > 0,
+            "expected the engine to read bytes from the SSD"
+        );
 
         // The aggregate report mirrors the per-cycle totals on the
         // critical path. `r.bytes_read` may exceed `total_bytes` because
@@ -4717,7 +4831,10 @@ mod tests {
         //     that was never a foreground miss.
         // The only guaranteed invariant is that the cold-start miss forces
         // at least one physical read, so the histogram is non-empty.
-        assert!(r.io_count > 0, "io histogram must record at least the cold-start read");
+        assert!(
+            r.io_count > 0,
+            "io histogram must record at least the cold-start read"
+        );
         // Latency histograms must have observed at least one sample of each
         // category (compute always, I/O at least once because a cold start
         // forces a miss).
@@ -4883,7 +5000,10 @@ mod tests {
             cache_slots
         );
         // Misses dominate when cache_slots is small relative to working set.
-        assert!(r.misses > r.hits / 2, "expected eviction churn to produce many misses");
+        assert!(
+            r.misses > r.hits / 2,
+            "expected eviction churn to produce many misses"
+        );
     }
 
     // ----------- Locality / Speculator / Union-Fetch tests ----------
@@ -5090,7 +5210,14 @@ mod tests {
         let cache_slots = 2;
         let predict_fanout = 1;
         let engine = build_engine(
-            &dir.path, num_experts, d_model, d_ff, cache_slots, top_k, predict_fanout, 0xDEADBEEF,
+            &dir.path,
+            num_experts,
+            d_model,
+            d_ff,
+            cache_slots,
+            top_k,
+            predict_fanout,
+            0xDEADBEEF,
         );
         for t in 0..16u64 {
             let _ = engine.generate(t).await.expect("generate should succeed");
@@ -5132,9 +5259,8 @@ mod tests {
         const TOP_K: usize = 2;
         const N: u64 = 32;
         let engine = build_engine(
-            &dir.path, /*num_experts=*/ 8, /*d_model=*/ 16,
-            /*d_ff=*/ 32, /*cache_slots=*/ 4, TOP_K,
-            /*predict_fanout=*/ 2, /*seed=*/ 0xE2E5EED1,
+            &dir.path, /*num_experts=*/ 8, /*d_model=*/ 16, /*d_ff=*/ 32,
+            /*cache_slots=*/ 4, TOP_K, /*predict_fanout=*/ 2, /*seed=*/ 0xE2E5EED1,
         );
         let mut total_fetches: u64 = 0;
         let mut total_prefetch: u64 = 0;
@@ -5178,7 +5304,11 @@ mod tests {
         let block_align = 4096usize;
         let expert_size = weight_bytes.div_ceil(block_align) * block_align;
         crate::io_provider::generate_synthetic_experts(
-            &dir.path, num_experts, expert_size, d_model, d_ff,
+            &dir.path,
+            num_experts,
+            expert_size,
+            d_model,
+            d_ff,
         )
         .expect("generate experts");
         let storage = Arc::new(
@@ -5196,7 +5326,12 @@ mod tests {
         let pool = BufferPool::new(pool_slots, expert_size, block_align);
         let cache = Arc::new(MultiLayerExpertCache::single_layer(cache_slots));
         let router = Router::Markov(Arc::new(TopKRouter::new(num_experts, 2, seed)));
-        let predictor = Arc::new(PredictiveLoader::new(num_experts, predict_fanout, 0.05, seed));
+        let predictor = Arc::new(PredictiveLoader::new(
+            num_experts,
+            predict_fanout,
+            0.05,
+            seed,
+        ));
         let mut opts = EngineOptions::default();
         opts.max_concurrent_prefetches = 1; // adversarial ceiling
         let engine = Arc::new(Engine::with_options(
@@ -5205,7 +5340,11 @@ mod tests {
             storage,
             router,
             predictor,
-            ModelShape { d_model, d_ff, hidden_seed: seed },
+            ModelShape {
+                d_model,
+                d_ff,
+                hidden_seed: seed,
+            },
             opts,
         ));
         // Fire a burst of prefetches well past the ceiling. With a
@@ -5322,14 +5461,23 @@ mod tests {
 
         // Build a plain engine (no GPU cache yet).
         let engine = build_engine(
-            &dir.path, num_experts, d_model, d_ff, cache_slots, top_k,
-            predict_fanout, seed,
+            &dir.path,
+            num_experts,
+            d_model,
+            d_ff,
+            cache_slots,
+            top_k,
+            predict_fanout,
+            seed,
         );
 
         // Warm the RAM cache with one expert so every moe_step is a
         // RAM hit (the path that drives promotion).
         let target_id: u32 = 0;
-        engine.warm_with(&[target_id]).await.expect("warm RAM cache");
+        engine
+            .warm_with(&[target_id])
+            .await
+            .expect("warm RAM cache");
         assert!(
             engine.core.cache.get(target_id).is_some(),
             "warm_with must leave the expert resident"
@@ -5363,7 +5511,9 @@ mod tests {
         // and passing the target expert id.
         let hidden = crate::inference::synth_hidden_state(0, d_model, seed);
         for t in 0..total_hits {
-            let _ = engine.moe_step(t, /*layer=*/ 0, &hidden, &[target_id]).await;
+            let _ = engine
+                .moe_step(t, /*layer=*/ 0, &hidden, &[target_id])
+                .await;
         }
 
         // Drain the channel — must contain exactly one message,
@@ -5439,9 +5589,17 @@ mod tests {
                 storage,
                 router,
                 predictor,
-                ModelShape { d_model, d_ff, hidden_seed: seed },
+                ModelShape {
+                    d_model,
+                    d_ff,
+                    hidden_seed: seed,
+                },
             )
-            .with_affinity(affinity.clone(), /*neighbors_k=*/ 2, /*decay_epoch=*/ 1_000_000),
+            .with_affinity(
+                affinity.clone(),
+                /*neighbors_k=*/ 2,
+                /*decay_epoch=*/ 1_000_000,
+            ),
         );
 
         // Co-fire global experts {4,5} in layer 1 (local {0,1}) a few
@@ -5453,11 +5611,22 @@ mod tests {
 
         // Layer 1's matrix (local namespace) must show 0 and 1 as mutual
         // neighbours.
-        assert_eq!(affinity.neighbors(1, 0, 2), vec![1], "local 0's neighbour in layer 1");
-        assert_eq!(affinity.neighbors(1, 1, 2), vec![0], "local 1's neighbour in layer 1");
+        assert_eq!(
+            affinity.neighbors(1, 0, 2),
+            vec![1],
+            "local 0's neighbour in layer 1"
+        );
+        assert_eq!(
+            affinity.neighbors(1, 1, 2),
+            vec![0],
+            "local 1's neighbour in layer 1"
+        );
         assert_eq!(affinity.affinity(1, 0, 1), 3, "co-fired three times");
         // No leakage into layer 0's matrix.
-        assert!(affinity.neighbors(0, 0, 2).is_empty(), "layer 0 must be untouched");
+        assert!(
+            affinity.neighbors(0, 0, 2).is_empty(),
+            "layer 0 must be untouched"
+        );
     }
 
     /// **Tier 1 — online static residency.** With no seed profile the
@@ -5503,7 +5672,11 @@ mod tests {
                 storage,
                 router,
                 predictor,
-                ModelShape { d_model, d_ff, hidden_seed: seed },
+                ModelShape {
+                    d_model,
+                    d_ff,
+                    hidden_seed: seed,
+                },
             )
             .with_static_residency(0.25, /*warmup_tokens=*/ 4, /*profile=*/ None),
         );
@@ -5515,12 +5688,20 @@ mod tests {
         // by the engine-owned observation counter, not the caller seed.
         for t in 0..3u64 {
             let cold = 6 + (t % 2) as u32; // 6 or 7, never as hot as {2,5}
-            let _ = engine.moe_step(0, /*layer=*/ 0, &hidden, &[2, 5, cold]).await;
+            let _ = engine
+                .moe_step(0, /*layer=*/ 0, &hidden, &[2, 5, cold])
+                .await;
         }
-        assert_eq!(cache.pinned_count(), 0, "warmup should not fire before 4 bumps");
+        assert_eq!(
+            cache.pinned_count(),
+            0,
+            "warmup should not fire before 4 bumps"
+        );
         for t in 3..8u64 {
             let cold = 6 + (t % 2) as u32;
-            let _ = engine.moe_step(0, /*layer=*/ 0, &hidden, &[2, 5, cold]).await;
+            let _ = engine
+                .moe_step(0, /*layer=*/ 0, &hidden, &[2, 5, cold])
+                .await;
         }
 
         // After warmup the hot set must be pinned exactly once.
@@ -5610,7 +5791,11 @@ mod tests {
         engine.credit_prefetch_use(&resident, second);
 
         assert_eq!(
-            engine.metrics.counters.prefetch_used.load(Ordering::Relaxed),
+            engine
+                .metrics
+                .counters
+                .prefetch_used
+                .load(Ordering::Relaxed),
             1,
             "only the first consumption of a shadow-backed resident is credited"
         );
@@ -5664,7 +5849,11 @@ mod tests {
                 storage,
                 router,
                 predictor,
-                ModelShape { d_model, d_ff, hidden_seed: seed },
+                ModelShape {
+                    d_model,
+                    d_ff,
+                    hidden_seed: seed,
+                },
             )
             .with_static_residency(0.25, /*warmup_tokens=*/ 100, Some(profile)),
         );
@@ -5674,7 +5863,11 @@ mod tests {
         let _ = engine.moe_step(0, /*layer=*/ 0, &hidden, &[5, 6]).await;
 
         assert_eq!(cache.pinned_count(), 2, "ceil(0.25*8)=2 experts pinned");
-        assert_eq!(cache.pinned_ids(), vec![0, 3], "profile's two hottest experts");
+        assert_eq!(
+            cache.pinned_ids(),
+            vec![0, 3],
+            "profile's two hottest experts"
+        );
     }
 
     /// **Layer-scoped speculator accuracy.** On the `moe_step` path the
@@ -5725,7 +5918,11 @@ mod tests {
                 storage,
                 router,
                 predictor,
-                ModelShape { d_model, d_ff, hidden_seed: seed },
+                ModelShape {
+                    d_model,
+                    d_ff,
+                    hidden_seed: seed,
+                },
             )
             .with_speculator(spec, /*top_k=*/ 2),
         );
@@ -5735,7 +5932,10 @@ mod tests {
             let base = layer * per_layer;
             let target = [base, base + 1];
             let preds = engine.speculator_predict_and_train(&hidden, &target, Some(layer));
-            assert!(!preds.is_empty(), "speculator must predict for layer {layer}");
+            assert!(
+                !preds.is_empty(),
+                "speculator must predict for layer {layer}"
+            );
             for &p in &preds {
                 assert!(
                     p >= base && p < base + per_layer,
@@ -5791,7 +5991,11 @@ mod tests {
                 storage,
                 router,
                 predictor,
-                ModelShape { d_model, d_ff, hidden_seed: seed },
+                ModelShape {
+                    d_model,
+                    d_ff,
+                    hidden_seed: seed,
+                },
             )
             .with_locality_monitor(monitor, 0.0),
         );
@@ -5851,7 +6055,11 @@ mod tests {
             storage,
             router,
             predictor,
-            ModelShape { d_model, d_ff, hidden_seed: seed },
+            ModelShape {
+                d_model,
+                d_ff,
+                hidden_seed: seed,
+            },
         ));
 
         // Contiguous: L -> L+1, and last-layer -> 0 (token boundary).
@@ -5909,7 +6117,11 @@ mod tests {
             storage,
             router,
             predictor,
-            ModelShape { d_model, d_ff, hidden_seed: seed },
+            ModelShape {
+                d_model,
+                d_ff,
+                hidden_seed: seed,
+            },
         ));
 
         // Helper: spawn a prefetch and wait until the id is resident.
@@ -6001,7 +6213,11 @@ mod tests {
                     storage,
                     router,
                     predictor,
-                    ModelShape { d_model, d_ff, hidden_seed: seed },
+                    ModelShape {
+                        d_model,
+                        d_ff,
+                        hidden_seed: seed,
+                    },
                 )
                 .with_speculator(spec, /*top_k=*/ 2)
                 .with_pipeline_depth(pipeline_depth),

--- a/rust-engine/src/expert_cache.rs
+++ b/rust-engine/src/expert_cache.rs
@@ -14,7 +14,7 @@
 
 use crate::buffer_pool::PooledBuffer;
 use crate::gguf_loader::DEFAULT_BLOCK_ALIGN;
-use crate::tensor_header::TensorHeader;
+use crate::tensor_header::{MixedExpertHeader, TensorHeader};
 use lru::LruCache;
 use once_cell::sync::OnceCell;
 use parking_lot::Mutex;
@@ -50,6 +50,8 @@ pub struct ExpertResident {
     /// begins. `0` for legacy blobs and synthetic fixtures (no UTH);
     /// `UTH_BYTES + page padding` for `gguf-convert` blobs.
     payload_offset: usize,
+    /// Parsed mixed-projection header, present only for UTH2 experts.
+    mixed_layout: Option<MixedExpertHeader>,
     /// Monotonic hit counter (Phase 2 — three-tier memory hierarchy).
     ///
     /// Bumped by [`GpuExpertCache::observe_ram_hit`] / engine routing
@@ -83,25 +85,38 @@ impl ExpertResident {
     /// payload offset once. Subsequent calls to [`Self::data`] do not
     /// re-probe the header.
     pub fn new(id: u32, buffer: PooledBuffer) -> Self {
-        let payload_offset = {
+        let (payload_offset, mixed_layout) = {
             let raw = buffer.as_slice();
-            let (_, payload) = TensorHeader::strip(raw, DEFAULT_BLOCK_ALIGN);
+            let (payload, mixed) =
+                if let Some((h, payload)) = MixedExpertHeader::strip(raw, DEFAULT_BLOCK_ALIGN) {
+                    (payload, Some(h))
+                } else {
+                    let (_, payload) = TensorHeader::strip(raw, DEFAULT_BLOCK_ALIGN);
+                    (payload, None)
+                };
             // `payload` is either `raw` unchanged (offset 0) or a suffix
             // subslice of it; derive the offset directly from the slice
             // lengths rather than via pointer arithmetic.
             let payload_offset = raw.len() - payload.len();
             debug_assert!(payload_offset <= raw.len());
-            payload_offset
+            (payload_offset, mixed)
         };
         Self {
             id,
             buffer,
             payload_offset,
+            mixed_layout,
             hits: AtomicU64::new(0),
             q4_0_padded: OnceCell::new(),
             heat_bits: AtomicU64::new(0.0f64.to_bits()),
             heat_last_epoch: AtomicU64::new(0),
         }
+    }
+
+    /// Parsed UTH2 layout for mixed-projection experts.
+    #[inline]
+    pub fn mixed_layout(&self) -> Option<MixedExpertHeader> {
+        self.mixed_layout
     }
 
     /// Increment the resident's monotonic hit counter and return the
@@ -492,7 +507,11 @@ pub struct GpuResident {
 
 impl GpuResident {
     pub fn new(id: u32, bytes: Vec<u8>) -> Self {
-        Self { id, bytes, dtype: crate::inference::WeightDtype::F32 }
+        Self {
+            id,
+            bytes,
+            dtype: crate::inference::WeightDtype::F32,
+        }
     }
 
     /// Like [`GpuResident::new`] but tagging the bytes with their
@@ -528,7 +547,7 @@ impl crate::backend::GpuStorage for GpuResident {
         self.bytes.len()
     }
     fn as_wgpu_buffer(&self) -> Option<&wgpu::Buffer> {
-        None   // GpuResident is host-side only; VRAM lives in VramExpertEntry
+        None // GpuResident is host-side only; VRAM lives in VramExpertEntry
     }
 }
 
@@ -821,8 +840,6 @@ impl GpuExpertCache {
         true
     }
 
-
-
     /// Number of Anchor Core entries.
     pub fn anchor_len(&self) -> usize {
         self.inner.lock().anchor.len()
@@ -856,8 +873,12 @@ mod tests {
         let pool = BufferPool::new(3, 4096, 4096);
         let cache = ExpertCache::new(2);
 
-        let _ = cache.insert(make(0, &pool)).map_err(|_| panic!("insert failed"));
-        let _ = cache.insert(make(1, &pool)).map_err(|_| panic!("insert failed"));
+        let _ = cache
+            .insert(make(0, &pool))
+            .map_err(|_| panic!("insert failed"));
+        let _ = cache
+            .insert(make(1, &pool))
+            .map_err(|_| panic!("insert failed"));
         // 2 of 3 slots are occupied by cache entries; 1 is free.
         let scratch = pool.try_acquire().expect("third slot free");
         assert!(pool.try_acquire().is_none());
@@ -883,12 +904,18 @@ mod tests {
     fn hit_updates_recency() {
         let pool = BufferPool::new(3, 4096, 4096);
         let cache = ExpertCache::new(2);
-        let _ = cache.insert(make(0, &pool)).map_err(|_| panic!("insert failed"));
-        let _ = cache.insert(make(1, &pool)).map_err(|_| panic!("insert failed"));
+        let _ = cache
+            .insert(make(0, &pool))
+            .map_err(|_| panic!("insert failed"));
+        let _ = cache
+            .insert(make(1, &pool))
+            .map_err(|_| panic!("insert failed"));
         // Touch expert 0 -> it is now most-recently used.
         let _ = cache.get(0);
         // Inserting expert 2 should evict 1, not 0.
-        let _ = cache.insert(make(2, &pool)).map_err(|_| panic!("insert failed"));
+        let _ = cache
+            .insert(make(2, &pool))
+            .map_err(|_| panic!("insert failed"));
         assert!(cache.contains(0));
         assert!(!cache.contains(1));
         assert!(cache.contains(2));
@@ -898,8 +925,12 @@ mod tests {
     fn pinned_entry_is_protected_from_eviction() {
         let pool = BufferPool::new(4, 4096, 4096);
         let cache = ExpertCache::new(2);
-        let _ = cache.insert(make(0, &pool)).map_err(|_| panic!("insert failed"));
-        let _ = cache.insert(make(1, &pool)).map_err(|_| panic!("insert failed"));
+        let _ = cache
+            .insert(make(0, &pool))
+            .map_err(|_| panic!("insert failed"));
+        let _ = cache
+            .insert(make(1, &pool))
+            .map_err(|_| panic!("insert failed"));
         // Pin expert 0. Even though it's the LRU, expert 1 must be
         // evicted instead when expert 2 is inserted.
         cache.pin(0);
@@ -919,8 +950,12 @@ mod tests {
     fn evict_lru_returns_none_when_all_pinned() {
         let pool = BufferPool::new(4, 4096, 4096);
         let cache = ExpertCache::new(2);
-        let _ = cache.insert(make(0, &pool)).map_err(|_| panic!("insert failed"));
-        let _ = cache.insert(make(1, &pool)).map_err(|_| panic!("insert failed"));
+        let _ = cache
+            .insert(make(0, &pool))
+            .map_err(|_| panic!("insert failed"));
+        let _ = cache
+            .insert(make(1, &pool))
+            .map_err(|_| panic!("insert failed"));
         cache.pin(0);
         cache.pin(1);
         assert!(cache.evict_lru().is_none());
@@ -936,13 +971,17 @@ mod tests {
         cache.set_cost_aware(true);
         // A (id 0) is loaded and then hit many times → high heat. The
         // hits make it most-recently-used for now.
-        let _ = cache.insert(make(0, &pool)).map_err(|_| panic!("insert failed"));
+        let _ = cache
+            .insert(make(0, &pool))
+            .map_err(|_| panic!("insert failed"));
         for _ in 0..10 {
             let _ = cache.get(0);
         }
         // B (id 1) is loaded cold. Now A is the LRU (B is MRU) but A is
         // far hotter than B.
-        let _ = cache.insert(make(1, &pool)).map_err(|_| panic!("insert failed"));
+        let _ = cache
+            .insert(make(1, &pool))
+            .map_err(|_| panic!("insert failed"));
         // Inserting C evicts a victim: cost-aware keeps hot A, drops cold B.
         let evicted = match cache.insert(make(2, &pool)) {
             Ok(Some(e)) => e,
@@ -964,17 +1003,24 @@ mod tests {
         // legacy strict-LRU outcome: the hot-but-LRU expert is evicted.
         let pool = BufferPool::new(4, 4096, 4096);
         let cache = ExpertCache::new(2);
-        let _ = cache.insert(make(0, &pool)).map_err(|_| panic!("insert failed"));
+        let _ = cache
+            .insert(make(0, &pool))
+            .map_err(|_| panic!("insert failed"));
         for _ in 0..10 {
             let _ = cache.get(0);
         }
-        let _ = cache.insert(make(1, &pool)).map_err(|_| panic!("insert failed"));
+        let _ = cache
+            .insert(make(1, &pool))
+            .map_err(|_| panic!("insert failed"));
         // 0 is MRU after the hits, then 1 is inserted → 1 MRU, 0 LRU.
         let evicted = match cache.insert(make(2, &pool)) {
             Ok(Some(e)) => e,
             other => panic!("expected an eviction, got ok={}", other.is_ok()),
         };
-        assert_eq!(evicted.id, 0, "pure LRU should evict the least-recently-used expert (0)");
+        assert_eq!(
+            evicted.id, 0,
+            "pure LRU should evict the least-recently-used expert (0)"
+        );
         assert!(!cache.contains(0));
         assert!(cache.contains(1));
         assert!(cache.contains(2));
@@ -989,7 +1035,9 @@ mod tests {
         let cache = ExpertCache::new(2);
         cache.set_cost_aware(true);
         // Make expert 0 very hot, then never touch it again.
-        let _ = cache.insert(make(0, &pool)).map_err(|_| panic!("insert failed"));
+        let _ = cache
+            .insert(make(0, &pool))
+            .map_err(|_| panic!("insert failed"));
         for _ in 0..20 {
             let _ = cache.get(0);
         }
@@ -1018,8 +1066,12 @@ mod tests {
         // `Err(resident)` rather than silently evicting a pinned slot.
         let pool = BufferPool::new(4, 4096, 4096);
         let cache = ExpertCache::new(2);
-        let _ = cache.insert(make(0, &pool)).map_err(|_| panic!("insert failed"));
-        let _ = cache.insert(make(1, &pool)).map_err(|_| panic!("insert failed"));
+        let _ = cache
+            .insert(make(0, &pool))
+            .map_err(|_| panic!("insert failed"));
+        let _ = cache
+            .insert(make(1, &pool))
+            .map_err(|_| panic!("insert failed"));
         cache.pin(0);
         cache.pin(1);
         let new_resident = make(2, &pool);

--- a/rust-engine/src/gguf.rs
+++ b/rust-engine/src/gguf.rs
@@ -17,15 +17,13 @@
 //!   (the engine never opens GGUFs on the inference hot path).
 //!
 //! The dtype map covers the five GGUF types the engine cares about:
-//! `F32(0)`, `F16(1)`, `Q4_0(2)`, `Q4_K(12)`, `Q6_K(14)`. Of those,
-//! `F32`/`F16`/`Q4_0`/`Q4_K` map onto the engine's [`WeightDtype`]; `Q6_K`
-//! is recognised so [`GgufFile::open`] doesn't fail on a Q6_K-quantised
-//! source, but tensors of that dtype are surfaced as `None` from
-//! [`GgufFile::tensor_dtype`] (and the loader falls back to seeded init
-//! for those tensors).
+//! `F32(0)`, `F16(1)`, `Q4_0(2)`, `Q4_K(12)`, `Q5_K(13)`, `Q6_K(14)`.
+//! Expert projections in those supported formats can stay quantized
+//! through conversion and runtime execution.
 
 use crate::inference::{
     WeightDtype, Q4K_BLOCK_BYTES, Q4K_BLOCK_ELEMS, Q4_0_BLOCK_BYTES, Q4_0_BLOCK_ELEMS,
+    Q5K_BLOCK_BYTES, Q5K_BLOCK_ELEMS, Q6K_BLOCK_BYTES, Q6K_BLOCK_ELEMS,
 };
 use std::collections::HashMap;
 use std::fs::File;
@@ -184,8 +182,7 @@ impl GgufFile {
     }
 
     /// Map this tensor's GGML dtype onto the engine's [`WeightDtype`].
-    /// `None` for dtypes the engine doesn't currently support (e.g.
-    /// Q6_K, Q5_*, Q8_*, the *_K variants other than Q4_K).
+    /// `None` for dtypes the engine doesn't currently support.
     pub fn tensor_dtype(&self, name: &str) -> Option<WeightDtype> {
         let info = self.tensors.get(name)?;
         ggml_to_weight_dtype(info.ggml_dtype)
@@ -194,7 +191,9 @@ impl GgufFile {
     /// Architecture string from `general.architecture` (e.g.
     /// `"llama"`, `"mixtral"`), if present.
     pub fn architecture(&self) -> Option<&str> {
-        self.metadata.get("general.architecture").and_then(|v| v.as_str())
+        self.metadata
+            .get("general.architecture")
+            .and_then(|v| v.as_str())
     }
 
     /// Whether the named tensor exists in this GGUF.
@@ -264,7 +263,13 @@ impl GgufFile {
             })?;
             tensors.insert(
                 name.clone(),
-                GgufTensorInfo { name, shape, ggml_dtype, offset, byte_len },
+                GgufTensorInfo {
+                    name,
+                    shape,
+                    ggml_dtype,
+                    offset,
+                    byte_len,
+                },
             );
         }
 
@@ -297,6 +302,8 @@ pub fn ggml_to_weight_dtype(code: u32) -> Option<WeightDtype> {
         ggml_dtype::BF16 => Some(WeightDtype::BF16),
         ggml_dtype::Q4_0 => Some(WeightDtype::Q4_0),
         ggml_dtype::Q4_K => Some(WeightDtype::Q4K),
+        ggml_dtype::Q5_K => Some(WeightDtype::Q5K),
+        ggml_dtype::Q6_K => Some(WeightDtype::Q6K),
         ggml_dtype::Q8_0 => Some(WeightDtype::Q8_0),
         _ => None,
     }
@@ -321,6 +328,11 @@ fn ggml_tensor_bytes(code: u32, shape: &[u64]) -> Option<u64> {
             let blocks = elems.div_ceil(Q4K_BLOCK_ELEMS as u64);
             blocks.checked_mul(Q4K_BLOCK_BYTES as u64)?
         }
+        ggml_dtype::Q5_K => {
+            // 256-element super-blocks of 176 bytes each.
+            let blocks = elems.div_ceil(Q5K_BLOCK_ELEMS as u64);
+            blocks.checked_mul(Q5K_BLOCK_BYTES as u64)?
+        }
         ggml_dtype::Q8_0 => {
             // 32-element blocks of 34 bytes each (1 f16 scale + 32 i8).
             let blocks = elems.div_ceil(32);
@@ -328,8 +340,8 @@ fn ggml_tensor_bytes(code: u32, shape: &[u64]) -> Option<u64> {
         }
         ggml_dtype::Q6_K => {
             // 256-element super-blocks of 210 bytes each.
-            let blocks = elems.div_ceil(256);
-            blocks.checked_mul(210)?
+            let blocks = elems.div_ceil(Q6K_BLOCK_ELEMS as u64);
+            blocks.checked_mul(Q6K_BLOCK_BYTES as u64)?
         }
         _ => return None,
     };
@@ -413,12 +425,8 @@ fn read_value_typed<'a>(cur: &mut Cursor<'a>, version: u32, ty: u32) -> io::Resu
         x if x == GgufType::INT32 as u32 => GgufValue::I32(cur.read_u32()? as i32),
         x if x == GgufType::UINT64 as u32 => GgufValue::U64(cur.read_u64()?),
         x if x == GgufType::INT64 as u32 => GgufValue::I64(cur.read_u64()? as i64),
-        x if x == GgufType::FLOAT32 as u32 => {
-            GgufValue::F32(f32::from_bits(cur.read_u32()?))
-        }
-        x if x == GgufType::FLOAT64 as u32 => {
-            GgufValue::F64(f64::from_bits(cur.read_u64()?))
-        }
+        x if x == GgufType::FLOAT32 as u32 => GgufValue::F32(f32::from_bits(cur.read_u32()?)),
+        x if x == GgufType::FLOAT64 as u32 => GgufValue::F64(f64::from_bits(cur.read_u64()?)),
         x if x == GgufType::BOOL as u32 => GgufValue::Bool(cur.read_u8()? != 0),
         x if x == GgufType::STRING as u32 => GgufValue::String(read_string(cur, version)?),
         x if x == GgufType::ARRAY as u32 => {
@@ -618,7 +626,9 @@ impl GgufStreamReader {
 
     /// `general.architecture`, if present.
     pub fn architecture(&self) -> Option<&str> {
-        self.metadata.get("general.architecture").and_then(|v| v.as_str())
+        self.metadata
+            .get("general.architecture")
+            .and_then(|v| v.as_str())
     }
 
     /// Try to parse the full header out of `bytes`. Returns `Ok(None)`
@@ -1018,7 +1028,9 @@ pub trait GgufSource {
         ggml_to_weight_dtype(info.ggml_dtype)
     }
     fn architecture(&self) -> Option<&str> {
-        self.metadata().get("general.architecture").and_then(|v| v.as_str())
+        self.metadata()
+            .get("general.architecture")
+            .and_then(|v| v.as_str())
     }
     fn has_tensor(&self, name: &str) -> bool {
         self.tensor_info(name).is_some()
@@ -1285,20 +1297,42 @@ mod tests {
     #[test]
     fn rejects_non_gguf_magic() {
         let bytes = b"NOPE\0\0\0\0".to_vec();
-        let err = GgufFile::parse(bytes).err().expect("expected parse failure");
+        let err = GgufFile::parse(bytes)
+            .err()
+            .expect("expected parse failure");
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
     }
 
     #[test]
     fn ggml_dtype_mapping_covers_supported_codes() {
-        assert_eq!(ggml_to_weight_dtype(ggml_dtype::F32), Some(WeightDtype::F32));
-        assert_eq!(ggml_to_weight_dtype(ggml_dtype::F16), Some(WeightDtype::F16));
-        assert_eq!(ggml_to_weight_dtype(ggml_dtype::Q4_0), Some(WeightDtype::Q4_0));
-        assert_eq!(ggml_to_weight_dtype(ggml_dtype::Q4_K), Some(WeightDtype::Q4K));
-        assert_eq!(ggml_to_weight_dtype(ggml_dtype::Q8_0), Some(WeightDtype::Q8_0));
-        // Unsupported: Q6_K, Q5_K, etc. — surface as None so the loader
-        // can skip / fall back to seeded init.
-        assert_eq!(ggml_to_weight_dtype(ggml_dtype::Q6_K), None);
+        assert_eq!(
+            ggml_to_weight_dtype(ggml_dtype::F32),
+            Some(WeightDtype::F32)
+        );
+        assert_eq!(
+            ggml_to_weight_dtype(ggml_dtype::F16),
+            Some(WeightDtype::F16)
+        );
+        assert_eq!(
+            ggml_to_weight_dtype(ggml_dtype::Q4_0),
+            Some(WeightDtype::Q4_0)
+        );
+        assert_eq!(
+            ggml_to_weight_dtype(ggml_dtype::Q4_K),
+            Some(WeightDtype::Q4K)
+        );
+        assert_eq!(
+            ggml_to_weight_dtype(ggml_dtype::Q8_0),
+            Some(WeightDtype::Q8_0)
+        );
+        assert_eq!(
+            ggml_to_weight_dtype(ggml_dtype::Q5_K),
+            Some(WeightDtype::Q5K)
+        );
+        assert_eq!(
+            ggml_to_weight_dtype(ggml_dtype::Q6_K),
+            Some(WeightDtype::Q6K)
+        );
     }
 
     #[test]
@@ -1308,10 +1342,7 @@ mod tests {
         // surface the same metadata, tensor info, and body bytes
         // as the eager `GgufFile::parse` path.
         let bytes = synth_gguf();
-        let dir = std::env::temp_dir().join(format!(
-            "gguf-stream-test-{}",
-            std::process::id()
-        ));
+        let dir = std::env::temp_dir().join(format!("gguf-stream-test-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         let path = dir.join("synth.gguf");
         std::fs::write(&path, &bytes).unwrap();

--- a/rust-engine/src/gguf_loader.rs
+++ b/rust-engine/src/gguf_loader.rs
@@ -27,12 +27,13 @@
 
 use crate::gguf::{ggml_dtype, GgufFile, GgufSource, GgufTensorInfo, GgufValue};
 use crate::inference::{
-    dequantize_f16_to_f32, expert_weight_bytes_for, WeightDtype,
-    Q4_0_BLOCK_BYTES, Q4_0_BLOCK_ELEMS, Q4K_BLOCK_BYTES, Q4K_BLOCK_ELEMS,
-    Q8_0_BLOCK_BYTES, Q8_0_BLOCK_ELEMS,
+    dequantize_f16_to_f32, expert_weight_bytes_for, projection_weight_bytes_for, WeightDtype,
+    Q4K_BLOCK_BYTES, Q4K_BLOCK_ELEMS, Q4_0_BLOCK_BYTES, Q4_0_BLOCK_ELEMS, Q5K_BLOCK_BYTES,
+    Q5K_BLOCK_ELEMS, Q6K_BLOCK_BYTES, Q6K_BLOCK_ELEMS, Q8_0_BLOCK_BYTES, Q8_0_BLOCK_ELEMS,
 };
-use crate::tensor_header::TensorHeader;
+use crate::tensor_header::{MixedExpertHeader, ProjectionRange, TensorHeader, UthDtypeId};
 use serde::Serialize;
+use std::collections::BTreeMap;
 use std::fs;
 use std::io::{self, Write};
 use std::path::Path;
@@ -85,6 +86,10 @@ struct ExtractedMetadata<'a> {
     weight_layout: &'a str,
     num_layers: usize,
     num_experts_per_layer: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    expert_layout_version: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    projection_dtype_histogram: Option<BTreeMap<String, usize>>,
 }
 
 /// Block alignment used for every expert file written by this loader.
@@ -152,7 +157,10 @@ pub struct ExtractOptions {
 
 impl Default for ExtractOptions {
     fn default() -> Self {
-        Self { emit_uth: true, native_quant: false }
+        Self {
+            emit_uth: true,
+            native_quant: false,
+        }
     }
 }
 
@@ -242,9 +250,14 @@ pub fn extract_experts_from_source(
         .or_else(|| lookup("feed_forward_length"))
         .and_then(|v| v.as_u64())
         .ok_or_else(|| {
-            io::Error::new(io::ErrorKind::InvalidData, "GGUF missing feed_forward_length")
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "GGUF missing feed_forward_length",
+            )
         })? as usize;
-    let top_k = lookup("expert_used_count").and_then(|v| v.as_u64()).unwrap_or(2) as usize;
+    let top_k = lookup("expert_used_count")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(2) as usize;
 
     info!(
         num_layers,
@@ -257,35 +270,41 @@ pub fn extract_experts_from_source(
         "gguf-convert: extracting experts"
     );
 
-    // Probe every layer's expert tensors to figure out whether the
-    // native pass-through path is *eligible*. We require:
-    //   * `opts.native_quant` was requested,
-    //   * gate / up / down are present in either the interleaved
-    //     (`ffn_gate_exps.weight`) or per-expert (`ffn_gate.{e}.weight`)
-    //     layout — both are supported, matching the F32 dequant path,
-    //   * gate / up / down all use the same Q4_0, Q4_K, *or* Q8_0 dtype,
-    //   * the per-expert weight count divides cleanly on the block
-    //     boundary (32 for Q4_0 / Q8_0, 256 for Q4_K) — otherwise
-    //     per-expert slicing wouldn't fall on block boundaries and we'd
-    //     corrupt the per-block scales.
-    //
-    // When ineligible we silently fall back to the F32 dequant path,
-    // which is what the loader has always done.
-    let native_dtype = if opts.native_quant {
-        detect_native_quant_dtype(gguf, num_layers, num_experts, d_model, d_ff)
+    let native_plan = if opts.native_quant {
+        let scan = scan_expert_quant_layouts(gguf, num_layers, num_experts, d_model, d_ff)?;
+        info!("\n{}", scan.concise_report());
+        if !scan.rejection_reasons.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                format!(
+                    "--native-quant requested but quantized expert output is not possible: {}",
+                    scan.rejection_reasons.join("; ")
+                ),
+            ));
+        }
+        let plan = scan.into_plan(DEFAULT_BLOCK_ALIGN, opts.emit_uth)?;
+        match &plan {
+            NativeQuantPlan::Homogeneous { dtype, .. } => {
+                info!(
+                    dtype = dtype.as_str(),
+                    "native quant pass-through is eligible"
+                );
+            }
+            NativeQuantPlan::Mixed { expert_size, .. } => {
+                info!(
+                    expert_size,
+                    "native mixed-projection quant pass-through is eligible"
+                );
+            }
+        }
+        Some(plan)
     } else {
         None
     };
-    let expert_dtype = native_dtype.unwrap_or(WeightDtype::F32);
-    if let Some(d) = native_dtype {
-        info!(?d, "native 4-bit pass-through is eligible — writing raw quantised blocks");
-    } else if opts.native_quant {
-        warn!(
-            "native 4-bit pass-through requested but not eligible \
-             (mixed dtypes, non-Q4 source, or per-expert weight count \
-             not block-aligned); falling back to F32 dequant"
-        );
-    }
+    let expert_dtype = native_plan
+        .as_ref()
+        .map(NativeQuantPlan::metadata_dtype)
+        .unwrap_or(WeightDtype::F32);
 
     let mut report = ExtractionReport {
         experts_written: 0,
@@ -307,11 +326,20 @@ pub fn extract_experts_from_source(
     // 64-byte U.T.H., page-padded to DEFAULT_BLOCK_ALIGN so the weight
     // payload still starts at a 4 KiB boundary. The total file size
     // therefore grows by exactly one block (4 KiB) per expert.
-    let payload_size = align_up(
-        expert_weight_bytes_for(d_model, d_ff, expert_dtype),
-        DEFAULT_BLOCK_ALIGN,
-    );
-    let header_overhead = if opts.emit_uth { DEFAULT_BLOCK_ALIGN } else { 0 };
+    let payload_size = match native_plan.as_ref() {
+        Some(NativeQuantPlan::Mixed {
+            payload_slot_size, ..
+        }) => *payload_slot_size,
+        _ => align_up(
+            expert_weight_bytes_for(d_model, d_ff, expert_dtype),
+            DEFAULT_BLOCK_ALIGN,
+        ),
+    };
+    let header_overhead = if opts.emit_uth {
+        DEFAULT_BLOCK_ALIGN
+    } else {
+        0
+    };
     // Defensive: an adversarially-large `llama.embedding_length` /
     // `llama.feed_forward_length` pair could push `payload_size` close
     // to `usize::MAX` and wrap to a small `expert_size` here, which
@@ -342,13 +370,13 @@ pub fn extract_experts_from_source(
 
     for layer in 0..num_layers {
         info!(layer, "extracting layer experts");
-        match native_dtype {
-            Some(d) => {
+        match native_plan.as_ref() {
+            Some(NativeQuantPlan::Homogeneous { dtype: d, .. }) => {
                 // Native pass-through: pull the raw quantised bytes
                 // for this layer's gate/up/down tensors and slice each
                 // expert's stride out without dequantising.
                 let per_expert =
-                    load_layer_expert_native_quant(gguf, layer, num_experts, d_model, d_ff, d)?;
+                    load_layer_expert_native_quant(gguf, layer, num_experts, d_model, d_ff, *d)?;
                 for (e, (gate, up, down)) in per_expert.into_iter().enumerate() {
                     // Safe: `layer < num_layers` and `e < num_experts`,
                     // so `layer * num_experts + e < total_experts`,
@@ -357,7 +385,60 @@ pub fn extract_experts_from_source(
                     let path = out_dir.join(format!("expert_{global_id}.bin"));
                     let mut bytes = Vec::with_capacity(expert_size);
                     if opts.emit_uth {
-                        TensorHeader::for_swiglu_expert(d, d_model, d_ff)
+                        TensorHeader::for_swiglu_expert(*d, d_model, d_ff)
+                            .write_padded(DEFAULT_BLOCK_ALIGN, &mut bytes);
+                        debug_assert_eq!(bytes.len(), DEFAULT_BLOCK_ALIGN);
+                    }
+                    bytes.extend_from_slice(&gate);
+                    bytes.extend_from_slice(&up);
+                    bytes.extend_from_slice(&down);
+                    if bytes.len() < expert_size {
+                        bytes.resize(expert_size, 0);
+                    }
+                    write_file(&path, &bytes)?;
+                    report.experts_written += 1;
+                    report.total_bytes += bytes.len() as u64;
+                }
+            }
+            Some(NativeQuantPlan::Mixed { layouts, .. }) => {
+                let per_expert = load_layer_expert_native_mixed(
+                    gguf,
+                    layer,
+                    num_experts,
+                    d_model,
+                    d_ff,
+                    layouts,
+                )?;
+                for (e, (layout, gate, up, down)) in per_expert.into_iter().enumerate() {
+                    let global_id = layer * num_experts + e;
+                    let path = out_dir.join(format!("expert_{global_id}.bin"));
+                    let mut bytes = Vec::with_capacity(expert_size);
+                    if opts.emit_uth {
+                        let gate_range = ProjectionRange {
+                            dtype: UthDtypeId::from_weight(layout.gate.dtype),
+                            offset: 0,
+                            len: gate.len() as u64,
+                            weights: layout.gate.weights as u32,
+                        };
+                        let up_range = ProjectionRange {
+                            dtype: UthDtypeId::from_weight(layout.up.dtype),
+                            offset: gate.len() as u64,
+                            len: up.len() as u64,
+                            weights: layout.up.weights as u32,
+                        };
+                        let down_offset = gate.len().checked_add(up.len()).ok_or_else(|| {
+                            io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                "mixed expert payload offset overflow",
+                            )
+                        })?;
+                        let down_range = ProjectionRange {
+                            dtype: UthDtypeId::from_weight(layout.down.dtype),
+                            offset: down_offset as u64,
+                            len: down.len() as u64,
+                            weights: layout.down.weights as u32,
+                        };
+                        MixedExpertHeader::new(d_model, d_ff, gate_range, up_range, down_range)
                             .write_padded(DEFAULT_BLOCK_ALIGN, &mut bytes);
                         debug_assert_eq!(bytes.len(), DEFAULT_BLOCK_ALIGN);
                     }
@@ -401,8 +482,16 @@ pub fn extract_experts_from_source(
     // the expert files and means the converter satisfies both APIs.
     let dense_specs: Vec<(&str, &[&str], Vec<u64>)> = vec![
         // (gguf_name, [engine_aliases...], expected_shape_innermost_first)
-        ("token_embd.weight", &["embedding.bin", "embed.bin"], vec![d_model as u64, 0]),
-        ("output_norm.weight", &["final_norm.bin", "final_rms.bin"], vec![d_model as u64]),
+        (
+            "token_embd.weight",
+            &["embedding.bin", "embed.bin"],
+            vec![d_model as u64, 0],
+        ),
+        (
+            "output_norm.weight",
+            &["final_norm.bin", "final_rms.bin"],
+            vec![d_model as u64],
+        ),
         ("output.weight", &["lm_head.bin"], vec![d_model as u64, 0]),
     ];
     for (gname, aliases, _) in &dense_specs {
@@ -453,19 +542,31 @@ pub fn extract_experts_from_source(
         };
         emit(
             format!("blk.{layer}.attn_q.weight"),
-            vec![format!("layer_{layer}_q.bin"), format!("attn_{layer}_q.bin")],
+            vec![
+                format!("layer_{layer}_q.bin"),
+                format!("attn_{layer}_q.bin"),
+            ],
         )?;
         emit(
             format!("blk.{layer}.attn_k.weight"),
-            vec![format!("layer_{layer}_k.bin"), format!("attn_{layer}_k.bin")],
+            vec![
+                format!("layer_{layer}_k.bin"),
+                format!("attn_{layer}_k.bin"),
+            ],
         )?;
         emit(
             format!("blk.{layer}.attn_v.weight"),
-            vec![format!("layer_{layer}_v.bin"), format!("attn_{layer}_v.bin")],
+            vec![
+                format!("layer_{layer}_v.bin"),
+                format!("attn_{layer}_v.bin"),
+            ],
         )?;
         emit(
             format!("blk.{layer}.attn_output.weight"),
-            vec![format!("layer_{layer}_o.bin"), format!("attn_{layer}_o.bin")],
+            vec![
+                format!("layer_{layer}_o.bin"),
+                format!("attn_{layer}_o.bin"),
+            ],
         )?;
         emit(
             format!("blk.{layer}.attn_norm.weight"),
@@ -529,6 +630,12 @@ pub fn extract_experts_from_source(
         weight_layout: "gate_proj || up_proj || down_proj (row-major)",
         num_layers,
         num_experts_per_layer: num_experts,
+        expert_layout_version: native_plan
+            .as_ref()
+            .and_then(NativeQuantPlan::metadata_layout_version),
+        projection_dtype_histogram: native_plan
+            .as_ref()
+            .and_then(NativeQuantPlan::metadata_histogram),
     };
     let meta_path = out_dir.join("metadata.json");
     let mut f = fs::File::create(&meta_path)?;
@@ -602,7 +709,12 @@ fn dense_tensor_to_f32(gguf: &dyn GgufSource, info: &GgufTensorInfo) -> io::Resu
             format!("tensor {} has no data slice", info.name),
         )
     })?;
-    bytes_to_f32(&data, info.ggml_dtype, info.elem_count() as usize, &info.name)
+    bytes_to_f32(
+        &data,
+        info.ggml_dtype,
+        info.elem_count() as usize,
+        &info.name,
+    )
 }
 
 fn bytes_to_f32(data: &[u8], dtype: u32, elems: usize, name: &str) -> io::Result<Vec<f32>> {
@@ -639,6 +751,16 @@ fn bytes_to_f32(data: &[u8], dtype: u32, elems: usize, name: &str) -> io::Result
         ggml_dtype::Q4_K => {
             let mut out = Vec::with_capacity(elems);
             crate::inference::dequantize_q4k_to_f32(data, elems, &mut out);
+            Ok(out)
+        }
+        ggml_dtype::Q5_K => {
+            let mut out = Vec::with_capacity(elems);
+            crate::inference::dequantize_q5k_to_f32(data, elems, &mut out);
+            Ok(out)
+        }
+        ggml_dtype::Q6_K => {
+            let mut out = Vec::with_capacity(elems);
+            crate::inference::dequantize_q6k_to_f32(data, elems, &mut out);
             Ok(out)
         }
         ggml_dtype::Q8_0 => {
@@ -773,7 +895,10 @@ fn load_layer_expert_matrices(
         }
         Ok(out)
     } else {
-        warn!(layer, "no expert weight tensor found in GGUF; emitting zero blobs");
+        warn!(
+            layer,
+            "no expert weight tensor found in GGUF; emitting zero blobs"
+        );
         Ok(zero_layer("no expert weight tensor"))
     }
 }
@@ -786,9 +911,10 @@ fn dense_layer_tensor_f32(
     name: &str,
     expected: usize,
 ) -> io::Result<Vec<f32>> {
-    let info = gguf.tensor_info(name).cloned().ok_or_else(|| {
-        io::Error::new(io::ErrorKind::NotFound, format!("tensor {name} missing"))
-    })?;
+    let info = gguf
+        .tensor_info(name)
+        .cloned()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, format!("tensor {name} missing")))?;
     let v = dense_tensor_to_f32(gguf, &info)?;
     if v.len() != expected {
         return Err(io::Error::new(
@@ -829,14 +955,8 @@ fn load_expert_matrices(
     let per_expert_gate = format!("blk.{layer}.ffn_gate.{expert}.weight");
 
     if gguf.has_tensor(&interleaved_gate) {
-        let gate = slice_expert_matrix(
-            gguf,
-            &interleaved_gate,
-            expert,
-            num_experts,
-            d_ff,
-            d_model,
-        )?;
+        let gate =
+            slice_expert_matrix(gguf, &interleaved_gate, expert, num_experts, d_ff, d_model)?;
         let up = slice_expert_matrix(
             gguf,
             &format!("blk.{layer}.ffn_up_exps.weight"),
@@ -874,7 +994,10 @@ fn load_expert_matrices(
         // matrices so the rest of the pipeline produces a syntactically
         // valid expert file (the engine will fall back to seeded init
         // at run time anyway when the file is shaped right but zeroed).
-        warn!(layer, expert, "no expert weight tensor found in GGUF; emitting zero blob");
+        warn!(
+            layer,
+            expert, "no expert weight tensor found in GGUF; emitting zero blob"
+        );
         Ok((
             vec![0.0; d_ff * d_model],
             vec![0.0; d_ff * d_model],
@@ -891,9 +1014,10 @@ fn load_per_expert_matrix(
     rows: usize,
     cols: usize,
 ) -> io::Result<Vec<f32>> {
-    let info = gguf.tensor_info(name).cloned().ok_or_else(|| {
-        io::Error::new(io::ErrorKind::NotFound, format!("tensor {name} missing"))
-    })?;
+    let info = gguf
+        .tensor_info(name)
+        .cloned()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, format!("tensor {name} missing")))?;
     let v = dense_tensor_to_f32(gguf, &info)?;
     let expected = rows * cols;
     if v.len() != expected {
@@ -925,9 +1049,10 @@ fn slice_expert_matrix(
     rows: usize,
     cols: usize,
 ) -> io::Result<Vec<f32>> {
-    let info = gguf.tensor_info(name).cloned().ok_or_else(|| {
-        io::Error::new(io::ErrorKind::NotFound, format!("tensor {name} missing"))
-    })?;
+    let info = gguf
+        .tensor_info(name)
+        .cloned()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, format!("tensor {name} missing")))?;
     let all = dense_tensor_to_f32(gguf, &info)?;
     let per_expert = rows * cols;
     let want = num_experts * per_expert;
@@ -947,58 +1072,434 @@ fn slice_expert_matrix(
 // (end of module body)
 
 // ---------------------------------------------------------------------
-// Native 4-bit pass-through (Industrial Upgrade Task 0).
+// Native mixed-projection quant pass-through.
 // ---------------------------------------------------------------------
 
-/// Map a single (gate, up, down) GGML dtype triple onto an eligible
-/// native [`WeightDtype`], or `None` when the triple can't be passed
-/// through unchanged.
-///
-/// Eligibility requires that:
-///   * all three tensors share the same GGML dtype (a mixed triple —
-///     e.g. `Q4_K_M`'s `Q6_K` down projection — is rejected), and
-///   * the dtype is one the engine reads back natively (`Q4_0`,
-///     `Q4_K`, or `Q8_0`), and
-///   * the per-expert weight count `d_ff * d_model` is a whole multiple
-///     of that dtype's block-element size (32 for `Q4_0` / `Q8_0`, 256
-///     for `Q4_K`) so each expert's payload falls on a clean block
-///     boundary.
-fn native_dtype_for_triple(
-    gate: u32,
-    up: u32,
-    down: u32,
-    per_expert: usize,
-) -> Option<WeightDtype> {
-    if gate != up || gate != down {
-        return None;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ProjectionQuantSpec {
+    dtype: WeightDtype,
+    block_elems: usize,
+    block_bytes: usize,
+    weights: usize,
+    payload_bytes: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ProjectionQuantLayout {
+    gate: ProjectionQuantSpec,
+    up: ProjectionQuantSpec,
+    down: ProjectionQuantSpec,
+}
+
+impl ProjectionQuantLayout {
+    fn payload_bytes(self) -> Option<usize> {
+        self.gate
+            .payload_bytes
+            .checked_add(self.up.payload_bytes)?
+            .checked_add(self.down.payload_bytes)
     }
-    match gate {
-        ggml_dtype::Q4_0 if per_expert % Q4_0_BLOCK_ELEMS == 0 => Some(WeightDtype::Q4_0),
-        ggml_dtype::Q4_K if per_expert % Q4K_BLOCK_ELEMS == 0 => Some(WeightDtype::Q4K),
-        ggml_dtype::Q8_0 if per_expert % Q8_0_BLOCK_ELEMS == 0 => Some(WeightDtype::Q8_0),
+
+    fn uniform_dtype(self) -> Option<WeightDtype> {
+        if self.gate.dtype == self.up.dtype && self.gate.dtype == self.down.dtype {
+            Some(self.gate.dtype)
+        } else {
+            None
+        }
+    }
+
+    fn triple_key(self) -> String {
+        format!(
+            "{}/{}/{}",
+            dtype_label(self.gate.dtype),
+            dtype_label(self.up.dtype),
+            dtype_label(self.down.dtype)
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ExpertQuantScan {
+    layouts: Vec<ProjectionQuantLayout>,
+    projection_histogram: BTreeMap<&'static str, BTreeMap<String, usize>>,
+    triple_layers: BTreeMap<String, Vec<usize>>,
+    missing_tensor_names: Vec<String>,
+    block_alignment_failures: Vec<String>,
+    rejection_reasons: Vec<String>,
+}
+
+impl ExpertQuantScan {
+    fn new() -> Self {
+        Self {
+            layouts: Vec::new(),
+            projection_histogram: BTreeMap::new(),
+            triple_layers: BTreeMap::new(),
+            missing_tensor_names: Vec::new(),
+            block_alignment_failures: Vec::new(),
+            rejection_reasons: Vec::new(),
+        }
+    }
+
+    fn record_layer_layout(&mut self, layer: usize, layout: ProjectionQuantLayout) {
+        for (projection, spec) in [
+            ("gate", layout.gate),
+            ("up", layout.up),
+            ("down", layout.down),
+        ] {
+            *self
+                .projection_histogram
+                .entry(projection)
+                .or_default()
+                .entry(dtype_label(spec.dtype).to_string())
+                .or_default() += 1;
+        }
+        let key = layout.triple_key();
+        let layers = self.triple_layers.entry(key).or_default();
+        if layers.last().copied() != Some(layer) {
+            layers.push(layer);
+        }
+    }
+
+    fn concise_report(&self) -> String {
+        let mut lines = vec!["expert quant scan:".to_string()];
+        for (triple, layers) in &self.triple_layers {
+            lines.push(format!("  {triple}: {} layers", layers.len()));
+        }
+        for projection in ["gate", "up", "down"] {
+            if let Some(hist) = self.projection_histogram.get(projection) {
+                let parts = hist
+                    .iter()
+                    .map(|(dtype, count)| format!("{dtype}={count}"))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                lines.push(format!("  {projection}: {parts}"));
+            }
+        }
+        if !self.missing_tensor_names.is_empty() {
+            lines.push(format!(
+                "  missing tensors: {}",
+                self.missing_tensor_names
+                    .iter()
+                    .take(8)
+                    .cloned()
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
+        }
+        if !self.block_alignment_failures.is_empty() {
+            lines.push(format!(
+                "  block alignment failures: {}",
+                self.block_alignment_failures
+                    .iter()
+                    .take(8)
+                    .cloned()
+                    .collect::<Vec<_>>()
+                    .join("; ")
+            ));
+        }
+        if !self.rejection_reasons.is_empty() {
+            lines.push(format!(
+                "  rejected: {}",
+                self.rejection_reasons
+                    .iter()
+                    .take(8)
+                    .cloned()
+                    .collect::<Vec<_>>()
+                    .join("; ")
+            ));
+        }
+        lines.join("\n")
+    }
+
+    fn into_plan(self, block_align: usize, emit_uth: bool) -> io::Result<NativeQuantPlan> {
+        if self.layouts.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "native quant scan found no expert layouts",
+            ));
+        }
+        let first = self.layouts[0];
+        if let Some(dtype) = first.uniform_dtype() {
+            if self
+                .layouts
+                .iter()
+                .all(|layout| layout.uniform_dtype() == Some(dtype))
+            {
+                return Ok(NativeQuantPlan::Homogeneous { dtype });
+            }
+        }
+        if !emit_uth {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "mixed native quant output requires UTH2; remove --no-uth",
+            ));
+        }
+        let histogram = self.expert_histogram();
+        let max_payload = self
+            .layouts
+            .iter()
+            .map(|layout| {
+                layout.payload_bytes().ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidData, "mixed payload size overflow")
+                })
+            })
+            .collect::<io::Result<Vec<_>>>()?
+            .into_iter()
+            .max()
+            .unwrap_or(0);
+        let payload_slot_size = align_up(max_payload, block_align);
+        let expert_size = payload_slot_size.checked_add(block_align).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, "mixed expert size overflow")
+        })?;
+        Ok(NativeQuantPlan::Mixed {
+            layouts: self.layouts,
+            payload_slot_size,
+            expert_size,
+            histogram,
+        })
+    }
+
+    fn expert_histogram(&self) -> BTreeMap<String, usize> {
+        let mut hist = BTreeMap::new();
+        for layout in &self.layouts {
+            *hist
+                .entry(layout.triple_key().to_ascii_lowercase())
+                .or_default() += 1;
+        }
+        hist
+    }
+}
+
+#[derive(Debug, Clone)]
+enum NativeQuantPlan {
+    Homogeneous {
+        dtype: WeightDtype,
+    },
+    Mixed {
+        layouts: Vec<ProjectionQuantLayout>,
+        payload_slot_size: usize,
+        expert_size: usize,
+        histogram: BTreeMap<String, usize>,
+    },
+}
+
+impl NativeQuantPlan {
+    fn metadata_dtype(&self) -> WeightDtype {
+        match self {
+            NativeQuantPlan::Homogeneous { dtype, .. } => *dtype,
+            NativeQuantPlan::Mixed { .. } => WeightDtype::Mixed,
+        }
+    }
+
+    fn metadata_layout_version(&self) -> Option<u32> {
+        match self {
+            NativeQuantPlan::Homogeneous { .. } => None,
+            NativeQuantPlan::Mixed { .. } => Some(2),
+        }
+    }
+
+    fn metadata_histogram(&self) -> Option<BTreeMap<String, usize>> {
+        match self {
+            NativeQuantPlan::Homogeneous { .. } => None,
+            NativeQuantPlan::Mixed { histogram, .. } => Some(histogram.clone()),
+        }
+    }
+}
+
+fn dtype_label(dtype: WeightDtype) -> &'static str {
+    match dtype {
+        WeightDtype::F32 => "F32",
+        WeightDtype::F16 => "F16",
+        WeightDtype::Int8 => "INT8",
+        WeightDtype::Q4K => "Q4_K",
+        WeightDtype::Q4_0 => "Q4_0",
+        WeightDtype::Q8_0 => "Q8_0",
+        WeightDtype::Q5K => "Q5_K",
+        WeightDtype::Q6K => "Q6_K",
+        WeightDtype::BF16 => "BF16",
+        WeightDtype::MXFP4 => "MXFP4",
+        WeightDtype::Mixed => "MIXED",
+    }
+}
+
+fn native_block_spec(dtype: WeightDtype) -> Option<(usize, usize)> {
+    match dtype {
+        WeightDtype::Q4_0 => Some((Q4_0_BLOCK_ELEMS, Q4_0_BLOCK_BYTES)),
+        WeightDtype::Q4K => Some((Q4K_BLOCK_ELEMS, Q4K_BLOCK_BYTES)),
+        WeightDtype::Q5K => Some((Q5K_BLOCK_ELEMS, Q5K_BLOCK_BYTES)),
+        WeightDtype::Q6K => Some((Q6K_BLOCK_ELEMS, Q6K_BLOCK_BYTES)),
+        WeightDtype::Q8_0 => Some((Q8_0_BLOCK_ELEMS, Q8_0_BLOCK_BYTES)),
         _ => None,
     }
 }
 
-/// Inspect every layer's expert tensors and determine whether the
-/// native 4-bit pass-through path can be used for the whole model.
-///
-/// Returns `Some(WeightDtype::Q4_0)` / `Some(WeightDtype::Q4K)` /
-/// `Some(WeightDtype::Q8_0)` when, for **every** layer:
-///   * gate / up / down are present in either the **interleaved**
-///     (`ffn_gate_exps.weight`) or the **per-expert**
-///     (`ffn_gate.{e}.weight`) layout — both are now supported by the
-///     native slicer, mirroring the F32 dequant path,
-///   * all three tensors share the same eligible GGML dtype (`Q4_0`,
-///     `Q4_K`, or `Q8_0`), and
-///   * the per-expert weight count `d_ff * d_model` is a whole multiple
-///     of the corresponding block-element size (32 or 256), so each
-///     expert's payload falls on a clean block boundary,
-///   * all layers expose the same dtype (the extractor writes one
-///     global `expert_dtype` into `metadata.json`, so a single
-///     ineligible layer poisons the whole run).
-///
-/// Returns `None` otherwise (the caller falls back to F32 dequant).
+fn native_spec_for_tensor(
+    info: &GgufTensorInfo,
+    weights: usize,
+    require_block_aligned: bool,
+    label: &str,
+) -> Result<ProjectionQuantSpec, String> {
+    let dtype = crate::gguf::ggml_to_weight_dtype(info.ggml_dtype).ok_or_else(|| {
+        format!(
+            "{label} uses GGML dtype {}, which MER can size but cannot decode natively",
+            info.ggml_dtype
+        )
+    })?;
+    let (block_elems, block_bytes) = native_block_spec(dtype).ok_or_else(|| {
+        format!(
+            "{label} uses {}, which is not a native quantized expert projection dtype",
+            dtype.as_str()
+        )
+    })?;
+    if require_block_aligned && weights % block_elems != 0 {
+        return Err(format!(
+            "{label} has {weights} weights, not divisible by {} block elements for {}",
+            block_elems,
+            dtype_label(dtype)
+        ));
+    }
+    let payload_bytes = projection_weight_bytes_for(weights, dtype).ok_or_else(|| {
+        format!(
+            "{label} payload byte size is unsupported for {}",
+            dtype.as_str()
+        )
+    })?;
+    Ok(ProjectionQuantSpec {
+        dtype,
+        block_elems,
+        block_bytes,
+        weights,
+        payload_bytes,
+    })
+}
+
+fn scan_expert_quant_layouts(
+    gguf: &dyn GgufSource,
+    num_layers: usize,
+    num_experts: usize,
+    d_model: usize,
+    d_ff: usize,
+) -> io::Result<ExpertQuantScan> {
+    let mut scan = ExpertQuantScan::new();
+    let weights = d_ff
+        .checked_mul(d_model)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "d_ff * d_model overflow"))?;
+
+    for layer in 0..num_layers {
+        let interleaved_gate = format!("blk.{layer}.ffn_gate_exps.weight");
+        if gguf.has_tensor(&interleaved_gate) {
+            let mut specs = Vec::new();
+            for (projection, name) in [
+                ("gate", interleaved_gate.clone()),
+                ("up", format!("blk.{layer}.ffn_up_exps.weight")),
+                ("down", format!("blk.{layer}.ffn_down_exps.weight")),
+            ] {
+                match gguf.tensor_info(&name) {
+                    Some(info) => {
+                        let label = format!("layer {layer} {projection} projection");
+                        match native_spec_for_tensor(info, weights, true, &label) {
+                            Ok(spec) => {
+                                let expected = num_experts
+                                    .checked_mul(spec.payload_bytes)
+                                    .ok_or_else(|| {
+                                        io::Error::new(
+                                            io::ErrorKind::InvalidData,
+                                            format!("tensor {name} byte count overflow"),
+                                        )
+                                    })?;
+                                if info.byte_len != expected as u64 {
+                                    scan.rejection_reasons.push(format!(
+                                        "tensor {name} has {} bytes, expected {expected}",
+                                        info.byte_len
+                                    ));
+                                }
+                                specs.push((projection, spec));
+                            }
+                            Err(reason) => {
+                                if reason.contains("not divisible") {
+                                    scan.block_alignment_failures.push(reason.clone());
+                                }
+                                scan.rejection_reasons.push(reason);
+                            }
+                        }
+                    }
+                    None => {
+                        scan.missing_tensor_names.push(name.clone());
+                        scan.rejection_reasons
+                            .push(format!("missing tensor {name}"));
+                    }
+                }
+            }
+            if specs.len() == 3 {
+                let layout = ProjectionQuantLayout {
+                    gate: specs[0].1,
+                    up: specs[1].1,
+                    down: specs[2].1,
+                };
+                scan.record_layer_layout(layer, layout);
+                scan.layouts
+                    .extend(std::iter::repeat(layout).take(num_experts));
+            }
+            continue;
+        }
+
+        let per_expert_gate0 = format!("blk.{layer}.ffn_gate.0.weight");
+        if gguf.has_tensor(&per_expert_gate0) {
+            let mut first_layout_for_layer = None;
+            for e in 0..num_experts {
+                let mut specs = Vec::new();
+                for (projection, name) in [
+                    ("gate", format!("blk.{layer}.ffn_gate.{e}.weight")),
+                    ("up", format!("blk.{layer}.ffn_up.{e}.weight")),
+                    ("down", format!("blk.{layer}.ffn_down.{e}.weight")),
+                ] {
+                    match gguf.tensor_info(&name) {
+                        Some(info) => {
+                            let label = format!("layer {layer} expert {e} {projection} projection");
+                            match native_spec_for_tensor(info, weights, false, &label) {
+                                Ok(spec) => {
+                                    if info.byte_len != spec.payload_bytes as u64 {
+                                        scan.rejection_reasons.push(format!(
+                                            "tensor {name} has {} bytes, expected {}",
+                                            info.byte_len, spec.payload_bytes
+                                        ));
+                                    }
+                                    specs.push((projection, spec));
+                                }
+                                Err(reason) => scan.rejection_reasons.push(reason),
+                            }
+                        }
+                        None => {
+                            scan.missing_tensor_names.push(name.clone());
+                            scan.rejection_reasons
+                                .push(format!("missing tensor {name}"));
+                        }
+                    }
+                }
+                if specs.len() == 3 {
+                    let layout = ProjectionQuantLayout {
+                        gate: specs[0].1,
+                        up: specs[1].1,
+                        down: specs[2].1,
+                    };
+                    first_layout_for_layer.get_or_insert(layout);
+                    scan.layouts.push(layout);
+                }
+            }
+            if let Some(layout) = first_layout_for_layer {
+                scan.record_layer_layout(layer, layout);
+            }
+        } else {
+            scan.missing_tensor_names.push(interleaved_gate.clone());
+            scan.missing_tensor_names.push(per_expert_gate0.clone());
+            scan.rejection_reasons.push(format!(
+                "layer {layer} has neither interleaved expert tensors nor per-expert tensors"
+            ));
+        }
+    }
+    Ok(scan)
+}
+
+#[cfg(test)]
 fn detect_native_quant_dtype(
     gguf: &dyn GgufSource,
     num_layers: usize,
@@ -1006,46 +1507,14 @@ fn detect_native_quant_dtype(
     d_model: usize,
     d_ff: usize,
 ) -> Option<WeightDtype> {
-    let mut chosen: Option<WeightDtype> = None;
-    let per_expert = d_ff.checked_mul(d_model)?;
-    for layer in 0..num_layers {
-        let interleaved_gate = format!("blk.{layer}.ffn_gate_exps.weight");
-        let per_expert_gate0 = format!("blk.{layer}.ffn_gate.0.weight");
-        let layer_dtype = if gguf.has_tensor(&interleaved_gate) {
-            // Interleaved layout: one `[d_model, d_ff, num_experts]`
-            // tensor per projection.
-            let g = gguf.tensor_info(&interleaved_gate)?;
-            let u = gguf.tensor_info(&format!("blk.{layer}.ffn_up_exps.weight"))?;
-            let d = gguf.tensor_info(&format!("blk.{layer}.ffn_down_exps.weight"))?;
-            native_dtype_for_triple(g.ggml_dtype, u.ggml_dtype, d.ggml_dtype, per_expert)?
-        } else if gguf.has_tensor(&per_expert_gate0) {
-            // Per-expert layout: a separate `[d_model, d_ff]` tensor for
-            // each expert. Every expert in the layer must share the same
-            // eligible dtype.
-            let mut layer_choice: Option<WeightDtype> = None;
-            for e in 0..num_experts {
-                let g = gguf.tensor_info(&format!("blk.{layer}.ffn_gate.{e}.weight"))?;
-                let u = gguf.tensor_info(&format!("blk.{layer}.ffn_up.{e}.weight"))?;
-                let d = gguf.tensor_info(&format!("blk.{layer}.ffn_down.{e}.weight"))?;
-                let dt =
-                    native_dtype_for_triple(g.ggml_dtype, u.ggml_dtype, d.ggml_dtype, per_expert)?;
-                match layer_choice {
-                    None => layer_choice = Some(dt),
-                    Some(c) if c == dt => {}
-                    _ => return None,
-                }
-            }
-            layer_choice?
-        } else {
-            return None;
-        };
-        match chosen {
-            None => chosen = Some(layer_dtype),
-            Some(c) if c == layer_dtype => {}
-            _ => return None,
-        }
+    let scan = scan_expert_quant_layouts(gguf, num_layers, num_experts, d_model, d_ff).ok()?;
+    if !scan.rejection_reasons.is_empty() {
+        return None;
     }
-    chosen
+    match scan.into_plan(DEFAULT_BLOCK_ALIGN, true).ok()? {
+        NativeQuantPlan::Homogeneous { dtype, .. } => Some(dtype),
+        NativeQuantPlan::Mixed { .. } => None,
+    }
 }
 
 /// Load the (gate, up, down) **raw quantised byte streams** for every
@@ -1078,16 +1547,31 @@ fn load_layer_expert_native_quant(
     let (block_elems, block_bytes) = match dtype {
         WeightDtype::Q4_0 => (Q4_0_BLOCK_ELEMS, Q4_0_BLOCK_BYTES),
         WeightDtype::Q4K => (Q4K_BLOCK_ELEMS, Q4K_BLOCK_BYTES),
+        WeightDtype::Q5K => (Q5K_BLOCK_ELEMS, Q5K_BLOCK_BYTES),
+        WeightDtype::Q6K => (Q6K_BLOCK_ELEMS, Q6K_BLOCK_BYTES),
         WeightDtype::Q8_0 => (Q8_0_BLOCK_ELEMS, Q8_0_BLOCK_BYTES),
         _ => {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
-                "load_layer_expert_native_quant: dtype must be Q4_0, Q4_K, or Q8_0",
+                "load_layer_expert_native_quant: dtype must be Q4_0, Q4_K, Q5_K, Q6_K, or Q8_0",
             ));
         }
     };
-    let per_expert_weights = d_ff.saturating_mul(d_model);
-    let per_expert_bytes = (per_expert_weights / block_elems) * block_bytes;
+    let per_expert_weights = d_ff
+        .checked_mul(d_model)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "d_ff * d_model overflow"))?;
+    if per_expert_weights % block_elems != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "per-expert weight count {per_expert_weights} is not block-aligned for {}",
+                dtype.as_str()
+            ),
+        ));
+    }
+    let per_expert_bytes = (per_expert_weights / block_elems)
+        .checked_mul(block_bytes)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "expert byte size overflow"))?;
 
     let read_tensor = |name: String| -> io::Result<Vec<u8>> {
         let info = gguf.tensor_info(&name).cloned().ok_or_else(|| {
@@ -1106,11 +1590,19 @@ fn load_layer_expert_native_quant(
         // per-expert stride out without dequantising.
         let read_layer_tensor = |name: String| -> io::Result<Vec<u8>> {
             let buf = read_tensor(name.clone())?;
-            let need = num_experts.saturating_mul(per_expert_bytes);
+            let need = num_experts.checked_mul(per_expert_bytes).ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "layer tensor byte size overflow",
+                )
+            })?;
             if buf.len() < need {
                 return Err(io::Error::new(
                     io::ErrorKind::UnexpectedEof,
-                    format!("tensor {name}: expected {need} quantised bytes, got {}", buf.len()),
+                    format!(
+                        "tensor {name}: expected {need} quantised bytes, got {}",
+                        buf.len()
+                    ),
                 ));
             }
             Ok(buf)
@@ -1159,6 +1651,116 @@ fn load_layer_expert_native_quant(
             let up = read_per_expert(format!("blk.{layer}.ffn_up.{e}.weight"))?;
             let down = read_per_expert(format!("blk.{layer}.ffn_down.{e}.weight"))?;
             out.push((gate, up, down));
+        }
+        Ok(out)
+    }
+}
+
+fn load_layer_expert_native_mixed(
+    gguf: &dyn GgufSource,
+    layer: usize,
+    num_experts: usize,
+    _d_model: usize,
+    _d_ff: usize,
+    layouts: &[ProjectionQuantLayout],
+) -> io::Result<Vec<(ProjectionQuantLayout, Vec<u8>, Vec<u8>, Vec<u8>)>> {
+    let base = layer
+        .checked_mul(num_experts)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "layer expert id overflow"))?;
+    let read_tensor = |name: String| -> io::Result<Vec<u8>> {
+        let info = gguf.tensor_info(&name).cloned().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::NotFound, format!("tensor {name} missing"))
+        })?;
+        gguf.read_tensor_owned(&info.name)?.ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("tensor {} has no data slice", info.name),
+            )
+        })
+    };
+
+    if gguf.has_tensor(&format!("blk.{layer}.ffn_gate_exps.weight")) {
+        let layout = *layouts.get(base).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, "missing mixed layout for layer")
+        })?;
+        let read_layer_tensor = |name: String, spec: ProjectionQuantSpec| -> io::Result<Vec<u8>> {
+            let buf = read_tensor(name.clone())?;
+            let need = num_experts.checked_mul(spec.payload_bytes).ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "layer tensor byte size overflow",
+                )
+            })?;
+            if buf.len() < need {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    format!(
+                        "tensor {name}: expected {need} quantised bytes, got {}",
+                        buf.len()
+                    ),
+                ));
+            }
+            Ok(buf)
+        };
+        let gate_all = read_layer_tensor(format!("blk.{layer}.ffn_gate_exps.weight"), layout.gate)?;
+        let up_all = read_layer_tensor(format!("blk.{layer}.ffn_up_exps.weight"), layout.up)?;
+        let down_all = read_layer_tensor(format!("blk.{layer}.ffn_down_exps.weight"), layout.down)?;
+
+        let mut out = Vec::with_capacity(num_experts);
+        for e in 0..num_experts {
+            let global = base + e;
+            let layout = *layouts.get(global).ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "missing mixed layout for expert",
+                )
+            })?;
+            let slice = |buf: &[u8], spec: ProjectionQuantSpec| -> io::Result<Vec<u8>> {
+                let start = e.checked_mul(spec.payload_bytes).ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidData, "expert slice offset overflow")
+                })?;
+                let end = start.checked_add(spec.payload_bytes).ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidData, "expert slice end overflow")
+                })?;
+                Ok(buf[start..end].to_vec())
+            };
+            out.push((
+                layout,
+                slice(&gate_all, layout.gate)?,
+                slice(&up_all, layout.up)?,
+                slice(&down_all, layout.down)?,
+            ));
+        }
+        Ok(out)
+    } else {
+        let read_per_expert = |name: String, spec: ProjectionQuantSpec| -> io::Result<Vec<u8>> {
+            let mut buf = read_tensor(name.clone())?;
+            if buf.len() < spec.payload_bytes {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    format!(
+                        "tensor {name}: expected {} quantised bytes, got {}",
+                        spec.payload_bytes,
+                        buf.len()
+                    ),
+                ));
+            }
+            buf.truncate(spec.payload_bytes);
+            Ok(buf)
+        };
+        let mut out = Vec::with_capacity(num_experts);
+        for e in 0..num_experts {
+            let global = base + e;
+            let layout = *layouts.get(global).ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "missing mixed layout for expert",
+                )
+            })?;
+            let gate = read_per_expert(format!("blk.{layer}.ffn_gate.{e}.weight"), layout.gate)?;
+            let up = read_per_expert(format!("blk.{layer}.ffn_up.{e}.weight"), layout.up)?;
+            let down = read_per_expert(format!("blk.{layer}.ffn_down.{e}.weight"), layout.down)?;
+            out.push((layout, gate, up, down));
         }
         Ok(out)
     }
@@ -1238,7 +1840,11 @@ mod tests {
             let mut f = fs::File::open(&path).unwrap();
             let mut buf = Vec::new();
             f.read_to_end(&mut buf).unwrap();
-            assert_eq!(buf.len() % DEFAULT_BLOCK_ALIGN, 0, "{path:?} not page-padded");
+            assert_eq!(
+                buf.len() % DEFAULT_BLOCK_ALIGN,
+                0,
+                "{path:?} not page-padded"
+            );
             let needed = 3 * d_model * d_ff * 4;
             assert!(buf.len() >= needed, "expert file too small");
         }
@@ -1272,26 +1878,17 @@ mod tests {
         // Default options → UTH present.
         let gguf = GgufFile::open(&gguf_path).expect("parse");
         let out = tmp.join("with-uth");
-        let _ = extract_experts_from_source(
-            &gguf,
-            &out,
-            1,
-            num_experts,
-            ExtractOptions::default(),
-        )
-        .expect("extract");
+        let _ = extract_experts_from_source(&gguf, &out, 1, num_experts, ExtractOptions::default())
+            .expect("extract");
         for e in 0..num_experts {
             let path = out.join(format!("expert_{e}.bin"));
             let buf = fs::read(&path).unwrap();
-            let header = crate::tensor_header::TensorHeader::probe(&buf)
-                .expect("U.T.H. must be present");
+            let header =
+                crate::tensor_header::TensorHeader::probe(&buf).expect("U.T.H. must be present");
             assert_eq!(header.dtype.to_weight(), WeightDtype::F32);
             assert_eq!(header.shape[0] as usize, d_ff);
             // After stripping, the first byte must be at a 4 KiB offset.
-            let (_, payload) = crate::tensor_header::TensorHeader::strip(
-                &buf,
-                DEFAULT_BLOCK_ALIGN,
-            );
+            let (_, payload) = crate::tensor_header::TensorHeader::strip(&buf, DEFAULT_BLOCK_ALIGN);
             assert_eq!(buf.len() - payload.len(), DEFAULT_BLOCK_ALIGN);
             // Payload is still a whole number of pages.
             assert_eq!(payload.len() % DEFAULT_BLOCK_ALIGN, 0);
@@ -1304,7 +1901,10 @@ mod tests {
             &out2,
             1,
             num_experts,
-            ExtractOptions { emit_uth: false, native_quant: false },
+            ExtractOptions {
+                emit_uth: false,
+                native_quant: false,
+            },
         )
         .expect("extract no-uth");
         for e in 0..num_experts {
@@ -1315,10 +1915,7 @@ mod tests {
                 "no-uth file must not carry a header"
             );
             // strip() must be a no-op when no header is present.
-            let (h, payload) = crate::tensor_header::TensorHeader::strip(
-                &buf,
-                DEFAULT_BLOCK_ALIGN,
-            );
+            let (h, payload) = crate::tensor_header::TensorHeader::strip(&buf, DEFAULT_BLOCK_ALIGN);
             assert!(h.is_none());
             assert_eq!(payload.len(), buf.len());
         }
@@ -1327,12 +1924,17 @@ mod tests {
     }
 
     fn tempfile_dir() -> std::path::PathBuf {
+        static NEXT_TMP_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
         let mut p = std::env::temp_dir();
         let nanos = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.subsec_nanos())
             .unwrap_or(0);
-        p.push(format!("gguf-loader-test-{}-{nanos}", std::process::id()));
+        let seq = NEXT_TMP_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        p.push(format!(
+            "gguf-loader-test-{}-{nanos}-{seq}",
+            std::process::id()
+        ));
         fs::create_dir_all(&p).unwrap();
         p
     }
@@ -1371,8 +1973,8 @@ mod tests {
         let mut out = Vec::new();
         out.extend_from_slice(GGUF_MAGIC);
         out.extend_from_slice(&3u32.to_le_bytes()); // version
-        // tensor_count: per layer we have 7 dense + 3 * num_experts FFN
-        // Actually we'll only put the FFN per-expert tensors and 1 attn_norm.
+                                                    // tensor_count: per layer we have 7 dense + 3 * num_experts FFN
+                                                    // Actually we'll only put the FFN per-expert tensors and 1 attn_norm.
         let per_layer_tensors = 1 /* attn_norm */ + 3 * num_experts;
         out.extend_from_slice(&(per_layer_tensors as u64).to_le_bytes());
         // metadata
@@ -1514,13 +2116,11 @@ mod tests {
         out
     }
 
-    /// `native_quant: true` against an F32-source GGUF must fall back
-    /// to the legacy F32 dequant path without erroring (the source
-    /// dtype is ineligible for native pass-through). The output
-    /// `metadata.json` should still report `dtype = "f32"`, matching
-    /// what was actually written.
+    /// `native_quant: true` now means quantized output is required.
+    /// F32-source experts must fail before writing expert files rather
+    /// than silently expanding a quantized checkpoint into F32 output.
     #[test]
-    fn extract_native_quant_falls_back_when_source_is_f32() {
+    fn extract_native_quant_fails_when_source_is_f32() {
         let d_model = 4usize;
         let d_ff = 8usize;
         let num_experts = 2usize;
@@ -1531,23 +2131,23 @@ mod tests {
         let gguf = GgufFile::open(&gguf_path).expect("parse");
 
         let out = tmp.join("native-fallback");
-        let report = extract_experts_from_source(
+        let err = extract_experts_from_source(
             &gguf,
             &out,
             1,
             num_experts,
-            ExtractOptions { emit_uth: true, native_quant: true },
+            ExtractOptions {
+                emit_uth: true,
+                native_quant: true,
+            },
         )
-        .expect("extract");
-        assert_eq!(report.experts_written, num_experts);
-        assert_eq!(
-            report.expert_dtype,
-            WeightDtype::F32,
-            "F32 source must fall back to F32 dequant"
+        .expect_err("F32 native quant should fail closed");
+        assert!(
+            err.to_string()
+                .contains("not a native quantized expert projection dtype"),
+            "{err}"
         );
-        let meta: serde_json::Value =
-            serde_json::from_slice(&fs::read(out.join("metadata.json")).unwrap()).unwrap();
-        assert_eq!(meta["dtype"], "f32");
+        assert!(!out.join("expert_0.bin").exists());
         let _ = fs::remove_dir_all(&tmp);
     }
 
@@ -1571,14 +2171,8 @@ mod tests {
         // 0 hints → all shape/layout params must be auto-detected from
         // the `qwen2moe.*` namespace.
         let out = tmp.join("auto-detect");
-        let report = extract_experts_from_source(
-            &gguf,
-            &out,
-            0,
-            0,
-            ExtractOptions::default(),
-        )
-        .expect("extract");
+        let report = extract_experts_from_source(&gguf, &out, 0, 0, ExtractOptions::default())
+            .expect("extract");
         assert_eq!(report.experts_written, num_experts);
         let meta: serde_json::Value =
             serde_json::from_slice(&fs::read(out.join("metadata.json")).unwrap()).unwrap();
@@ -1617,14 +2211,8 @@ mod tests {
         // 0 hints → d_ff must be auto-detected from
         // `qwen2moe.expert_feed_forward_length`, not the dense key.
         let out = tmp.join("moe-d-ff");
-        let report = extract_experts_from_source(
-            &gguf,
-            &out,
-            0,
-            0,
-            ExtractOptions::default(),
-        )
-        .expect("extract");
+        let report = extract_experts_from_source(&gguf, &out, 0, 0, ExtractOptions::default())
+            .expect("extract");
         assert_eq!(report.experts_written, num_experts);
         let meta: serde_json::Value =
             serde_json::from_slice(&fs::read(out.join("metadata.json")).unwrap()).unwrap();
@@ -1701,9 +2289,21 @@ mod tests {
             ("general.architecture", 8, lstring(b"llama")),
             ("general.name", 8, lstring(b"synth")),
             ("llama.block_count", 4, 1u32.to_le_bytes().to_vec()),
-            ("llama.expert_count", 4, (num_experts as u32).to_le_bytes().to_vec()),
-            ("llama.embedding_length", 4, (d_model as u32).to_le_bytes().to_vec()),
-            ("llama.feed_forward_length", 4, (d_ff as u32).to_le_bytes().to_vec()),
+            (
+                "llama.expert_count",
+                4,
+                (num_experts as u32).to_le_bytes().to_vec(),
+            ),
+            (
+                "llama.embedding_length",
+                4,
+                (d_model as u32).to_le_bytes().to_vec(),
+            ),
+            (
+                "llama.feed_forward_length",
+                4,
+                (d_ff as u32).to_le_bytes().to_vec(),
+            ),
             ("llama.expert_used_count", 4, 2u32.to_le_bytes().to_vec()),
         ];
         out.extend_from_slice(&(kvs.len() as u64).to_le_bytes());
@@ -1717,33 +2317,36 @@ mod tests {
 
         let mut tensor_data_blobs: Vec<Vec<u8>> = Vec::new();
         let mut cur_off: u64 = 0;
-        let mut push_raw = |out: &mut Vec<u8>,
-                            name: &str,
-                            shape: &[u64],
-                            dtype: u32,
-                            mut blob: Vec<u8>| {
-            let nb = name.as_bytes();
-            out.extend_from_slice(&(nb.len() as u64).to_le_bytes());
-            out.extend_from_slice(nb);
-            out.extend_from_slice(&(shape.len() as u32).to_le_bytes());
-            for d in shape {
-                out.extend_from_slice(&d.to_le_bytes());
-            }
-            out.extend_from_slice(&dtype.to_le_bytes());
-            out.extend_from_slice(&cur_off.to_le_bytes());
-            cur_off += blob.len() as u64;
-            while cur_off % 32 != 0 {
-                blob.push(0);
-                cur_off += 1;
-            }
-            tensor_data_blobs.push(blob);
-        };
+        let mut push_raw =
+            |out: &mut Vec<u8>, name: &str, shape: &[u64], dtype: u32, mut blob: Vec<u8>| {
+                let nb = name.as_bytes();
+                out.extend_from_slice(&(nb.len() as u64).to_le_bytes());
+                out.extend_from_slice(nb);
+                out.extend_from_slice(&(shape.len() as u32).to_le_bytes());
+                for d in shape {
+                    out.extend_from_slice(&d.to_le_bytes());
+                }
+                out.extend_from_slice(&dtype.to_le_bytes());
+                out.extend_from_slice(&cur_off.to_le_bytes());
+                cur_off += blob.len() as u64;
+                while cur_off % 32 != 0 {
+                    blob.push(0);
+                    cur_off += 1;
+                }
+                tensor_data_blobs.push(blob);
+            };
 
         let mut attn = Vec::with_capacity(d_model * 4);
         for _ in 0..d_model {
             attn.extend_from_slice(&1.0f32.to_le_bytes());
         }
-        push_raw(&mut out, "blk.0.attn_norm.weight", &[d_model as u64], ggml_dtype::F32, attn);
+        push_raw(
+            &mut out,
+            "blk.0.attn_norm.weight",
+            &[d_model as u64],
+            ggml_dtype::F32,
+            attn,
+        );
         for e in 0..num_experts {
             push_raw(
                 &mut out,
@@ -1765,6 +2368,129 @@ mod tests {
                 &[d_ff as u64, d_model as u64],
                 ggml_dtype::Q4_0,
                 expert_blob.clone(),
+            );
+        }
+        while out.len() % 32 != 0 {
+            out.push(0);
+        }
+        for blob in &tensor_data_blobs {
+            out.extend_from_slice(blob);
+        }
+        out
+    }
+
+    fn build_synth_gguf_mixed_per_expert(
+        d_model: usize,
+        d_ff: usize,
+        num_experts: usize,
+    ) -> Vec<u8> {
+        use crate::gguf::GGUF_MAGIC;
+        assert_eq!((d_ff * d_model) % Q4_0_BLOCK_ELEMS, 0);
+        assert_eq!((d_ff * d_model) % Q8_0_BLOCK_ELEMS, 0);
+        let q4_blocks = (d_ff * d_model) / Q4_0_BLOCK_ELEMS;
+        let q8_blocks = (d_ff * d_model) / Q8_0_BLOCK_ELEMS;
+        let q4_block: Vec<u8> = {
+            let mut b = half::f16::from_f32(0.1).to_bits().to_le_bytes().to_vec();
+            b.extend_from_slice(&[0x88u8; 16]);
+            b
+        };
+        let q8_block: Vec<u8> = {
+            let mut b = half::f16::from_f32(0.1).to_bits().to_le_bytes().to_vec();
+            b.extend_from_slice(&[1u8; 32]);
+            b
+        };
+        let q4_blob = q4_block.repeat(q4_blocks);
+        let q8_blob = q8_block.repeat(q8_blocks);
+
+        let mut out = Vec::new();
+        out.extend_from_slice(GGUF_MAGIC);
+        out.extend_from_slice(&3u32.to_le_bytes());
+        let per_layer_tensors = 1 + 3 * num_experts;
+        out.extend_from_slice(&(per_layer_tensors as u64).to_le_bytes());
+        let kvs: Vec<(&str, u32, Vec<u8>)> = vec![
+            ("general.alignment", 4, 32u32.to_le_bytes().to_vec()),
+            ("general.architecture", 8, lstring(b"llama")),
+            ("general.name", 8, lstring(b"mixed-synth")),
+            ("llama.block_count", 4, 1u32.to_le_bytes().to_vec()),
+            (
+                "llama.expert_count",
+                4,
+                (num_experts as u32).to_le_bytes().to_vec(),
+            ),
+            (
+                "llama.embedding_length",
+                4,
+                (d_model as u32).to_le_bytes().to_vec(),
+            ),
+            (
+                "llama.feed_forward_length",
+                4,
+                (d_ff as u32).to_le_bytes().to_vec(),
+            ),
+            ("llama.expert_used_count", 4, 2u32.to_le_bytes().to_vec()),
+        ];
+        out.extend_from_slice(&(kvs.len() as u64).to_le_bytes());
+        for (k, ty, payload) in &kvs {
+            let kb = k.as_bytes();
+            out.extend_from_slice(&(kb.len() as u64).to_le_bytes());
+            out.extend_from_slice(kb);
+            out.extend_from_slice(&ty.to_le_bytes());
+            out.extend_from_slice(payload);
+        }
+
+        let mut tensor_data_blobs: Vec<Vec<u8>> = Vec::new();
+        let mut cur_off: u64 = 0;
+        let mut push_raw =
+            |out: &mut Vec<u8>, name: &str, shape: &[u64], dtype: u32, mut blob: Vec<u8>| {
+                let nb = name.as_bytes();
+                out.extend_from_slice(&(nb.len() as u64).to_le_bytes());
+                out.extend_from_slice(nb);
+                out.extend_from_slice(&(shape.len() as u32).to_le_bytes());
+                for d in shape {
+                    out.extend_from_slice(&d.to_le_bytes());
+                }
+                out.extend_from_slice(&dtype.to_le_bytes());
+                out.extend_from_slice(&cur_off.to_le_bytes());
+                cur_off += blob.len() as u64;
+                while cur_off % 32 != 0 {
+                    blob.push(0);
+                    cur_off += 1;
+                }
+                tensor_data_blobs.push(blob);
+            };
+
+        let mut attn = Vec::with_capacity(d_model * 4);
+        for _ in 0..d_model {
+            attn.extend_from_slice(&1.0f32.to_le_bytes());
+        }
+        push_raw(
+            &mut out,
+            "blk.0.attn_norm.weight",
+            &[d_model as u64],
+            ggml_dtype::F32,
+            attn,
+        );
+        for e in 0..num_experts {
+            push_raw(
+                &mut out,
+                &format!("blk.0.ffn_gate.{e}.weight"),
+                &[d_model as u64, d_ff as u64],
+                ggml_dtype::Q4_0,
+                q4_blob.clone(),
+            );
+            push_raw(
+                &mut out,
+                &format!("blk.0.ffn_up.{e}.weight"),
+                &[d_model as u64, d_ff as u64],
+                ggml_dtype::Q4_0,
+                q4_blob.clone(),
+            );
+            push_raw(
+                &mut out,
+                &format!("blk.0.ffn_down.{e}.weight"),
+                &[d_ff as u64, d_model as u64],
+                ggml_dtype::Q8_0,
+                q8_blob.clone(),
             );
         }
         while out.len() % 32 != 0 {
@@ -1805,7 +2531,10 @@ mod tests {
             &out,
             1,
             num_experts,
-            ExtractOptions { emit_uth: true, native_quant: true },
+            ExtractOptions {
+                emit_uth: true,
+                native_quant: true,
+            },
         )
         .expect("extract");
         assert_eq!(report.experts_written, num_experts);
@@ -1824,14 +2553,79 @@ mod tests {
         let f32_payload = 3 * d_ff * d_model * 4;
         for e in 0..num_experts {
             let buf = fs::read(out.join(format!("expert_{e}.bin"))).unwrap();
-            let (_, payload) =
-                crate::tensor_header::TensorHeader::strip(&buf, DEFAULT_BLOCK_ALIGN);
+            let (_, payload) = crate::tensor_header::TensorHeader::strip(&buf, DEFAULT_BLOCK_ALIGN);
             assert!(
                 payload.len() >= q4_payload && payload.len() < f32_payload,
                 "expert {e} payload {} should be raw Q4_0 ({q4_payload}), not F32 ({f32_payload})",
                 payload.len()
             );
         }
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn extract_native_quant_mixed_per_expert_writes_uth2() {
+        let d_model = 64usize;
+        let d_ff = 128usize;
+        let num_experts = 2usize;
+        let bytes = build_synth_gguf_mixed_per_expert(d_model, d_ff, num_experts);
+        let tmp = tempfile_dir();
+        let gguf_path = tmp.join("synth_mixed.gguf");
+        fs::write(&gguf_path, &bytes).unwrap();
+        let gguf = GgufFile::open(&gguf_path).expect("parse");
+
+        let scan = scan_expert_quant_layouts(&gguf, 1, num_experts, d_model, d_ff).unwrap();
+        let report = scan.concise_report();
+        assert!(report.contains("Q4_0/Q4_0/Q8_0: 1 layers"), "{report}");
+        assert!(report.contains("gate: Q4_0=1"), "{report}");
+
+        let out = tmp.join("native-mixed");
+        let extract = extract_experts_from_source(
+            &gguf,
+            &out,
+            1,
+            num_experts,
+            ExtractOptions {
+                emit_uth: true,
+                native_quant: true,
+            },
+        )
+        .expect("extract mixed");
+        assert_eq!(extract.experts_written, num_experts);
+        assert_eq!(extract.expert_dtype, WeightDtype::Mixed);
+
+        let meta: serde_json::Value =
+            serde_json::from_slice(&fs::read(out.join("metadata.json")).unwrap()).unwrap();
+        assert_eq!(meta["dtype"], "mixed");
+        assert_eq!(meta["expert_layout_version"], 2);
+        assert_eq!(
+            meta["projection_dtype_histogram"]["q4_0/q4_0/q8_0"],
+            num_experts
+        );
+
+        let q4_payload = (d_ff * d_model / Q4_0_BLOCK_ELEMS) * Q4_0_BLOCK_BYTES;
+        let q8_payload = (d_ff * d_model / Q8_0_BLOCK_ELEMS) * Q8_0_BLOCK_BYTES;
+        let first = fs::read(out.join("expert_0.bin")).unwrap();
+        let second = fs::read(out.join("expert_1.bin")).unwrap();
+        assert_eq!(first.len(), second.len());
+        assert_eq!(first.len() % DEFAULT_BLOCK_ALIGN, 0);
+        let (header, payload) =
+            crate::tensor_header::MixedExpertHeader::strip(&first, DEFAULT_BLOCK_ALIGN)
+                .expect("UTH2");
+        assert_eq!(header.gate.dtype.to_weight(), WeightDtype::Q4_0);
+        assert_eq!(header.up.dtype.to_weight(), WeightDtype::Q4_0);
+        assert_eq!(header.down.dtype.to_weight(), WeightDtype::Q8_0);
+        assert_eq!(header.gate.len as usize, q4_payload);
+        assert_eq!(header.up.offset as usize, q4_payload);
+        assert_eq!(header.down.offset as usize, q4_payload * 2);
+        assert_eq!(header.down.len as usize, q8_payload);
+        assert!(payload.len() > q4_payload * 2 + q8_payload);
+        let weights = crate::inference::OwnedExpertWeights::from_bytes_mixed_quant(
+            payload, header, d_model, d_ff,
+        )
+        .expect("runtime mixed decode");
+        assert_eq!(weights.gate.len(), d_ff * d_model);
+        assert_eq!(weights.down.len(), d_model * d_ff);
         let _ = fs::remove_dir_all(&tmp);
     }
 }

--- a/rust-engine/src/gguf_loader.rs
+++ b/rust-engine/src/gguf_loader.rs
@@ -1107,6 +1107,12 @@ impl ProjectionQuantLayout {
         }
     }
 
+    fn all_projections_block_aligned(self) -> bool {
+        [self.gate, self.up, self.down]
+            .into_iter()
+            .all(|spec| spec.weights % spec.block_elems == 0)
+    }
+
     fn triple_key(self) -> String {
         format!(
             "{}/{}/{}",
@@ -1223,6 +1229,10 @@ impl ExpertQuantScan {
                 .layouts
                 .iter()
                 .all(|layout| layout.uniform_dtype() == Some(dtype))
+                && self
+                    .layouts
+                    .iter()
+                    .all(|layout| layout.all_projections_block_aligned())
             {
                 return Ok(NativeQuantPlan::Homogeneous { dtype });
             }
@@ -2241,6 +2251,58 @@ mod tests {
         // (32 % 256 != 0); the converter must fall back to F32.
         let q4k_block_elems = 256usize;
         assert_ne!(per_expert_weights % q4k_block_elems, 0);
+    }
+
+    #[test]
+    fn uniform_tail_block_layout_uses_uth2_plan() {
+        let weights = Q5K_BLOCK_ELEMS + 1;
+        let payload_bytes =
+            projection_weight_bytes_for(weights, WeightDtype::Q5K).expect("Q5_K sizing");
+        let spec = ProjectionQuantSpec {
+            dtype: WeightDtype::Q5K,
+            block_elems: Q5K_BLOCK_ELEMS,
+            block_bytes: Q5K_BLOCK_BYTES,
+            weights,
+            payload_bytes,
+        };
+        let layout = ProjectionQuantLayout {
+            gate: spec,
+            up: spec,
+            down: spec,
+        };
+        assert_eq!(payload_bytes, Q5K_BLOCK_BYTES * 2);
+        assert!(!layout.all_projections_block_aligned());
+
+        let mut scan = ExpertQuantScan::new();
+        scan.layouts.push(layout);
+        match scan
+            .into_plan(DEFAULT_BLOCK_ALIGN, true)
+            .expect("UTH2 plan")
+        {
+            NativeQuantPlan::Mixed {
+                payload_slot_size,
+                expert_size,
+                layouts,
+                histogram,
+            } => {
+                let payload = layout.payload_bytes().expect("layout payload");
+                assert_eq!(layouts, vec![layout]);
+                assert_eq!(payload_slot_size, align_up(payload, DEFAULT_BLOCK_ALIGN));
+                assert_eq!(expert_size, payload_slot_size + DEFAULT_BLOCK_ALIGN);
+                assert_eq!(histogram.get("q5_k/q5_k/q5_k"), Some(&1));
+            }
+            other => panic!("tail-block per-expert layout must use UTH2, got {other:?}"),
+        }
+
+        let mut no_uth_scan = ExpertQuantScan::new();
+        no_uth_scan.layouts.push(layout);
+        let err = no_uth_scan
+            .into_plan(DEFAULT_BLOCK_ALIGN, false)
+            .expect_err("tail-block layout needs UTH2");
+        assert!(
+            err.to_string().contains("requires UTH2"),
+            "unexpected error: {err}"
+        );
     }
 
     fn lstring(s: &[u8]) -> Vec<u8> {

--- a/rust-engine/src/inference.rs
+++ b/rust-engine/src/inference.rs
@@ -154,7 +154,14 @@ pub enum WeightDtype {
     /// in a given RAM budget versus `F16`. See [`Q4K_BLOCK_BYTES`] /
     /// [`Q4K_BLOCK_ELEMS`] for the layout constants and
     /// [`dequantize_q4k_block`] for the inverse kernel.
-    #[serde(alias = "Q4K", alias = "Q4_K", alias = "Q4_K_M", alias = "q4_k", alias = "q4_k_m", alias = "q4km")]
+    #[serde(
+        alias = "Q4K",
+        alias = "Q4_K",
+        alias = "Q4_K_M",
+        alias = "q4_k",
+        alias = "q4_k_m",
+        alias = "q4km"
+    )]
     Q4K,
     /// **GGUF-style Q4_0 block quantisation.** Each 32-weight block
     /// occupies 18 bytes: an `f16` block scale `d` followed by 16
@@ -187,6 +194,17 @@ pub enum WeightDtype {
     /// kernel.
     #[serde(alias = "Q8_0", alias = "q80", alias = "q8_0_gguf")]
     Q8_0,
+    /// **GGUF-style Q5_K block quantisation.** Each 256-weight block
+    /// occupies 176 bytes. MER supports this as a native expert
+    /// projection dtype, primarily for mixed GGUF MoE experts whose
+    /// gate/up/down projections do not share one quant format.
+    #[serde(alias = "Q5K", alias = "Q5_K", alias = "q5_k")]
+    Q5K,
+    /// **GGUF-style Q6_K block quantisation.** Each 256-weight block
+    /// occupies 210 bytes. Like [`Self::Q5K`], this is supported for
+    /// native mixed expert projections and homogeneous expert blobs.
+    #[serde(alias = "Q6K", alias = "Q6_K", alias = "q6_k")]
+    Q6K,
     /// Little-endian IEEE-754 `bfloat16` (`half::bf16`), 2 bytes per
     /// weight, no header. Decodes to f32 exactly like [`Self::F16`] but
     /// via `half::bf16::from_le_bytes`. BF16 is the native dense-body
@@ -208,6 +226,11 @@ pub enum WeightDtype {
     /// [`crate::dequant::dequant_mxfp4`].
     #[serde(alias = "MXFP4", alias = "mxfp4", alias = "mx_fp4")]
     MXFP4,
+    /// Versioned mixed-projection expert storage. This is a runtime
+    /// dispatch label used with UTH2 headers; each projection's real
+    /// dtype and byte range is recorded independently in the header.
+    #[serde(alias = "MIXED", alias = "mixed")]
+    Mixed,
 }
 
 impl WeightDtype {
@@ -232,11 +255,14 @@ impl WeightDtype {
             WeightDtype::Q4_0 => 1,
             // 34 / 32 rounded up = 2; not used for sizing — see docs.
             WeightDtype::Q8_0 => 2,
+            // K-quants are sized exactly by `expert_weight_bytes_for`.
+            WeightDtype::Q5K | WeightDtype::Q6K => 1,
             WeightDtype::BF16 => 2,
             // ~4.25 bits/weight; sizing is done exactly via
             // [`expert_weight_bytes_for`] — this rounded value is only a
             // placeholder for callers that ignore the block layout.
             WeightDtype::MXFP4 => 1,
+            WeightDtype::Mixed => 0,
         }
     }
 
@@ -254,8 +280,11 @@ impl WeightDtype {
             | WeightDtype::Q4K
             | WeightDtype::Q4_0
             | WeightDtype::Q8_0
+            | WeightDtype::Q5K
+            | WeightDtype::Q6K
             | WeightDtype::BF16
-            | WeightDtype::MXFP4 => 0,
+            | WeightDtype::MXFP4
+            | WeightDtype::Mixed => 0,
             WeightDtype::Int8 => INT8_HEADER_BYTES,
         }
     }
@@ -269,8 +298,11 @@ impl WeightDtype {
             "q4k" | "q4_k" | "q4_k_m" | "q4km" => Some(WeightDtype::Q4K),
             "q4_0" | "q40" | "q4" => Some(WeightDtype::Q4_0),
             "q8_0" | "q80" => Some(WeightDtype::Q8_0),
+            "q5k" | "q5_k" => Some(WeightDtype::Q5K),
+            "q6k" | "q6_k" => Some(WeightDtype::Q6K),
             "bf16" | "bfloat16" => Some(WeightDtype::BF16),
             "mxfp4" | "mx_fp4" => Some(WeightDtype::MXFP4),
+            "mixed" => Some(WeightDtype::Mixed),
             _ => None,
         }
     }
@@ -284,8 +316,11 @@ impl WeightDtype {
             WeightDtype::Q4K => "q4k",
             WeightDtype::Q4_0 => "q4_0",
             WeightDtype::Q8_0 => "q8_0",
+            WeightDtype::Q5K => "q5k",
+            WeightDtype::Q6K => "q6k",
             WeightDtype::BF16 => "bf16",
             WeightDtype::MXFP4 => "mxfp4",
+            WeightDtype::Mixed => "mixed",
         }
     }
 }
@@ -312,7 +347,11 @@ impl Int8ExpertMeta {
         let g = f32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
         let u = f32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
         let d = f32::from_le_bytes([bytes[8], bytes[9], bytes[10], bytes[11]]);
-        Some(Self { gate_scale: g, up_scale: u, down_scale: d })
+        Some(Self {
+            gate_scale: g,
+            up_scale: u,
+            down_scale: d,
+        })
     }
 
     /// Serialise the header to its on-disk byte layout.
@@ -517,6 +556,147 @@ pub fn dequantize_q4k_to_f32(src: &[u8], n_weights: usize, dst: &mut Vec<f32>) {
         dequantize_q4k_block(s, d);
     }
     // Truncate any padding at the tail (for n_weights not divisible by 256).
+    dst.truncate(n_weights);
+}
+
+// ---------------------------------------------------------------------
+// Q5_K / Q6_K (GGUF K-quants).
+// ---------------------------------------------------------------------
+
+/// Number of weights per Q5_K/Q6_K super-block.
+pub const Q5K_BLOCK_ELEMS: usize = 256;
+pub const Q6K_BLOCK_ELEMS: usize = 256;
+/// Bytes per Q5_K super-block on disk.
+///
+/// Upstream layout: `d: f16`, `dmin: f16`, `scales[12]`, `qh[32]`,
+/// `qs[128]` for 176 bytes total. Ported from GGML/Candle
+/// `BlockQ5K` (`candle-core/src/quantized/k_quants.rs`, which cites
+/// llama.cpp `k_quants.c`).
+pub const Q5K_BLOCK_BYTES: usize = 2 + 2 + 12 + 32 + 128;
+/// Bytes per Q6_K super-block on disk.
+///
+/// Upstream layout: `ql[128]`, `qh[64]`, signed `scales[16]`, `d: f16`
+/// for 210 bytes total. Ported from GGML/Candle `BlockQ6K`.
+pub const Q6K_BLOCK_BYTES: usize = 128 + 64 + 16 + 2;
+
+/// Dequantise one Q5_K super-block into `dst`.
+pub fn dequantize_q5k_block(src: &[u8], dst: &mut [f32]) {
+    assert_eq!(
+        src.len(),
+        Q5K_BLOCK_BYTES,
+        "Q5_K block must be {Q5K_BLOCK_BYTES} bytes"
+    );
+    assert_eq!(
+        dst.len(),
+        Q5K_BLOCK_ELEMS,
+        "Q5_K dst must hold {Q5K_BLOCK_ELEMS} floats"
+    );
+
+    let d = half::f16::from_bits(u16::from_le_bytes([src[0], src[1]])).to_f32();
+    let dmin = half::f16::from_bits(u16::from_le_bytes([src[2], src[3]])).to_f32();
+    let scales: [u8; 12] = src[4..16].try_into().expect("12-byte slice");
+    let pairs = q4k_unpack_scales(&scales);
+    let qh = &src[16..48];
+    let qs = &src[48..176];
+
+    let mut is = 0usize;
+    let mut hi_low_mask = 1u8;
+    let mut hi_high_mask = 2u8;
+    let mut out = 0usize;
+    for j in (0..Q5K_BLOCK_ELEMS).step_by(64) {
+        let q = &qs[j / 2..j / 2 + 32];
+        let (sc1, min1) = pairs[is];
+        let (sc2, min2) = pairs[is + 1];
+        let d1 = d * sc1 as f32;
+        let m1 = dmin * min1 as f32;
+        let d2 = d * sc2 as f32;
+        let m2 = dmin * min2 as f32;
+        for (&ql, &qh) in q.iter().zip(qh.iter()) {
+            let hi = if qh & hi_low_mask != 0 { 16.0 } else { 0.0 };
+            dst[out] = d1 * ((ql & 0x0F) as f32 + hi) - m1;
+            out += 1;
+        }
+        for (&ql, &qh) in q.iter().zip(qh.iter()) {
+            let hi = if qh & hi_high_mask != 0 { 16.0 } else { 0.0 };
+            dst[out] = d2 * ((ql >> 4) as f32 + hi) - m2;
+            out += 1;
+        }
+        is += 2;
+        hi_low_mask <<= 2;
+        hi_high_mask <<= 2;
+    }
+}
+
+/// Dequantise a contiguous Q5_K stream of `n_weights` weights.
+pub fn dequantize_q5k_to_f32(src: &[u8], n_weights: usize, dst: &mut Vec<f32>) {
+    let blocks = n_weights.div_ceil(Q5K_BLOCK_ELEMS);
+    assert!(
+        src.len() >= blocks * Q5K_BLOCK_BYTES,
+        "Q5_K source has {} bytes, need {} for {n_weights} weights",
+        src.len(),
+        blocks * Q5K_BLOCK_BYTES
+    );
+    dst.clear();
+    dst.resize(blocks * Q5K_BLOCK_ELEMS, 0.0);
+    for b in 0..blocks {
+        let s = &src[b * Q5K_BLOCK_BYTES..(b + 1) * Q5K_BLOCK_BYTES];
+        let d = &mut dst[b * Q5K_BLOCK_ELEMS..(b + 1) * Q5K_BLOCK_ELEMS];
+        dequantize_q5k_block(s, d);
+    }
+    dst.truncate(n_weights);
+}
+
+/// Dequantise one Q6_K super-block into `dst`.
+pub fn dequantize_q6k_block(src: &[u8], dst: &mut [f32]) {
+    assert_eq!(
+        src.len(),
+        Q6K_BLOCK_BYTES,
+        "Q6_K block must be {Q6K_BLOCK_BYTES} bytes"
+    );
+    assert_eq!(
+        dst.len(),
+        Q6K_BLOCK_ELEMS,
+        "Q6_K dst must hold {Q6K_BLOCK_ELEMS} floats"
+    );
+
+    let ql = &src[0..128];
+    let qh = &src[128..192];
+    let scales = &src[192..208];
+    let d = half::f16::from_bits(u16::from_le_bytes([src[208], src[209]])).to_f32();
+
+    for ip in 0..2 {
+        for il in 0..32 {
+            let is = 8 * ip + il / 16;
+            let out = 128 * ip + il;
+            let ql_base = 64 * ip + il;
+            let qh_byte = qh[32 * ip + il];
+            let sc = |idx: usize| -> f32 { scales[idx] as i8 as f32 };
+            let q =
+                |low: u8, high_bits: u8| -> f32 { (((low | (high_bits << 4)) as i32) - 32) as f32 };
+            dst[out] = d * sc(is) * q(ql[ql_base] & 0x0F, qh_byte & 0x03);
+            dst[out + 32] = d * sc(is + 2) * q(ql[ql_base + 32] & 0x0F, (qh_byte >> 2) & 0x03);
+            dst[out + 64] = d * sc(is + 4) * q(ql[ql_base] >> 4, (qh_byte >> 4) & 0x03);
+            dst[out + 96] = d * sc(is + 6) * q(ql[ql_base + 32] >> 4, (qh_byte >> 6) & 0x03);
+        }
+    }
+}
+
+/// Dequantise a contiguous Q6_K stream of `n_weights` weights.
+pub fn dequantize_q6k_to_f32(src: &[u8], n_weights: usize, dst: &mut Vec<f32>) {
+    let blocks = n_weights.div_ceil(Q6K_BLOCK_ELEMS);
+    assert!(
+        src.len() >= blocks * Q6K_BLOCK_BYTES,
+        "Q6_K source has {} bytes, need {} for {n_weights} weights",
+        src.len(),
+        blocks * Q6K_BLOCK_BYTES
+    );
+    dst.clear();
+    dst.resize(blocks * Q6K_BLOCK_ELEMS, 0.0);
+    for b in 0..blocks {
+        let s = &src[b * Q6K_BLOCK_BYTES..(b + 1) * Q6K_BLOCK_BYTES];
+        let d = &mut dst[b * Q6K_BLOCK_ELEMS..(b + 1) * Q6K_BLOCK_ELEMS];
+        dequantize_q6k_block(s, d);
+    }
     dst.truncate(n_weights);
 }
 
@@ -844,6 +1024,34 @@ pub const fn mxfp4_projection_bytes(rows: usize, cols: usize) -> usize {
     weight_bytes.saturating_add(scale_bytes)
 }
 
+/// Exact byte count for one projection with `weights` logical weights
+/// in a native expert-storage dtype. Returns `None` for dtypes that do
+/// not have an independent projection byte stream (notably `Mixed`,
+/// which is a header-level dispatch label).
+pub fn projection_weight_bytes_for(weights: usize, dtype: WeightDtype) -> Option<usize> {
+    Some(match dtype {
+        WeightDtype::F32 => weights.checked_mul(4)?,
+        WeightDtype::F16 | WeightDtype::BF16 => weights.checked_mul(2)?,
+        WeightDtype::Int8 => weights,
+        WeightDtype::Q4K => weights
+            .div_ceil(Q4K_BLOCK_ELEMS)
+            .checked_mul(Q4K_BLOCK_BYTES)?,
+        WeightDtype::Q4_0 => weights
+            .div_ceil(Q4_0_BLOCK_ELEMS)
+            .checked_mul(Q4_0_BLOCK_BYTES)?,
+        WeightDtype::Q8_0 => weights
+            .div_ceil(Q8_0_BLOCK_ELEMS)
+            .checked_mul(Q8_0_BLOCK_BYTES)?,
+        WeightDtype::Q5K => weights
+            .div_ceil(Q5K_BLOCK_ELEMS)
+            .checked_mul(Q5K_BLOCK_BYTES)?,
+        WeightDtype::Q6K => weights
+            .div_ceil(Q6K_BLOCK_ELEMS)
+            .checked_mul(Q6K_BLOCK_BYTES)?,
+        WeightDtype::MXFP4 | WeightDtype::Mixed => return None,
+    })
+}
+
 /// Number of bytes an expert with these dimensions occupies on disk
 /// for the given dtype, **including** any per-expert header (e.g. the
 /// 12-byte INT8 scale header).
@@ -880,6 +1088,18 @@ pub const fn expert_weight_bytes_for(d_model: usize, d_ff: usize, dtype: WeightD
             let total_blocks = one_blocks.saturating_mul(3);
             total_blocks.saturating_mul(Q8_0_BLOCK_BYTES)
         }
+        WeightDtype::Q5K => {
+            let one = d_model.saturating_mul(d_ff);
+            let one_blocks = one.div_ceil(Q5K_BLOCK_ELEMS);
+            let total_blocks = one_blocks.saturating_mul(3);
+            total_blocks.saturating_mul(Q5K_BLOCK_BYTES)
+        }
+        WeightDtype::Q6K => {
+            let one = d_model.saturating_mul(d_ff);
+            let one_blocks = one.div_ceil(Q6K_BLOCK_ELEMS);
+            let total_blocks = one_blocks.saturating_mul(3);
+            total_blocks.saturating_mul(Q6K_BLOCK_BYTES)
+        }
         WeightDtype::MXFP4 => {
             // Three projections (gate, up, down) stored back to back.
             // Each projection is its packed U8 weight bytes (two E2M1
@@ -892,9 +1112,10 @@ pub const fn expert_weight_bytes_for(d_model: usize, d_ff: usize, dtype: WeightD
             let down = mxfp4_projection_bytes(d_model, d_ff);
             gate.saturating_add(up).saturating_add(down)
         }
+        WeightDtype::Mixed => 0,
         _ => {
-            let payload = expert_weight_count(d_model, d_ff)
-                .saturating_mul(dtype.bytes_per_weight());
+            let payload =
+                expert_weight_count(d_model, d_ff).saturating_mul(dtype.bytes_per_weight());
             payload.saturating_add(dtype.header_bytes())
         }
     }
@@ -923,12 +1144,20 @@ pub enum ExpertWeightsError {
     /// `Result` rather than panicking so the engine can log and skip
     /// the offending expert instead of aborting the whole run.
     Candle(String),
+    /// The expert's self-describing header is malformed or incompatible
+    /// with the runtime shape/dtype dispatch.
+    InvalidLayout(String),
 }
 
 impl fmt::Display for ExpertWeightsError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ExpertWeightsError::BufferTooSmall { have, need, d_model, d_ff } => write!(
+            ExpertWeightsError::BufferTooSmall {
+                have,
+                need,
+                d_model,
+                d_ff,
+            } => write!(
                 f,
                 "expert buffer too small: have {have} bytes, need {need} for \
                  d_model={d_model}, d_ff={d_ff}"
@@ -938,8 +1167,12 @@ impl fmt::Display for ExpertWeightsError {
                 "expert buffer is not f32-aligned: addr=0x{addr:x}, required={required}"
             ),
             ExpertWeightsError::Candle(msg) => {
-                write!(f, "candle-core operation failed during expert forward pass: {msg}")
+                write!(
+                    f,
+                    "candle-core operation failed during expert forward pass: {msg}"
+                )
             }
+            ExpertWeightsError::InvalidLayout(msg) => write!(f, "invalid expert layout: {msg}"),
         }
     }
 }
@@ -999,9 +1232,8 @@ impl<'a> ExpertWeights<'a> {
         //   is correct.
         // * The lifetime of the resulting `&[f32]` is tied to `bytes`, so
         //   the borrow checker prevents mutation while the view exists.
-        let floats: &'a [f32] = unsafe {
-            std::slice::from_raw_parts(bytes.as_ptr().cast::<f32>(), need_floats)
-        };
+        let floats: &'a [f32] =
+            unsafe { std::slice::from_raw_parts(bytes.as_ptr().cast::<f32>(), need_floats) };
 
         let gate_len = d_ff * d_model;
         let up_len = d_ff * d_model;
@@ -1010,7 +1242,13 @@ impl<'a> ExpertWeights<'a> {
         let (up, rest) = rest.split_at(up_len);
         let (down, _trailing) = rest.split_at(down_len);
 
-        Ok(Self { d_model, d_ff, gate, up, down })
+        Ok(Self {
+            d_model,
+            d_ff,
+            gate,
+            up,
+            down,
+        })
     }
 
     /// Build the three-matrix view from a fully-materialised `&[f32]`
@@ -1038,9 +1276,14 @@ impl<'a> ExpertWeights<'a> {
         let (gate, rest) = floats[..need_floats].split_at(gate_len);
         let (up, rest) = rest.split_at(up_len);
         let (down, _trailing) = rest.split_at(down_len);
-        Ok(Self { d_model, d_ff, gate, up, down })
+        Ok(Self {
+            d_model,
+            d_ff,
+            gate,
+            up,
+            down,
+        })
     }
-
 
     /// **The memory bridge to Candle.**
     ///
@@ -1066,12 +1309,11 @@ impl<'a> ExpertWeights<'a> {
         device: &Device,
     ) -> Result<(Tensor, Tensor, Tensor), ExpertWeightsError> {
         let map_err = |e: candle_core::Error| ExpertWeightsError::Candle(e.to_string());
-        let gate = Tensor::from_slice(self.gate, (self.d_ff, self.d_model), device)
-            .map_err(map_err)?;
-        let up = Tensor::from_slice(self.up, (self.d_ff, self.d_model), device)
-            .map_err(map_err)?;
-        let down = Tensor::from_slice(self.down, (self.d_model, self.d_ff), device)
-            .map_err(map_err)?;
+        let gate =
+            Tensor::from_slice(self.gate, (self.d_ff, self.d_model), device).map_err(map_err)?;
+        let up = Tensor::from_slice(self.up, (self.d_ff, self.d_model), device).map_err(map_err)?;
+        let down =
+            Tensor::from_slice(self.down, (self.d_model, self.d_ff), device).map_err(map_err)?;
         Ok((gate, up, down))
     }
 
@@ -1221,16 +1463,36 @@ fn gate_up_swiglu(gate: &[f32], up: &[f32], x: &[f32], gated: &mut [f32], d_mode
             // and neither aliases `gate`, `up`, or `x`.
             unsafe {
                 matrixmultiply::sgemm(
-                    d_ff, d_model, 1, 1.0,
-                    gate.as_ptr(), d_model as isize, 1,
-                    x.as_ptr(), 1, 1,
-                    0.0, gated.as_mut_ptr(), 1, 1,
+                    d_ff,
+                    d_model,
+                    1,
+                    1.0,
+                    gate.as_ptr(),
+                    d_model as isize,
+                    1,
+                    x.as_ptr(),
+                    1,
+                    1,
+                    0.0,
+                    gated.as_mut_ptr(),
+                    1,
+                    1,
                 );
                 matrixmultiply::sgemm(
-                    d_ff, d_model, 1, 1.0,
-                    up.as_ptr(), d_model as isize, 1,
-                    x.as_ptr(), 1, 1,
-                    0.0, u_vec.as_mut_ptr(), 1, 1,
+                    d_ff,
+                    d_model,
+                    1,
+                    1.0,
+                    up.as_ptr(),
+                    d_model as isize,
+                    1,
+                    x.as_ptr(),
+                    1,
+                    1,
+                    0.0,
+                    u_vec.as_mut_ptr(),
+                    1,
+                    1,
                 );
             }
             for (g, &u) in gated.iter_mut().zip(u_vec.iter()) {
@@ -1273,10 +1535,20 @@ fn down_proj(down: &[f32], gated: &[f32], y: &mut [f32], d_ff: usize) {
         let d_model = y.len();
         unsafe {
             matrixmultiply::sgemm(
-                d_model, d_ff, 1, 1.0,
-                down.as_ptr(), d_ff as isize, 1,
-                gated.as_ptr(), 1, 1,
-                0.0, y.as_mut_ptr(), 1, 1,
+                d_model,
+                d_ff,
+                1,
+                1.0,
+                down.as_ptr(),
+                d_ff as isize,
+                1,
+                gated.as_ptr(),
+                1,
+                1,
+                0.0,
+                y.as_mut_ptr(),
+                1,
+                1,
             );
         }
     }
@@ -1358,8 +1630,7 @@ impl OwnedExpertWeights {
         let gate_blocks = gate_n.div_ceil(Q4K_BLOCK_ELEMS);
         let up_blocks = up_n.div_ceil(Q4K_BLOCK_ELEMS);
         let down_blocks = down_n.div_ceil(Q4K_BLOCK_ELEMS);
-        let need_bytes = (gate_blocks + up_blocks + down_blocks)
-            .saturating_mul(Q4K_BLOCK_BYTES);
+        let need_bytes = (gate_blocks + up_blocks + down_blocks).saturating_mul(Q4K_BLOCK_BYTES);
         if bytes.len() < need_bytes {
             return Err(ExpertWeightsError::BufferTooSmall {
                 have: bytes.len(),
@@ -1436,8 +1707,7 @@ impl OwnedExpertWeights {
         let gate_blocks = gate_n.div_ceil(Q4_0_BLOCK_ELEMS);
         let up_blocks = up_n.div_ceil(Q4_0_BLOCK_ELEMS);
         let down_blocks = down_n.div_ceil(Q4_0_BLOCK_ELEMS);
-        let need_bytes = (gate_blocks + up_blocks + down_blocks)
-            .saturating_mul(Q4_0_BLOCK_BYTES);
+        let need_bytes = (gate_blocks + up_blocks + down_blocks).saturating_mul(Q4_0_BLOCK_BYTES);
         let buf = q4_expert_bytes_with_tolerance(bytes, need_bytes, d_model, d_ff)?;
         let bytes: &[u8] = &buf;
 
@@ -1537,8 +1807,7 @@ impl OwnedExpertWeights {
         let gate_blocks = gate_n.div_ceil(Q8_0_BLOCK_ELEMS);
         let up_blocks = up_n.div_ceil(Q8_0_BLOCK_ELEMS);
         let down_blocks = down_n.div_ceil(Q8_0_BLOCK_ELEMS);
-        let need_bytes = (gate_blocks + up_blocks + down_blocks)
-            .saturating_mul(Q8_0_BLOCK_BYTES);
+        let need_bytes = (gate_blocks + up_blocks + down_blocks).saturating_mul(Q8_0_BLOCK_BYTES);
         if bytes.len() < need_bytes {
             return Err(ExpertWeightsError::BufferTooSmall {
                 have: bytes.len(),
@@ -1576,6 +1845,146 @@ impl OwnedExpertWeights {
             gate: gate_buf,
             up: up_buf,
             down: down_buf,
+            col_indices: None,
+        })
+    }
+
+    /// Build an owned weight set by dequantising a **Q5_K** expert byte
+    /// buffer into a fresh `Vec<f32>`.
+    pub fn from_bytes_q5k(
+        bytes: &[u8],
+        d_model: usize,
+        d_ff: usize,
+    ) -> Result<Self, ExpertWeightsError> {
+        let gate_n = d_ff.saturating_mul(d_model);
+        let up_n = d_ff.saturating_mul(d_model);
+        let down_n = d_model.saturating_mul(d_ff);
+        let gate_blocks = gate_n.div_ceil(Q5K_BLOCK_ELEMS);
+        let up_blocks = up_n.div_ceil(Q5K_BLOCK_ELEMS);
+        let down_blocks = down_n.div_ceil(Q5K_BLOCK_ELEMS);
+        let need_bytes = (gate_blocks + up_blocks + down_blocks).saturating_mul(Q5K_BLOCK_BYTES);
+        if bytes.len() < need_bytes {
+            return Err(ExpertWeightsError::BufferTooSmall {
+                have: bytes.len(),
+                need: need_bytes,
+                d_model,
+                d_ff,
+            });
+        }
+
+        let mut off = 0;
+        let mut gate_buf = Vec::new();
+        dequantize_q5k_to_f32(
+            &bytes[off..off + gate_blocks * Q5K_BLOCK_BYTES],
+            gate_n,
+            &mut gate_buf,
+        );
+        off += gate_blocks * Q5K_BLOCK_BYTES;
+        let mut up_buf = Vec::new();
+        dequantize_q5k_to_f32(
+            &bytes[off..off + up_blocks * Q5K_BLOCK_BYTES],
+            up_n,
+            &mut up_buf,
+        );
+        off += up_blocks * Q5K_BLOCK_BYTES;
+        let mut down_buf = Vec::new();
+        dequantize_q5k_to_f32(
+            &bytes[off..off + down_blocks * Q5K_BLOCK_BYTES],
+            down_n,
+            &mut down_buf,
+        );
+
+        Ok(Self {
+            d_model,
+            d_ff,
+            gate: gate_buf,
+            up: up_buf,
+            down: down_buf,
+            col_indices: None,
+        })
+    }
+
+    /// Build an owned weight set by dequantising a **Q6_K** expert byte
+    /// buffer into a fresh `Vec<f32>`.
+    pub fn from_bytes_q6k(
+        bytes: &[u8],
+        d_model: usize,
+        d_ff: usize,
+    ) -> Result<Self, ExpertWeightsError> {
+        let gate_n = d_ff.saturating_mul(d_model);
+        let up_n = d_ff.saturating_mul(d_model);
+        let down_n = d_model.saturating_mul(d_ff);
+        let gate_blocks = gate_n.div_ceil(Q6K_BLOCK_ELEMS);
+        let up_blocks = up_n.div_ceil(Q6K_BLOCK_ELEMS);
+        let down_blocks = down_n.div_ceil(Q6K_BLOCK_ELEMS);
+        let need_bytes = (gate_blocks + up_blocks + down_blocks).saturating_mul(Q6K_BLOCK_BYTES);
+        if bytes.len() < need_bytes {
+            return Err(ExpertWeightsError::BufferTooSmall {
+                have: bytes.len(),
+                need: need_bytes,
+                d_model,
+                d_ff,
+            });
+        }
+
+        let mut off = 0;
+        let mut gate_buf = Vec::new();
+        dequantize_q6k_to_f32(
+            &bytes[off..off + gate_blocks * Q6K_BLOCK_BYTES],
+            gate_n,
+            &mut gate_buf,
+        );
+        off += gate_blocks * Q6K_BLOCK_BYTES;
+        let mut up_buf = Vec::new();
+        dequantize_q6k_to_f32(
+            &bytes[off..off + up_blocks * Q6K_BLOCK_BYTES],
+            up_n,
+            &mut up_buf,
+        );
+        off += up_blocks * Q6K_BLOCK_BYTES;
+        let mut down_buf = Vec::new();
+        dequantize_q6k_to_f32(
+            &bytes[off..off + down_blocks * Q6K_BLOCK_BYTES],
+            down_n,
+            &mut down_buf,
+        );
+
+        Ok(Self {
+            d_model,
+            d_ff,
+            gate: gate_buf,
+            up: up_buf,
+            down: down_buf,
+            col_indices: None,
+        })
+    }
+
+    /// Build an owned weight set from a UTH2 mixed-projection expert.
+    pub fn from_bytes_mixed_quant(
+        bytes: &[u8],
+        header: crate::tensor_header::MixedExpertHeader,
+        d_model: usize,
+        d_ff: usize,
+    ) -> Result<Self, ExpertWeightsError> {
+        if header.d_model as usize != d_model || header.d_ff as usize != d_ff {
+            return Err(ExpertWeightsError::InvalidLayout(format!(
+                "UTH2 shape d_model={} d_ff={} does not match runtime d_model={} d_ff={}",
+                header.d_model, header.d_ff, d_model, d_ff
+            )));
+        }
+        header
+            .validate(bytes.len() as u64)
+            .map_err(ExpertWeightsError::InvalidLayout)?;
+        let expected = d_model.saturating_mul(d_ff);
+        let gate = decode_mixed_projection(bytes, header.gate, expected, d_model, d_ff, "gate")?;
+        let up = decode_mixed_projection(bytes, header.up, expected, d_model, d_ff, "up")?;
+        let down = decode_mixed_projection(bytes, header.down, expected, d_model, d_ff, "down")?;
+        Ok(Self {
+            d_model,
+            d_ff,
+            gate,
+            up,
+            down,
             col_indices: None,
         })
     }
@@ -1641,44 +2050,56 @@ impl OwnedExpertWeights {
 
         // Decode one [rows × cols] projection starting at `off`, returning
         // the dequantised f32 matrix and the new offset.
-let decode_proj = |off: usize, rows: usize, cols: usize| -> Result<(Vec<f32>, usize), ExpertWeightsError> {
-    let weight_bytes = rows.saturating_mul(cols.div_ceil(2));
-    let scale_bytes = rows.saturating_mul(cols.div_ceil(MXFP4_SCALE_BLOCK));
-    let w_end = off.checked_add(weight_bytes).ok_or(ExpertWeightsError::BufferTooSmall {
-        have: bytes.len(),
-        need: need_bytes,
-        d_model,
-        d_ff,
-    })?;
-    let s_end = w_end.checked_add(scale_bytes).ok_or(ExpertWeightsError::BufferTooSmall {
-        have: bytes.len(),
-        need: need_bytes,
-        d_model,
-        d_ff,
-    })?;
-    let packed = bytes.get(off..w_end).ok_or(ExpertWeightsError::BufferTooSmall {
-        have: bytes.len(),
-        need: need_bytes,
-        d_model,
-        d_ff,
-    })?;
-    let scales = bytes.get(w_end..s_end).ok_or(ExpertWeightsError::BufferTooSmall {
-        have: bytes.len(),
-        need: need_bytes,
-        d_model,
-        d_ff,
-    })?;
-    let out = crate::dequant::dequant_mxfp4(packed, scales, rows, cols);
-    if out.len() != rows.saturating_mul(cols) {
-        return Err(ExpertWeightsError::BufferTooSmall {
-            have: bytes.len(),
-            need: need_bytes,
-            d_model,
-            d_ff,
-        });
-    }
-    Ok((out, s_end))
-};
+        let decode_proj = |off: usize,
+                           rows: usize,
+                           cols: usize|
+         -> Result<(Vec<f32>, usize), ExpertWeightsError> {
+            let weight_bytes = rows.saturating_mul(cols.div_ceil(2));
+            let scale_bytes = rows.saturating_mul(cols.div_ceil(MXFP4_SCALE_BLOCK));
+            let w_end =
+                off.checked_add(weight_bytes)
+                    .ok_or(ExpertWeightsError::BufferTooSmall {
+                        have: bytes.len(),
+                        need: need_bytes,
+                        d_model,
+                        d_ff,
+                    })?;
+            let s_end =
+                w_end
+                    .checked_add(scale_bytes)
+                    .ok_or(ExpertWeightsError::BufferTooSmall {
+                        have: bytes.len(),
+                        need: need_bytes,
+                        d_model,
+                        d_ff,
+                    })?;
+            let packed = bytes
+                .get(off..w_end)
+                .ok_or(ExpertWeightsError::BufferTooSmall {
+                    have: bytes.len(),
+                    need: need_bytes,
+                    d_model,
+                    d_ff,
+                })?;
+            let scales = bytes
+                .get(w_end..s_end)
+                .ok_or(ExpertWeightsError::BufferTooSmall {
+                    have: bytes.len(),
+                    need: need_bytes,
+                    d_model,
+                    d_ff,
+                })?;
+            let out = crate::dequant::dequant_mxfp4(packed, scales, rows, cols);
+            if out.len() != rows.saturating_mul(cols) {
+                return Err(ExpertWeightsError::BufferTooSmall {
+                    have: bytes.len(),
+                    need: need_bytes,
+                    d_model,
+                    d_ff,
+                });
+            }
+            Ok((out, s_end))
+        };
 
         let (gate, off) = decode_proj(0, d_ff, d_model)?;
         let (up, off) = decode_proj(off, d_ff, d_model)?;
@@ -1743,7 +2164,14 @@ let decode_proj = |off: usize, rows: usize, cols: usize| -> Result<(Vec<f32>, us
             &payload[gate_len + up_len..gate_len + up_len + down_len],
             meta.down_scale,
         );
-        Ok(Self { d_model, d_ff, gate, up, down, col_indices: None })
+        Ok(Self {
+            d_model,
+            d_ff,
+            gate,
+            up,
+            down,
+            col_indices: None,
+        })
     }
 
     /// Build an owned weight set by dequantising a little-endian `f16`
@@ -1803,7 +2231,10 @@ let decode_proj = |off: usize, rows: usize, cols: usize| -> Result<(Vec<f32>, us
     ) -> Result<Self, ExpertWeightsError> {
         let m = col_indices.len();
         for &c in col_indices {
-            assert!(c < d_model, "col index {c} out of range for d_model={d_model}");
+            assert!(
+                c < d_model,
+                "col index {c} out of range for d_model={d_model}"
+            );
         }
         let packed_floats = d_ff
             .saturating_mul(m)
@@ -1841,6 +2272,8 @@ let decode_proj = |off: usize, rows: usize, cols: usize| -> Result<(Vec<f32>, us
             | WeightDtype::Q4K
             | WeightDtype::Q4_0
             | WeightDtype::Q8_0
+            | WeightDtype::Q5K
+            | WeightDtype::Q6K
             | WeightDtype::MXFP4 => {
                 // Partial-load + INT8 / Q4K / Q4_0 / Q8_0 / MXFP4 isn't
                 // supported (the partial-load packing is column-major
@@ -1854,6 +2287,11 @@ let decode_proj = |off: usize, rows: usize, cols: usize| -> Result<(Vec<f32>, us
                     d_model,
                     d_ff,
                 });
+            }
+            WeightDtype::Mixed => {
+                return Err(ExpertWeightsError::InvalidLayout(
+                    "partial-load does not support mixed UTH2 experts".to_string(),
+                ));
             }
         };
         let gate_len = d_ff * m;
@@ -1935,6 +2373,86 @@ let decode_proj = |off: usize, rows: usize, cols: usize| -> Result<(Vec<f32>, us
     }
 }
 
+fn decode_mixed_projection(
+    payload: &[u8],
+    range: crate::tensor_header::ProjectionRange,
+    expected_weights: usize,
+    d_model: usize,
+    d_ff: usize,
+    name: &str,
+) -> Result<Vec<f32>, ExpertWeightsError> {
+    let dtype = range.dtype.to_weight();
+    let expected_bytes = projection_weight_bytes_for(expected_weights, dtype).ok_or_else(|| {
+        ExpertWeightsError::InvalidLayout(format!(
+            "{name} projection uses {}, which is not supported in mixed UTH2 experts",
+            dtype.as_str()
+        ))
+    })?;
+    if range.weights as usize != expected_weights {
+        return Err(ExpertWeightsError::InvalidLayout(format!(
+            "{name} projection records {} weights, expected {expected_weights}",
+            range.weights
+        )));
+    }
+    if range.len as usize != expected_bytes {
+        return Err(ExpertWeightsError::InvalidLayout(format!(
+            "{name} projection length {} does not match {} bytes required for {}",
+            range.len,
+            expected_bytes,
+            dtype.as_str()
+        )));
+    }
+    let start: usize = range.offset.try_into().map_err(|_| {
+        ExpertWeightsError::InvalidLayout(format!("{name} projection offset overflows usize"))
+    })?;
+    let end = start.checked_add(expected_bytes).ok_or_else(|| {
+        ExpertWeightsError::InvalidLayout(format!("{name} projection range overflows usize"))
+    })?;
+    let bytes = payload
+        .get(start..end)
+        .ok_or_else(|| ExpertWeightsError::BufferTooSmall {
+            have: payload.len(),
+            need: end,
+            d_model,
+            d_ff,
+        })?;
+
+    let mut out = Vec::with_capacity(expected_weights);
+    match dtype {
+        WeightDtype::F32 => {
+            for chunk in bytes.chunks_exact(4) {
+                out.push(f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]));
+            }
+        }
+        WeightDtype::F16 => dequantize_f16_to_f32(bytes, &mut out),
+        WeightDtype::BF16 => {
+            out.extend(
+                bytes
+                    .chunks_exact(2)
+                    .map(|c| half::bf16::from_le_bytes([c[0], c[1]]).to_f32()),
+            );
+        }
+        WeightDtype::Q4K => dequantize_q4k_to_f32(bytes, expected_weights, &mut out),
+        WeightDtype::Q4_0 => dequantize_q4_0_to_f32(bytes, expected_weights, &mut out),
+        WeightDtype::Q8_0 => dequantize_q8_0_to_f32(bytes, expected_weights, &mut out),
+        WeightDtype::Q5K => dequantize_q5k_to_f32(bytes, expected_weights, &mut out),
+        WeightDtype::Q6K => dequantize_q6k_to_f32(bytes, expected_weights, &mut out),
+        WeightDtype::Int8 | WeightDtype::MXFP4 | WeightDtype::Mixed => {
+            return Err(ExpertWeightsError::InvalidLayout(format!(
+                "{name} projection dtype {} cannot be decoded independently",
+                dtype.as_str()
+            )));
+        }
+    }
+    if out.len() != expected_weights {
+        return Err(ExpertWeightsError::InvalidLayout(format!(
+            "{name} projection decoded {} weights, expected {expected_weights}",
+            out.len()
+        )));
+    }
+    Ok(out)
+}
+
 /// Generate the per-token hidden-state vector that flows into the FFN.
 ///
 /// In a real model this would be the residual-stream activation produced
@@ -1979,7 +2497,11 @@ fn summarise_output(token_idx: u64, expert_id: u32, y: &[f32]) -> InferenceOutpu
         digest ^= bits;
         digest = digest.wrapping_mul(FNV_PRIME);
     }
-    InferenceOutput { expert_id, digest, out_norm }
+    InferenceOutput {
+        expert_id,
+        digest,
+        out_norm,
+    }
 }
 
 /// Run one expert's FFN on the hidden state. The buffer behind `resident`
@@ -2034,9 +2556,7 @@ pub fn run_inference_gpu(
         use candle_core::{Device, Tensor};
         static CUDA_DEVICE: std::sync::OnceLock<Result<Device, String>> =
             std::sync::OnceLock::new();
-        let dev = match CUDA_DEVICE
-            .get_or_init(|| Device::new_cuda(0).map_err(|e| e.to_string()))
-        {
+        let dev = match CUDA_DEVICE.get_or_init(|| Device::new_cuda(0).map_err(|e| e.to_string())) {
             Ok(dev) => dev,
             Err(e) => {
                 static WARNED: std::sync::Once = std::sync::Once::new();
@@ -2058,7 +2578,10 @@ pub fn run_inference_gpu(
         let u = up_t.matmul(&x_t).map_err(map_err)?;
         // GPT-OSS `swiglu_limit` clamp before silu (no-op otherwise).
         let g = clamp_swiglu_gate(g).map_err(map_err)?;
-        let gated = Tensor::silu(&g).map_err(map_err)?.mul(&u).map_err(map_err)?;
+        let gated = Tensor::silu(&g)
+            .map_err(map_err)?
+            .mul(&u)
+            .map_err(map_err)?;
         let y_t = down_t.matmul(&gated).map_err(map_err)?;
         let y_t = y_t.squeeze(1).map_err(map_err)?;
         let y: HiddenState = y_t.to_vec1::<f32>().map_err(map_err)?;
@@ -2181,6 +2704,54 @@ pub fn run_inference_q8_0(
     Ok((out, y))
 }
 
+/// Q5_K counterpart of [`run_inference`].
+pub fn run_inference_q5k(
+    token_idx: u64,
+    resident: &ExpertResident,
+    x: &[f32],
+    d_model: usize,
+    d_ff: usize,
+) -> Result<(InferenceOutput, HiddenState), ExpertWeightsError> {
+    let weights = OwnedExpertWeights::from_bytes_q5k(resident.data(), d_model, d_ff)?;
+    let y = weights.forward(x);
+    let out = summarise_output(token_idx, resident.id, &y);
+    Ok((out, y))
+}
+
+/// Q6_K counterpart of [`run_inference`].
+pub fn run_inference_q6k(
+    token_idx: u64,
+    resident: &ExpertResident,
+    x: &[f32],
+    d_model: usize,
+    d_ff: usize,
+) -> Result<(InferenceOutput, HiddenState), ExpertWeightsError> {
+    let weights = OwnedExpertWeights::from_bytes_q6k(resident.data(), d_model, d_ff)?;
+    let y = weights.forward(x);
+    let out = summarise_output(token_idx, resident.id, &y);
+    Ok((out, y))
+}
+
+/// UTH2 mixed-projection counterpart of [`run_inference`].
+pub fn run_inference_mixed_quant(
+    token_idx: u64,
+    resident: &ExpertResident,
+    x: &[f32],
+    d_model: usize,
+    d_ff: usize,
+) -> Result<(InferenceOutput, HiddenState), ExpertWeightsError> {
+    let header = resident.mixed_layout().ok_or_else(|| {
+        ExpertWeightsError::InvalidLayout(
+            "runtime dtype is mixed but resident expert has no valid UTH2 header".to_string(),
+        )
+    })?;
+    let weights =
+        OwnedExpertWeights::from_bytes_mixed_quant(resident.data(), header, d_model, d_ff)?;
+    let y = weights.forward(x);
+    let out = summarise_output(token_idx, resident.id, &y);
+    Ok((out, y))
+}
+
 /// BF16 counterpart of [`run_inference`]: dequantises the resident
 /// `bf16` bytes into an owned `Vec<f32>` (via
 /// [`OwnedExpertWeights::from_bytes_bf16`]) and runs the same SwiGLU
@@ -2259,8 +2830,7 @@ use std::sync::Arc as StdArc;
 /// than skipping the expert, we accept files within one block
 /// alignment of the expected size and zero-pad the (≤ one page) tail
 /// so the per-matrix block slices stay in-bounds. See gist Fix 1.
-pub(crate) const EXPERT_SIZE_TOLERANCE_BYTES: usize =
-    crate::gguf_loader::DEFAULT_BLOCK_ALIGN;
+pub(crate) const EXPERT_SIZE_TOLERANCE_BYTES: usize = crate::gguf_loader::DEFAULT_BLOCK_ALIGN;
 
 /// Return a buffer that is at least `need` bytes long — either a
 /// borrowed view of `bytes` or, when `bytes` is slightly short, an
@@ -2323,8 +2893,8 @@ fn cpu_qtensor_from_blocks(
     let map_err = |e: candle_core::Error| ExpertWeightsError::Candle(e.to_string());
     // `QStorage::from_data` copies the bytes into typed block storage,
     // so a borrowed `Cow` is sufficient.
-    let storage = QStorage::from_data(Cow::Borrowed(bytes), &Device::Cpu, dtype)
-        .map_err(map_err)?;
+    let storage =
+        QStorage::from_data(Cow::Borrowed(bytes), &Device::Cpu, dtype).map_err(map_err)?;
     QTensor::new(storage, (rows, cols)).map_err(map_err)
 }
 
@@ -2345,15 +2915,15 @@ fn forward_qmm(
     // `[1, d_model]` so the result is `[1, d_ff]` / `[1, d_model]`.
     let x_t = Tensor::from_slice(x, (1, d_model), &Device::Cpu).map_err(map_err)?;
 
-    let g = gate.forward(&x_t).map_err(map_err)?;        // [1, d_ff]
-    let u = up.forward(&x_t).map_err(map_err)?;          // [1, d_ff]
-    // GPT-OSS `swiglu_limit` clamp before silu (no-op otherwise).
+    let g = gate.forward(&x_t).map_err(map_err)?; // [1, d_ff]
+    let u = up.forward(&x_t).map_err(map_err)?; // [1, d_ff]
+                                                // GPT-OSS `swiglu_limit` clamp before silu (no-op otherwise).
     let g = clamp_swiglu_gate(g).map_err(map_err)?;
     let gated = candle_core::Tensor::silu(&g)
         .map_err(map_err)?
         .mul(&u)
-        .map_err(map_err)?;                              // [1, d_ff]
-    let y = down.forward(&gated).map_err(map_err)?;      // [1, d_model]
+        .map_err(map_err)?; // [1, d_ff]
+    let y = down.forward(&gated).map_err(map_err)?; // [1, d_model]
     let y = y.squeeze(0).map_err(map_err)?;
     y.to_vec1::<f32>().map_err(map_err)
 }
@@ -2413,15 +2983,24 @@ fn forward_q4_0_qmm_from_exact_bytes(
     let down_b = &bytes[2 * one_bytes..3 * one_bytes];
 
     let gate = QMatMul::from_arc(StdArc::new(cpu_qtensor_from_blocks(
-        gate_b, d_ff, d_model, GgmlDType::Q4_0,
+        gate_b,
+        d_ff,
+        d_model,
+        GgmlDType::Q4_0,
     )?))
     .map_err(|e| ExpertWeightsError::Candle(e.to_string()))?;
     let up = QMatMul::from_arc(StdArc::new(cpu_qtensor_from_blocks(
-        up_b, d_ff, d_model, GgmlDType::Q4_0,
+        up_b,
+        d_ff,
+        d_model,
+        GgmlDType::Q4_0,
     )?))
     .map_err(|e| ExpertWeightsError::Candle(e.to_string()))?;
     let down = QMatMul::from_arc(StdArc::new(cpu_qtensor_from_blocks(
-        down_b, d_model, d_ff, GgmlDType::Q4_0,
+        down_b,
+        d_model,
+        d_ff,
+        GgmlDType::Q4_0,
     )?))
     .map_err(|e| ExpertWeightsError::Candle(e.to_string()))?;
 
@@ -2477,15 +3056,24 @@ pub fn run_inference_q4k_qmm(
     let down_b = &bytes[2 * one_bytes..3 * one_bytes];
 
     let gate = QMatMul::from_arc(StdArc::new(cpu_qtensor_from_blocks(
-        gate_b, d_ff, d_model, GgmlDType::Q4K,
+        gate_b,
+        d_ff,
+        d_model,
+        GgmlDType::Q4K,
     )?))
     .map_err(|e| ExpertWeightsError::Candle(e.to_string()))?;
     let up = QMatMul::from_arc(StdArc::new(cpu_qtensor_from_blocks(
-        up_b, d_ff, d_model, GgmlDType::Q4K,
+        up_b,
+        d_ff,
+        d_model,
+        GgmlDType::Q4K,
     )?))
     .map_err(|e| ExpertWeightsError::Candle(e.to_string()))?;
     let down = QMatMul::from_arc(StdArc::new(cpu_qtensor_from_blocks(
-        down_b, d_model, d_ff, GgmlDType::Q4K,
+        down_b,
+        d_model,
+        d_ff,
+        GgmlDType::Q4K,
     )?))
     .map_err(|e| ExpertWeightsError::Candle(e.to_string()))?;
 
@@ -2524,15 +3112,24 @@ pub fn run_inference_q8_0_qmm(
     let down_b = &bytes[2 * one_bytes..3 * one_bytes];
 
     let gate = QMatMul::from_arc(StdArc::new(cpu_qtensor_from_blocks(
-        gate_b, d_ff, d_model, GgmlDType::Q8_0,
+        gate_b,
+        d_ff,
+        d_model,
+        GgmlDType::Q8_0,
     )?))
     .map_err(|e| ExpertWeightsError::Candle(e.to_string()))?;
     let up = QMatMul::from_arc(StdArc::new(cpu_qtensor_from_blocks(
-        up_b, d_ff, d_model, GgmlDType::Q8_0,
+        up_b,
+        d_ff,
+        d_model,
+        GgmlDType::Q8_0,
     )?))
     .map_err(|e| ExpertWeightsError::Candle(e.to_string()))?;
     let down = QMatMul::from_arc(StdArc::new(cpu_qtensor_from_blocks(
-        down_b, d_model, d_ff, GgmlDType::Q8_0,
+        down_b,
+        d_model,
+        d_ff,
+        GgmlDType::Q8_0,
     )?))
     .map_err(|e| ExpertWeightsError::Candle(e.to_string()))?;
 
@@ -2554,13 +3151,8 @@ pub fn run_inference_partial(
     d_ff: usize,
     dtype: WeightDtype,
 ) -> Result<(InferenceOutput, HiddenState), ExpertWeightsError> {
-    let weights = OwnedExpertWeights::from_bytes_partial(
-        resident.data(),
-        col_indices,
-        d_model,
-        d_ff,
-        dtype,
-    )?;
+    let weights =
+        OwnedExpertWeights::from_bytes_partial(resident.data(), col_indices, d_model, d_ff, dtype)?;
     let y = weights.forward_partial(x);
     let out = summarise_output(token_idx, resident.id, &y);
     Ok((out, y))
@@ -2660,7 +3252,10 @@ mod tests {
         let x = synth_hidden_state(7, d_model, 1234);
         let y = w.forward(&x);
         assert_eq!(y.len(), d_model);
-        assert!(y.iter().all(|v| v.is_finite()), "got non-finite output: {y:?}");
+        assert!(
+            y.iter().all(|v| v.is_finite()),
+            "got non-finite output: {y:?}"
+        );
     }
 
     #[test]
@@ -2788,7 +3383,10 @@ mod tests {
     fn int8_short_buffer_returns_error() {
         let bytes = vec![0u8; INT8_HEADER_BYTES + 4]; // way too small
         let res = OwnedExpertWeights::from_bytes_int8(&bytes, 8, 8);
-        assert!(matches!(res, Err(ExpertWeightsError::BufferTooSmall { .. })));
+        assert!(matches!(
+            res,
+            Err(ExpertWeightsError::BufferTooSmall { .. })
+        ));
     }
 
     #[test]
@@ -2964,13 +3562,53 @@ mod tests {
     }
 
     #[test]
+    fn q5k_q6k_zero_blocks_decode_to_zero() {
+        assert_eq!(Q5K_BLOCK_ELEMS, 256);
+        assert_eq!(Q5K_BLOCK_BYTES, 176);
+        assert_eq!(Q6K_BLOCK_ELEMS, 256);
+        assert_eq!(Q6K_BLOCK_BYTES, 210);
+
+        let mut out = vec![1.0f32; Q5K_BLOCK_ELEMS];
+        dequantize_q5k_block(&vec![0u8; Q5K_BLOCK_BYTES], &mut out);
+        assert!(out.iter().all(|&v| v == 0.0));
+
+        let mut out = vec![1.0f32; Q6K_BLOCK_ELEMS];
+        dequantize_q6k_block(&vec![0u8; Q6K_BLOCK_BYTES], &mut out);
+        assert!(out.iter().all(|&v| v == 0.0));
+    }
+
+    #[test]
+    fn q5k_q6k_owned_experts_reject_short_input() {
+        let d_model = 256;
+        let d_ff = 1;
+        let q5_total = expert_weight_bytes_for(d_model, d_ff, WeightDtype::Q5K);
+        let q6_total = expert_weight_bytes_for(d_model, d_ff, WeightDtype::Q6K);
+        assert_eq!(q5_total, Q5K_BLOCK_BYTES * 3);
+        assert_eq!(q6_total, Q6K_BLOCK_BYTES * 3);
+        assert!(OwnedExpertWeights::from_bytes_q5k(&vec![0; q5_total - 1], d_model, d_ff).is_err());
+        assert!(OwnedExpertWeights::from_bytes_q6k(&vec![0; q6_total - 1], d_model, d_ff).is_err());
+    }
+
+    #[test]
     fn bf16_mxfp4_dtypes_round_trip_through_str() {
         assert_eq!(WeightDtype::from_str_opt("bf16"), Some(WeightDtype::BF16));
-        assert_eq!(WeightDtype::from_str_opt("BFloat16"), Some(WeightDtype::BF16));
+        assert_eq!(
+            WeightDtype::from_str_opt("BFloat16"),
+            Some(WeightDtype::BF16)
+        );
         assert_eq!(WeightDtype::from_str_opt("mxfp4"), Some(WeightDtype::MXFP4));
-        assert_eq!(WeightDtype::from_str_opt("MX_FP4"), Some(WeightDtype::MXFP4));
+        assert_eq!(
+            WeightDtype::from_str_opt("MX_FP4"),
+            Some(WeightDtype::MXFP4)
+        );
+        assert_eq!(WeightDtype::from_str_opt("q5_k"), Some(WeightDtype::Q5K));
+        assert_eq!(WeightDtype::from_str_opt("Q6K"), Some(WeightDtype::Q6K));
+        assert_eq!(WeightDtype::from_str_opt("mixed"), Some(WeightDtype::Mixed));
         assert_eq!(WeightDtype::BF16.as_str(), "bf16");
         assert_eq!(WeightDtype::MXFP4.as_str(), "mxfp4");
+        assert_eq!(WeightDtype::Q5K.as_str(), "q5k");
+        assert_eq!(WeightDtype::Q6K.as_str(), "q6k");
+        assert_eq!(WeightDtype::Mixed.as_str(), "mixed");
         assert_eq!(WeightDtype::BF16.bytes_per_weight(), 2);
         assert_eq!(WeightDtype::MXFP4.bytes_per_weight(), 1);
     }
@@ -3020,14 +3658,9 @@ mod tests {
         let fill = 0.1;
         let cols: Vec<usize> = (0..d_model).collect();
         let packed = make_packed_partial_buffer(d_model, d_ff, &cols, fill);
-        let owned = OwnedExpertWeights::from_bytes_partial(
-            &packed,
-            &cols,
-            d_model,
-            d_ff,
-            WeightDtype::F32,
-        )
-        .unwrap();
+        let owned =
+            OwnedExpertWeights::from_bytes_partial(&packed, &cols, d_model, d_ff, WeightDtype::F32)
+                .unwrap();
 
         let full = make_weights_buffer(d_model, d_ff, fill);
         let full_view = ExpertWeights::from_bytes(full.as_slice(), d_model, d_ff).unwrap();
@@ -3048,14 +3681,9 @@ mod tests {
         let cols: Vec<usize> = (0..d_model).step_by(2).collect();
         assert_eq!(cols.len(), 4);
         let packed = make_packed_partial_buffer(d_model, d_ff, &cols, fill);
-        let owned = OwnedExpertWeights::from_bytes_partial(
-            &packed,
-            &cols,
-            d_model,
-            d_ff,
-            WeightDtype::F32,
-        )
-        .unwrap();
+        let owned =
+            OwnedExpertWeights::from_bytes_partial(&packed, &cols, d_model, d_ff, WeightDtype::F32)
+                .unwrap();
         let x = synth_hidden_state(0, d_model, 1);
         let y = owned.forward_partial(&x);
         assert_eq!(y.len(), d_model);
@@ -3214,7 +3842,10 @@ mod tests {
         let d_ff = 32;
         let bytes = vec![0u8; 100]; // way too small
         let res = OwnedExpertWeights::from_bytes_q4k(&bytes, d_model, d_ff);
-        assert!(matches!(res, Err(ExpertWeightsError::BufferTooSmall { .. })));
+        assert!(matches!(
+            res,
+            Err(ExpertWeightsError::BufferTooSmall { .. })
+        ));
     }
 
     // -----------------------------------------------------------------
@@ -3406,7 +4037,10 @@ mod tests {
         let d_ff = 32;
         let bytes = vec![0u8; 16]; // way too small
         let res = OwnedExpertWeights::from_bytes_q4_0(&bytes, d_model, d_ff);
-        assert!(matches!(res, Err(ExpertWeightsError::BufferTooSmall { .. })));
+        assert!(matches!(
+            res,
+            Err(ExpertWeightsError::BufferTooSmall { .. })
+        ));
     }
 
     #[test]
@@ -3428,8 +4062,7 @@ mod tests {
         }
 
         let f32_bytes =
-            OwnedExpertWeights::dequantize_q4_0_expert_to_f32_bytes(&bytes, d_model, d_ff)
-                .unwrap();
+            OwnedExpertWeights::dequantize_q4_0_expert_to_f32_bytes(&bytes, d_model, d_ff).unwrap();
         // Exactly three tightly-packed F32 projection matrices.
         assert_eq!(f32_bytes.len(), 3 * d_model * d_ff * 4);
 
@@ -3459,9 +4092,11 @@ mod tests {
         let d_model = 32;
         let d_ff = 32;
         let bytes = vec![0u8; 16]; // far too small
-        let res =
-            OwnedExpertWeights::dequantize_q4_0_expert_to_f32_bytes(&bytes, d_model, d_ff);
-        assert!(matches!(res, Err(ExpertWeightsError::BufferTooSmall { .. })));
+        let res = OwnedExpertWeights::dequantize_q4_0_expert_to_f32_bytes(&bytes, d_model, d_ff);
+        assert!(matches!(
+            res,
+            Err(ExpertWeightsError::BufferTooSmall { .. })
+        ));
     }
 
     /// Scalar reference for `gate_up_swiglu`, deliberately independent
@@ -3516,10 +4151,10 @@ mod tests {
         }
 
         let cases = [
-            (8usize, 16usize),   // small
-            (8, 32),             // grow scratch (d_ff bigger than first call)
-            (8, 16),             // shrink back — scratch len stays >= d_ff
-            (4, 4),              // tiny, exercises d_ff == d_model
+            (8usize, 16usize), // small
+            (8, 32),           // grow scratch (d_ff bigger than first call)
+            (8, 16),           // shrink back — scratch len stays >= d_ff
+            (4, 4),            // tiny, exercises d_ff == d_model
         ];
 
         for (idx, &(d_model, d_ff)) in cases.iter().enumerate() {
@@ -3548,7 +4183,8 @@ mod tests {
                     diff <= tol,
                     "blas vs scalar mismatch at case {idx}, idx {i}: \
                      blas={} ref={} diff={diff} tol={tol}",
-                    out_blas[i], out_ref[i]
+                    out_blas[i],
+                    out_ref[i]
                 );
             }
         }

--- a/rust-engine/src/io_provider.rs
+++ b/rust-engine/src/io_provider.rs
@@ -227,7 +227,6 @@ fn saturating_increment_u32(c: &AtomicU32) -> u32 {
     }
 }
 
-
 /// Configuration for the storage layer.
 #[derive(Clone, Debug)]
 pub struct StorageConfig {
@@ -580,10 +579,7 @@ impl NvmeStorage {
     ///
     /// Builder-style: returns `self` for chaining at construction
     /// (`NvmeStorage::new(cfg)?.with_packed_blob(blob)`).
-    pub fn with_packed_blob(
-        mut self,
-        blob: Arc<crate::packed_storage::PackedBlob>,
-    ) -> Self {
+    pub fn with_packed_blob(mut self, blob: Arc<crate::packed_storage::PackedBlob>) -> Self {
         self.packed = Some(blob);
         self
     }
@@ -861,8 +857,7 @@ impl NvmeStorage {
         // arrived here because they observed `tripped == true`
         // synchronises-with that Release and therefore reads the
         // real, non-zero stamp.
-        if last != 0
-            && now.saturating_sub(last) < STORAGE_BREAKER_PROBE_INTERVAL.as_millis() as u64
+        if last != 0 && now.saturating_sub(last) < STORAGE_BREAKER_PROBE_INTERVAL.as_millis() as u64
         {
             return false;
         }
@@ -943,7 +938,10 @@ impl NvmeStorage {
                     let (tripped, cf, drive_tripped, dcf) = self.note_read_failure(expert_id);
                     let err = io::Error::new(
                         io::ErrorKind::UnexpectedEof,
-                        format!("short read on expert {expert_id}: got {n} bytes, expected {}", dst.len()),
+                        format!(
+                            "short read on expert {expert_id}: got {n} bytes, expected {}",
+                            dst.len()
+                        ),
                     );
                     if drive_tripped {
                         return Err(HardwareFailure::DriveUnavailable {
@@ -1477,7 +1475,6 @@ impl NvmeStorage {
 
         Ok(pos)
     }
-
 }
 
 /// **Tier 2.** Build a packed blob + manifest from a source storage.
@@ -1524,7 +1521,10 @@ pub async fn pack_experts(
         writer.write_all(buf.as_slice())?;
     }
     writer.flush()?;
-    writer.into_inner().map_err(|e| e.into_error())?.sync_all()?;
+    writer
+        .into_inner()
+        .map_err(|e| e.into_error())?
+        .sync_all()?;
     let manifest = crate::packed_storage::PackedManifest::uniform(
         order.to_vec(),
         expert_size as u64,
@@ -1577,7 +1577,14 @@ pub fn generate_synthetic_experts(
     d_model: usize,
     d_ff: usize,
 ) -> io::Result<()> {
-    generate_synthetic_experts_with_dtype(dir, num_experts, expert_size, d_model, d_ff, WeightDtype::F32)
+    generate_synthetic_experts_with_dtype(
+        dir,
+        num_experts,
+        expert_size,
+        d_model,
+        d_ff,
+        WeightDtype::F32,
+    )
 }
 
 /// Generate `num_experts` deterministic test files in `dir`. Each file
@@ -1623,6 +1630,19 @@ pub fn generate_synthetic_experts_with_dtype(
     let zero_pad = vec![0u8; (1 << 20).min(pad_bytes.max(1))];
     let chunk_floats = 16 * 1024;
 
+    if matches!(
+        dtype,
+        WeightDtype::Q5K | WeightDtype::Q6K | WeightDtype::Mixed
+    ) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "synthetic expert generation does not support dtype {}",
+                dtype.as_str()
+            ),
+        ));
+    }
+
     for id in 0..num_experts {
         let path = dir.join(format!("expert_{id}.bin"));
         let mut f = OpenOptions::new()
@@ -1631,8 +1651,8 @@ pub fn generate_synthetic_experts_with_dtype(
             .truncate(true)
             .open(&path)?;
 
-        let mut state: u64 = 0x9E37_79B9_7F4A_7C15u64
-            .wrapping_add((id as u64).wrapping_mul(0xBF58_476D_1CE4_E5B9));
+        let mut state: u64 =
+            0x9E37_79B9_7F4A_7C15u64.wrapping_add((id as u64).wrapping_mul(0xBF58_476D_1CE4_E5B9));
 
         // For INT8, write the 12-byte per-tensor scale header first.
         // Synthetic weights are drawn from `U(-scale, +scale)`, so the
@@ -1709,14 +1729,12 @@ pub fn generate_synthetic_experts_with_dtype(
                         *slot = 0.0;
                     }
                     match dtype {
-                        WeightDtype::Q4_0 => quantize_q4_0_block(
-                            &block_floats[..block_elems],
-                            &mut block_bytes_buf,
-                        ),
-                        WeightDtype::Q8_0 => quantize_q8_0_block(
-                            &block_floats[..block_elems],
-                            &mut block_bytes_buf,
-                        ),
+                        WeightDtype::Q4_0 => {
+                            quantize_q4_0_block(&block_floats[..block_elems], &mut block_bytes_buf)
+                        }
+                        WeightDtype::Q8_0 => {
+                            quantize_q8_0_block(&block_floats[..block_elems], &mut block_bytes_buf)
+                        }
                         _ => unreachable!(),
                     }
                     f.write_all(&block_bytes_buf)?;
@@ -1787,7 +1805,10 @@ pub fn generate_synthetic_experts_with_dtype(
                         WeightDtype::Q4K => unreachable!("Q4K handled above"),
                         WeightDtype::Q4_0 => unreachable!("Q4_0 handled above"),
                         WeightDtype::Q8_0 => unreachable!("Q8_0 handled above"),
+                        WeightDtype::Q5K => unreachable!("Q5K rejected above"),
+                        WeightDtype::Q6K => unreachable!("Q6K rejected above"),
                         WeightDtype::MXFP4 => unreachable!("MXFP4 handled above"),
+                        WeightDtype::Mixed => unreachable!("mixed rejected above"),
                     }
                 }
                 f.write_all(&buf)?;
@@ -2069,9 +2090,8 @@ impl Manifest {
                 Some(h) => (block_align, Some(h.dtype.to_weight())),
                 None => (0usize, None),
             };
-            let payload_size = (file_size as usize)
-                .saturating_sub(payload_offset)
-                & !(block_align - 1);
+            let payload_size =
+                (file_size as usize).saturating_sub(payload_offset) & !(block_align - 1);
 
             entries.insert(
                 id,
@@ -2086,7 +2106,10 @@ impl Manifest {
             );
         }
 
-        Ok(Self { entries, block_align })
+        Ok(Self {
+            entries,
+            block_align,
+        })
     }
 
     /// Look up a manifest entry by expert id. `None` if the file
@@ -2361,7 +2384,7 @@ mod tests {
             expert_size,
             block_align: block,
             use_direct_io: false,
-                num_experts_per_layer: None,
+            num_experts_per_layer: None,
         })
         .unwrap();
 
@@ -2382,10 +2405,17 @@ mod tests {
         }
         let ids: Vec<u32> = (0..num_experts).collect();
         let mut buf_refs: Vec<&mut crate::buffer_pool::PooledBuffer> = bufs.iter_mut().collect();
-        let total = storage.read_experts_batch(&ids, &mut buf_refs).await.unwrap();
+        let total = storage
+            .read_experts_batch(&ids, &mut buf_refs)
+            .await
+            .unwrap();
         assert_eq!(total, expert_size * num_experts as usize);
         for (i, b) in bufs.iter().enumerate() {
-            assert_eq!(b.as_slice(), ref_bufs[i].as_slice(), "mismatch on expert {i}");
+            assert_eq!(
+                b.as_slice(),
+                ref_bufs[i].as_slice(),
+                "mismatch on expert {i}"
+            );
         }
 
         // Cleanup
@@ -2439,7 +2469,9 @@ mod tests {
 
         let blob =
             crate::packed_storage::PackedBlob::open(&blob_path, &manifest_path, false).unwrap();
-        let packed = NvmeStorage::new(cfg).unwrap().with_packed_blob(Arc::new(blob));
+        let packed = NvmeStorage::new(cfg)
+            .unwrap()
+            .with_packed_blob(Arc::new(blob));
         assert!(packed.is_packed());
 
         // Single packed reads match the per-file bytes.
@@ -2461,8 +2493,7 @@ mod tests {
         for _ in &ids {
             bufs.push(pool.acquire().await);
         }
-        let mut buf_refs: Vec<&mut crate::buffer_pool::PooledBuffer> =
-            bufs.iter_mut().collect();
+        let mut buf_refs: Vec<&mut crate::buffer_pool::PooledBuffer> = bufs.iter_mut().collect();
         let total = packed
             .read_experts_batch(&ids, &mut buf_refs)
             .await
@@ -2645,9 +2676,7 @@ mod tests {
         std::fs::write(dir.join("expert_0.bin"), vec![0u8; expert_size]).unwrap();
         std::fs::write(dir.join("expert_1.bin"), vec![0u8; expert_size]).unwrap();
 
-        let manifest = Arc::new(
-            Manifest::scan(&[dir.clone()], [0u32, 1u32], block, None).unwrap(),
-        );
+        let manifest = Arc::new(Manifest::scan(&[dir.clone()], [0u32, 1u32], block, None).unwrap());
         let storage = NvmeStorage::new(StorageConfig {
             base_path: dir.clone(),
             expert_size,
@@ -2874,7 +2903,7 @@ mod tests {
     #[test]
     fn try_admit_probe_admits_at_most_one_per_interval() {
         let stamp = AtomicU64::new(0); // last probe was "long ago"
-        // First call wins the CAS and advances `stamp` to now.
+                                       // First call wins the CAS and advances `stamp` to now.
         assert!(NvmeStorage::try_admit_probe(&stamp));
         let first = stamp.load(Ordering::Acquire);
         assert!(first >= 1, "stamp should advance past zero");
@@ -2892,8 +2921,14 @@ mod tests {
     #[test]
     fn transient_io_error_classification() {
         use std::io::{Error, ErrorKind};
-        assert!(is_transient_io_error(&Error::new(ErrorKind::Interrupted, "")));
-        assert!(is_transient_io_error(&Error::new(ErrorKind::WouldBlock, "")));
+        assert!(is_transient_io_error(&Error::new(
+            ErrorKind::Interrupted,
+            ""
+        )));
+        assert!(is_transient_io_error(&Error::new(
+            ErrorKind::WouldBlock,
+            ""
+        )));
         assert!(is_transient_io_error(&Error::new(ErrorKind::TimedOut, "")));
         // EIO maps to a raw-OS retryable error too.
         let eio = Error::from_raw_os_error(libc::EIO);
@@ -2903,10 +2938,16 @@ mod tests {
         // the short read on the first observation rather than wasting
         // 3×backoff. Short reads are handled by a dedicated branch in
         // `read_at_with_retries` that fails fast.
-        assert!(!is_transient_io_error(&Error::new(ErrorKind::UnexpectedEof, "")));
+        assert!(!is_transient_io_error(&Error::new(
+            ErrorKind::UnexpectedEof,
+            ""
+        )));
         // Permission denied is NOT transient — surfacing it lets the
         // operator fix the mount rather than retry forever.
-        assert!(!is_transient_io_error(&Error::new(ErrorKind::PermissionDenied, "")));
+        assert!(!is_transient_io_error(&Error::new(
+            ErrorKind::PermissionDenied,
+            ""
+        )));
     }
 
     /// `HardwareFailure` converts to an `io::Error` and round-trips
@@ -2920,9 +2961,7 @@ mod tests {
         };
         let ioerr: io::Error = hf.into();
         let inner = ioerr.into_inner().expect("inner");
-        let hf = inner
-            .downcast::<HardwareFailure>()
-            .expect("downcast");
+        let hf = inner.downcast::<HardwareFailure>().expect("downcast");
         match *hf {
             HardwareFailure::ExpertUnavailable { expert_id, .. } => assert_eq!(expert_id, 7),
             _ => panic!("wrong variant"),

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -56,9 +56,9 @@ mod session;
 mod tensor_header;
 mod tokenizer;
 mod transformer;
-mod workload;
 #[cfg(feature = "tui")]
 mod tui;
+mod workload;
 
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
@@ -70,9 +70,9 @@ use tracing_subscriber::EnvFilter;
 use crate::backend::Backend;
 use crate::buffer_pool::BufferPool;
 use crate::engine::{Engine, EngineOptions, ModelShape};
-use crate::multi_layer_cache::MultiLayerExpertCache;
 use crate::inference::expert_weight_bytes_for;
 use crate::io_provider::{NvmeStorage, StorageConfig};
+use crate::multi_layer_cache::MultiLayerExpertCache;
 use crate::router::{
     LayeredExpertAffinity, LocalityMonitor, NeuralSpeculator, PredictiveLoader, TopKRouter,
 };
@@ -531,17 +531,11 @@ enum Cmd {
         legacy_eager: bool,
         /// **Native quantised pass-through.** When set and the
         /// source GGUF stores its expert tensors as `Q4_0`, `Q4_K`,
-        /// or `Q8_0`, write the raw quantised block stream to disk
+        /// `Q5_K`, `Q6_K`, or `Q8_0`, write the raw quantised block stream to disk
         /// instead of dequantising to F32 first. The output
-        /// `expert_<id>.bin` is then ~7× smaller (Q4_0 / Q4_K) or
-        /// ~4× smaller (Q8_0) than F32, and the engine's
-        /// `run_inference_q4_0` / `run_inference_q4k` /
-        /// `run_inference_q8_0` paths consume it directly. Falls
-        /// back to F32 dequant when the source dtype isn't one of
-        /// the supported quantisations or the per-expert weight
-        /// count isn't a clean multiple of the block size; the
-        /// converter's emitted `metadata.json::dtype` records what
-        /// was actually written.
+        /// `expert_<id>.bin` stays quantized. Mixed projection triples
+        /// are written with UTH2 headers. If quantized output is not
+        /// possible, conversion fails before writing expert files.
         #[arg(long, default_value_t = false)]
         native_quant: bool,
     },
@@ -666,7 +660,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // `--gpu` it must initialise the GPU compute backend *before* the
     // default CPU backend claims the `OnceLock` (gist Fix 2), mirroring
     // `cmd_serve`. A failed GPU init falls back to `install_default`.
-    let run_gpu_cache = if let Cmd::Run { gpu: true, gpu_cache_mb, .. } = &cli.cmd {
+    let run_gpu_cache = if let Cmd::Run {
+        gpu: true,
+        gpu_cache_mb,
+        ..
+    } = &cli.cmd
+    {
         install_run_gpu_backend(*gpu_cache_mb)
     } else if !matches!(cli.cmd, Cmd::Serve { .. }) {
         crate::backend::install_default();
@@ -690,7 +689,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             d_ff,
             block_align,
             dtype,
-        } => cmd_gen_data(&data_dir, num_experts, expert_size, d_model, d_ff, block_align, &dtype),
+        } => cmd_gen_data(
+            &data_dir,
+            num_experts,
+            expert_size,
+            d_model,
+            d_ff,
+            block_align,
+            &dtype,
+        ),
         Cmd::Repack {
             data_dir,
             out_blob,
@@ -784,66 +791,68 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     packed_manifest,
                 } = cli.cmd
                 {
-                    let dtype = crate::inference::WeightDtype::from_str_opt(&dtype)
-                        .ok_or_else(|| format!("--dtype: unknown value {dtype:?} (use 'f32' or 'f16')"))?;
+                    let dtype =
+                        crate::inference::WeightDtype::from_str_opt(&dtype).ok_or_else(|| {
+                            format!("--dtype: unknown value {dtype:?} (use 'f32' or 'f16')")
+                        })?;
                     cmd_run(
                         RunArgs {
-                        data_dir,
-                        num_experts,
-                        expert_size,
-                        d_model,
-                        d_ff,
-                        cache_slots,
-                        top_k,
-                        tokens,
-                        predict_fanout,
-                        predict_min_prob,
-                        no_direct,
-                        block_align,
-                        seed,
-                        dtype,
-                        partial_load_fraction,
-                        pin_after_observations,
-                        alias_map_path: alias_map,
-                        io_uring,
-                        token_pause_us,
-                        first_token,
-                        no_prefetch,
-                        io_only,
-                        force_ssd,
-                        router_clusters,
-                        router_intra_p,
-                        router_matrix,
-                        gate_weights,
-                        trace_out,
-                        gpu_expert_cache: if gpu { run_gpu_cache.clone() } else { None },
-                        pipeline_depth,
-                        speculator,
-                        speculator_hidden_dim,
-                        speculator_top_k,
-                        locality,
-                        locality_window,
-                        locality_threshold_pct,
-                        affinity,
-                        affinity_neighbors_k,
-                        affinity_decay_epoch,
-                        prefetch_governor,
-                        prefetch_precision_floor,
-                        prefetch_contention_weight,
-                        cost_aware_eviction,
-                        pregate,
-                        static_residency_fraction,
-                        static_residency_warmup_tokens,
-                        static_residency_profile,
-                        profile_out,
-                        workload,
-                        zipf_s,
-                        workload_correlation,
-                        replay_trace,
-                        num_layers,
-                        num_experts_per_layer,
-                        packed_blob,
-                        packed_manifest,
+                            data_dir,
+                            num_experts,
+                            expert_size,
+                            d_model,
+                            d_ff,
+                            cache_slots,
+                            top_k,
+                            tokens,
+                            predict_fanout,
+                            predict_min_prob,
+                            no_direct,
+                            block_align,
+                            seed,
+                            dtype,
+                            partial_load_fraction,
+                            pin_after_observations,
+                            alias_map_path: alias_map,
+                            io_uring,
+                            token_pause_us,
+                            first_token,
+                            no_prefetch,
+                            io_only,
+                            force_ssd,
+                            router_clusters,
+                            router_intra_p,
+                            router_matrix,
+                            gate_weights,
+                            trace_out,
+                            gpu_expert_cache: if gpu { run_gpu_cache.clone() } else { None },
+                            pipeline_depth,
+                            speculator,
+                            speculator_hidden_dim,
+                            speculator_top_k,
+                            locality,
+                            locality_window,
+                            locality_threshold_pct,
+                            affinity,
+                            affinity_neighbors_k,
+                            affinity_decay_epoch,
+                            prefetch_governor,
+                            prefetch_precision_floor,
+                            prefetch_contention_weight,
+                            cost_aware_eviction,
+                            pregate,
+                            static_residency_fraction,
+                            static_residency_warmup_tokens,
+                            static_residency_profile,
+                            profile_out,
+                            workload,
+                            zipf_s,
+                            workload_correlation,
+                            replay_trace,
+                            num_layers,
+                            num_experts_per_layer,
+                            packed_blob,
+                            packed_manifest,
                         },
                         startup_pinned,
                     )
@@ -984,11 +993,8 @@ fn maybe_attach_packed_blob(
 ) -> Result<NvmeStorage, Box<dyn std::error::Error>> {
     match (packed_blob, packed_manifest) {
         (Some(blob_path), Some(manifest_path)) => {
-            let blob = crate::packed_storage::PackedBlob::open(
-                blob_path,
-                manifest_path,
-                use_direct_io,
-            )?;
+            let blob =
+                crate::packed_storage::PackedBlob::open(blob_path, manifest_path, use_direct_io)?;
             blob.validate()
                 .map_err(|e| format!("packed blob validation failed: {e}"))?;
             let slot = blob.manifest().expert_size;
@@ -1058,12 +1064,12 @@ async fn cmd_serve(config_path: PathBuf) -> Result<(), Box<dyn std::error::Error
         if let Some(arch_str) = cfg.real_transformer.architecture.clone() {
             resolved_architecture = crate::architecture::Architecture::from_model_type(&arch_str)
                 .ok_or_else(|| {
-                    format!(
-                        "[real_transformer] architecture = \"{arch_str}\" is not a recognised \
+                format!(
+                    "[real_transformer] architecture = \"{arch_str}\" is not a recognised \
                          model_type (expected one of: mixtral, qwen3, qwen3_moe, deepseek_v3, \
                          mistral3, phi3)"
-                    )
-                })?;
+                )
+            })?;
         } else if let Some(dir) = cfg.real_transformer.weights_dir.clone() {
             match crate::architecture::HfConfig::from_dir(&dir) {
                 Ok(Some(hf)) => {
@@ -1076,8 +1082,7 @@ async fn cmd_serve(config_path: PathBuf) -> Result<(), Box<dyn std::error::Error
                     // Map the checkpoint's routing hyperparameters (scoring
                     // function, group-limited top-K, routed scaling factor,
                     // `norm_topk_prob`) so they reach the per-layer gate.
-                    resolved_advanced =
-                        crate::model::RealModelConfig::from_hf_config(&hf).advanced;
+                    resolved_advanced = crate::model::RealModelConfig::from_hf_config(&hf).advanced;
                     // GPT-OSS SwiGLU gate clamp: install the process-global
                     // limit so the expert-FFN hot path applies it (no-op for
                     // every architecture that leaves `swiglu_limit` unset).
@@ -1107,11 +1112,9 @@ async fn cmd_serve(config_path: PathBuf) -> Result<(), Box<dyn std::error::Error
                 }
                 Ok(None) => {} // no config.json — keep TOML-derived config
                 Err(e) => {
-                    return Err(format!(
-                        "failed to read config.json from {}: {e}",
-                        dir.display()
-                    )
-                    .into());
+                    return Err(
+                        format!("failed to read config.json from {}: {e}", dir.display()).into(),
+                    );
                 }
             }
         }
@@ -1156,7 +1159,11 @@ async fn cmd_serve(config_path: PathBuf) -> Result<(), Box<dyn std::error::Error
     };
     if cfg.real_transformer.compute_offload == crate::backend::ComputeOffload::Gpu {
         let num_layers = cfg.model.num_layers;
-        let max_seq_len = if cfg.real_transformer.window_size == 0 { 4096 } else { cfg.real_transformer.window_size };
+        let max_seq_len = if cfg.real_transformer.window_size == 0 {
+            4096
+        } else {
+            cfg.real_transformer.window_size
+        };
         let num_heads = cfg.real_transformer.num_heads;
         let num_kv_heads = if cfg.real_transformer.num_kv_heads == 0 {
             num_heads
@@ -1164,7 +1171,11 @@ async fn cmd_serve(config_path: PathBuf) -> Result<(), Box<dyn std::error::Error
             cfg.real_transformer.num_kv_heads
         };
         let head_dim = if cfg.real_transformer.head_dim == 0 {
-            if num_heads > 0 { cfg.model.d_model / num_heads } else { 64 }
+            if num_heads > 0 {
+                cfg.model.d_model / num_heads
+            } else {
+                64
+            }
         } else {
             cfg.real_transformer.head_dim
         };
@@ -1188,9 +1199,7 @@ async fn cmd_serve(config_path: PathBuf) -> Result<(), Box<dyn std::error::Error
         } else {
             info!(
                 device = device_name,
-                compute_plane,
-                has_device,
-                "GpuBackend installed for dense backbone"
+                compute_plane, has_device, "GpuBackend installed for dense backbone"
             );
         }
     }
@@ -1269,7 +1278,11 @@ async fn cmd_serve(config_path: PathBuf) -> Result<(), Box<dyn std::error::Error
             cfg.storage.block_align,
         )
     } else {
-        BufferPool::new(primary_slots, cfg.model.expert_size, cfg.storage.block_align)
+        BufferPool::new(
+            primary_slots,
+            cfg.model.expert_size,
+            cfg.storage.block_align,
+        )
     };
     let cache = {
         let num_layers = cfg.model.num_layers.max(1);
@@ -1299,8 +1312,9 @@ async fn cmd_serve(config_path: PathBuf) -> Result<(), Box<dyn std::error::Error
     // count. Otherwise layer-≥1 ids silently fall outside the
     // predictor's row table and the locality monitor's `is_hot` always
     // returns false for them.
-    let total_experts: u32 =
-        (cfg.model.num_layers as u32).saturating_mul(cfg.model.num_experts).max(cfg.model.num_experts);
+    let total_experts: u32 = (cfg.model.num_layers as u32)
+        .saturating_mul(cfg.model.num_experts)
+        .max(cfg.model.num_experts);
 
     let predictor = Arc::new(PredictiveLoader::new(
         total_experts,
@@ -1330,7 +1344,11 @@ async fn cmd_serve(config_path: PathBuf) -> Result<(), Box<dyn std::error::Error
         } else {
             rt.head_dim
         };
-        let num_kv_heads = if rt.num_kv_heads == 0 { rt.num_heads } else { rt.num_kv_heads };
+        let num_kv_heads = if rt.num_kv_heads == 0 {
+            rt.num_heads
+        } else {
+            rt.num_kv_heads
+        };
         // Hyperparameters were already reconciled from `config.json` (when
         // present) at the top of `cmd_serve`, so `cfg.model` /
         // `cfg.real_transformer` are the single source of truth here. We
@@ -1349,7 +1367,11 @@ async fn cmd_serve(config_path: PathBuf) -> Result<(), Box<dyn std::error::Error
             top_k: cfg.model.top_k,
             rope_base: rt.rope_base,
             rms_eps: rt.rms_eps,
-            window_size: if rt.window_size == 0 { None } else { Some(rt.window_size) },
+            window_size: if rt.window_size == 0 {
+                None
+            } else {
+                Some(rt.window_size)
+            },
             architecture: resolved_architecture,
             first_k_dense_replace: resolved_first_k_dense_replace,
             advanced: resolved_advanced,
@@ -1371,20 +1393,20 @@ async fn cmd_serve(config_path: PathBuf) -> Result<(), Box<dyn std::error::Error
     // path costs one additional `vocab_size * d_model * 4` bytes of
     // resident memory. See `draft::DraftEngine::from_main` for the exact
     // allocation site.
-    let draft_engine: Option<Arc<crate::draft::DraftEngine>> =
-        if cfg.predictive.speculator_enabled {
-            real_model.as_ref().map(|m| {
-                let d = crate::draft::DraftEngine::from_main(m);
-                tracing::info!(
-                    vocab_size = m.config.vocab_size,
-                    d_model = m.config.d_model,
-                    "draft engine built for speculative decoding"
-                );
-                Arc::new(d)
-            })
-        } else {
-            None
-        };
+    let draft_engine: Option<Arc<crate::draft::DraftEngine>> = if cfg.predictive.speculator_enabled
+    {
+        real_model.as_ref().map(|m| {
+            let d = crate::draft::DraftEngine::from_main(m);
+            tracing::info!(
+                vocab_size = m.config.vocab_size,
+                d_model = m.config.d_model,
+                "draft engine built for speculative decoding"
+            );
+            Arc::new(d)
+        })
+    } else {
+        None
+    };
 
     let speculation_k = cfg.real_transformer.speculation_base_depth.max(1);
 
@@ -1470,8 +1492,8 @@ async fn cmd_serve(config_path: PathBuf) -> Result<(), Box<dyn std::error::Error
             .locality_window
             .saturating_mul(cfg.model.num_layers.max(1));
         let monitor = Arc::new(LocalityMonitor::new(total_experts, window));
-        engine_builder = engine_builder
-            .with_locality_monitor(monitor, cfg.predictive.locality_threshold_pct);
+        engine_builder =
+            engine_builder.with_locality_monitor(monitor, cfg.predictive.locality_threshold_pct);
     }
     if cfg.predictive.speculator_enabled {
         let top_k = if cfg.predictive.speculator_top_k == 0 {
@@ -1496,7 +1518,10 @@ async fn cmd_serve(config_path: PathBuf) -> Result<(), Box<dyn std::error::Error
     // layer-qualified geometry (`num_experts_per_layer`).
     if cfg.predictive.affinity_enabled {
         let num_layers = cfg.model.num_layers.max(1);
-        let affinity = Arc::new(LayeredExpertAffinity::new(num_layers, cfg.model.num_experts));
+        let affinity = Arc::new(LayeredExpertAffinity::new(
+            num_layers,
+            cfg.model.num_experts,
+        ));
         engine_builder = engine_builder.with_affinity(
             affinity,
             cfg.predictive.affinity_neighbors_k,
@@ -1545,9 +1570,8 @@ async fn cmd_serve(config_path: PathBuf) -> Result<(), Box<dyn std::error::Error
         // bytes into VRAM without conversion or repacking. Parse it
         // here purely so the startup log records the operator's
         // declared intent.
-        let dtype_for_logging =
-            crate::inference::WeightDtype::from_str_opt(&cfg.gpu_cache.dtype)
-                .unwrap_or(crate::inference::WeightDtype::F16);
+        let dtype_for_logging = crate::inference::WeightDtype::from_str_opt(&cfg.gpu_cache.dtype)
+            .unwrap_or(crate::inference::WeightDtype::F16);
         info!(
             vram_capacity_mb = cfg.gpu_cache.vram_capacity_mb,
             anchor_ratio = cfg.gpu_cache.vram_anchor_ratio,
@@ -1587,12 +1611,17 @@ async fn cmd_serve(config_path: PathBuf) -> Result<(), Box<dyn std::error::Error
         } else {
             rt.head_dim
         };
-        let num_kv_heads = if rt.num_kv_heads == 0 { rt.num_heads } else { rt.num_kv_heads };
+        let num_kv_heads = if rt.num_kv_heads == 0 {
+            rt.num_heads
+        } else {
+            rt.num_kv_heads
+        };
         let batch_cfg = crate::batch_scheduler::BatchConfig {
             max_batch_size: rt.max_batch_size,
             batch_timeout: std::time::Duration::from_millis(rt.batch_timeout_ms),
-            idle_eviction_threshold:
-                std::time::Duration::from_millis(rt.idle_eviction_threshold_ms),
+            idle_eviction_threshold: std::time::Duration::from_millis(
+                rt.idle_eviction_threshold_ms,
+            ),
             speculation_base_depth: rt.speculation_base_depth,
             // Pool back-pressure ladder is now config-driven
             // (gist Part 1, fix #4). Validation in `Config::validate`
@@ -1658,9 +1687,8 @@ async fn cmd_serve(config_path: PathBuf) -> Result<(), Box<dyn std::error::Error
         // Sweep every TTL/2 (or once a minute, whichever is shorter) so
         // peak memory stays bounded but the evictor doesn't dominate
         // the wakeup budget.
-        let sweep = std::time::Duration::from_secs(
-            (cfg.server.session_ttl_secs / 2).max(1).min(60),
-        );
+        let sweep =
+            std::time::Duration::from_secs((cfg.server.session_ttl_secs / 2).max(1).min(60));
         store.spawn_evictor(sweep);
         Some(store)
     } else {
@@ -1898,7 +1926,12 @@ fn cmd_gen_data(
     );
     let started = Instant::now();
     crate::io_provider::generate_synthetic_experts_with_dtype(
-        data_dir, num_experts, expert_size, d_model, d_ff, dtype,
+        data_dir,
+        num_experts,
+        expert_size,
+        d_model,
+        d_ff,
+        dtype,
     )?;
     let total_bytes = num_experts as u64 * expert_size as u64;
     info!(
@@ -2020,7 +2053,10 @@ async fn cmd_repack(args: RepackArgs) -> Result<(), Box<dyn std::error::Error>> 
         );
         ranked
     } else {
-        info!(num_experts = args.num_experts, "repack: using numeric expert order");
+        info!(
+            num_experts = args.num_experts,
+            "repack: using numeric expert order"
+        );
         (0..args.num_experts).collect()
     };
 
@@ -2048,14 +2084,9 @@ async fn cmd_repack(args: RepackArgs) -> Result<(), Box<dyn std::error::Error>> 
         "repack: writing packed blob"
     );
     let started = Instant::now();
-    let manifest = crate::io_provider::pack_experts(
-        &storage,
-        &pool,
-        &order,
-        &args.out_blob,
-        &manifest_path,
-    )
-    .await?;
+    let manifest =
+        crate::io_provider::pack_experts(&storage, &pool, &order, &args.out_blob, &manifest_path)
+            .await?;
     info!(
         elapsed_s = started.elapsed().as_secs_f64(),
         blob_mib = manifest.blob_len() as f64 / (1024.0 * 1024.0),
@@ -2124,7 +2155,10 @@ struct RunArgs {
     packed_manifest: Option<PathBuf>,
 }
 
-async fn cmd_run(mut args: RunArgs, startup_pinned: bool) -> Result<(), Box<dyn std::error::Error>> {
+async fn cmd_run(
+    mut args: RunArgs,
+    startup_pinned: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
     // 0) If `metadata.json` exists alongside the expert blobs (e.g. as
     //    written by `scripts/extract_mixtral_experts.py`), use it to fill
     //    in any args the user didn't override on the command line. We
@@ -2231,7 +2265,10 @@ async fn cmd_run(mut args: RunArgs, startup_pinned: bool) -> Result<(), Box<dyn 
     // single-dir path is unchanged. Done early because the io_uring
     // NUMA probe below also takes the (canonical) data dir.
     let data_dirs: Vec<PathBuf> = parse_striped_data_dir(&args.data_dir)?;
-    let primary_dir = data_dirs.first().cloned().unwrap_or_else(|| args.data_dir.clone());
+    let primary_dir = data_dirs
+        .first()
+        .cloned()
+        .unwrap_or_else(|| args.data_dir.clone());
     for d in &data_dirs {
         if !d.is_dir() {
             return Err(format!(
@@ -2282,7 +2319,10 @@ async fn cmd_run(mut args: RunArgs, startup_pinned: bool) -> Result<(), Box<dyn 
             // pinning entirely.
             let numa_node = detect_data_dir_numa_node(&args.data_dir);
             if let Some(n) = numa_node {
-                info!(numa_node = n, "detected NUMA node for data dir; will pin io_uring");
+                info!(
+                    numa_node = n,
+                    "detected NUMA node for data dir; will pin io_uring"
+                );
             }
             // Build the backend from the same pool we'll hand the
             // engine; the registration happens inside ::new(). We log
@@ -2450,7 +2490,11 @@ async fn cmd_run(mut args: RunArgs, startup_pinned: bool) -> Result<(), Box<dyn 
     };
     let predictor = Arc::new(PredictiveLoader::new(
         args.num_experts,
-        if args.no_prefetch { 0 } else { args.predict_fanout },
+        if args.no_prefetch {
+            0
+        } else {
+            args.predict_fanout
+        },
         resolve_predict_min_prob(args.predict_min_prob, args.num_experts),
         args.seed,
     ));
@@ -2564,7 +2608,8 @@ async fn cmd_run(mut args: RunArgs, startup_pinned: bool) -> Result<(), Box<dyn 
         if args.static_residency_fraction > 0.0 {
             let profile = match args.static_residency_profile.as_ref() {
                 Some(path) => {
-                    let p = crate::residency::ResidencyProfile::load_json(std::path::Path::new(path))?;
+                    let p =
+                        crate::residency::ResidencyProfile::load_json(std::path::Path::new(path))?;
                     info!(
                         path = %path,
                         experts = p.len(),
@@ -2720,7 +2765,10 @@ async fn cmd_run(mut args: RunArgs, startup_pinned: bool) -> Result<(), Box<dyn 
                     crate::workload::Workload::Skewed => (
                         t,
                         0,
-                        skewed_stream.as_mut().expect("skewed stream").next_experts(),
+                        skewed_stream
+                            .as_mut()
+                            .expect("skewed stream")
+                            .next_experts(),
                     ),
                     _ => {
                         let record = replay_stream
@@ -2736,9 +2784,7 @@ async fn cmd_run(mut args: RunArgs, startup_pinned: bool) -> Result<(), Box<dyn 
                 };
                 let hidden = crate::inference::synth_hidden_state(tok_idx, args.d_model, args.seed);
                 let pre = engine.report();
-                let _ = engine
-                    .moe_step(tok_idx, layer_idx, &hidden, &experts)
-                    .await;
+                let _ = engine.moe_step(tok_idx, layer_idx, &hidden, &experts).await;
                 let post = engine.report();
                 crate::engine::CycleStats {
                     hits: post.hits.saturating_sub(pre.hits),
@@ -3037,7 +3083,12 @@ fn load_gate_weights(
         buf.copy_from_slice(chunk);
         weights.push(f32::from_le_bytes(buf));
     }
-    Ok(crate::gating::LinearGate::new(weights, num_experts, d_model, top_k))
+    Ok(crate::gating::LinearGate::new(
+        weights,
+        num_experts,
+        d_model,
+        top_k,
+    ))
 }
 
 /// Discover and concatenate the per-layer `gate_<L>.bin` files in `dir`,
@@ -3049,9 +3100,12 @@ fn read_gate_dir_concatenated(
     dir: &std::path::Path,
 ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
     let mut entries: Vec<(u32, PathBuf)> = Vec::new();
-    for entry in std::fs::read_dir(dir)
-        .map_err(|e| format!("failed to scan gate-weights directory {}: {e}", dir.display()))?
-    {
+    for entry in std::fs::read_dir(dir).map_err(|e| {
+        format!(
+            "failed to scan gate-weights directory {}: {e}",
+            dir.display()
+        )
+    })? {
         let entry = entry
             .map_err(|e| format!("failed to read a directory entry in {}: {e}", dir.display()))?;
         let path = entry.path();
@@ -3101,8 +3155,12 @@ fn read_gate_dir_concatenated(
     );
     let mut bytes = Vec::new();
     for (idx, p) in &entries {
-        let mut chunk = std::fs::read(p)
-            .map_err(|e| format!("failed to read gate file {} (layer {idx}): {e}", p.display()))?;
+        let mut chunk = std::fs::read(p).map_err(|e| {
+            format!(
+                "failed to read gate file {} (layer {idx}): {e}",
+                p.display()
+            )
+        })?;
         bytes.append(&mut chunk);
     }
     Ok(bytes)
@@ -3225,7 +3283,11 @@ fn read_local_node_cpus() -> Option<Vec<usize>> {
             out.push(part.parse().ok()?);
         }
     }
-    if out.is_empty() { None } else { Some(out) }
+    if out.is_empty() {
+        None
+    } else {
+        Some(out)
+    }
 }
 
 /// Detect the NUMA node of the block device backing `data_dir`.
@@ -3256,7 +3318,11 @@ pub fn detect_data_dir_numa_node(data_dir: &std::path::Path) -> Option<i32> {
         let body = std::fs::read_to_string(&sys_path).ok()?;
         let node: i32 = body.trim().parse().ok()?;
         // Kernel reports `-1` when NUMA is disabled or unknown.
-        if node < 0 { None } else { Some(node) }
+        if node < 0 {
+            None
+        } else {
+            Some(node)
+        }
     }
     #[cfg(not(target_os = "linux"))]
     {
@@ -3268,9 +3334,7 @@ pub fn detect_data_dir_numa_node(data_dir: &std::path::Path) -> Option<i32> {
 /// Parse `--data-dir` into a list of directories. If the path
 /// stringifies to a comma-separated list, split it; otherwise return a
 /// single-element vec. Used by gist Phase 4 (multi-drive striping).
-fn parse_striped_data_dir(
-    p: &std::path::Path,
-) -> Result<Vec<PathBuf>, Box<dyn std::error::Error>> {
+fn parse_striped_data_dir(p: &std::path::Path) -> Result<Vec<PathBuf>, Box<dyn std::error::Error>> {
     let s = p.to_string_lossy();
     if s.contains(',') {
         let dirs: Vec<PathBuf> = s
@@ -3309,7 +3373,10 @@ fn cmd_gguf_convert(
         native_quant,
         "opening GGUF file"
     );
-    let opts = crate::gguf_loader::ExtractOptions { emit_uth, native_quant };
+    let opts = crate::gguf_loader::ExtractOptions {
+        emit_uth,
+        native_quant,
+    };
     let source = crate::gguf::open_gguf_source(gguf_path, legacy_eager)?;
     if let Some(arch) = source.architecture() {
         info!(architecture = arch, "GGUF source opened");
@@ -3555,11 +3622,7 @@ mod tests {
     #[test]
     fn parse_order_file_strips_inline_comments() {
         let path = tempdir_unique("order-inline-comments.txt");
-        std::fs::write(
-            &path,
-            "# full-line comment\n12  # hot expert\n3,4\n8 9\n",
-        )
-        .unwrap();
+        std::fs::write(&path, "# full-line comment\n12  # hot expert\n3,4\n8 9\n").unwrap();
         let ids = parse_order_file(&path).unwrap();
         assert_eq!(ids, vec![12, 3, 4, 8, 9]);
         let _ = std::fs::remove_file(&path);
@@ -3568,7 +3631,10 @@ mod tests {
     #[test]
     fn repack_order_validation_rejects_duplicate_ids() {
         let err = validate_order(&[0, 1, 1], 4).unwrap_err();
-        assert!(err.contains("duplicate expert id 1"), "unexpected error: {err}");
+        assert!(
+            err.contains("duplicate expert id 1"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]
@@ -3604,8 +3670,10 @@ mod tests {
         write("gate_0.bin", &[1.0, 2.0]);
         write("notes.txt", &[]);
 
-        let gate = load_gate_weights(&dir, /*num_experts=*/ 2, /*d_model=*/ 2, /*top_k=*/ 1)
-            .expect("directory gate load should succeed");
+        let gate = load_gate_weights(
+            &dir, /*num_experts=*/ 2, /*d_model=*/ 2, /*top_k=*/ 1,
+        )
+        .expect("directory gate load should succeed");
         // Concatenation must be layer 0 then layer 1.
         assert_eq!(gate.weights, vec![1.0, 2.0, 3.0, 4.0]);
         assert_eq!(gate.num_experts, 2);

--- a/rust-engine/src/tensor_header.rs
+++ b/rust-engine/src/tensor_header.rs
@@ -47,12 +47,21 @@ use std::fmt;
 /// 4-byte ASCII magic at the start of every U.T.H. blob.
 pub const UTH_MAGIC: [u8; 4] = *b"UTH1";
 
+/// 4-byte ASCII magic for the mixed-projection expert header.
+pub const UTH2_MAGIC: [u8; 4] = *b"UTH2";
+
 /// Total on-disk size of the header itself (excluding any page padding
 /// that may follow it).
 pub const UTH_BYTES: usize = 64;
 
 /// Current header version. Incremented on incompatible layout changes.
 pub const UTH_VERSION: u16 = 1;
+
+/// Current mixed-projection header version.
+pub const UTH2_VERSION: u16 = 2;
+
+/// Fixed on-disk size of the UTH2 header itself, excluding page padding.
+pub const UTH2_BYTES: usize = 128;
 
 /// `flags` bit indicating that the payload (post-header) is itself
 /// page-aligned (i.e. the writer padded the header region up to the
@@ -75,6 +84,9 @@ pub enum UthDtypeId {
     Q8_0 = 5,
     BF16 = 6,
     MXFP4 = 7,
+    Q5K = 8,
+    Q6K = 9,
+    Mixed = 10,
 }
 
 impl UthDtypeId {
@@ -88,6 +100,9 @@ impl UthDtypeId {
             WeightDtype::Q8_0 => UthDtypeId::Q8_0,
             WeightDtype::BF16 => UthDtypeId::BF16,
             WeightDtype::MXFP4 => UthDtypeId::MXFP4,
+            WeightDtype::Q5K => UthDtypeId::Q5K,
+            WeightDtype::Q6K => UthDtypeId::Q6K,
+            WeightDtype::Mixed => UthDtypeId::Mixed,
         }
     }
 
@@ -101,6 +116,9 @@ impl UthDtypeId {
             UthDtypeId::Q8_0 => WeightDtype::Q8_0,
             UthDtypeId::BF16 => WeightDtype::BF16,
             UthDtypeId::MXFP4 => WeightDtype::MXFP4,
+            UthDtypeId::Q5K => WeightDtype::Q5K,
+            UthDtypeId::Q6K => WeightDtype::Q6K,
+            UthDtypeId::Mixed => WeightDtype::Mixed,
         }
     }
 
@@ -114,8 +132,237 @@ impl UthDtypeId {
             5 => Some(UthDtypeId::Q8_0),
             6 => Some(UthDtypeId::BF16),
             7 => Some(UthDtypeId::MXFP4),
+            8 => Some(UthDtypeId::Q5K),
+            9 => Some(UthDtypeId::Q6K),
+            10 => Some(UthDtypeId::Mixed),
             _ => None,
         }
+    }
+}
+
+/// One projection range inside a mixed UTH2 expert payload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProjectionRange {
+    pub dtype: UthDtypeId,
+    pub offset: u64,
+    pub len: u64,
+    pub weights: u32,
+}
+
+impl ProjectionRange {
+    pub fn end(self) -> Option<u64> {
+        self.offset.checked_add(self.len)
+    }
+}
+
+/// Parsed UTH2 mixed expert header. Offsets are relative to the payload
+/// start, not the start of the file, so page padding after the header is
+/// never part of any projection range.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MixedExpertHeader {
+    pub version: u16,
+    pub d_model: u32,
+    pub d_ff: u32,
+    pub flags: u32,
+    pub gate: ProjectionRange,
+    pub up: ProjectionRange,
+    pub down: ProjectionRange,
+}
+
+impl MixedExpertHeader {
+    pub fn new(
+        d_model: usize,
+        d_ff: usize,
+        gate: ProjectionRange,
+        up: ProjectionRange,
+        down: ProjectionRange,
+    ) -> Self {
+        Self {
+            version: UTH2_VERSION,
+            d_model: d_model as u32,
+            d_ff: d_ff as u32,
+            flags: UTH_FLAG_PAGE_ALIGNED_PAYLOAD,
+            gate,
+            up,
+            down,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn projection_payload_len(&self) -> Option<u64> {
+        [self.gate, self.up, self.down]
+            .into_iter()
+            .map(ProjectionRange::end)
+            .try_fold(0u64, |max_end, end| end.map(|e| max_end.max(e)))
+    }
+
+    pub fn validate(&self, payload_len: u64) -> Result<(), String> {
+        if self.version != UTH2_VERSION {
+            return Err(format!("unsupported UTH2 version {}", self.version));
+        }
+        if self.d_model == 0 || self.d_ff == 0 {
+            return Err("UTH2 d_model and d_ff must be non-zero".to_string());
+        }
+        let ranges = [("gate", self.gate), ("up", self.up), ("down", self.down)];
+        for (name, r) in ranges {
+            if r.dtype == UthDtypeId::Mixed {
+                return Err(format!("UTH2 {name} projection cannot use mixed dtype id"));
+            }
+            if r.len == 0 {
+                return Err(format!("UTH2 {name} projection has zero length"));
+            }
+            let end = r
+                .end()
+                .ok_or_else(|| format!("UTH2 {name} range overflows u64"))?;
+            if end > payload_len {
+                return Err(format!(
+                    "UTH2 {name} range {}..{} exceeds payload length {}",
+                    r.offset, end, payload_len
+                ));
+            }
+        }
+        let mut sorted = [
+            (
+                "gate",
+                self.gate.offset,
+                self.gate.end().unwrap_or(u64::MAX),
+            ),
+            ("up", self.up.offset, self.up.end().unwrap_or(u64::MAX)),
+            (
+                "down",
+                self.down.offset,
+                self.down.end().unwrap_or(u64::MAX),
+            ),
+        ];
+        sorted.sort_by_key(|(_, start, _)| *start);
+        for pair in sorted.windows(2) {
+            let (left_name, _left_start, left_end) = pair[0];
+            let (right_name, right_start, _right_end) = pair[1];
+            if left_end > right_start {
+                return Err(format!(
+                    "UTH2 projection ranges overlap: {left_name} and {right_name}"
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    pub fn to_bytes(&self) -> [u8; UTH2_BYTES] {
+        let mut buf = [0u8; UTH2_BYTES];
+        buf[0..4].copy_from_slice(&UTH2_MAGIC);
+        buf[4..6].copy_from_slice(&self.version.to_le_bytes());
+        buf[6..8].copy_from_slice(&3u16.to_le_bytes());
+        buf[8..12].copy_from_slice(&self.d_model.to_le_bytes());
+        buf[12..16].copy_from_slice(&self.d_ff.to_le_bytes());
+        buf[16..20].copy_from_slice(&self.flags.to_le_bytes());
+
+        for (i, (role, p)) in [(0u8, self.gate), (1u8, self.up), (2u8, self.down)]
+            .into_iter()
+            .enumerate()
+        {
+            let off = 24 + i * 24;
+            buf[off] = p.dtype as u8;
+            buf[off + 1] = role;
+            buf[off + 4..off + 12].copy_from_slice(&p.offset.to_le_bytes());
+            buf[off + 12..off + 20].copy_from_slice(&p.len.to_le_bytes());
+            buf[off + 20..off + 24].copy_from_slice(&p.weights.to_le_bytes());
+        }
+        buf
+    }
+
+    pub fn write_padded(&self, block_align: usize, dst: &mut Vec<u8>) {
+        let start = dst.len();
+        dst.extend_from_slice(&self.to_bytes());
+        let after = dst.len() - start;
+        let pad = if block_align > 0 {
+            (block_align - (after % block_align)) % block_align
+        } else {
+            0
+        };
+        dst.resize(dst.len() + pad, 0);
+    }
+
+    pub fn probe(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() < UTH2_BYTES || bytes[0..4] != UTH2_MAGIC {
+            return None;
+        }
+        let version = u16::from_le_bytes([bytes[4], bytes[5]]);
+        if version != UTH2_VERSION {
+            return None;
+        }
+        let projection_count = u16::from_le_bytes([bytes[6], bytes[7]]);
+        if projection_count != 3 {
+            return None;
+        }
+        let d_model = u32::from_le_bytes([bytes[8], bytes[9], bytes[10], bytes[11]]);
+        let d_ff = u32::from_le_bytes([bytes[12], bytes[13], bytes[14], bytes[15]]);
+        let flags = u32::from_le_bytes([bytes[16], bytes[17], bytes[18], bytes[19]]);
+
+        let read_projection = |idx: usize, expected_role: u8| -> Option<ProjectionRange> {
+            let off = 24 + idx * 24;
+            if bytes[off + 1] != expected_role {
+                return None;
+            }
+            let dtype = UthDtypeId::from_u8(bytes[off])?;
+            let offset = u64::from_le_bytes([
+                bytes[off + 4],
+                bytes[off + 5],
+                bytes[off + 6],
+                bytes[off + 7],
+                bytes[off + 8],
+                bytes[off + 9],
+                bytes[off + 10],
+                bytes[off + 11],
+            ]);
+            let len = u64::from_le_bytes([
+                bytes[off + 12],
+                bytes[off + 13],
+                bytes[off + 14],
+                bytes[off + 15],
+                bytes[off + 16],
+                bytes[off + 17],
+                bytes[off + 18],
+                bytes[off + 19],
+            ]);
+            let weights = u32::from_le_bytes([
+                bytes[off + 20],
+                bytes[off + 21],
+                bytes[off + 22],
+                bytes[off + 23],
+            ]);
+            Some(ProjectionRange {
+                dtype,
+                offset,
+                len,
+                weights,
+            })
+        };
+
+        Some(Self {
+            version,
+            d_model,
+            d_ff,
+            flags,
+            gate: read_projection(0, 0)?,
+            up: read_projection(1, 1)?,
+            down: read_projection(2, 2)?,
+        })
+    }
+
+    pub fn strip<'a>(bytes: &'a [u8], block_align: usize) -> Option<(Self, &'a [u8])> {
+        let h = Self::probe(bytes)?;
+        let prefix = if (h.flags & UTH_FLAG_PAGE_ALIGNED_PAYLOAD) != 0 && block_align > 0 {
+            let pad = (block_align - (UTH2_BYTES % block_align)) % block_align;
+            UTH2_BYTES + pad
+        } else {
+            UTH2_BYTES
+        };
+        if prefix > bytes.len() {
+            return None;
+        }
+        let payload = &bytes[prefix..];
+        h.validate(payload.len() as u64).ok()?;
+        Some((h, payload))
     }
 }
 
@@ -170,8 +417,11 @@ impl TensorHeader {
             | WeightDtype::Q4K
             | WeightDtype::Q4_0
             | WeightDtype::Q8_0
+            | WeightDtype::Q5K
+            | WeightDtype::Q6K
             | WeightDtype::BF16
-            | WeightDtype::MXFP4 => (0, 0),
+            | WeightDtype::MXFP4
+            | WeightDtype::Mixed => (0, 0),
         };
         Self {
             version: UTH_VERSION,
@@ -244,12 +494,8 @@ impl TensorHeader {
         let mut shape = [0u32; UTH_MAX_RANK];
         for i in 0..UTH_MAX_RANK {
             let off = 8 + i * 4;
-            shape[i] = u32::from_le_bytes([
-                bytes[off],
-                bytes[off + 1],
-                bytes[off + 2],
-                bytes[off + 3],
-            ]);
+            shape[i] =
+                u32::from_le_bytes([bytes[off], bytes[off + 1], bytes[off + 2], bytes[off + 3]]);
         }
         let quant_scale_offset = u32::from_le_bytes([bytes[24], bytes[25], bytes[26], bytes[27]]);
         let quant_scale_count = u32::from_le_bytes([bytes[28], bytes[29], bytes[30], bytes[31]]);
@@ -331,6 +577,9 @@ mod tests {
             WeightDtype::Q4K,
             WeightDtype::Q4_0,
             WeightDtype::Q8_0,
+            WeightDtype::Q5K,
+            WeightDtype::Q6K,
+            WeightDtype::Mixed,
         ] {
             let h = TensorHeader::for_swiglu_expert(dtype, 512, 2048);
             let bytes = h.to_bytes();
@@ -358,6 +607,9 @@ mod tests {
             WeightDtype::Q4K,
             WeightDtype::Q4_0,
             WeightDtype::Q8_0,
+            WeightDtype::Q5K,
+            WeightDtype::Q6K,
+            WeightDtype::Mixed,
         ] {
             let h = TensorHeader::for_swiglu_expert(dtype, 512, 2048);
             assert_eq!(
@@ -399,6 +651,122 @@ mod tests {
         assert!(parsed.is_none());
         assert_eq!(payload.as_ptr(), buf.as_ptr());
         assert_eq!(payload.len(), buf.len());
+    }
+
+    #[test]
+    fn mixed_uth2_roundtrip_and_strip() {
+        let h = MixedExpertHeader::new(
+            64,
+            128,
+            ProjectionRange {
+                dtype: UthDtypeId::Q4_0,
+                offset: 0,
+                len: 18,
+                weights: 32,
+            },
+            ProjectionRange {
+                dtype: UthDtypeId::Q4K,
+                offset: 18,
+                len: 144,
+                weights: 256,
+            },
+            ProjectionRange {
+                dtype: UthDtypeId::Q5K,
+                offset: 162,
+                len: 176,
+                weights: 256,
+            },
+        );
+        let bytes = h.to_bytes();
+        assert_eq!(&bytes[..4], &UTH2_MAGIC);
+        assert_eq!(MixedExpertHeader::probe(&bytes), Some(h));
+
+        let mut file = Vec::new();
+        h.write_padded(4096, &mut file);
+        assert_eq!(file.len(), 4096);
+        file.extend_from_slice(&vec![0xA5; 338]);
+        file.extend_from_slice(&vec![0; 4096 - 338]);
+        let (parsed, payload) = MixedExpertHeader::strip(&file, 4096).expect("strip UTH2");
+        assert_eq!(parsed, h);
+        assert_eq!(payload[0], 0xA5);
+        assert_eq!(parsed.projection_payload_len(), Some(338));
+    }
+
+    #[test]
+    fn mixed_uth2_rejects_unknown_or_malformed_ranges() {
+        let h = MixedExpertHeader::new(
+            64,
+            128,
+            ProjectionRange {
+                dtype: UthDtypeId::Q4_0,
+                offset: 0,
+                len: 18,
+                weights: 32,
+            },
+            ProjectionRange {
+                dtype: UthDtypeId::Q4K,
+                offset: 18,
+                len: 144,
+                weights: 256,
+            },
+            ProjectionRange {
+                dtype: UthDtypeId::Q5K,
+                offset: 162,
+                len: 176,
+                weights: 256,
+            },
+        );
+        let mut future = h.to_bytes();
+        future[4..6].copy_from_slice(&3u16.to_le_bytes());
+        assert!(MixedExpertHeader::probe(&future).is_none());
+
+        let overlapping = MixedExpertHeader::new(
+            64,
+            128,
+            ProjectionRange {
+                dtype: UthDtypeId::Q4_0,
+                offset: 0,
+                len: 18,
+                weights: 32,
+            },
+            ProjectionRange {
+                dtype: UthDtypeId::Q4K,
+                offset: 8,
+                len: 144,
+                weights: 256,
+            },
+            ProjectionRange {
+                dtype: UthDtypeId::Q5K,
+                offset: 162,
+                len: 176,
+                weights: 256,
+            },
+        );
+        assert!(overlapping.validate(4096).is_err());
+
+        let past_end = MixedExpertHeader::new(
+            64,
+            128,
+            ProjectionRange {
+                dtype: UthDtypeId::Q4_0,
+                offset: 0,
+                len: 18,
+                weights: 32,
+            },
+            ProjectionRange {
+                dtype: UthDtypeId::Q4K,
+                offset: 18,
+                len: 144,
+                weights: 256,
+            },
+            ProjectionRange {
+                dtype: UthDtypeId::Q5K,
+                offset: 162,
+                len: 176,
+                weights: 256,
+            },
+        );
+        assert!(past_end.validate(200).is_err());
     }
 
     #[test]
@@ -452,7 +820,8 @@ mod tests {
         // 16 K iterations × up to 256 B input ≈ 4 MiB of work, well
         // under the test budget even in debug mode.
         for trial in 0..16384u64 {
-            let len = ((trial.wrapping_mul(0x9E37_79B9_7F4A_7C15)) % (4 * UTH_BYTES as u64 + 1)) as usize;
+            let len =
+                ((trial.wrapping_mul(0x9E37_79B9_7F4A_7C15)) % (4 * UTH_BYTES as u64 + 1)) as usize;
             let mut buf = vec![0u8; len];
             fill_random(&mut buf, trial.wrapping_mul(0x1234_5678) ^ 0xDEAD_BEEF);
             // Property: probe must return either `None` or a fully-
@@ -491,7 +860,8 @@ mod tests {
         // a panic here would crash the engine on a malformed
         // expert_<id>.bin.
         for trial in 0..4096u64 {
-            let len = ((trial.wrapping_mul(0x517C_C1B7_2722_0A95)) % (3 * UTH_BYTES as u64 + 1)) as usize;
+            let len =
+                ((trial.wrapping_mul(0x517C_C1B7_2722_0A95)) % (3 * UTH_BYTES as u64 + 1)) as usize;
             let mut buf = vec![0u8; len];
             fill_random(&mut buf, trial.wrapping_add(0x0123_4567_89AB_CDEF));
             for block in [16usize, 64, 512, 4096] {


### PR DESCRIPTION
## Summary

- Adds UTH2 mixed expert headers with per-projection dtype, offset, length, and weight metadata while preserving the existing homogeneous UTH1 path.
- Extends native GGUF expert extraction to fail closed for unsupported `--native-quant`, support mixed projection layouts, fixed-size padded expert slots, and Q5_K/Q6_K sizing/dequantization.
- Wires runtime dispatch for `mixed`, Q5_K, and Q6_K experts through cache header parsing and owned dequantized execution.
- Updates metadata and tests for mixed per-expert extraction, UTH2 validation, Q5_K/Q6_K decode boundaries, and native-quant fail-closed behavior.

## Validation

- `cargo test` passed: 498 unit tests, 4 concurrency-stress tests, doc tests.
- `git diff --cached --check` passed before commit; `git diff --check` passed after cleanup.
- `cargo build --release --features "avx512,blas,tokenizer"` passed.

## Known local validation blockers

- `cargo fmt --check` fails on pre-existing formatting in unmodified files such as `block_pool.rs`, `router.rs`, `transformer.rs`, and `tui.rs`; I kept this PR scoped instead of reformatting the repository.
- `cargo clippy --all-targets -- -D warnings` fails on existing `src/router.rs` lint debt before reaching the modified modules.
- `cargo clippy --all-targets --all-features -- -D warnings` and `cargo build --release --features "cuda,avx512,blas,tokenizer,io_uring"` are not runnable on this macOS host because CUDA needs `nvcc` and `io_uring` is Linux-specific.
- The requested manual Mixtral GGUF fixture was not present at `/mnt/localssd/models/mixtral-8x22b-q4ks/Mixtral-8x22B-v0.1.Q4_K_S-merged.gguf` on this machine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional expert quantization formats, including Q5_K, Q6_K, and mixed-layout experts.
  * Improved expert extraction output with richer metadata and support for mixed-projection layouts.
  * Added broader tensor header support for the newer expert layout format.

* **Bug Fixes**
  * Fixed size and decoding handling for Q5_K and Q6_K tensor data.
  * Tightened validation for expert layouts and quantized inputs to prevent unsupported fallbacks.
  * Improved checks around mixed-layout expert loading and header parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->