### PR TITLE
Harden mixed-quant GGUF conversion and runtime execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1670,7 +1670,8 @@ micro-expert-router gen-data
   --d-model <N>              FFN hidden dim (default 512)
   --d-ff <N>                 FFN intermediate dim (default 2048)
   --block-align <BYTES>      O_DIRECT alignment (default 4096)
-  --dtype <DTYPE>            f32 | f16 | int8 | q4k | q4_0 | q8_0 (default f32)
+  --dtype <DTYPE>            f32 | f16 | bf16 | int8 | q4k | q4_0 | q8_0
+                              | mxfp4 (default f32)
 
 micro-expert-router repack    # Tier 2: build a packed expert blob + manifest
   --data-dir <PATH>          Source dir of expert_<id>.bin (default ./data)
@@ -1703,8 +1704,10 @@ micro-expert-router run
                               runs tested 16, 64, and 128 slots.
   --top-k <K>                Active experts per token (default 2, distinct)
   --tokens <N>               Stream length
-  --dtype <DTYPE>            f32 | f16 | int8 | q4k | q4_0 | q8_0 (default f32).
-                              Must match gen-data / the offline extractor.
+  --dtype <DTYPE>            f32 | f16 | bf16 | int8 | q4k | q4_0 | q5k
+                              | q6k | q8_0 | mxfp4 | mixed (default f32).
+                              Must match gen-data / gguf-convert / the
+                              offline extractor.
   --predict-fanout <N>       Prefetch candidates per token (default 2)
   --pipeline-depth <N>       Look-ahead pipeline depth (default 3). In serve
                               mode, how many MoE layers ahead the speculator
@@ -2442,7 +2445,7 @@ explains which of these the change moves and why.
 
 The engine reads weight bytes straight off the SSD; halving, or
 quartering, the byte width of each weight halves / quarters every
-read. Six on-disk dtypes are first-class:
+read. Seven on-disk modes are first-class in the energy table:
 
 | `--dtype` | Bytes / weight | Per-blob header | Compute kernel | Use |
 |---|---:|:---:|---|---|
@@ -2454,16 +2457,18 @@ read. Six on-disk dtypes are first-class:
 | `q8_0` | ~1.0625 | none (block-internal) | **default**: candle `QMatMul` directly over the on-disk `Q8_0` 32-block stream (one `f16` scale + 32 signed `i8` weights per block). **Fallback**: 32-block dequant when `cols % 32 != 0`. | GGUF-compatible 8-bit; same density as `int8` but with **per-block** scales, so dynamic range stays bounded inside each 32-weight neighbourhood |
 | `mixed` | varies by projection | UTH2 required | CPU direct projection dispatch over gate/up/down ranges without full-weight F32 expansion. Supported projection dtypes include `Q4_0`, `Q4_K`, `Q5_K`, `Q6_K`, `Q8_0`, `F32`, `F16`, and `BF16`; unsupported projection dtypes fail before execution. | GGUF mixed expert triples such as `Q4_K/Q4_K/Q6_K`; GPU execution is not advertised for Q5_K/Q6_K |
 
-Selectable on **`gen-data`** (synthetic data, every dtype has a
-matching generator arm), on **`gguf-convert`** (input format detected
-from the GGUF tensor dtype, pass `--native-quant` to write raw
-`Q4_0` / `Q4_K` / `Q5_K` / `Q6_K` / `Q8_0` projection streams and UTH2
-mixed layouts instead of dequantising to F32), and on **`run` / `serve`**
-(must match the on-disk files). Native quant conversion is fail-closed:
-unsupported projection dtypes or unsafe shapes abort preflight instead of
-silently expanding experts to F32. The forward pass dispatches to
-`inference::run_inference_*` per dtype, all producing scalar `f32`
-SwiGLU output, so a benchmark run is a one-flag diff.
+Selectable on **`gen-data`** for the synthetic generator dtypes (`f32`,
+`f16`, `bf16`, `int8`, `q4k`, `q4_0`, `q8_0`, `mxfp4`), on
+**`gguf-convert`** from the GGUF tensor dtype (pass `--native-quant` to
+write raw `Q4_0` / `Q4_K` / `Q5_K` / `Q6_K` / `Q8_0` projection streams
+and UTH2 mixed layouts instead of dequantising to F32), and on **`run` /
+`serve`** for every runtime dtype accepted by the engine (`f32`, `f16`,
+`bf16`, `int8`, `q4k`, `q4_0`, `q5k`, `q6k`, `q8_0`, `mxfp4`, `mixed`).
+The runtime dtype must match the on-disk files. Native quant conversion
+is fail-closed: unsupported projection dtypes or unsafe shapes abort
+preflight instead of silently expanding experts to F32. The forward pass
+dispatches to `inference::run_inference_*` per dtype, all producing
+scalar `f32` SwiGLU output, so a benchmark run is a one-flag diff.
 
 **Quantised fast path.** For `q4k`, `q4_0`, and `q8_0` the engine
 prefers the `QMatMul` path (`run_inference_q4_0_qmm` /

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Current status:
 | **Verified expert-streaming benchmark target** | Mixtral 8x7B Q4_0 expert blobs from `mixtral-8x7b-instruct-v0.1.Q4_0.gguf`, run on the CPU path with 256 layer-qualified experts and top-2 routing. |
 | **Implemented, not benchmark-validated here** | Mixtral/Llama-MoE `mixtral`, Qwen3-MoE `qwen3_moe`, DeepSeek-V3/V3.1 `deepseek_v3`, MiMo-V2-Flash `mimo_v2_flash`, and GPT-OSS `gpt_oss` source paths. See [Supported model architectures](#supported-model-architectures) for the implementation details and limitations. |
 | **Dense model support only** | Qwen3 dense, Mistral Small 3, and Phi-4 load dense decoder tensors but do not exercise SSD expert streaming. |
-| **Unsupported or known limitation** | Arbitrary sparse MoEs, arbitrary GGUF quantization recipes, and mixed expert projection dtypes are not automatically validated or supported. |
+| **Unsupported or known limitation** | Arbitrary sparse MoEs and arbitrary GGUF quantization recipes are not automatically supported. Mixed expert projection dtypes are supported only when every projection maps to an executable CPU kernel and the dataset carries UTH2 metadata. |
 
 ---
 
@@ -507,7 +507,7 @@ The Rust crate (`rust-engine/`) is organised into single-responsibility modules:
 | `io_uring_storage` | Linux-only `io_uring` backend with **registered fixed buffers** (`IORING_REGISTER_BUFFERS`) and a batched `submit_and_wait(K)` entry point (`read_experts_batch_fixed`). Also exposes `read_experts_batch_fixed_promote`, the **zero-latency speculative → resident** path: one `submit_and_wait(K)` against shadow `PooledBuffer`s, then a `BufferPool::promote_shadow` per CQE so the bytes that just arrived become resident without a re-read. Built behind the `io_uring` cargo feature. |
 | `router` | The three-signal predictive controller in one module: `TopKRouter` (deterministic 1st-order Markov router, clustered locality by default, or a precomputed `N×N` matrix), `PredictiveLoader` (online **1st- and 2nd-order** sparse Markov predictor with a Laplace prior, plus the unified `predict_unified(S ∪ L ∪ M)` scoring API and the extended `predict_unified_with_spatial(…)` that folds in **expert-affinity** + **UTH-spatial** neighbours when a seed scores ≥ 0.80), `LocalityMonitor` (sliding-window heat map, the **L** arm), `NeuralSpeculator` (2-layer MLP trained online by SGD on an off-path worker thread, the **M** arm), `ExpertAffinity` (lock-free `N×N` `AtomicU32` co-occurrence matrix tracking which experts fire together in the same MoE layer) plus the new `LayeredExpertAffinity` wrapper that **keeps one matrix per layer** (gist Part 2 fix #2) so layer-0 co-firings cannot leak into other layers' neighbour signal, and a background **exponential-decay worker** (gist Part 2 fix #7) that right-shifts the counter matrix per `epoch_threshold` cumulative observations to prevent atomic saturation, and `SpeculationController` (latency-aware speculation window, grows under rising `ssd_stall_us`, clamps to 0 under critical pool pressure; `update_from_stall` swaps the high-water-mark with one relaxed atomic, no `compare_exchange`). |
 | `gating` | Production routing path: `LinearGate` computes `softmax(W_gate · x) → top-K` exactly the way Mixtral does. `Router` is an enum the engine holds polymorphically, `Router::Linear` in the real-transformer path, `Router::Markov` for the benchmark / `--io-only` path. |
-| `inference` | SwiGLU expert FFN (`y = down · (silu(gate·x) ⊙ (up·x))`), executed through the **`candle-core`** tensor backend. Implemented per dtype: `run_inference` (F32, zero-copy reinterpret + Candle matmul), `run_inference_f16` / `_int8` / `_q8_0` (dequantise to `f32` then the same Candle SwiGLU kernel), and `run_inference_partial` (load only the top-M input columns by magnitude). For the GGUF block-quantised dtypes the engine prefers a **`QMatMul` fast path** (`run_inference_q4_0_qmm` / `run_inference_q4k_qmm` / `run_inference_q8_0_qmm`) that hands the on-disk quantised blocks straight to candle's GGML kernels, no F32 dequantise of the weights. The legacy `run_inference_q4_0` / `run_inference_q4k` / `run_inference_q8_0` dequant kernels are kept as a graceful fallback when `cols % block_size != 0`. All variants run directly over the bytes streamed off NVMe; the proprietary `ExpertResident` / `BufferPool` / `expert_cache` / O_DIRECT I/O substrate is untouched. |
+| `inference` | SwiGLU expert FFN (`y = down · (silu(gate·x) ⊙ (up·x))`), executed through the **`candle-core`** tensor backend. Implemented per dtype: `run_inference` (F32, zero-copy reinterpret + Candle matmul), `run_inference_f16` / `_int8` / `_q8_0` (dequantise to `f32` then the same Candle SwiGLU kernel), and `run_inference_partial` (load only the top-M input columns by magnitude). For homogeneous GGUF block-quantised dtypes the engine prefers a **`QMatMul` fast path** (`run_inference_q4_0_qmm` / `run_inference_q4k_qmm` / `run_inference_q8_0_qmm`) that hands the on-disk quantised blocks straight to candle's GGML kernels, no F32 dequantise of the weights. For `dtype=mixed`, UTH2 supplies independent gate/up/down dtype+range metadata and the CPU path executes each projection directly from its quantised bytes (`Q4_0`, `Q4_K`, `Q5_K`, `Q6_K`, `Q8_0`, plus float projections) without materialising full F32 matrices per activation. The legacy dequant kernels remain as reference/debug paths. All variants run directly over the bytes streamed off NVMe; the proprietary `ExpertResident` / `BufferPool` / `expert_cache` / O_DIRECT I/O substrate is untouched. |
 | `transformer` | Scalar `f32` dense pieces of the Mixtral / Llama decoder layer: `RmsNorm`, `apply_rope_inplace`, `MultiHeadSelfAttention` (with **GQA** when `num_kv_heads < num_heads` and optional **sliding-window** attention, resolved **per layer** so hybrid SWA/global families like MiMo-V2 and GPT-OSS mix modes within one model), `TransformerLayer`, `KvCache` (16-token blocks, can be backed by the `block_pool` slab; `evict_before` drops leading blocks to bound sliding-window caches), `LMHead`, and the `matmul_row_major` dispatch. `matmul_row_major` auto-escalates: scalar → runtime row-parallel (always compiled, via `parallel::par_row_chunks`) → `matrixmultiply` SGEMV under `--features blas`. |
 | `parallel` | Architecture-agnostic **row-parallel execution helper** shared by every dense kernel across every supported family (`matmul_row_major`, the per-expert `gate_up_swiglu` / `down_proj`, the MoE router gate, DeepSeek MLA projections, the LM head). `par_row_chunks` fans disjoint output-row chunks onto a **shared, process-wide `rayon` work-stealing pool** that is created once and reused, so the per-token hot path never spawns/joins OS threads per call (the previous `std::thread::scope` design spawned fresh threads on every matmul), and concurrent requests under continuous batching contend for **one bounded pool** instead of each oversubscribing the box by `N × cores`. The pool is sized at startup by `init_global_pool` to the host's logical cores **minus a small reservation** (`default_compute_threads`: 0 on ≤4-core hosts, 1 on 5–8, two from 9 up, growing by one per extra 16 cores) so a saturated fan-out cannot starve the tokio async runtime; `RAYON_NUM_THREADS` overrides it. Matmuls below an element threshold run inline on the caller; output is bit-identical to the serial reference. |
 | `model` | `RealModel`, full multi-layer decoder built on top of `transformer`. Owns the dense (resident) weights, drives the per-token forward (`embedding → stacked layers → final RMSNorm → LM head`), and addresses experts as `global_id = layer * num_experts + local_id` so the existing single-namespace cache + storage layers work unchanged. Loads dense weights from per-tensor `.bin` files (`from_dir`) **or** HuggingFace `.safetensors` shards (`from_safetensors`); `from_dir_auto` picks the right one. Missing tensors fall back to a deterministic seeded init. Also exposes `peek_experts` (cheap, side-effect-free routing pre-pass) and `step_speculative` (verify K draft tokens with a unified expert prefetch, gist Phase 2; the preview KV growth for positions `k ≥ 1` is now seeded from a layer-0 draft-token embedding + RoPE projection rather than zero vectors so the verifier's lookahead is not routed on garbage activations, gist Part 2 fix #3). |
@@ -517,9 +517,9 @@ The Rust crate (`rust-engine/`) is organised into single-responsibility modules:
 | `session` | In-memory KV-cache session store (`DashMap`-backed) for multi-turn chat. Per-session position cursor + idle-TTL evictor. TTL-driven `evict_expired` now zeroizes each expired session's KV buffers **before** the `Arc<SessionState>` is dropped (gist Part 1 fix #1) so residual user context cannot survive in freed heap pages; `delete` does the same on explicit removal. |
 | `batch_scheduler` | **Continuous batching + multi-tenant fair-share.** An `mpsc`-fed background task drains per-token `StepRequest`s, fuses up to `max_batch_size` requests (or whatever has arrived within `batch_timeout_ms`) into a single batch, and runs their `RealModel::step` calls concurrently against the shared `Engine`. Owns a central `RequestRegistry` so the channel carries only `{ id, token, pos, params }` per token, never the full `Vec<KvCache>`, and optionally owns the shared `BlockPool` for paged KV. Each batched step starts with a **peek/warm pre-pass** that calls `RealModel::peek_experts` for every request, unions the predicted expert ids, and fires one `engine.warm_with(&ids)` so the NVMe sees one read per unique expert across the entire batch (gist Phase 1). Registered sessions carry a **`SessionClass`** (`Interactive` weight 4, `Audit` weight 1) consumed by the **Weighted Round-Robin admission policy** so an Audit flood cannot starve Interactive callers, plus a monotonic `last_activity_us` timestamp the scheduler loop uses to **reclaim KV blocks** from sessions idle ≥ `idle_eviction_threshold` (default 5 s) when the pool crosses its soft-cap. Under `PressureLevel::Critical` the scheduler suspends the shared `SpeculationController` so prefetch depth is clamped to zero. |
 | `engine` | Top-level orchestrator. Owns the router, predictor (`S` + `L` + `M`), cache, pool, storage, alias map, frequency-pin counters, HDR histograms, and the alias/locality/speculator atomic telemetry. Drives the per-token cycle (`Engine::generate` and `Engine::moe_step`), schedules `union_prefetch`es, and reconciles the locality hot set with the cache's pin set. `spawn_prefetch` is **bounded** by a `tokio::sync::Semaphore` sized from `EngineOptions::max_concurrent_prefetches` (default 64, configurable via `[real_transformer].max_concurrent_prefetches`, gist Part 1 fix #3): an owned permit is acquired *before* `tokio::spawn`, so the bound is enforced before any task work happens; refusals bump `Counters::prefetch_dropped_concurrency` (also surfaced on `EngineReport`). `Engine::fetch_once` likewise bounds its `tokio::task::yield_now()` spin loop at `EngineOptions::max_fetch_yields` (default 128, configurable via `[real_transformer].max_fetch_yields`, gist feedback #1.3): when the cache is full of pinned residents and no `PooledBuffer` frees within the budget, `fetch_once` returns `FetchOnceError::PoolStarved` instead of yielding indefinitely. |
-| `gguf` | Minimal **GGUF reader** (versions 1, 2, 3): magic / metadata / tensor table, recognises `F32`, `F16`, `Q4_0`, `Q4_K`, `Q6_K`, `Q8_0`. Two single-file readers ship side-by-side: `GgufFile::open` (eager, slurps the file into RAM, useful for tests) and `GgufStreamReader::open` (streaming, keeps only the header resident and seeks tensor bodies on demand, the default for `gguf-convert`). Standard `*-00001-of-00005.gguf` shard sets are opened as one read-only `GgufSource` without merging shard files. |
-| `gguf_loader` | Glue from a `GgufSource` → per-expert `.bin` files + `metadata.json` + dense weight files. Each expert file is page-aligned and (by default) prefixed with a 64-byte **Unified Tensor Header**; `--no-uth` opts out. Pass `--native-quant` to write raw `Q4_0` / `Q4_K` / `Q8_0` block streams to disk instead of dequantising to F32 (~7× smaller `.bin` files for the 4-bit dtypes, ~4× smaller for `Q8_0`; falls back automatically if the source dtype is ineligible). Driven by the `gguf-convert` subcommand. |
-| `tensor_header` | 64-byte **U.T.H.** (`UTH1` magic, dtype, shape, quant-scale offset, AMX tile hint, flags). Self-describing prefix written by `gguf-convert` and transparently stripped by `ExpertResident::data()` so downstream kernels never see it. |
+| `gguf` | Minimal **GGUF reader** (versions 1, 2, 3): magic / metadata / tensor table, recognises `F32`, `F16`, `Q4_0`, `Q4_K`, `Q5_K`, `Q6_K`, `Q8_0`. Two single-file readers ship side-by-side: `GgufFile::open` (eager, slurps the file into RAM, useful for tests) and `GgufStreamReader::open` (streaming, keeps only the header resident and seeks tensor bodies on demand, the default for `gguf-convert`). Standard `*-00001-of-00005.gguf` shard sets are opened as one read-only `GgufSource` without merging shard files; shard 1 supplies canonical model metadata and later shards may omit duplicated model-level keys when tensor/split metadata remains consistent. |
+| `gguf_loader` | Glue from a `GgufSource` → per-expert `.bin` files + `metadata.json` + optional dense weight files. Conversion preflights the expert layout before publishing output, writes into a sibling staging directory, validates the staged dataset, then renames it into place. Each expert file is page-aligned and (by default) prefixed with **UTH1** for homogeneous tensors or **UTH2** for mixed projection layouts; `--no-uth` opts out where the selected layout permits it. Pass `--native-quant` to write raw `Q4_0` / `Q4_K` / `Q5_K` / `Q6_K` / `Q8_0` projection streams to disk instead of dequantising to F32; unsupported or non-executable layouts fail during preflight. `--experts-only` skips dense tensor extraction and records `conversion_mode=experts_only`. |
+| `tensor_header` | **U.T.H.** metadata prefix. `UTH1` is a 64-byte homogeneous tensor header (`dtype`, shape, quant-scale offset, AMX tile hint, flags). `UTH2` is a mixed-projection expert header with independent gate/up/down dtype, offset, length, and weight counts. Both are padded to the configured block alignment and transparently stripped by `ExpertResident::data()` so downstream kernels see payload bytes only. |
 | `kernels` | Runtime CPU-feature dispatcher (`mod.rs::detect()` + `current()` + `cpu_features()`), with `scalar.rs` (always on, also home of the `swiglu_f32` reference oracle plus the `dot_int8_int8` scalar reference for VNNI), `avx2.rs` (always compiled on x86_64, no cargo feature; the `#[target_feature]` entry points are gated on the runtime probe), `avx512.rs` (`--features avx512`, `#[target_feature]` fused int8 dequant + dot, the 4×-unrolled `dot_f32_avx512`, the fused per-row `swiglu_f32_avx512` kernel, **and** the AVX-512 VNNI int8×int8 dot `dot_int8_int8_avx512_vnni` built on `_mm512_dpbusd_epi32`, gist Part 2 fix #8, with the i8→u8 bias-trick correction so the inner reduction stays in i32 integer registers), and `amx.rs` (`--features amx`, skeleton until tile intrinsics stabilise on stable Rust). The dispatcher also exposes `swiglu_f32_into(gate_w, up_w, x, rows, cols, y)` which routes to the AVX-512 fused kernel on capable hosts and the scalar reference elsewhere, caller owns `y`, no allocation on the hot path. The probe reads `/proc/cpuinfo` to recognise Sapphire-Rapids-class Xeons so AMX can be preferred on the chips it ships on. The selected backend is logged once at startup. |
 | `backend` | Plugin-system math `Backend` trait (`matmul`, `matmul_into`, `swiglu_into`, `softmax`, `silu_inplace`) with three built-in implementations: `ScalarBackend` (pure Rust reference), `CandleBackend` (default CPU executor, dispatches through `kernels::dot_f32` / `kernels::swiglu_f32_into`, no `candle_core::Tensor` rebuild on the hot path, **zero allocation** in either call), and `GpuBackend` (gist Part 2 fix #5, budget-GPU executor selected by `[real_transformer].compute_offload = "gpu"`; both the integration seam and the `wgpu` compute pipeline compile on every build, the `gpu` cargo feature is now a no-op kept only for backwards compatibility). Both CPU backends override `matmul_into` to dispatch through `kernels::dot_f32` (auto-escalates AVX-512 → AVX2 → scalar). The active backend is installed once at startup via `backend::install_default()` (or, when `compute_offload = "gpu"`, `set_backend(GpuBackend::try_new())` runs first) and resolved on the hot path through `backend::current()`, a single `OnceLock` load, no `cfg!` dispatch. New executors (Burn, Tract, custom CUDA) implement `Backend` and call `set_backend(Arc<dyn Backend>)` before the first token is generated. |
 | `io_reactor` | **Actor-pattern I/O reactor** (gist Part 5 doc fix). Wraps an `NvmeStorage` behind a single-owner tokio task that runs a **bounded serial loop**: it dequeues read requests from a bounded `mpsc` channel one at a time, `await`s the read inline, replies over the per-request `oneshot`, and only then pulls the next request, the bounded queue therefore also bounds active I/O concurrency. `IoReactorHandle` is cheaply cloneable (the sender side is reference-counted by tokio); workers issue `read_expert(id, buf)` without ever touching a shared `DashMap` shard / `RwLock` write guard. Backpressure is automatic, when the I/O substrate saturates, callers park on `mpsc::send` instead of overflowing a per-thread queue. Exposed as a standalone helper alongside the legacy `engine` path so the in-flight `DashMap<u32, Notify>` deduplicator can retire one subsystem at a time. |
@@ -532,7 +532,7 @@ The Rust crate (`rust-engine/`) is organised into single-responsibility modules:
 | `rpc` | Sharded `RouteExperts` RPC frames (gist Part 4): the deterministic `shard_for_expert` routing function plus the packed `RouteExpertsRequest` / `RouteExpertsResponse` f16 wire frames documented in `docs/distributed.md`. Dependency-free so the default build stays slim; the real `tonic`/`prost` gRPC transport in `grpc` (behind `--features grpc`) reuses these frames and their f16 pack/unpack helpers as the single source of truth for the on-wire layout. |
 | `distributed` | `ShardRouter` trait + `LocalShardRouter` default for distributed expert sharding. Routes expert lookups into `ShardInstruction::{Local, Remote}` decisions; remote fetches return a boxed `ShardFetchFuture` (object-safe without `async-trait`) and surface structured `ShardRouterError`s (`Timeout`, `Unreachable`, `NotFound`, `Transport`, `PartialFailure { node, delivered, missing }`, the last covers streaming-gRPC partial-success responses where some experts arrived and others did not) wrapped in `InferenceError::RemoteShardFetchFailed`. The default `LocalShardRouter` always routes locally, so single-node deployments behave identically to today; new transports plug in by implementing the trait. `RpcShardRouter` is a working gRPC router: with `--features grpc` its `fetch_remote` performs a real tonic `Health` round-trip against the owning shard (via `grpc::probe_remote`) and translates tonic status codes through `map_tonic_status` (`DeadlineExceeded`/`Cancelled` → `Timeout`, `Unavailable` → `Unreachable`, `NotFound` → `NotFound`, `Aborted`/other → `Transport`); without the feature the remote path returns a structured `Unreachable`. |
 | `grpc` | **Real gRPC/tonic transport for expert sharding (behind `--features grpc`).** The `ExpertShard` server (`grpc::serve` over a `ShardCompute` backend), the `ShardClient` (`route_experts` + `health`), and `probe_remote` (the reachability check `RpcShardRouter::fetch_remote` calls). Bridges the packed-f16 `rpc` frames to the committed `prost` stubs in `grpc_gen` (generated from `proto/route_experts.proto`; **no build-time `protoc`**). Off by default so `tonic`/`prost` (~150 crates) stay out of the standard build. |
-| `main` | `clap`-based CLI with `gen-data`, `run`, `gguf-convert`, `validate-predictor`, `serve`, and (with `--features tui`, on by default) `monitor` subcommands; structured `tracing` logs; `--first-token 3,7` to reproduce the spec example; `--io-only` for pure-I/O benchmarking; `--force-ssd` to refuse page-cache shortcuts; `--data-dir DIR1,DIR2...` for multi-drive striping; and auto-loading of `metadata.json` (written by `scripts/extract_mixtral_experts.py` or `gguf-convert`) so a real Mixtral checkpoint runs with no further flags. |
+| `main` | `clap`-based CLI with `gen-data`, `run`, `gguf-convert`, `validate-data`, `validate-predictor`, `serve`, and (with `--features tui`, on by default) `monitor` subcommands; structured `tracing` logs; `--first-token 3,7` to reproduce the spec example; `--io-only` for pure-I/O benchmarking; `--force-ssd` to refuse page-cache shortcuts; `--data-dir DIR1,DIR2...` for multi-drive striping; and auto-loading of `metadata.json` (written by `scripts/extract_mixtral_experts.py` or `gguf-convert`) so a real Mixtral checkpoint runs with no further flags. |
 
 ### Key design decisions
 
@@ -1865,12 +1865,18 @@ micro-expert-router gguf-convert
                               expert blob (compat with pre-UTH consumers)
   --legacy-eager             Use the in-memory GGUF reader instead of the
                               default streaming reader
-  --native-quant             For Q4_0 / Q4_K / Q8_0 source tensors,
+  --native-quant             For executable quantised source tensors
+                              (Q4_0 / Q4_K / Q5_K / Q6_K / Q8_0),
                               write the raw quantised block stream to
                               disk instead of dequantising to F32.
-                              Falls back to F32 (with a logged warning)
-                              when the source dtype isn't quantised or
-                              shapes aren't block-aligned.
+                              Fails during preflight when the source dtype
+                              or shape cannot be executed safely.
+  --experts-only             Write expert blobs + metadata only, skipping
+                              dense transformer tensor extraction.
+
+micro-expert-router validate-data
+  --data-dir <PATH>          Validate converted expert_<id>.bin files and
+                              metadata.json before running inference.
 
 micro-expert-router validate-predictor
   --trace <PATH>             JSONL trace from `run --trace-out`
@@ -1935,15 +1941,15 @@ cargo run --release --manifest-path rust-engine/Cargo.toml -- \
 the engine's built-in GGUF reader handles llama.cpp / Ollama-style
 files directly. The currently verified Mixtral conversion and benchmark
 path is **Q4_0**. Native passthrough supports homogeneous expert
-projection triples in `Q4_0`, `Q4_K`, or `Q8_0` when gate, up, and down
-all share that dtype and the tensor shapes satisfy the block-alignment
-requirements. Arbitrary model-level `Q4_K_M` files are **not** the same
-as homogeneous `q4k` expert blobs: common `Q4_K_M` recipes can mix
-`Q4_K` and `Q6_K` projections, and mixed triples are unsupported until
-the runtime format supports per-projection dtypes. The output directory
-has the same shape as the Mixtral extractor's:
-`expert_<layer>_<id>.bin` blobs + `metadata.json` + per-tensor dense
-weight files.
+projection triples in `Q4_0`, `Q4_K`, `Q5_K`, `Q6_K`, or `Q8_0`.
+When gate, up, and down use different executable projection dtypes, the
+converter writes `dtype=mixed` experts with UTH2 range metadata and the
+runtime dispatches each projection independently. Arbitrary model-level
+quantization recipes are still not automatically supported: every
+expert projection must be present, sized correctly, block-addressable,
+and executable by the CPU runtime. The output directory uses global
+`expert_<id>.bin` blobs + `metadata.json`; full conversion also writes
+per-tensor dense weight files.
 
 `gguf-convert` defaults to a **streaming reader** that parses only
 the GGUF header and seeks each tensor body on demand, a strict win
@@ -1951,34 +1957,41 @@ for ≥ 100 GB checkpoints. `--gguf-path` may point to a normal GGUF
 or to any file in a standard split set such as
 `Model-Q4_0-00002-of-00005.gguf`; the converter discovers sibling
 shards, validates split metadata when present, and exposes one tensor
-namespace without merging files. Pass `--legacy-eager` to fall back to the
-in-memory reader for ordinary single-file GGUFs. By default every `expert_<id>.bin` is prefixed with
-a 64-byte **Unified Tensor Header** (dtype + shape + AMX tile hint +
-quant-scale offset) padded to 4 KiB so the weight payload still
-starts at an `O_DIRECT`-friendly boundary; pass `--no-uth` to opt
-out for compatibility with consumers that pre-date the header.
+namespace without merging files. Shard 1 is the canonical source of
+model-level metadata such as `general.architecture`; later shards may
+omit those keys, and any repeated canonical value must match shard 1.
+Pass `--legacy-eager` to fall back to the in-memory reader for ordinary
+single-file GGUFs. By default every `expert_<id>.bin` is prefixed with a
+Unified Tensor Header padded to the configured block alignment so the
+weight payload still starts at an `O_DIRECT`-friendly boundary: UTH1 for
+homogeneous experts, UTH2 for mixed per-projection experts. Pass
+`--no-uth` only for layouts that do not require UTH2.
 
-For source GGUFs whose expert tensors are already stored as homogeneous
-`Q4_0`, `Q4_K`, or `Q8_0`, pass `--native-quant` to write the **raw
-quantised block stream** to disk instead of dequantising to F32 first.
-The output `expert_<id>.bin` is then ~7× smaller for the 4-bit dtypes
-(~4× smaller for `Q8_0`) and the engine's `run_inference_q4_0` /
-`run_inference_q4k` / `run_inference_q8_0` paths consume it directly.
-The flag falls back automatically (with a logged warning) when the
-source dtype is ineligible, mixed, or not block-aligned; the converter
-records what was actually written into `metadata.json::dtype`.
+Pass `--native-quant` to write the **raw quantised block stream** to disk
+instead of dequantising to F32 first. Conversion is fail-closed: if any
+required expert tensor is missing, malformed, unsupported, or not
+executable by the planned runtime, preflight fails before the final
+output directory is created. The converter writes into a sibling
+`.tmp-<pid>-<nonce>` staging directory, validates every staged expert
+file and `metadata.json`, then atomically renames staging into place.
+Existing nonempty output directories are refused rather than destroyed.
 
-> **Conversion warning:** logs containing `emitting zero blob` mean the
-> converter wrote placeholder expert weights because source tensors were
-> missing or unsupported. That output is useful for surfacing a loader
-> problem, but it is **not** a successful usable model conversion.
+Use `--experts-only` for the expert-streaming benchmark path. It writes
+expert blobs and metadata, skips dense transformer tensors, and records
+`"conversion_mode": "experts_only"` in `metadata.json`. Validate any
+converted dataset explicitly with:
+
+```bash
+./target/release/micro-expert-router validate-data \
+    --data-dir ./mixtral-data
+```
 
 ```bash
 ./target/release/micro-expert-router gguf-convert \
     --gguf-path ./mixtral-8x7b-instruct-v0.1.Q4_0.gguf \
     --out-dir   ./mixtral-data \
     --native-quant \
-    # add --no-uth and/or --legacy-eager if your tooling needs them
+    --experts-only
 
 ./target/release/micro-expert-router run --data-dir ./mixtral-data
 ```
@@ -2165,12 +2178,14 @@ is that **Q4_0 is the verified practical path for running Mixtral 8x7B
 expert blobs from SSD**: it fits the full 8x7B expert namespace in
 about 24 GB of NVMe and keeps per-layer cold-miss I/O in the tens of
 milliseconds on PCIe-4-class storage. Homogeneous `Q4_K` can use the
-same native expert-blob path when eligible, but mixed `Q4_K/Q6_K`
-model-level recipes need converter/runtime work before they should be
-documented as usable. Mixtral-8x22B needs PCIe-5 or multi-drive striping
-(see `--data-dir DIR1,DIR2...`) to stay interactive at 4-bit; bf16 /
-f16 are best treated as fidelity references rather than production
-knobs.
+same native expert-blob path when eligible, and mixed executable triples
+such as `Q4_K/Q4_K/Q6_K` are represented with UTH2 and run on the CPU
+mixed path without full-weight F32 expansion. Mixtral-8x22B still needs
+PCIe-5 or multi-drive striping (see `--data-dir DIR1,DIR2...`) to stay
+interactive at 4-bit, and this README does not claim a measured 8x22B
+end-to-end throughput result without running the original split
+checkpoint; bf16 / f16 are best treated as fidelity references rather
+than production knobs.
 
 ### Routing model, Markov chain, transition matrix, or LinearGate
 
@@ -2230,7 +2245,7 @@ the learned per-layer `LinearGate` driven by hidden state.
 | Verified end-to-end benchmark | Mixtral 8x7B Q4_0 expert blobs, 256 layer-qualified experts, top-2 routing, CPU path | Latest observed cache-scaling results are in the benchmark section above. |
 | Implemented but not benchmark-validated here | Mixtral/Llama-MoE, Qwen3-MoE, DeepSeek-V3/V3.1, MiMo-V2-Flash, GPT-OSS source paths | Architecture parsing, model construction, routing, and runtime hooks exist, but this README should not imply published throughput/quality validation for each family. |
 | Loader/schema or dense support | Qwen3 dense, Mistral Small 3, Phi-4 | Useful for tensor-name coverage and dense smoke runs; they do not exercise SSD expert streaming. |
-| Known limitations | Arbitrary sparse MoE families, mixed `Q4_K/Q6_K` expert triples, unsupported projection dtypes, and conversion logs with `emitting zero blob` | Require separate implementation or validation before being documented as usable. |
+| Known limitations | Arbitrary sparse MoE families, unsupported projection dtypes, dense quantized GGUF transformer kernels, and unvalidated quantization recipes outside the executable projection set | Require separate implementation or validation before being documented as usable. |
 
 Per-expert sizing is still useful for planning: a Mixtral 8x7B expert is
 about 336 MiB at bf16/f16, about 168-178 MiB at int8/Q8_0, and about
@@ -2437,15 +2452,18 @@ read. Six on-disk dtypes are first-class:
 | `q4k` | ~0.5625 | none (block-internal) | **default**: candle `QMatMul` directly over a homogeneous on-disk `Q4_K` 256-block stream, no F32 dequant of the weights. **Fallback**: 256-block dequant (f16 super-scale + 6-bit sub-scales + 4-bit weights) when `cols % 256 != 0`. | GGUF-compatible 4-bit expert blob; do not confuse with arbitrary model-level `Q4_K_M` recipes |
 | `q4_0` | ~0.5625 | none (block-internal) | **default**: candle `QMatMul` directly over the on-disk `Q4_0` 32-block stream, no F32 dequant of the weights. **Fallback**: 32-block dequant (f16 scale, symmetric 4-bit nibbles) when `cols % 32 != 0`. | the most widely-used 4-bit format; chosen by the predictive-controller spec |
 | `q8_0` | ~1.0625 | none (block-internal) | **default**: candle `QMatMul` directly over the on-disk `Q8_0` 32-block stream (one `f16` scale + 32 signed `i8` weights per block). **Fallback**: 32-block dequant when `cols % 32 != 0`. | GGUF-compatible 8-bit; same density as `int8` but with **per-block** scales, so dynamic range stays bounded inside each 32-weight neighbourhood |
+| `mixed` | varies by projection | UTH2 required | CPU direct projection dispatch over gate/up/down ranges without full-weight F32 expansion. Supported projection dtypes include `Q4_0`, `Q4_K`, `Q5_K`, `Q6_K`, `Q8_0`, `F32`, `F16`, and `BF16`; unsupported projection dtypes fail before execution. | GGUF mixed expert triples such as `Q4_K/Q4_K/Q6_K`; GPU execution is not advertised for Q5_K/Q6_K |
 
 Selectable on **`gen-data`** (synthetic data, every dtype has a
 matching generator arm), on **`gguf-convert`** (input format detected
-from the GGUF tensor dtype, output written in the same dtype, pass
-`--native-quant` to write the raw `Q4_0` / `Q4_K` / `Q8_0` block
-stream instead of dequantising to F32), and on **`run` / `serve`**
-(must match the on-disk files). The forward pass dispatches to
-`inference::run_inference_*` per dtype, all producing the same scalar
-`f32` SwiGLU output, so a benchmark run is a one-flag diff.
+from the GGUF tensor dtype, pass `--native-quant` to write raw
+`Q4_0` / `Q4_K` / `Q5_K` / `Q6_K` / `Q8_0` projection streams and UTH2
+mixed layouts instead of dequantising to F32), and on **`run` / `serve`**
+(must match the on-disk files). Native quant conversion is fail-closed:
+unsupported projection dtypes or unsafe shapes abort preflight instead of
+silently expanding experts to F32. The forward pass dispatches to
+`inference::run_inference_*` per dtype, all producing scalar `f32`
+SwiGLU output, so a benchmark run is a one-flag diff.
 
 **Quantised fast path.** For `q4k`, `q4_0`, and `q8_0` the engine
 prefers the `QMatMul` path (`run_inference_q4_0_qmm` /
@@ -2457,6 +2475,14 @@ path on real Mixtral shapes (`d_model=4096`, `d_ff=14336`, all three
 formats block-aligned). The dequant kernel remains as a graceful
 fallback for shapes that aren't block-aligned and is always selected
 when `EngineOptions::use_qmm_for_q4 = false`.
+
+**Mixed quantized path.** For `mixed`, UTH2 is parsed when the expert
+becomes resident using the dataset's configured `block_align`; the hot
+path reuses those projection ranges and allocates only activation-sized
+F32 buffers (`d_ff` and `d_model`). The reference full-dequant decoder is
+kept for tests/debugging, while normal mixed execution increments the
+mixed/quantized dispatch counters and should leave
+`mixed_dequant_fallbacks` at zero.
 
 **How this saves energy.** Every cache miss reads
 `3 · d_model · d_ff` weights off the SSD. Going from `f32` → `f16`

--- a/rust-engine/src/engine.rs
+++ b/rust-engine/src/engine.rs
@@ -4371,6 +4371,7 @@ impl Engine {
             r.expert_size,
             if r.dtype == WeightDtype::Mixed {
                 r.expert_size
+                    .saturating_sub(self.core.storage.config().block_align)
             } else {
                 crate::inference::expert_weight_bytes_for(r.d_model, r.d_ff, r.dtype)
             },

--- a/rust-engine/src/engine.rs
+++ b/rust-engine/src/engine.rs
@@ -1483,11 +1483,16 @@ fn dispatch_expert_forward(
     static LOG_FIRST_EXPERT_SIZE_ONCE: std::sync::Once = std::sync::Once::new();
     LOG_FIRST_EXPERT_SIZE_ONCE.call_once(|| {
         let actual = r.data().len();
-        let expected = crate::inference::expert_weight_bytes_for(d_model, d_ff, dtype);
+        let expected = if dtype == WeightDtype::Mixed {
+            r.buffer.as_slice().len()
+        } else {
+            crate::inference::expert_weight_bytes_for(d_model, d_ff, dtype)
+        };
         info!(
             expert = r.id,
             dtype = dtype.as_str(),
-            actual_bytes = actual,
+            payload_bytes = actual,
+            physical_slot_bytes = r.buffer.as_slice().len(),
             expected_bytes = expected,
             d_model,
             d_ff,
@@ -2753,7 +2758,11 @@ impl Engine {
                     .counters
                     .bytes_read
                     .fetch_add(buf.len() as u64, Ordering::Relaxed);
-                let resident = Arc::new(ExpertResident::new(id, buf));
+                let resident = Arc::new(ExpertResident::new_with_block_align(
+                    id,
+                    buf,
+                    self.core.storage.config().block_align,
+                ));
                 match self.core.cache.insert(resident.clone()) {
                     Ok(Some(_evicted)) => debug!(expert = id, "inserted (with eviction)"),
                     Ok(None) => debug!(expert = id, "inserted"),
@@ -2957,7 +2966,11 @@ impl Engine {
                     // identical either way (promotion only changes the
                     // drop destination), and a shadow-backed resident
                     // serves cache hits exactly like a primary-backed one.
-                    let resident = Arc::new(ExpertResident::new(id, buf));
+                    let resident = Arc::new(ExpertResident::new_with_block_align(
+                        id,
+                        buf,
+                        me.core.storage.config().block_align,
+                    ));
                     // Prefetches are best-effort: if the cache rejects
                     // the insert (every slot pinned), the resident drops
                     // here and its buffer returns to the shadow pool —
@@ -4224,6 +4237,7 @@ impl Engine {
             top_k: self.core.router.top_k(),
             d_model: self.core.shape.d_model,
             d_ff: self.core.shape.d_ff,
+            expert_size: self.core.storage.config().expert_size,
             predictor_observations: self.core.predictor.observations(),
             tokens_processed: tokens,
             avg_io_wait_us,
@@ -4351,12 +4365,26 @@ impl Engine {
             r.num_experts, r.top_k, r.cache_capacity, r.pool_capacity
         );
         info!(
-            "ffn shape:     d_model={}  d_ff={}  bytes/expert={} (dtype={})",
+            "ffn shape:     d_model={}  d_ff={}  expert slot={} bytes  payload={} bytes (dtype={})",
             r.d_model,
             r.d_ff,
-            crate::inference::expert_weight_bytes_for(r.d_model, r.d_ff, r.dtype),
+            r.expert_size,
+            if r.dtype == WeightDtype::Mixed {
+                r.expert_size
+            } else {
+                crate::inference::expert_weight_bytes_for(r.d_model, r.d_ff, r.dtype)
+            },
             r.dtype.as_str()
         );
+        if r.dtype == WeightDtype::Mixed {
+            info!(
+                "mixed quant:   experts={}  projections={}  dequant_fallbacks={}  unsupported_dispatches={}",
+                crate::inference::mixed_expert_dispatches(),
+                crate::inference::quantized_projection_dispatches(),
+                crate::inference::mixed_dequant_fallbacks(),
+                crate::inference::unsupported_quant_dispatches()
+            );
+        }
         info!(
             "lookups:       hits={}  misses={}  hit_rate={:.2}%",
             r.hits, r.misses, hit_rate
@@ -4509,6 +4537,7 @@ pub struct EngineReport {
     pub top_k: usize,
     pub d_model: usize,
     pub d_ff: usize,
+    pub expert_size: usize,
     pub predictor_observations: u64,
     /// Number of `Engine::generate` calls completed.
     pub tokens_processed: u64,

--- a/rust-engine/src/expert_cache.rs
+++ b/rust-engine/src/expert_cache.rs
@@ -896,6 +896,28 @@ mod tests {
         assert_eq!(resident.data().len(), block_align);
         assert!(resident.data()[..64].iter().all(|&b| b == 0xA5));
         assert!(resident.data()[64..].iter().all(|&b| b == 0));
+
+        let range = |offset| crate::tensor_header::ProjectionRange {
+            dtype: crate::tensor_header::UthDtypeId::F32,
+            offset,
+            len: 16,
+            weights: 4,
+        };
+        let mixed =
+            crate::tensor_header::MixedExpertHeader::new(2, 2, range(0), range(16), range(32));
+        let mut mixed_file = Vec::new();
+        mixed.write_padded(block_align, &mut mixed_file);
+        mixed_file.extend_from_slice(&[0x5Au8; 64]);
+        mixed_file.resize(block_align * 2, 0);
+
+        let pool = BufferPool::new(1, mixed_file.len(), block_align);
+        let mut buffer = pool.try_acquire().unwrap();
+        buffer.as_mut_slice().copy_from_slice(&mixed_file);
+        let resident = ExpertResident::new_with_block_align(1, buffer, block_align);
+        assert!(resident.mixed_layout().is_some());
+        assert_eq!(resident.data().len(), block_align);
+        assert!(resident.data()[..64].iter().all(|&b| b == 0x5A));
+        assert!(resident.data()[64..].iter().all(|&b| b == 0));
     }
 
     #[test]

--- a/rust-engine/src/expert_cache.rs
+++ b/rust-engine/src/expert_cache.rs
@@ -85,13 +85,21 @@ impl ExpertResident {
     /// payload offset once. Subsequent calls to [`Self::data`] do not
     /// re-probe the header.
     pub fn new(id: u32, buffer: PooledBuffer) -> Self {
+        Self::new_with_block_align(id, buffer, DEFAULT_BLOCK_ALIGN)
+    }
+
+    /// Construct a resident expert using the block alignment declared
+    /// by the storage metadata. This is required for UTH1/UTH2 payload
+    /// offsets to be parsed correctly when a dataset was converted with
+    /// an alignment other than 4096 bytes.
+    pub fn new_with_block_align(id: u32, buffer: PooledBuffer, block_align: usize) -> Self {
         let (payload_offset, mixed_layout) = {
             let raw = buffer.as_slice();
             let (payload, mixed) =
-                if let Some((h, payload)) = MixedExpertHeader::strip(raw, DEFAULT_BLOCK_ALIGN) {
+                if let Some((h, payload)) = MixedExpertHeader::strip(raw, block_align) {
                     (payload, Some(h))
                 } else {
-                    let (_, payload) = TensorHeader::strip(raw, DEFAULT_BLOCK_ALIGN);
+                    let (_, payload) = TensorHeader::strip(raw, block_align);
                     (payload, None)
                 };
             // `payload` is either `raw` unchanged (offset 0) or a suffix
@@ -866,6 +874,28 @@ mod tests {
     fn make(id: u32, pool: &BufferPool) -> Arc<ExpertResident> {
         let buffer = pool.try_acquire().unwrap();
         Arc::new(ExpertResident::new(id, buffer))
+    }
+
+    #[test]
+    fn resident_uses_configured_block_align_for_uth_payload() {
+        let block_align = 8192usize;
+        let mut file = Vec::new();
+        crate::tensor_header::TensorHeader::for_swiglu_expert(
+            crate::inference::WeightDtype::F32,
+            8,
+            16,
+        )
+        .write_padded(block_align, &mut file);
+        file.extend_from_slice(&[0xA5u8; 64]);
+        file.resize(block_align * 2, 0);
+
+        let pool = BufferPool::new(1, file.len(), block_align);
+        let mut buffer = pool.try_acquire().unwrap();
+        buffer.as_mut_slice().copy_from_slice(&file);
+        let resident = ExpertResident::new_with_block_align(0, buffer, block_align);
+        assert_eq!(resident.data().len(), block_align);
+        assert!(resident.data()[..64].iter().all(|&b| b == 0xA5));
+        assert!(resident.data()[64..].iter().all(|&b| b == 0));
     }
 
     #[test]

--- a/rust-engine/src/gguf.rs
+++ b/rust-engine/src/gguf.rs
@@ -903,21 +903,19 @@ fn validate_shards(readers: &[GgufStreamReader], expected_count: usize) -> io::R
             ));
         }
 
-        let arch = metadata_str(&reader.metadata, "general.architecture", shard_number)?
-            .ok_or_else(|| {
-                io::Error::new(
+        if let Some(arch) = metadata_str(&reader.metadata, "general.architecture", shard_number)? {
+            if arch != expected_arch {
+                return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
                     format!(
-                        "GGUF shard {shard_number} missing required metadata `general.architecture`"
+                        "GGUF shard {shard_number} metadata `general.architecture` mismatch: expected `{expected_arch}`, actual `{arch}`"
                     ),
-                )
-            })?;
-        if arch != expected_arch {
+                ));
+            }
+        } else if shard_number == 1 {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!(
-                    "GGUF shard {shard_number} general.architecture `{arch}` disagrees with shard 1 `{expected_arch}`"
-                ),
+                format!("GGUF shard 1 missing required metadata `general.architecture`"),
             ));
         }
 
@@ -1186,18 +1184,29 @@ mod tests {
         extra_metadata: &[(&str, GgufValue)],
         tensors: &[SynthTensor],
     ) -> Vec<u8> {
+        synth_gguf_custom_maybe_arch(Some(arch), extra_metadata, tensors)
+    }
+
+    fn synth_gguf_custom_maybe_arch(
+        arch: Option<&str>,
+        extra_metadata: &[(&str, GgufValue)],
+        tensors: &[SynthTensor],
+    ) -> Vec<u8> {
         let mut out = Vec::new();
         out.extend_from_slice(GGUF_MAGIC);
         out.extend_from_slice(&3u32.to_le_bytes());
         out.extend_from_slice(&(tensors.len() as u64).to_le_bytes());
-        out.extend_from_slice(&(2u64 + extra_metadata.len() as u64).to_le_bytes());
+        let base_metadata = 1u64 + u64::from(arch.is_some());
+        out.extend_from_slice(&(base_metadata + extra_metadata.len() as u64).to_le_bytes());
 
         push_metadata(&mut out, "general.alignment", &GgufValue::U32(32));
-        push_metadata(
-            &mut out,
-            "general.architecture",
-            &GgufValue::String(arch.to_owned()),
-        );
+        if let Some(arch) = arch {
+            push_metadata(
+                &mut out,
+                "general.architecture",
+                &GgufValue::String(arch.to_owned()),
+            );
+        }
         for (key, value) in extra_metadata {
             push_metadata(&mut out, key, value);
         }
@@ -1254,6 +1263,26 @@ mod tests {
             ("split.tensors.count", GgufValue::U64(split_tensors_count)),
         ];
         let bytes = synth_gguf_custom(arch, &metadata, tensors);
+        std::fs::write(&path, bytes).unwrap();
+        path
+    }
+
+    fn write_synth_shard_without_arch(
+        dir: &Path,
+        prefix: &str,
+        idx: usize,
+        count: usize,
+        tensors: &[SynthTensor],
+        split_count: u64,
+        split_tensors_count: u64,
+    ) -> PathBuf {
+        let path = shard_path(dir, prefix, idx, count);
+        let metadata = [
+            ("split.no", GgufValue::U32((idx - 1) as u32)),
+            ("split.count", GgufValue::U64(split_count)),
+            ("split.tensors.count", GgufValue::U64(split_tensors_count)),
+        ];
+        let bytes = synth_gguf_custom_maybe_arch(None, &metadata, tensors);
         std::fs::write(&path, bytes).unwrap();
         path
     }
@@ -1443,6 +1472,27 @@ mod tests {
     }
 
     #[test]
+    fn later_shards_may_omit_model_metadata() {
+        let dir = temp_test_dir("gguf-shards-metadata-inheritance");
+        let shard1_tensors = [synth_f32_tensor("left", &[1.0, 2.0, 3.0, 4.0])];
+        let shard2_tensors = [synth_f32_tensor("right", &[9.0, 10.0, 11.0, 12.0])];
+        let shard1 = write_synth_shard(&dir, "Model-Q4_K_M", 1, 2, "llama", &shard1_tensors, 2, 2);
+        write_synth_shard_without_arch(&dir, "Model-Q4_K_M", 2, 2, &shard2_tensors, 2, 2);
+
+        let source = open_gguf_source(&shard1, false).expect("open shard set");
+        assert_eq!(source.architecture(), Some("llama"));
+        assert!(source.tensor_info("left").is_some());
+        assert!(source.tensor_info("right").is_some());
+        let right = source
+            .read_tensor_owned("right")
+            .unwrap()
+            .expect("right tensor");
+        assert_eq!(right, f32_bytes(&[9.0, 10.0, 11.0, 12.0]));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
     fn missing_shard_fails_clearly() {
         let dir = temp_test_dir("gguf-shards-missing");
         let shard2_tensors = [synth_f32_tensor("right", &[9.0, 10.0, 11.0, 12.0])];
@@ -1501,7 +1551,9 @@ mod tests {
 
         let err = open_err(&shard1);
         assert!(
-            err.contains("general.architecture `qwen2moe` disagrees"),
+            err.contains("metadata `general.architecture` mismatch")
+                && err.contains("expected `llama`")
+                && err.contains("actual `qwen2moe`"),
             "{err}"
         );
 

--- a/rust-engine/src/gguf_loader.rs
+++ b/rust-engine/src/gguf_loader.rs
@@ -32,11 +32,12 @@ use crate::inference::{
     Q5K_BLOCK_ELEMS, Q6K_BLOCK_BYTES, Q6K_BLOCK_ELEMS, Q8_0_BLOCK_BYTES, Q8_0_BLOCK_ELEMS,
 };
 use crate::tensor_header::{MixedExpertHeader, ProjectionRange, TensorHeader, UthDtypeId};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fs;
 use std::io::{self, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use tracing::{info, warn};
 
 /// Summary of what `extract_experts_from_gguf` wrote.
@@ -70,7 +71,10 @@ pub struct ExtractionReport {
 
 #[derive(Serialize)]
 struct ExtractedMetadata<'a> {
+    format_version: u32,
+    conversion_mode: &'a str,
     model: &'a str,
+    architecture: &'a str,
     /// `-1` here means "experts from all layers were concatenated";
     /// we mirror the convention of [`scripts/extract_mixtral_experts.py`]
     /// which writes a single integer for one-layer dumps and `-1` for
@@ -81,6 +85,7 @@ struct ExtractedMetadata<'a> {
     d_model: usize,
     d_ff: usize,
     expert_size: usize,
+    maximum_payload_bytes: usize,
     block_align: usize,
     dtype: &'a str,
     weight_layout: &'a str,
@@ -90,11 +95,331 @@ struct ExtractedMetadata<'a> {
     expert_layout_version: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     projection_dtype_histogram: Option<BTreeMap<String, usize>>,
+    experts_written: usize,
+    dense_tensors_written: usize,
 }
 
 /// Block alignment used for every expert file written by this loader.
 /// Mirrors the engine's default in `main.rs`.
 pub const DEFAULT_BLOCK_ALIGN: usize = 4096;
+
+#[derive(Debug, Clone)]
+struct ConversionPreflightPlan {
+    architecture: String,
+    num_layers: usize,
+    num_experts: usize,
+    total_experts: usize,
+    d_model: usize,
+    d_ff: usize,
+    top_k: usize,
+    expert_size: usize,
+    maximum_payload_bytes: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ConversionGeometry {
+    num_layers: usize,
+    num_experts: usize,
+    total_experts: usize,
+    d_model: usize,
+    d_ff: usize,
+    top_k: usize,
+}
+
+fn metadata_lookup<'a>(
+    meta: &'a std::collections::HashMap<String, GgufValue>,
+    arch: Option<&str>,
+    suffix: &str,
+) -> Option<&'a GgufValue> {
+    let dotted = format!(".{suffix}");
+    meta.get(&format!("llama.{suffix}"))
+        .or_else(|| arch.and_then(|a| meta.get(&format!("{a}.{suffix}"))))
+        .or_else(|| {
+            meta.iter()
+                .filter(|(k, _)| k.ends_with(&dotted))
+                .min_by(|(a, _), (b, _)| a.cmp(b))
+                .map(|(_, v)| v)
+        })
+}
+
+fn resolve_geometry(
+    gguf: &dyn GgufSource,
+    num_layers_hint: usize,
+    num_experts_hint: usize,
+) -> io::Result<ConversionGeometry> {
+    let meta = gguf.metadata();
+    let arch = meta.get("general.architecture").and_then(|v| v.as_str());
+    let lookup = |suffix: &str| metadata_lookup(meta, arch, suffix);
+
+    let num_layers = if num_layers_hint > 0 {
+        num_layers_hint
+    } else {
+        lookup("block_count")
+            .and_then(|v| v.as_u64())
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "GGUF missing `block_count`; pass --num-layers explicitly",
+                )
+            })? as usize
+    };
+    let num_experts = if num_experts_hint > 0 {
+        num_experts_hint
+    } else {
+        lookup("expert_count").and_then(|v| v.as_u64()).unwrap_or(0) as usize
+    };
+    if num_experts == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "GGUF has no `expert_count` and no --num-experts override",
+        ));
+    }
+    let d_model = lookup("embedding_length")
+        .and_then(|v| v.as_u64())
+        .ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, "GGUF missing embedding_length")
+        })? as usize;
+    let d_ff = lookup("expert_feed_forward_length")
+        .or_else(|| lookup("feed_forward_length"))
+        .and_then(|v| v.as_u64())
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "GGUF missing feed_forward_length",
+            )
+        })? as usize;
+    let top_k = lookup("expert_used_count")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(2) as usize;
+    let total_experts = num_experts.checked_mul(num_layers).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "num_experts * num_layers overflows usize: num_experts={num_experts}, num_layers={num_layers}"
+            ),
+        )
+    })?;
+
+    Ok(ConversionGeometry {
+        num_layers,
+        num_experts,
+        total_experts,
+        d_model,
+        d_ff,
+        top_k,
+    })
+}
+
+fn build_preflight_plan(
+    gguf: &dyn GgufSource,
+    num_layers_hint: usize,
+    num_experts_hint: usize,
+    opts: &ExtractOptions,
+) -> io::Result<ConversionPreflightPlan> {
+    let geometry = resolve_geometry(gguf, num_layers_hint, num_experts_hint)?;
+    let (expert_size, maximum_payload_bytes) = if opts.native_quant {
+        let scan = scan_expert_quant_layouts(
+            gguf,
+            geometry.num_layers,
+            geometry.num_experts,
+            geometry.d_model,
+            geometry.d_ff,
+        )?;
+        if !scan.rejection_reasons.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                format!(
+                    "native quantization cannot continue: {}",
+                    scan.rejection_reasons.join("; ")
+                ),
+            ));
+        }
+        match scan.into_plan(DEFAULT_BLOCK_ALIGN, opts.emit_uth)? {
+            NativeQuantPlan::Homogeneous { dtype } => {
+                let payload = align_up(
+                    expert_weight_bytes_for(geometry.d_model, geometry.d_ff, dtype),
+                    DEFAULT_BLOCK_ALIGN,
+                );
+                (
+                    payload
+                        + if opts.emit_uth {
+                            DEFAULT_BLOCK_ALIGN
+                        } else {
+                            0
+                        },
+                    payload,
+                )
+            }
+            NativeQuantPlan::Mixed {
+                expert_size,
+                payload_slot_size,
+                ..
+            } => (expert_size, payload_slot_size),
+        }
+    } else {
+        preflight_f32_expert_tensors(gguf, geometry)?;
+        let payload = align_up(
+            expert_weight_bytes_for(geometry.d_model, geometry.d_ff, WeightDtype::F32),
+            DEFAULT_BLOCK_ALIGN,
+        );
+        (
+            payload
+                + if opts.emit_uth {
+                    DEFAULT_BLOCK_ALIGN
+                } else {
+                    0
+                },
+            payload,
+        )
+    };
+
+    Ok(ConversionPreflightPlan {
+        architecture: gguf.architecture().unwrap_or("unknown").to_string(),
+        num_layers: geometry.num_layers,
+        num_experts: geometry.num_experts,
+        total_experts: geometry.total_experts,
+        d_model: geometry.d_model,
+        d_ff: geometry.d_ff,
+        top_k: geometry.top_k,
+        expert_size,
+        maximum_payload_bytes,
+    })
+}
+
+fn preflight_f32_expert_tensors(
+    gguf: &dyn GgufSource,
+    geometry: ConversionGeometry,
+) -> io::Result<()> {
+    let weights = geometry.d_model.checked_mul(geometry.d_ff).ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidData, "d_model * d_ff overflows usize")
+    })?;
+    for layer in 0..geometry.num_layers {
+        let interleaved_gate = format!("blk.{layer}.ffn_gate_exps.weight");
+        if gguf.has_tensor(&interleaved_gate) {
+            for name in [
+                interleaved_gate,
+                format!("blk.{layer}.ffn_up_exps.weight"),
+                format!("blk.{layer}.ffn_down_exps.weight"),
+            ] {
+                let info = gguf.tensor_info(&name).ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::NotFound, format!("missing tensor {name}"))
+                })?;
+                if crate::gguf::ggml_to_weight_dtype(info.ggml_dtype).is_none() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::Unsupported,
+                        format!(
+                            "tensor {name} uses unsupported GGML dtype {}",
+                            info.ggml_dtype
+                        ),
+                    ));
+                }
+                let expected = weights.checked_mul(geometry.num_experts).ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidData, "expert tensor shape overflow")
+                })?;
+                if info.elem_count() != expected as u64 {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!(
+                            "tensor {name} has {} elements, expected {expected}",
+                            info.elem_count()
+                        ),
+                    ));
+                }
+            }
+            continue;
+        }
+
+        if !gguf.has_tensor(&format!("blk.{layer}.ffn_gate.0.weight")) {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("layer {layer} has no expert tensors"),
+            ));
+        }
+        for expert in 0..geometry.num_experts {
+            for name in [
+                format!("blk.{layer}.ffn_gate.{expert}.weight"),
+                format!("blk.{layer}.ffn_up.{expert}.weight"),
+                format!("blk.{layer}.ffn_down.{expert}.weight"),
+            ] {
+                let info = gguf.tensor_info(&name).ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::NotFound, format!("missing tensor {name}"))
+                })?;
+                if crate::gguf::ggml_to_weight_dtype(info.ggml_dtype).is_none() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::Unsupported,
+                        format!(
+                            "tensor {name} uses unsupported GGML dtype {}",
+                            info.ggml_dtype
+                        ),
+                    ));
+                }
+                if info.elem_count() != weights as u64 {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!(
+                            "tensor {name} has {} elements, expected {weights}",
+                            info.elem_count()
+                        ),
+                    ));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn ensure_final_output_available(out_dir: &Path) -> io::Result<()> {
+    match fs::metadata(out_dir) {
+        Ok(meta) if meta.is_dir() => {
+            if fs::read_dir(out_dir)?.next().is_some() {
+                return Err(io::Error::new(
+                    io::ErrorKind::AlreadyExists,
+                    format!(
+                        "output directory {} already exists and is not empty; remove it before conversion",
+                        out_dir.display()
+                    ),
+                ));
+            }
+            fs::remove_dir(out_dir)?;
+        }
+        Ok(_) => {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                format!(
+                    "output path {} exists and is not a directory",
+                    out_dir.display()
+                ),
+            ));
+        }
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+        Err(e) => return Err(e),
+    }
+    Ok(())
+}
+
+fn staging_dir_for(out_dir: &Path) -> io::Result<PathBuf> {
+    static NEXT: AtomicU64 = AtomicU64::new(0);
+    let parent = out_dir.parent().unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(parent)?;
+    let name = out_dir
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("gguf-output");
+    for _ in 0..1024 {
+        let nonce = NEXT.fetch_add(1, Ordering::Relaxed);
+        let candidate = parent.join(format!(".{name}.tmp-{}-{nonce}", std::process::id()));
+        if !candidate.exists() {
+            return Ok(candidate);
+        }
+    }
+    Err(io::Error::new(
+        io::ErrorKind::AlreadyExists,
+        format!(
+            "could not allocate a staging directory for {} after 1024 attempts",
+            out_dir.display()
+        ),
+    ))
+}
 
 /// Extract Mixtral expert + dense weights from `gguf` into `out_dir`.
 ///
@@ -147,12 +472,14 @@ pub struct ExtractOptions {
     /// ~672 MiB f32 down to ~96 MiB Q4_0 — half a GiB less per
     /// expert read off the SSD).
     ///
-    /// Layers / models that don't satisfy the alignment precondition
-    /// **fall back to F32 dequant** transparently and the converter
-    /// keeps making forward progress; the report's `expert_dtype`
-    /// records what was actually written so downstream tooling /
-    /// `metadata.json` always describe the on-disk reality.
+    /// Layers / models that don't satisfy the native quant preconditions
+    /// fail during preflight before any final output is published.
     pub native_quant: bool,
+
+    /// Convert only routed experts. Dense transformer tensors are
+    /// skipped deliberately, metadata records `experts_only`, and the
+    /// resulting dataset remains valid for expert-streaming runs.
+    pub experts_only: bool,
 }
 
 impl Default for ExtractOptions {
@@ -160,6 +487,7 @@ impl Default for ExtractOptions {
         Self {
             emit_uth: true,
             native_quant: false,
+            experts_only: false,
         }
     }
 }
@@ -172,6 +500,51 @@ impl Default for ExtractOptions {
 /// header resident and seeks tensor bodies on demand). For checkpoints
 /// ≥ ~10 GB the streaming reader is the right default.
 pub fn extract_experts_from_source(
+    gguf: &dyn GgufSource,
+    out_dir: &Path,
+    num_layers_hint: usize,
+    num_experts_hint: usize,
+    opts: ExtractOptions,
+) -> io::Result<ExtractionReport> {
+    let plan = build_preflight_plan(gguf, num_layers_hint, num_experts_hint, &opts)?;
+    info!(
+        architecture = %plan.architecture,
+        num_layers = plan.num_layers,
+        experts_per_layer = plan.num_experts,
+        total_experts = plan.total_experts,
+        d_model = plan.d_model,
+        d_ff = plan.d_ff,
+        top_k = plan.top_k,
+        expert_size = plan.expert_size,
+        maximum_payload_bytes = plan.maximum_payload_bytes,
+        native_quant = opts.native_quant,
+        experts_only = opts.experts_only,
+        "gguf-convert preflight complete"
+    );
+
+    ensure_final_output_available(out_dir)?;
+    let staging_dir = staging_dir_for(out_dir)?;
+    let result = (|| {
+        fs::create_dir(&staging_dir)?;
+        let report = extract_experts_from_source_inner(
+            gguf,
+            &staging_dir,
+            num_layers_hint,
+            num_experts_hint,
+            opts,
+        )?;
+        validate_data_dir(&staging_dir)?;
+        fs::rename(&staging_dir, out_dir)?;
+        Ok(report)
+    })();
+
+    if result.is_err() {
+        let _ = fs::remove_dir_all(&staging_dir);
+    }
+    result
+}
+
+fn extract_experts_from_source_inner(
     gguf: &dyn GgufSource,
     out_dir: &Path,
     num_layers_hint: usize,
@@ -475,140 +848,147 @@ pub fn extract_experts_from_source(
         }
     }
 
-    // Dense weights. The engine's `RealModel::from_dir` uses its own
-    // file-name convention (`embed.bin`, `attn_<L>_q.bin`, …), so we
-    // write *both* the gist-mandated llama.cpp-style names and the
-    // engine's native names. The duplicate write is small relative to
-    // the expert files and means the converter satisfies both APIs.
-    let dense_specs: Vec<(&str, &[&str], Vec<u64>)> = vec![
-        // (gguf_name, [engine_aliases...], expected_shape_innermost_first)
-        (
-            "token_embd.weight",
-            &["embedding.bin", "embed.bin"],
-            vec![d_model as u64, 0],
-        ),
-        (
-            "output_norm.weight",
-            &["final_norm.bin", "final_rms.bin"],
-            vec![d_model as u64],
-        ),
-        ("output.weight", &["lm_head.bin"], vec![d_model as u64, 0]),
-    ];
-    for (gname, aliases, _) in &dense_specs {
-        if let Some(info) = gguf.tensor_info(gname).cloned() {
-            match dense_tensor_to_f32(gguf, &info) {
-                Ok(f32s) => {
-                    for alias in *aliases {
-                        let path = out_dir.join(alias);
-                        let bytes = f32_vec_to_le_bytes(&f32s);
-                        write_file(&path, &bytes)?;
-                        report.dense_written += 1;
-                        report.total_bytes += bytes.len() as u64;
-                    }
-                }
-                Err(e) => {
-                    warn!(name = gname, error = %e, "skipping dense tensor");
-                    report.skipped += 1;
-                }
-            }
-        } else {
-            report.skipped += 1;
-        }
-    }
-
-    // Per-layer dense tensors.
-    for layer in 0..num_layers {
-        let mut emit = |gname: String, aliases: Vec<String>| -> io::Result<()> {
-            if let Some(info) = gguf.tensor_info(&gname).cloned() {
+    if opts.experts_only {
+        info!(
+            num_layers,
+            "experts-only conversion selected; skipping dense tensor extraction"
+        );
+    } else {
+        // Dense weights. The engine's `RealModel::from_dir` uses its own
+        // file-name convention (`embed.bin`, `attn_<L>_q.bin`, …), so we
+        // write *both* the gist-mandated llama.cpp-style names and the
+        // engine's native names. The duplicate write is small relative to
+        // the expert files and means the converter satisfies both APIs.
+        let dense_specs: Vec<(&str, &[&str], Vec<u64>)> = vec![
+            // (gguf_name, [engine_aliases...], expected_shape_innermost_first)
+            (
+                "token_embd.weight",
+                &["embedding.bin", "embed.bin"],
+                vec![d_model as u64, 0],
+            ),
+            (
+                "output_norm.weight",
+                &["final_norm.bin", "final_rms.bin"],
+                vec![d_model as u64],
+            ),
+            ("output.weight", &["lm_head.bin"], vec![d_model as u64, 0]),
+        ];
+        for (gname, aliases, _) in &dense_specs {
+            if let Some(info) = gguf.tensor_info(gname).cloned() {
                 match dense_tensor_to_f32(gguf, &info) {
                     Ok(f32s) => {
-                        let bytes = f32_vec_to_le_bytes(&f32s);
-                        for alias in &aliases {
+                        for alias in *aliases {
                             let path = out_dir.join(alias);
+                            let bytes = f32_vec_to_le_bytes(&f32s);
                             write_file(&path, &bytes)?;
                             report.dense_written += 1;
                             report.total_bytes += bytes.len() as u64;
                         }
                     }
                     Err(e) => {
-                        warn!(name = gname, error = %e, "skipping per-layer dense tensor");
+                        warn!(name = gname, error = %e, "skipping dense tensor");
                         report.skipped += 1;
                     }
                 }
             } else {
                 report.skipped += 1;
             }
-            Ok(())
-        };
-        emit(
-            format!("blk.{layer}.attn_q.weight"),
-            vec![
-                format!("layer_{layer}_q.bin"),
-                format!("attn_{layer}_q.bin"),
-            ],
-        )?;
-        emit(
-            format!("blk.{layer}.attn_k.weight"),
-            vec![
-                format!("layer_{layer}_k.bin"),
-                format!("attn_{layer}_k.bin"),
-            ],
-        )?;
-        emit(
-            format!("blk.{layer}.attn_v.weight"),
-            vec![
-                format!("layer_{layer}_v.bin"),
-                format!("attn_{layer}_v.bin"),
-            ],
-        )?;
-        emit(
-            format!("blk.{layer}.attn_output.weight"),
-            vec![
-                format!("layer_{layer}_o.bin"),
-                format!("attn_{layer}_o.bin"),
-            ],
-        )?;
-        emit(
-            format!("blk.{layer}.attn_norm.weight"),
-            vec![
-                format!("layer_{layer}_attn_norm.bin"),
-                format!("rms_attn_{layer}.bin"),
-            ],
-        )?;
-        emit(
-            format!("blk.{layer}.ffn_norm.weight"),
-            vec![
-                format!("layer_{layer}_ffn_norm.bin"),
-                format!("rms_moe_{layer}.bin"),
-            ],
-        )?;
-        emit(
-            format!("blk.{layer}.ffn_gate_inp.weight"),
-            vec![format!("gate_{layer}.bin")],
-        )?;
-        // Qwen2-MoE-style "shared experts" — dense FFN tensors applied to
-        // *every* token in addition to the routed experts. They are stored
-        // under the `_shexp` suffix and were previously dropped, leaving the
-        // converted engine missing weights. Emit them as dense `.bin` files
-        // (both the gguf-style name and an engine-friendly alias). Files are
-        // only written when the tensor exists, so non-MoE / no-shared-expert
-        // architectures (e.g. Mixtral) are unaffected.
-        emit(
-            format!("blk.{layer}.ffn_gate_shexp.weight"),
-            vec![format!("layer_{layer}_shexp_gate.bin")],
-        )?;
-        emit(
-            format!("blk.{layer}.ffn_up_shexp.weight"),
-            vec![format!("layer_{layer}_shexp_up.bin")],
-        )?;
-        emit(
-            format!("blk.{layer}.ffn_down_shexp.weight"),
-            vec![format!("layer_{layer}_shexp_down.bin")],
-        )?;
-        emit(
-            format!("blk.{layer}.ffn_gate_inp_shexp.weight"),
-            vec![format!("layer_{layer}_shexp_gate_inp.bin")],
-        )?;
+        }
+
+        // Per-layer dense tensors.
+        for layer in 0..num_layers {
+            let mut emit = |gname: String, aliases: Vec<String>| -> io::Result<()> {
+                if let Some(info) = gguf.tensor_info(&gname).cloned() {
+                    match dense_tensor_to_f32(gguf, &info) {
+                        Ok(f32s) => {
+                            let bytes = f32_vec_to_le_bytes(&f32s);
+                            for alias in &aliases {
+                                let path = out_dir.join(alias);
+                                write_file(&path, &bytes)?;
+                                report.dense_written += 1;
+                                report.total_bytes += bytes.len() as u64;
+                            }
+                        }
+                        Err(e) => {
+                            warn!(name = gname, error = %e, "skipping per-layer dense tensor");
+                            report.skipped += 1;
+                        }
+                    }
+                } else {
+                    report.skipped += 1;
+                }
+                Ok(())
+            };
+            emit(
+                format!("blk.{layer}.attn_q.weight"),
+                vec![
+                    format!("layer_{layer}_q.bin"),
+                    format!("attn_{layer}_q.bin"),
+                ],
+            )?;
+            emit(
+                format!("blk.{layer}.attn_k.weight"),
+                vec![
+                    format!("layer_{layer}_k.bin"),
+                    format!("attn_{layer}_k.bin"),
+                ],
+            )?;
+            emit(
+                format!("blk.{layer}.attn_v.weight"),
+                vec![
+                    format!("layer_{layer}_v.bin"),
+                    format!("attn_{layer}_v.bin"),
+                ],
+            )?;
+            emit(
+                format!("blk.{layer}.attn_output.weight"),
+                vec![
+                    format!("layer_{layer}_o.bin"),
+                    format!("attn_{layer}_o.bin"),
+                ],
+            )?;
+            emit(
+                format!("blk.{layer}.attn_norm.weight"),
+                vec![
+                    format!("layer_{layer}_attn_norm.bin"),
+                    format!("rms_attn_{layer}.bin"),
+                ],
+            )?;
+            emit(
+                format!("blk.{layer}.ffn_norm.weight"),
+                vec![
+                    format!("layer_{layer}_ffn_norm.bin"),
+                    format!("rms_moe_{layer}.bin"),
+                ],
+            )?;
+            emit(
+                format!("blk.{layer}.ffn_gate_inp.weight"),
+                vec![format!("gate_{layer}.bin")],
+            )?;
+            // Qwen2-MoE-style "shared experts" — dense FFN tensors applied to
+            // *every* token in addition to the routed experts. They are stored
+            // under the `_shexp` suffix and were previously dropped, leaving the
+            // converted engine missing weights. Emit them as dense `.bin` files
+            // (both the gguf-style name and an engine-friendly alias). Files are
+            // only written when the tensor exists, so non-MoE / no-shared-expert
+            // architectures (e.g. Mixtral) are unaffected.
+            emit(
+                format!("blk.{layer}.ffn_gate_shexp.weight"),
+                vec![format!("layer_{layer}_shexp_gate.bin")],
+            )?;
+            emit(
+                format!("blk.{layer}.ffn_up_shexp.weight"),
+                vec![format!("layer_{layer}_shexp_up.bin")],
+            )?;
+            emit(
+                format!("blk.{layer}.ffn_down_shexp.weight"),
+                vec![format!("layer_{layer}_shexp_down.bin")],
+            )?;
+            emit(
+                format!("blk.{layer}.ffn_gate_inp_shexp.weight"),
+                vec![format!("layer_{layer}_shexp_gate_inp.bin")],
+            )?;
+        }
     }
 
     // metadata.json
@@ -618,13 +998,21 @@ pub fn extract_experts_from_source(
         .and_then(|v| v.as_str())
         .unwrap_or("gguf-extracted");
     let meta = ExtractedMetadata {
+        format_version: 2,
+        conversion_mode: if opts.experts_only {
+            "experts_only"
+        } else {
+            "full"
+        },
         model: model_name,
+        architecture: arch.unwrap_or("unknown"),
         layer: if num_layers == 1 { 0 } else { -1 },
         num_experts: total_experts,
         top_k,
         d_model,
         d_ff,
         expert_size,
+        maximum_payload_bytes: payload_size,
         block_align: DEFAULT_BLOCK_ALIGN,
         dtype: expert_dtype.as_str(),
         weight_layout: "gate_proj || up_proj || down_proj (row-major)",
@@ -636,6 +1024,8 @@ pub fn extract_experts_from_source(
         projection_dtype_histogram: native_plan
             .as_ref()
             .and_then(NativeQuantPlan::metadata_histogram),
+        experts_written: report.experts_written,
+        dense_tensors_written: report.dense_written,
     };
     let meta_path = out_dir.join("metadata.json");
     let mut f = fs::File::create(&meta_path)?;
@@ -659,6 +1049,199 @@ fn write_file(path: &Path, bytes: &[u8]) -> io::Result<()> {
         fs::create_dir_all(parent)?;
     }
     fs::write(path, bytes)
+}
+
+#[derive(Debug, Clone)]
+pub struct DataValidationReport {
+    pub num_experts: usize,
+    pub expert_size: usize,
+    pub block_align: usize,
+    pub dtype: WeightDtype,
+    pub mixed_experts: usize,
+}
+
+#[derive(Debug, Deserialize)]
+struct ValidationMetadata {
+    num_experts: usize,
+    d_model: usize,
+    d_ff: usize,
+    expert_size: usize,
+    #[serde(default = "default_validation_block_align")]
+    block_align: usize,
+    dtype: String,
+    #[serde(default)]
+    expert_layout_version: Option<u32>,
+    #[serde(default)]
+    projection_dtype_histogram: Option<BTreeMap<String, usize>>,
+    #[serde(default)]
+    experts_written: Option<usize>,
+}
+
+fn default_validation_block_align() -> usize {
+    DEFAULT_BLOCK_ALIGN
+}
+
+pub fn validate_data_dir(data_dir: &Path) -> io::Result<DataValidationReport> {
+    let meta_path = data_dir.join("metadata.json");
+    let body = fs::read_to_string(&meta_path).map_err(|e| {
+        io::Error::new(
+            e.kind(),
+            format!("failed to read metadata {}: {e}", meta_path.display()),
+        )
+    })?;
+    let meta: ValidationMetadata = serde_json::from_str(&body).map_err(|e| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("metadata {} is invalid JSON: {e}", meta_path.display()),
+        )
+    })?;
+    let dtype = WeightDtype::from_str_opt(&meta.dtype).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("metadata dtype {:?} is not supported", meta.dtype),
+        )
+    })?;
+    if meta.block_align == 0 || !meta.block_align.is_power_of_two() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("metadata block_align {} is invalid", meta.block_align),
+        ));
+    }
+    if meta.expert_size == 0 || meta.expert_size % meta.block_align != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "metadata expert_size {} is not aligned to block_align {}",
+                meta.expert_size, meta.block_align
+            ),
+        ));
+    }
+    if let Some(written) = meta.experts_written {
+        if written != meta.num_experts {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "metadata experts_written {written} does not match num_experts {}",
+                    meta.num_experts
+                ),
+            ));
+        }
+    }
+    if dtype == WeightDtype::Mixed && meta.expert_layout_version != Some(2) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "metadata dtype=mixed requires expert_layout_version=2",
+        ));
+    }
+
+    let mut observed_mixed = 0usize;
+    let mut observed_hist = BTreeMap::<String, usize>::new();
+    for id in 0..meta.num_experts {
+        let path = data_dir.join(format!("expert_{id}.bin"));
+        let stat = fs::metadata(&path).map_err(|e| {
+            io::Error::new(
+                e.kind(),
+                format!(
+                    "expert file {} is missing or unreadable: {e}",
+                    path.display()
+                ),
+            )
+        })?;
+        if stat.len() != meta.expert_size as u64 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "expert file {} has {} bytes, expected {}",
+                    path.display(),
+                    stat.len(),
+                    meta.expert_size
+                ),
+            ));
+        }
+        let head_len = meta.block_align.min(meta.expert_size);
+        let mut head = vec![0u8; head_len];
+        let mut file = fs::File::open(&path)?;
+        use std::io::Read;
+        file.read_exact(&mut head)?;
+
+        if dtype == WeightDtype::Mixed {
+            let header = MixedExpertHeader::probe(&head).ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "expert file {} is mixed but has no valid UTH2 header",
+                        path.display()
+                    ),
+                )
+            })?;
+            if header.d_model as usize != meta.d_model || header.d_ff as usize != meta.d_ff {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "expert file {} UTH2 shape d_model={} d_ff={} disagrees with metadata d_model={} d_ff={}",
+                        path.display(),
+                        header.d_model,
+                        header.d_ff,
+                        meta.d_model,
+                        meta.d_ff
+                    ),
+                ));
+            }
+            let payload_len = meta
+                .expert_size
+                .checked_sub(meta.block_align)
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "expert payload length underflow",
+                    )
+                })?;
+            header
+                .validate(payload_len as u64)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+            let key = format!(
+                "{}/{}/{}",
+                dtype_label(header.gate.dtype.to_weight()).to_ascii_lowercase(),
+                dtype_label(header.up.dtype.to_weight()).to_ascii_lowercase(),
+                dtype_label(header.down.dtype.to_weight()).to_ascii_lowercase()
+            );
+            *observed_hist.entry(key).or_default() += 1;
+            observed_mixed += 1;
+        } else if let Some(header) = TensorHeader::probe(&head) {
+            let header_dtype = header.dtype.to_weight();
+            if header_dtype != dtype {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "expert file {} UTH dtype {} disagrees with metadata dtype {}",
+                        path.display(),
+                        header_dtype.as_str(),
+                        dtype.as_str()
+                    ),
+                ));
+            }
+        }
+    }
+
+    if let Some(expected_hist) = meta.projection_dtype_histogram {
+        if dtype == WeightDtype::Mixed && expected_hist != observed_hist {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "mixed projection histogram mismatch: metadata {:?}, observed {:?}",
+                    expected_hist, observed_hist
+                ),
+            ));
+        }
+    }
+
+    Ok(DataValidationReport {
+        num_experts: meta.num_experts,
+        expert_size: meta.expert_size,
+        block_align: meta.block_align,
+        dtype,
+        mixed_experts: observed_mixed,
+    })
 }
 
 fn f32_vec_to_le_bytes(v: &[f32]) -> Vec<u8> {
@@ -785,15 +1368,9 @@ fn bytes_to_f32(data: &[u8], dtype: u32, elems: usize, name: &str) -> io::Result
 /// (`O(1)` full-tensor decodes instead of `O(num_experts)`) and slices
 /// each expert's stride from the cached f32 buffer.
 ///
-/// Fallbacks mirror `load_expert_matrices`:
-/// * If a layer has neither interleaved nor per-expert tensors,
-///   `num_experts` deterministic-zero triples are produced (the engine
-///   reseeds these at runtime).
-/// * If a tensor uses a dtype `bytes_to_f32` doesn't understand yet
-///   (e.g. some Q6_K/Q8_0 variants), the whole layer falls back to
-///   zero blobs — matching the documented "recognised for sizing only"
-///   behaviour. The convert never aborts on a single unsupported
-///   layer.
+/// Required expert tensors are fail-closed: missing, malformed, or
+/// unsupported expert weights abort conversion instead of writing
+/// placeholder zero blobs.
 fn load_layer_expert_matrices(
     gguf: &dyn GgufSource,
     layer: usize,
@@ -806,19 +1383,6 @@ fn load_layer_expert_matrices(
     let interleaved_down_name = format!("blk.{layer}.ffn_down_exps.weight");
     let per_expert_gate0 = format!("blk.{layer}.ffn_gate.0.weight");
 
-    let zero_layer = |reason: &str| {
-        warn!(layer, reason, "emitting zero blob for layer experts");
-        (0..num_experts)
-            .map(|_| {
-                (
-                    vec![0.0f32; d_ff * d_model],
-                    vec![0.0f32; d_ff * d_model],
-                    vec![0.0f32; d_model * d_ff],
-                )
-            })
-            .collect::<Vec<_>>()
-    };
-
     if gguf.has_tensor(&interleaved_gate_name) {
         // Decode each interleaved tensor exactly once and reuse it for
         // all experts in the layer.
@@ -828,9 +1392,6 @@ fn load_layer_expert_matrices(
             num_experts * d_ff * d_model,
         ) {
             Ok(v) => v,
-            Err(err) if err.kind() == io::ErrorKind::Unsupported => {
-                return Ok(zero_layer("unsupported dtype in interleaved gate tensor"));
-            }
             Err(err) => return Err(err),
         };
         let up_all = match dense_layer_tensor_f32(
@@ -839,9 +1400,6 @@ fn load_layer_expert_matrices(
             num_experts * d_ff * d_model,
         ) {
             Ok(v) => v,
-            Err(err) if err.kind() == io::ErrorKind::Unsupported => {
-                return Ok(zero_layer("unsupported dtype in interleaved up tensor"));
-            }
             Err(err) => return Err(err),
         };
         let down_all = match dense_layer_tensor_f32(
@@ -850,9 +1408,6 @@ fn load_layer_expert_matrices(
             num_experts * d_model * d_ff,
         ) {
             Ok(v) => v,
-            Err(err) if err.kind() == io::ErrorKind::Unsupported => {
-                return Ok(zero_layer("unsupported dtype in interleaved down tensor"));
-            }
             Err(err) => return Err(err),
         };
 
@@ -872,34 +1427,24 @@ fn load_layer_expert_matrices(
         Ok(out)
     } else if gguf.has_tensor(&per_expert_gate0) {
         // Per-expert tensors: each expert's tensors are already
-        // separate, so a layer-level cache buys nothing — just dispatch
-        // to `load_expert_matrices`, catching Unsupported per expert.
+        // separate, so a layer-level cache buys nothing.
         let mut out = Vec::with_capacity(num_experts);
         for e in 0..num_experts {
-            match load_expert_matrices(gguf, layer, e, num_experts, d_model, d_ff) {
-                Ok(triple) => out.push(triple),
-                Err(err) if err.kind() == io::ErrorKind::Unsupported => {
-                    warn!(
-                        layer,
-                        expert = e,
-                        "unsupported dtype in per-expert tensor; emitting zero blob"
-                    );
-                    out.push((
-                        vec![0.0f32; d_ff * d_model],
-                        vec![0.0f32; d_ff * d_model],
-                        vec![0.0f32; d_model * d_ff],
-                    ));
-                }
-                Err(err) => return Err(err),
-            }
+            out.push(load_expert_matrices(
+                gguf,
+                layer,
+                e,
+                num_experts,
+                d_model,
+                d_ff,
+            )?);
         }
         Ok(out)
     } else {
-        warn!(
-            layer,
-            "no expert weight tensor found in GGUF; emitting zero blobs"
-        );
-        Ok(zero_layer("no expert weight tensor"))
+        Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("layer {layer} has no expert weight tensors"),
+        ))
     }
 }
 
@@ -990,18 +1535,9 @@ fn load_expert_matrices(
         )?;
         Ok((gate, up, down))
     } else {
-        // No expert tensors present — fall back to deterministic-zero
-        // matrices so the rest of the pipeline produces a syntactically
-        // valid expert file (the engine will fall back to seeded init
-        // at run time anyway when the file is shaped right but zeroed).
-        warn!(
-            layer,
-            expert, "no expert weight tensor found in GGUF; emitting zero blob"
-        );
-        Ok((
-            vec![0.0; d_ff * d_model],
-            vec![0.0; d_ff * d_model],
-            vec![0.0; d_model * d_ff],
+        Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("layer {layer} expert {expert} has no expert weight tensors"),
         ))
     }
 }
@@ -1914,6 +2450,7 @@ mod tests {
             ExtractOptions {
                 emit_uth: false,
                 native_quant: false,
+                experts_only: false,
             },
         )
         .expect("extract no-uth");
@@ -1930,6 +2467,66 @@ mod tests {
             assert_eq!(payload.len(), buf.len());
         }
 
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn validate_data_dir_rejects_corrupt_expert_file() {
+        let d_model = 4usize;
+        let d_ff = 8usize;
+        let num_experts = 2usize;
+        let bytes = build_synth_gguf(d_model, d_ff, num_experts);
+        let tmp = tempfile_dir();
+        let gguf_path = tmp.join("synth.gguf");
+        fs::write(&gguf_path, &bytes).unwrap();
+        let gguf = GgufFile::open(&gguf_path).expect("parse");
+
+        let out = tmp.join("validate-corrupt");
+        extract_experts_from_source(&gguf, &out, 1, num_experts, ExtractOptions::default())
+            .expect("extract");
+        fs::write(out.join("expert_0.bin"), vec![0u8; 32]).unwrap();
+
+        let err = validate_data_dir(&out).expect_err("corrupt expert must fail validation");
+        assert!(
+            err.to_string().contains("has 32 bytes, expected"),
+            "unexpected error: {err}"
+        );
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn experts_only_conversion_skips_dense_outputs() {
+        let d_model = 4usize;
+        let d_ff = 8usize;
+        let num_experts = 2usize;
+        let bytes = build_synth_gguf(d_model, d_ff, num_experts);
+        let tmp = tempfile_dir();
+        let gguf_path = tmp.join("synth.gguf");
+        fs::write(&gguf_path, &bytes).unwrap();
+        let gguf = GgufFile::open(&gguf_path).expect("parse");
+
+        let out = tmp.join("experts-only");
+        let report = extract_experts_from_source(
+            &gguf,
+            &out,
+            1,
+            num_experts,
+            ExtractOptions {
+                emit_uth: true,
+                native_quant: false,
+                experts_only: true,
+            },
+        )
+        .expect("extract experts only");
+
+        assert_eq!(report.experts_written, num_experts);
+        assert_eq!(report.dense_written, 0);
+        assert!(!out.join("rms_attn_0.bin").exists());
+        let meta: serde_json::Value =
+            serde_json::from_slice(&fs::read(out.join("metadata.json")).unwrap()).unwrap();
+        assert_eq!(meta["conversion_mode"], "experts_only");
+        assert_eq!(meta["dense_tensors_written"], 0);
+        validate_data_dir(&out).expect("experts-only output validates");
         let _ = fs::remove_dir_all(&tmp);
     }
 
@@ -2149,6 +2746,7 @@ mod tests {
             ExtractOptions {
                 emit_uth: true,
                 native_quant: true,
+                experts_only: false,
             },
         )
         .expect_err("F32 native quant should fail closed");
@@ -2596,6 +3194,7 @@ mod tests {
             ExtractOptions {
                 emit_uth: true,
                 native_quant: true,
+                experts_only: false,
             },
         )
         .expect("extract");
@@ -2650,6 +3249,7 @@ mod tests {
             ExtractOptions {
                 emit_uth: true,
                 native_quant: true,
+                experts_only: false,
             },
         )
         .expect("extract mixed");
@@ -2688,6 +3288,33 @@ mod tests {
         .expect("runtime mixed decode");
         assert_eq!(weights.gate.len(), d_ff * d_model);
         assert_eq!(weights.down.len(), d_model * d_ff);
+
+        let pool = crate::buffer_pool::BufferPool::new(1, first.len(), DEFAULT_BLOCK_ALIGN);
+        let mut buf = pool.try_acquire().expect("pooled buffer");
+        buf.as_mut_slice()[..first.len()].copy_from_slice(&first);
+        let resident =
+            crate::expert_cache::ExpertResident::new_with_block_align(0, buf, DEFAULT_BLOCK_ALIGN);
+        let x: Vec<f32> = (0..d_model)
+            .map(|i| (i as f32 + 1.0) / d_model as f32)
+            .collect();
+        let expected = weights.forward(&x);
+        let before_mixed = crate::inference::mixed_expert_dispatches();
+        let before_fallback = crate::inference::mixed_dequant_fallbacks();
+        let (_out, actual) =
+            crate::inference::run_inference_mixed_quant(7, &resident, &x, d_model, d_ff)
+                .expect("direct mixed inference");
+        assert_eq!(
+            crate::inference::mixed_expert_dispatches(),
+            before_mixed + 1
+        );
+        assert_eq!(crate::inference::mixed_dequant_fallbacks(), before_fallback);
+        assert_eq!(actual.len(), expected.len());
+        for (idx, (a, b)) in actual.iter().zip(expected.iter()).enumerate() {
+            assert!(
+                (a - b).abs() <= 1e-5,
+                "mixed direct output mismatch at {idx}: actual={a}, expected={b}"
+            );
+        }
         let _ = fs::remove_dir_all(&tmp);
     }
 }

--- a/rust-engine/src/gguf_loader.rs
+++ b/rust-engine/src/gguf_loader.rs
@@ -408,8 +408,10 @@ fn staging_dir_for(out_dir: &Path) -> io::Result<PathBuf> {
     for _ in 0..1024 {
         let nonce = NEXT.fetch_add(1, Ordering::Relaxed);
         let candidate = parent.join(format!(".{name}.tmp-{}-{nonce}", std::process::id()));
-        if !candidate.exists() {
-            return Ok(candidate);
+        match fs::create_dir(&candidate) {
+            Ok(()) => return Ok(candidate),
+            Err(e) if e.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(e) => return Err(e),
         }
     }
     Err(io::Error::new(
@@ -525,7 +527,6 @@ pub fn extract_experts_from_source(
     ensure_final_output_available(out_dir)?;
     let staging_dir = staging_dir_for(out_dir)?;
     let result = (|| {
-        fs::create_dir(&staging_dir)?;
         let report = extract_experts_from_source_inner(
             gguf,
             &staging_dir,
@@ -1081,6 +1082,35 @@ fn default_validation_block_align() -> usize {
     DEFAULT_BLOCK_ALIGN
 }
 
+fn tensor_header_prefix_len(header_bytes: usize, flags: u32, block_align: usize) -> usize {
+    if (flags & crate::tensor_header::UTH_FLAG_PAGE_ALIGNED_PAYLOAD) != 0 && block_align > 0 {
+        align_up(header_bytes, block_align)
+    } else {
+        header_bytes
+    }
+}
+
+fn validate_payload_len(
+    path: &Path,
+    dtype: WeightDtype,
+    payload_len: usize,
+    expected_payload: usize,
+) -> io::Result<()> {
+    if payload_len < expected_payload {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "expert file {} payload has {} bytes, expected at least {} for dtype {}",
+                path.display(),
+                payload_len,
+                expected_payload,
+                dtype.as_str()
+            ),
+        ));
+    }
+    Ok(())
+}
+
 pub fn validate_data_dir(data_dir: &Path) -> io::Result<DataValidationReport> {
     let meta_path = data_dir.join("metadata.json");
     let body = fs::read_to_string(&meta_path).map_err(|e| {
@@ -1133,6 +1163,14 @@ pub fn validate_data_dir(data_dir: &Path) -> io::Result<DataValidationReport> {
             "metadata dtype=mixed requires expert_layout_version=2",
         ));
     }
+    let expected_payload = if dtype == WeightDtype::Mixed {
+        None
+    } else {
+        Some(align_up(
+            expert_weight_bytes_for(meta.d_model, meta.d_ff, dtype),
+            meta.block_align,
+        ))
+    };
 
     let mut observed_mixed = 0usize;
     let mut observed_hist = BTreeMap::<String, usize>::new();
@@ -1158,7 +1196,9 @@ pub fn validate_data_dir(data_dir: &Path) -> io::Result<DataValidationReport> {
                 ),
             ));
         }
-        let head_len = meta.block_align.min(meta.expert_size);
+        let head_len = meta
+            .expert_size
+            .min(crate::tensor_header::UTH2_BYTES.max(crate::tensor_header::UTH_BYTES));
         let mut head = vec![0u8; head_len];
         let mut file = fs::File::open(&path)?;
         use std::io::Read;
@@ -1187,15 +1227,17 @@ pub fn validate_data_dir(data_dir: &Path) -> io::Result<DataValidationReport> {
                     ),
                 ));
             }
-            let payload_len = meta
-                .expert_size
-                .checked_sub(meta.block_align)
-                .ok_or_else(|| {
-                    io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        "expert payload length underflow",
-                    )
-                })?;
+            let prefix_len = tensor_header_prefix_len(
+                crate::tensor_header::UTH2_BYTES,
+                header.flags,
+                meta.block_align,
+            );
+            let payload_len = meta.expert_size.checked_sub(prefix_len).ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "expert payload length underflow",
+                )
+            })?;
             header
                 .validate(payload_len as u64)
                 .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
@@ -1207,19 +1249,35 @@ pub fn validate_data_dir(data_dir: &Path) -> io::Result<DataValidationReport> {
             );
             *observed_hist.entry(key).or_default() += 1;
             observed_mixed += 1;
-        } else if let Some(header) = TensorHeader::probe(&head) {
-            let header_dtype = header.dtype.to_weight();
-            if header_dtype != dtype {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!(
-                        "expert file {} UTH dtype {} disagrees with metadata dtype {}",
-                        path.display(),
-                        header_dtype.as_str(),
-                        dtype.as_str()
-                    ),
-                ));
-            }
+        } else {
+            let payload_len = if let Some(header) = TensorHeader::probe(&head) {
+                let header_dtype = header.dtype.to_weight();
+                if header_dtype != dtype {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!(
+                            "expert file {} UTH dtype {} disagrees with metadata dtype {}",
+                            path.display(),
+                            header_dtype.as_str(),
+                            dtype.as_str()
+                        ),
+                    ));
+                }
+                let prefix_len = tensor_header_prefix_len(
+                    crate::tensor_header::UTH_BYTES,
+                    header.flags,
+                    meta.block_align,
+                );
+                meta.expert_size.checked_sub(prefix_len).ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "expert payload length underflow",
+                    )
+                })?
+            } else {
+                meta.expert_size
+            };
+            validate_payload_len(&path, dtype, payload_len, expected_payload.unwrap())?;
         }
     }
 
@@ -2495,6 +2553,38 @@ mod tests {
     }
 
     #[test]
+    fn validate_data_dir_rejects_truncated_non_mixed_payload_even_when_metadata_matches() {
+        let d_model = 4usize;
+        let d_ff = 8usize;
+        let num_experts = 2usize;
+        let bytes = build_synth_gguf(d_model, d_ff, num_experts);
+        let tmp = tempfile_dir();
+        let gguf_path = tmp.join("synth.gguf");
+        fs::write(&gguf_path, &bytes).unwrap();
+        let gguf = GgufFile::open(&gguf_path).expect("parse");
+
+        let out = tmp.join("validate-truncated-payload");
+        extract_experts_from_source(&gguf, &out, 1, num_experts, ExtractOptions::default())
+            .expect("extract");
+
+        let expert = out.join("expert_0.bin");
+        let truncated = fs::read(&expert).unwrap()[..DEFAULT_BLOCK_ALIGN].to_vec();
+        fs::write(&expert, truncated).unwrap();
+        let meta_path = out.join("metadata.json");
+        let mut meta: serde_json::Value =
+            serde_json::from_slice(&fs::read(&meta_path).unwrap()).unwrap();
+        meta["expert_size"] = serde_json::json!(DEFAULT_BLOCK_ALIGN);
+        fs::write(&meta_path, serde_json::to_vec_pretty(&meta).unwrap()).unwrap();
+
+        let err = validate_data_dir(&out).expect_err("truncated payload must fail validation");
+        assert!(
+            err.to_string().contains("payload has 0 bytes"),
+            "unexpected error: {err}"
+        );
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
     fn experts_only_conversion_skips_dense_outputs() {
         let d_model = 4usize;
         let d_ff = 8usize;
@@ -3299,15 +3389,13 @@ mod tests {
             .collect();
         let expected = weights.forward(&x);
         let before_mixed = crate::inference::mixed_expert_dispatches();
-        let before_fallback = crate::inference::mixed_dequant_fallbacks();
         let (_out, actual) =
             crate::inference::run_inference_mixed_quant(7, &resident, &x, d_model, d_ff)
                 .expect("direct mixed inference");
-        assert_eq!(
-            crate::inference::mixed_expert_dispatches(),
-            before_mixed + 1
+        assert!(
+            crate::inference::mixed_expert_dispatches() > before_mixed,
+            "direct mixed inference should increment the mixed dispatch counter"
         );
-        assert_eq!(crate::inference::mixed_dequant_fallbacks(), before_fallback);
         assert_eq!(actual.len(), expected.len());
         for (idx, (a, b)) in actual.iter().zip(expected.iter()).enumerate() {
             assert!(

--- a/rust-engine/src/inference.rs
+++ b/rust-engine/src/inference.rs
@@ -59,6 +59,7 @@ compile_error!(
 
 use crate::expert_cache::ExpertResident;
 use std::fmt;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 // Hugging Face Candle is the math backend for the per-expert SwiGLU
 // forward pass. The on-disk f32 layout (gate || up || down, row-major)
@@ -1960,6 +1961,7 @@ impl OwnedExpertWeights {
     }
 
     /// Build an owned weight set from a UTH2 mixed-projection expert.
+    #[allow(dead_code)]
     pub fn from_bytes_mixed_quant(
         bytes: &[u8],
         header: crate::tensor_header::MixedExpertHeader,
@@ -2373,6 +2375,7 @@ impl OwnedExpertWeights {
     }
 }
 
+#[allow(dead_code)]
 fn decode_mixed_projection(
     payload: &[u8],
     range: crate::tensor_header::ProjectionRange,
@@ -2451,6 +2454,244 @@ fn decode_mixed_projection(
         )));
     }
     Ok(out)
+}
+
+static QUANTIZED_PROJECTION_DISPATCHES: AtomicU64 = AtomicU64::new(0);
+static MIXED_EXPERT_DISPATCHES: AtomicU64 = AtomicU64::new(0);
+static MIXED_DEQUANT_FALLBACKS: AtomicU64 = AtomicU64::new(0);
+static UNSUPPORTED_QUANT_DISPATCHES: AtomicU64 = AtomicU64::new(0);
+
+pub fn quantized_projection_dispatches() -> u64 {
+    QUANTIZED_PROJECTION_DISPATCHES.load(Ordering::Relaxed)
+}
+
+pub fn mixed_expert_dispatches() -> u64 {
+    MIXED_EXPERT_DISPATCHES.load(Ordering::Relaxed)
+}
+
+pub fn mixed_dequant_fallbacks() -> u64 {
+    MIXED_DEQUANT_FALLBACKS.load(Ordering::Relaxed)
+}
+
+pub fn unsupported_quant_dispatches() -> u64 {
+    UNSUPPORTED_QUANT_DISPATCHES.load(Ordering::Relaxed)
+}
+
+pub struct QuantProjectionView<'a> {
+    dtype: WeightDtype,
+    bytes: &'a [u8],
+    rows: usize,
+    cols: usize,
+    weights: usize,
+}
+
+pub struct MixedQuantExpertView<'a> {
+    gate: QuantProjectionView<'a>,
+    up: QuantProjectionView<'a>,
+    down: QuantProjectionView<'a>,
+}
+
+impl<'a> MixedQuantExpertView<'a> {
+    fn from_payload(
+        payload: &'a [u8],
+        header: crate::tensor_header::MixedExpertHeader,
+        d_model: usize,
+        d_ff: usize,
+    ) -> Result<Self, ExpertWeightsError> {
+        if header.d_model as usize != d_model || header.d_ff as usize != d_ff {
+            return Err(ExpertWeightsError::InvalidLayout(format!(
+                "UTH2 shape d_model={} d_ff={} does not match runtime d_model={} d_ff={}",
+                header.d_model, header.d_ff, d_model, d_ff
+            )));
+        }
+        header
+            .validate(payload.len() as u64)
+            .map_err(ExpertWeightsError::InvalidLayout)?;
+        Ok(Self {
+            gate: projection_view(payload, header.gate, d_ff, d_model, "gate")?,
+            up: projection_view(payload, header.up, d_ff, d_model, "up")?,
+            down: projection_view(payload, header.down, d_model, d_ff, "down")?,
+        })
+    }
+}
+
+fn projection_view<'a>(
+    payload: &'a [u8],
+    range: crate::tensor_header::ProjectionRange,
+    rows: usize,
+    cols: usize,
+    name: &str,
+) -> Result<QuantProjectionView<'a>, ExpertWeightsError> {
+    let dtype = range.dtype.to_weight();
+    let weights = rows.checked_mul(cols).ok_or_else(|| {
+        ExpertWeightsError::InvalidLayout(format!("{name} projection shape overflows usize"))
+    })?;
+    if range.weights as usize != weights {
+        return Err(ExpertWeightsError::InvalidLayout(format!(
+            "{name} projection records {} weights, expected {weights}",
+            range.weights
+        )));
+    }
+    let expected_bytes = projection_weight_bytes_for(weights, dtype).ok_or_else(|| {
+        UNSUPPORTED_QUANT_DISPATCHES.fetch_add(1, Ordering::Relaxed);
+        ExpertWeightsError::InvalidLayout(format!(
+            "{name} projection dtype {} is not executable by direct mixed dispatch",
+            dtype.as_str()
+        ))
+    })?;
+    if range.len as usize != expected_bytes {
+        return Err(ExpertWeightsError::InvalidLayout(format!(
+            "{name} projection length {} does not match {expected_bytes} bytes for {}",
+            range.len,
+            dtype.as_str()
+        )));
+    }
+    let start: usize = range.offset.try_into().map_err(|_| {
+        ExpertWeightsError::InvalidLayout(format!("{name} projection offset overflows usize"))
+    })?;
+    let end = start.checked_add(expected_bytes).ok_or_else(|| {
+        ExpertWeightsError::InvalidLayout(format!("{name} projection range overflows usize"))
+    })?;
+    let bytes = payload
+        .get(start..end)
+        .ok_or_else(|| ExpertWeightsError::BufferTooSmall {
+            have: payload.len(),
+            need: end,
+            d_model: cols,
+            d_ff: rows,
+        })?;
+    Ok(QuantProjectionView {
+        dtype,
+        bytes,
+        rows,
+        cols,
+        weights,
+    })
+}
+
+fn quantized_matvec(
+    view: &QuantProjectionView<'_>,
+    x: &[f32],
+) -> Result<Vec<f32>, ExpertWeightsError> {
+    if x.len() != view.cols {
+        return Err(ExpertWeightsError::InvalidLayout(format!(
+            "projection input length {} does not match cols {}",
+            x.len(),
+            view.cols
+        )));
+    }
+    QUANTIZED_PROJECTION_DISPATCHES.fetch_add(1, Ordering::Relaxed);
+    let mut y = vec![0.0f32; view.rows];
+    match view.dtype {
+        WeightDtype::F32 => {
+            for (idx, chunk) in view.bytes.chunks_exact(4).take(view.weights).enumerate() {
+                let row = idx / view.cols;
+                let col = idx % view.cols;
+                let w = f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+                y[row] += w * x[col];
+            }
+        }
+        WeightDtype::F16 => {
+            for (idx, chunk) in view.bytes.chunks_exact(2).take(view.weights).enumerate() {
+                let row = idx / view.cols;
+                let col = idx % view.cols;
+                let w = half::f16::from_le_bytes([chunk[0], chunk[1]]).to_f32();
+                y[row] += w * x[col];
+            }
+        }
+        WeightDtype::BF16 => {
+            for (idx, chunk) in view.bytes.chunks_exact(2).take(view.weights).enumerate() {
+                let row = idx / view.cols;
+                let col = idx % view.cols;
+                let w = half::bf16::from_le_bytes([chunk[0], chunk[1]]).to_f32();
+                y[row] += w * x[col];
+            }
+        }
+        WeightDtype::Q4_0 => matvec_block_stream(
+            view,
+            x,
+            &mut y,
+            Q4_0_BLOCK_ELEMS,
+            Q4_0_BLOCK_BYTES,
+            dequantize_q4_0_block,
+        )?,
+        WeightDtype::Q4K => matvec_block_stream(
+            view,
+            x,
+            &mut y,
+            Q4K_BLOCK_ELEMS,
+            Q4K_BLOCK_BYTES,
+            dequantize_q4k_block,
+        )?,
+        WeightDtype::Q5K => matvec_block_stream(
+            view,
+            x,
+            &mut y,
+            Q5K_BLOCK_ELEMS,
+            Q5K_BLOCK_BYTES,
+            dequantize_q5k_block,
+        )?,
+        WeightDtype::Q6K => matvec_block_stream(
+            view,
+            x,
+            &mut y,
+            Q6K_BLOCK_ELEMS,
+            Q6K_BLOCK_BYTES,
+            dequantize_q6k_block,
+        )?,
+        WeightDtype::Q8_0 => matvec_block_stream(
+            view,
+            x,
+            &mut y,
+            Q8_0_BLOCK_ELEMS,
+            Q8_0_BLOCK_BYTES,
+            dequantize_q8_0_block,
+        )?,
+        WeightDtype::Int8 | WeightDtype::MXFP4 | WeightDtype::Mixed => {
+            UNSUPPORTED_QUANT_DISPATCHES.fetch_add(1, Ordering::Relaxed);
+            return Err(ExpertWeightsError::InvalidLayout(format!(
+                "projection dtype {} is not executable by direct mixed dispatch",
+                view.dtype.as_str()
+            )));
+        }
+    }
+    Ok(y)
+}
+
+fn matvec_block_stream(
+    view: &QuantProjectionView<'_>,
+    x: &[f32],
+    y: &mut [f32],
+    block_elems: usize,
+    block_bytes: usize,
+    decode: fn(&[u8], &mut [f32]),
+) -> Result<(), ExpertWeightsError> {
+    let blocks = view.weights.div_ceil(block_elems);
+    let need = blocks.checked_mul(block_bytes).ok_or_else(|| {
+        ExpertWeightsError::InvalidLayout("quantized projection byte size overflow".to_string())
+    })?;
+    if view.bytes.len() < need {
+        return Err(ExpertWeightsError::BufferTooSmall {
+            have: view.bytes.len(),
+            need,
+            d_model: view.cols,
+            d_ff: view.rows,
+        });
+    }
+    let mut scratch = vec![0.0f32; block_elems];
+    for block in 0..blocks {
+        let start = block * block_bytes;
+        decode(&view.bytes[start..start + block_bytes], &mut scratch);
+        let base = block * block_elems;
+        let n = (view.weights - base).min(block_elems);
+        for (i, &w) in scratch.iter().take(n).enumerate() {
+            let flat = base + i;
+            let row = flat / view.cols;
+            let col = flat % view.cols;
+            y[row] += w * x[col];
+        }
+    }
+    Ok(())
 }
 
 /// Generate the per-token hidden-state vector that flows into the FFN.
@@ -2745,9 +2986,21 @@ pub fn run_inference_mixed_quant(
             "runtime dtype is mixed but resident expert has no valid UTH2 header".to_string(),
         )
     })?;
-    let weights =
-        OwnedExpertWeights::from_bytes_mixed_quant(resident.data(), header, d_model, d_ff)?;
-    let y = weights.forward(x);
+    MIXED_EXPERT_DISPATCHES.fetch_add(1, Ordering::Relaxed);
+    let view = MixedQuantExpertView::from_payload(resident.data(), header, d_model, d_ff)?;
+    let gate = quantized_matvec(&view.gate, x)?;
+    let up = quantized_matvec(&view.up, x)?;
+    let limit = swiglu_limit();
+    let mut hidden = vec![0.0f32; d_ff];
+    for i in 0..d_ff {
+        let g = if let Some(limit) = limit {
+            gate[i].clamp(-limit, limit)
+        } else {
+            gate[i]
+        };
+        hidden[i] = silu(g) * up[i];
+    }
+    let y = quantized_matvec(&view.down, &hidden)?;
     let out = summarise_output(token_idx, resident.id, &y);
     Ok((out, y))
 }

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -77,6 +77,10 @@ use crate::router::{
     LayeredExpertAffinity, LocalityMonitor, NeuralSpeculator, PredictiveLoader, TopKRouter,
 };
 
+const SUPPORTED_SYNTHETIC_DTYPES: &str = "f32, f16, bf16, int8, q4k, q4_0, q8_0, mxfp4";
+const SUPPORTED_RUNTIME_DTYPES: &str =
+    "f32, f16, bf16, int8, q4k, q4_0, q5k, q6k, q8_0, mxfp4, mixed";
+
 /// MoE execution engine that streams experts from NVMe via O_DIRECT pread(2).
 #[derive(Parser, Debug)]
 #[command(name = "micro-expert-router", version, about)]
@@ -122,8 +126,9 @@ enum Cmd {
         /// without `EINVAL`. Must match what `run` is invoked with.
         #[arg(long, default_value_t = 4096)]
         block_align: usize,
-        /// On-disk weight dtype: `f32` (default) or `f16`. Selects the
-        /// byte width of every weight in the generated files.
+        /// On-disk weight dtype for synthetic files: f32, f16, bf16, int8,
+        /// q4k, q4_0, q8_0, or mxfp4. q5k, q6k, and mixed are GGUF/runtime
+        /// formats and are not synthesized by this generator.
         #[arg(long, default_value = "f32")]
         dtype: String,
     },
@@ -236,10 +241,9 @@ enum Cmd {
         /// PRNG seed for reproducible runs.
         #[arg(long, default_value_t = 0xC0FFEE)]
         seed: u64,
-        /// On-disk weight dtype: `f32` (default, 4 B/weight) or `f16`
-        /// (2 B/weight). Halving the byte width halves SSD-read bytes
-        /// per cache miss, which is the dominant energy term in this
-        /// engine. Must match what `gen-data` was invoked with.
+        /// On-disk weight dtype. Accepts f32, f16, bf16, int8, q4k, q4_0,
+        /// q5k, q6k, q8_0, mxfp4, or mixed. Must match the generated or
+        /// converted expert dataset.
         #[arg(long, default_value = "f32")]
         dtype: String,
         /// Fraction (`0.1..=1.0`) of input dimensions loaded per expert
@@ -805,7 +809,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 {
                     let dtype =
                         crate::inference::WeightDtype::from_str_opt(&dtype).ok_or_else(|| {
-                            format!("--dtype: unknown value {dtype:?} (use 'f32' or 'f16')")
+                            format!(
+                                "--dtype: unknown value {dtype:?} (supported: {SUPPORTED_RUNTIME_DTYPES})"
+                            )
                         })?;
                     cmd_run(
                         RunArgs {
@@ -1901,8 +1907,20 @@ fn cmd_gen_data(
 ) -> Result<(), Box<dyn std::error::Error>> {
     use crate::inference::WeightDtype;
     let dtype = WeightDtype::from_str_opt(dtype_str).ok_or_else(|| {
-        format!("--dtype: unknown value {dtype_str:?} (use 'f32', 'f16', or 'int8')")
+        format!(
+            "--dtype: unknown value {dtype_str:?} (supported for gen-data: {SUPPORTED_SYNTHETIC_DTYPES})"
+        )
     })?;
+    if matches!(
+        dtype,
+        WeightDtype::Q5K | WeightDtype::Q6K | WeightDtype::Mixed
+    ) {
+        return Err(format!(
+            "gen-data does not synthesize dtype {}; use gguf-convert --native-quant or an offline extractor for this layout",
+            dtype.as_str()
+        )
+        .into());
+    }
     if block_align == 0 || !block_align.is_power_of_two() {
         return Err(format!(
             "--block-align ({block_align}) must be a positive power of two \

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -538,6 +538,18 @@ enum Cmd {
         /// possible, conversion fails before writing expert files.
         #[arg(long, default_value_t = false)]
         native_quant: bool,
+        /// Convert only routed expert blobs and metadata. Dense
+        /// transformer tensors are skipped deliberately; the output is
+        /// valid for expert-streaming benchmarks, not full-model runs.
+        #[arg(long, default_value_t = false)]
+        experts_only: bool,
+    },
+
+    /// Validate a converted expert dataset before running inference.
+    ValidateData {
+        /// Directory containing `expert_<id>.bin` files and metadata.json.
+        #[arg(long)]
+        data_dir: PathBuf,
     },
 
     /// Replay a routing trace through the predictive prefetcher and
@@ -876,6 +888,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             no_uth,
             legacy_eager,
             native_quant,
+            experts_only,
         } => cmd_gguf_convert(
             &gguf_path,
             &out_dir,
@@ -884,7 +897,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             !no_uth,
             legacy_eager,
             native_quant,
+            experts_only,
         ),
+        Cmd::ValidateData { data_dir } => cmd_validate_data(&data_dir),
         Cmd::ValidatePredictor { trace, cache_slots } => {
             let rt = tokio::runtime::Builder::new_multi_thread()
                 .enable_all()
@@ -2167,6 +2182,11 @@ async fn cmd_run(
     apply_metadata_if_present(&mut args);
 
     let weight_bytes = expert_weight_bytes_for(args.d_model, args.d_ff, args.dtype);
+    let reported_weight_bytes = if args.dtype == crate::inference::WeightDtype::Mixed {
+        args.expert_size
+    } else {
+        weight_bytes
+    };
     info!(
         num_experts = args.num_experts,
         top_k = args.top_k,
@@ -2174,7 +2194,7 @@ async fn cmd_run(
         expert_mib = args.expert_size as f64 / (1024.0 * 1024.0),
         d_model = args.d_model,
         d_ff = args.d_ff,
-        weight_mib = weight_bytes as f64 / (1024.0 * 1024.0),
+        weight_mib = reported_weight_bytes as f64 / (1024.0 * 1024.0),
         direct_io = !args.no_direct,
         block_align = args.block_align,
         io_only = args.io_only,
@@ -2250,7 +2270,7 @@ async fn cmd_run(
         )
         .into());
     }
-    if weight_bytes > args.expert_size {
+    if weight_bytes > 0 && weight_bytes > args.expert_size {
         return Err(format!(
             "expert_size ({}) is too small for the SwiGLU weights of d_model={}, \
              d_ff={} ({} bytes). Increase --expert-size or shrink --d-model / --d-ff \
@@ -2881,6 +2901,7 @@ mod cli_defaults {
     pub const D_MODEL: usize = 512;
     pub const D_FF: usize = 2048;
     pub const TOP_K: usize = 2;
+    pub const BLOCK_ALIGN: usize = 4096;
 }
 
 /// Hand-rolled `metadata.json` parser. The only fields we care about are
@@ -2940,6 +2961,12 @@ fn apply_metadata_if_present(args: &mut RunArgs) {
         args.expert_size as u64,
         cli_defaults::EXPERT_SIZE as u64,
         &mut |v| args.expert_size = v as usize,
+    );
+    set_if_default(
+        "block_align",
+        args.block_align as u64,
+        cli_defaults::BLOCK_ALIGN as u64,
+        &mut |v| args.block_align = v as usize,
     );
     if args.dtype == crate::inference::WeightDtype::F32 {
         if let Some(dtype_str) = parse_json_string(&body, "dtype") {
@@ -3365,17 +3392,20 @@ fn cmd_gguf_convert(
     emit_uth: bool,
     legacy_eager: bool,
     native_quant: bool,
+    experts_only: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     info!(
         path = %gguf_path.display(),
         emit_uth,
         legacy_eager,
         native_quant,
+        experts_only,
         "opening GGUF file"
     );
     let opts = crate::gguf_loader::ExtractOptions {
         emit_uth,
         native_quant,
+        experts_only,
     };
     let source = crate::gguf::open_gguf_source(gguf_path, legacy_eager)?;
     if let Some(arch) = source.architecture() {
@@ -3407,6 +3437,19 @@ fn cmd_gguf_convert(
         "gguf-convert: wrote {} expert files + {} dense tensors ({:.2} GiB total). \
          At 7 GB/s aggregate SSD read bandwidth, a full warm-up scan would take ~{:.2}s.",
         report.experts_written, report.dense_written, total_gib, read_time_at_7gbps
+    );
+    Ok(())
+}
+
+fn cmd_validate_data(data_dir: &PathBuf) -> Result<(), Box<dyn std::error::Error>> {
+    let report = crate::gguf_loader::validate_data_dir(data_dir)?;
+    println!(
+        "validate-data: ok (experts={}, expert_size={} bytes, block_align={}, dtype={}, mixed_experts={})",
+        report.num_experts,
+        report.expert_size,
+        report.block_align,
+        report.dtype.as_str(),
+        report.mixed_experts
     );
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Add fail-closed GGUF conversion preflight, atomic staging/publish, staged dataset validation, `validate-data`, and `--experts-only` conversion mode.
- Preserve native/mixed quant layouts with richer metadata, UTH2 validation, block-align-aware resident parsing, and shard metadata tolerance for later split GGUF shards.
- Execute UTH2 mixed experts directly from projection byte ranges for supported CPU dtypes (`F32`, `F16`, `BF16`, `Q4_0`, `Q4_K`, `Q5_K`, `Q6_K`, `Q8_0`) without materializing full F32 matrices per activation.
- Update runtime reporting and README docs to describe the current mixed-quant support and fail-closed conversion behavior.

## Tests

- `cargo test`
- `rustfmt --edition 2021 --check --config skip_children=true src/gguf.rs src/gguf_loader.rs src/inference.rs src/expert_cache.rs src/engine.rs src/main.rs`
- `git diff --check`

## Notes

- I did not run a full conversion against the original multi-shard 8x22B checkpoint in this environment, so the PR keeps that as a measured-validation item rather than claiming it as completed.
- A full recursive rustfmt check still reports pre-existing formatting drift in untouched modules, so this PR only formats/checks the edited files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a data validation command to check converted datasets before inference.
  * Added an expert-only conversion mode for generating smaller expert-focused outputs.
  * Expanded support for mixed-precision expert execution and reporting.

* **Bug Fixes**
  * Improved handling of shard metadata so later shards can omit repeated architecture info.
  * Conversion now fails fast on missing or unsupported expert data instead of producing placeholder output.
  * Corrected alignment handling for converted expert data.

* **Documentation**
  * Updated setup and command-line documentation to reflect the latest conversion, validation, and mixed-precision behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->