### PR TITLE
Stabilize Rayon autotune selection for CPU placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1597,6 +1597,8 @@ env -u RAYON_NUM_THREADS ./target/release/micro-expert-router \
   --progress-timeout-secs 300 \
   run \
   --autotune-rayon \
+  --autotune-repeats 2 \
+  --autotune-coarse-tokens 512 \
   --autotune-tokens 2000 \
   ...
 ```
@@ -1611,6 +1613,8 @@ env -u RAYON_NUM_THREADS ./target/release/micro-expert-router \
   --progress-timeout-secs 300 \
   run \
   --autotune-rayon \
+  --autotune-repeats 2 \
+  --autotune-coarse-tokens 512 \
   --autotune-tokens 2000 \
   ...
 ```
@@ -1640,6 +1644,14 @@ reproduction. A known-good setting on one VM, such as `25` Rayon threads
 inside CPU mask `0-24`, is not a universal recommendation for other
 cloud shapes, bare-metal hosts, containers, models, quantization types,
 or backends.
+
+Autotune runs a short coarse pass over the candidate set, then repeated
+fine probes for the top candidates. The saved profile records the
+effective CPU mask, logical core count, repeats, per-probe metrics,
+candidate summaries, selected confidence, and selection reason. Low
+confidence profiles are retained for auditability, but normal runs do
+not reuse them unless `--reuse-low-confidence-rayon-profile` is passed.
+Use `--autotune-print-table` to emit a concise coarse/fine probe table.
 
 For config-driven `serve` and `bench-real` runs, placement and watchdog
 controls live under `[performance]`:
@@ -1819,7 +1831,14 @@ micro-expert-router run
   --tokens <N>               Stream length
   --autotune-rayon           Probe Rayon worker counts before startup pool
                               initialization and run with the winner.
-  --autotune-tokens <N>      Tokens per autotune probe (default 2000).
+  --autotune-tokens <N>      Tokens per fine autotune probe (default 2000).
+  --autotune-repeats <N>     Repeated fine probes per finalist (default 2).
+  --autotune-coarse-tokens <N>
+                              Tokens per coarse probe (default 512).
+  --autotune-top-candidates <N>
+                              Coarse winners promoted to fine probes
+                              (default 3).
+  --autotune-print-table     Print the coarse/fine autotune probe table.
   --dtype <DTYPE>            f32 | f16 | bf16 | int8 | q4k | q4_0 | q5k
                               | q6k | q8_0 | mxfp4 | mixed (default f32).
                               Must match gen-data / gguf-convert / the

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ The previous June 25 results remain available as a
     - [Predictive architecture (`[predictive]`)](#predictive-architecture-predictive)
     - [Real-transformer pipeline](#real-transformer-pipeline)
     - [Hardware auto-escalation](#hardware-auto-escalation)
+    - [CPU/Rayon autotune](#cpurayon-autotune)
     - [Decoupled math backend](#decoupled-math-backend)
     - [Speculative engine warm-up](#speculative-engine-warm-up)
     - [Distributed expert sharding](#distributed-expert-sharding)
@@ -379,13 +380,15 @@ when the GPU cache is enabled:
   joins OS threads per call, and — critically — every concurrent
   request under continuous batching shares **one bounded pool** instead
   of each fanning out to `cores` fresh threads and oversubscribing the
-  box. The pool is **sized once at startup to the host's logical cores
-  minus a small reservation** (0 on <=4-core hosts, 1 on 5-8, 2 on 9-31,
-  and `n/16` on 32+; see
+  box. The pool is **sized once at startup**. A matching CPU/Rayon
+  autotune profile is used first when present; otherwise MER falls back
+  to the host's logical cores minus a small reservation (0 on <=4-core
+  hosts, 1 on 5-8, 2 on 9-31, and `n/16` on 32+; see
   [`parallel::default_compute_threads`](rust-engine/src/parallel.rs)) so a
   saturated fan-out can never starve the async runtime — the tokio workers
   driving the scheduler, the gRPC server, and io_uring SSD streaming. Set
-  `RAYON_NUM_THREADS` to override the default on a per-deployment basis.
+  `RAYON_NUM_THREADS` to override both autotune profiles and the default
+  on a per-deployment basis.
   **No cargo feature is required.** The historic `--features simd`
   flag is retained as a deprecated no-op so existing build scripts keep
   working.
@@ -1411,8 +1414,9 @@ without recompilation:
    amortise the fork-join. The pool is created once and reused, so the
    per-token hot path never spawns OS threads per call and concurrent
    requests share one bounded pool instead of oversubscribing the
-   machine. It is sized at startup to the host's logical cores minus a
-   small async-runtime reservation (`RAYON_NUM_THREADS` overrides).
+   machine. It is sized at startup from a matching CPU/Rayon autotune
+   profile when one exists, otherwise to the host's logical cores minus a
+   small async-runtime reservation (`RAYON_NUM_THREADS` overrides both).
    **Replaces the old `--features simd` build-time flag**;
    that feature is now a no-op kept for backwards compatibility.
 3. **Scalar fallback**, single-threaded fused loop, the validation
@@ -1429,6 +1433,63 @@ on. The selected backend is logged once at startup:
 ```
 INFO auto-escalation selected math kernel backend backend=avx2 vendor=GenuineIntel ... avx2=true avx512=true amx_int8=true sapphire_rapids=true
 ```
+
+#### CPU/Rayon autotune
+
+Using every visible vCPU is not always the fastest CPU setting. The Rayon
+pool competes with tokio scheduler workers, SSD completion handling, cache
+traffic, and quantized kernel placement. The fixed
+`default_compute_threads(logical)` fallback keeps async headroom, but VM
+tests showed that a fixed heuristic can still land in a slow regime on a
+new host.
+
+Run the autotuner on the same host, data directory, dtype, cache size, and
+backend path you plan to benchmark:
+
+```bash
+./target/release/micro-expert-router run \
+  --data-dir ./data \
+  --dtype q4_0 \
+  --cache-slots 124 \
+  --tokens 10000 \
+  --autotune-rayon \
+  --autotune-tokens 128
+```
+
+`--autotune-rayon` launches short child-process probes, one per candidate,
+with `RAYON_NUM_THREADS=<candidate>`. The parent process does not build
+Rayon's global pool during probing; after it selects the winner, it builds
+the pool exactly once for the real run. By default the candidate set is a
+window around `parallel::default_compute_threads(logical)` plus the full
+visible logical-core count. On a 32-vCPU host this includes at least
+`24, 26, 27, 28, 29, 30, 31, 32`.
+
+Each child emits JSON with the candidate thread count, `sustained_tps`,
+`compute_p50_us`, `compute_p95_us`, hit rate, token count, cache slots,
+dtype, backend/quant path, and success/failure. The parent chooses the
+lowest `compute_p50_us`, breaking ties with higher `sustained_tps`, and
+ignores failed/invalid probes.
+
+The selected profile is saved under:
+
+```text
+~/.cache/mer/autotune/<machine-and-model-fingerprint>.json
+```
+
+If `XDG_CACHE_HOME` is set, MER uses
+`$XDG_CACHE_HOME/mer/autotune/` instead. Normal `run`, `serve`, and
+`bench-real` startups use a matching saved profile automatically. An
+explicit `RAYON_NUM_THREADS` still wins over a saved profile. Re-run
+`run --autotune-rayon` to force a fresh measurement and replace the saved
+profile for that host/model/backend fingerprint.
+
+The strongest fast/slow evidence so far came from Mixtral 8x7B Q4_0
+expert-streaming runs using the QMatMul path. Do not read any selected
+thread count, including 30, as universal. Qwen-MoE, OLMoE, Q8_0, mixed
+projection dtypes, dense matvec backend choices, and other quant kernels
+should be benchmarked independently because the best count can vary with
+host shape, model shape, dtype, quant kernel, cache size, and runtime
+placement.
 
 ```bash
 cargo build --release                # default, auto-escalation only
@@ -1732,6 +1793,14 @@ micro-expert-router run
                               runs tested 16, 64, and 128 slots.
   --top-k <K>                Active experts per token (default 2, distinct)
   --tokens <N>               Stream length
+  --autotune-rayon           Probe candidate Rayon thread counts in child
+                              processes, save the best profile, then run
+                              the real benchmark with the selected pool size.
+  --autotune-tokens <N>      Tokens per child probe (default 96)
+  --autotune-candidates <N,..>  Optional comma-separated candidate counts.
+                              Defaults to a window around
+                              default_compute_threads(logical), plus the
+                              full visible logical-core count.
   --dtype <DTYPE>            f32 | f16 | bf16 | int8 | q4k | q4_0 | q5k
                               | q6k | q8_0 | mxfp4 | mixed (default f32).
                               Must match gen-data / gguf-convert / the

--- a/README.md
+++ b/README.md
@@ -1615,6 +1615,8 @@ env -u RAYON_NUM_THREADS ./target/release/micro-expert-router \
   --autotune-rayon \
   --autotune-repeats 2 \
   --autotune-coarse-tokens 512 \
+  --autotune-slow-p95-ms 110 \
+  --autotune-slow-p99-ms 150 \
   --autotune-tokens 2000 \
   ...
 ```
@@ -1646,12 +1648,17 @@ cloud shapes, bare-metal hosts, containers, models, quantization types,
 or backends.
 
 Autotune runs a short coarse pass over the candidate set, then repeated
-fine probes for the top candidates. The saved profile records the
-effective CPU mask, logical core count, repeats, per-probe metrics,
-candidate summaries, selected confidence, and selection reason. Low
-confidence profiles are retained for auditability, but normal runs do
-not reuse them unless `--reuse-low-confidence-rayon-profile` is passed.
-Use `--autotune-print-table` to emit a concise coarse/fine probe table.
+fine probes for the top candidates plus anchor candidates: MER's default
+compute thread count, all logical cores, logical cores minus one, and any
+previous high-confidence profile for the same placement key. The saved
+profile records the effective CPU mask, logical core count, repeats,
+per-probe metrics, candidate summaries, selected confidence, and
+selection reason. Low-confidence profiles are retained only when
+explicitly allowed, and normal runs do not reuse them unless
+`--reuse-low-confidence-rayon-profile` is passed. Low-confidence
+autotune results are not used for the current run unless
+`--allow-low-confidence-rayon-autotune` is passed. Use
+`--autotune-print-table` to emit a concise coarse/fine probe table.
 
 For config-driven `serve` and `bench-real` runs, placement and watchdog
 controls live under `[performance]`:
@@ -1839,6 +1846,13 @@ micro-expert-router run
                               Coarse winners promoted to fine probes
                               (default 3).
   --autotune-print-table     Print the coarse/fine autotune probe table.
+  --autotune-slow-p95-ms <MS>
+                              Slow-regime worst-p95 cutoff (default 80).
+  --autotune-slow-p99-ms <MS>
+                              Slow-regime worst-p99 cutoff (default 120).
+  --allow-low-confidence-rayon-autotune
+                              Permit a low-confidence autotune result for
+                              this run.
   --dtype <DTYPE>            f32 | f16 | bf16 | int8 | q4k | q4_0 | q5k
                               | q6k | q8_0 | mxfp4 | mixed (default f32).
                               Must match gen-data / gguf-convert / the

--- a/README.md
+++ b/README.md
@@ -1453,7 +1453,7 @@ backend path you plan to benchmark:
   --cache-slots 124 \
   --tokens 10000 \
   --autotune-rayon \
-  --autotune-tokens 128
+  --autotune-tokens 256
 ```
 
 `--autotune-rayon` launches short child-process probes, one per candidate,
@@ -1466,9 +1466,13 @@ visible logical-core count. On a 32-vCPU host this includes at least
 
 Each child emits JSON with the candidate thread count, `sustained_tps`,
 `compute_p50_us`, `compute_p95_us`, hit rate, token count, cache slots,
-dtype, backend/quant path, and success/failure. The parent chooses the
-lowest `compute_p50_us`, breaking ties with higher `sustained_tps`, and
-ignores failed/invalid probes.
+dtype, backend/quant path, and success/failure. The parent avoids
+bimodal candidates by first preferring probes whose tail compute latency
+stays below the slow-regime threshold (`compute_p95_us < 80000`), then
+chooses the lowest `compute_p50_us` and breaks ties with higher
+`sustained_tps`. If every valid candidate has slow-tail p95, it falls
+back to the p50/tps rule rather than claiming the lowest-p50 candidate
+is always best. Failed or invalid probes are ignored.
 
 The selected profile is saved under:
 
@@ -1796,7 +1800,7 @@ micro-expert-router run
   --autotune-rayon           Probe candidate Rayon thread counts in child
                               processes, save the best profile, then run
                               the real benchmark with the selected pool size.
-  --autotune-tokens <N>      Tokens per child probe (default 96)
+  --autotune-tokens <N>      Tokens per child probe (default 256)
   --autotune-candidates <N,..>  Optional comma-separated candidate counts.
                               Defaults to a window around
                               default_compute_threads(logical), plus the

--- a/README.md
+++ b/README.md
@@ -1615,11 +1615,21 @@ env -u RAYON_NUM_THREADS ./target/release/micro-expert-router \
   --autotune-rayon \
   --autotune-repeats 2 \
   --autotune-coarse-tokens 512 \
-  --autotune-slow-p95-ms 110 \
-  --autotune-slow-p99-ms 150 \
+  --autotune-slow-p95-ms 180 \
+  --autotune-slow-p99-ms 320 \
   --autotune-tokens 2000 \
   ...
 ```
+
+`--autotune-rayon` improves thread-count discovery and observability; it
+does not guarantee stable throughput on noisy VMs. The autotune p95/p99
+thresholds are based on end-to-end token cycle latency, so they should be
+looser than the compute-only FFN latency reported in the final run
+summary. On VMs, child-process autotune probes may find a fast regime
+that the final parent run does not always reproduce. On bare metal or
+dedicated pinned hosts, a high-confidence saved profile is more likely to
+remain reusable. On noisy VMs, per-run autotune is recommended for
+benchmark runs.
 
 For exact benchmark reproduction, pin both the placement and the worker
 count:

--- a/README.md
+++ b/README.md
@@ -159,8 +159,6 @@ The previous June 25 results remain available as a
     - [Predictive architecture (`[predictive]`)](#predictive-architecture-predictive)
     - [Real-transformer pipeline](#real-transformer-pipeline)
     - [Hardware auto-escalation](#hardware-auto-escalation)
-    - [CPU/Rayon autotune](#cpurayon-autotune)
-    - [CPU placement and progress watchdog](#cpu-placement-and-progress-watchdog)
     - [Decoupled math backend](#decoupled-math-backend)
     - [Speculative engine warm-up](#speculative-engine-warm-up)
     - [Distributed expert sharding](#distributed-expert-sharding)
@@ -381,15 +379,16 @@ when the GPU cache is enabled:
   joins OS threads per call, and — critically — every concurrent
   request under continuous batching shares **one bounded pool** instead
   of each fanning out to `cores` fresh threads and oversubscribing the
-  box. The pool is **sized once at startup**. A matching CPU/Rayon
-  autotune profile is used first when present; otherwise MER falls back
-  to the host's logical cores minus a small reservation (0 on <=4-core
-  hosts, 1 on 5-8, 2 on 9-31, and `n/16` on 32+; see
+  box. The pool is **sized once at startup to the effective logical cores
+  visible after any process affinity/cpuset limit, minus a small
+  reservation** (0 on <=4-core hosts, 1 on 5-8, 2 on 9-31, and `n/16` on
+  32+; see
   [`parallel::default_compute_threads`](rust-engine/src/parallel.rs)) so a
   saturated fan-out can never starve the async runtime — the tokio workers
-  driving the scheduler, the gRPC server, and io_uring SSD streaming. Set
-  `RAYON_NUM_THREADS` to override both autotune profiles and the default
-  on a per-deployment basis.
+  driving the scheduler, the gRPC server, and io_uring SSD streaming. Use
+  `--autotune-rayon` to choose a worker count for the current placement, or
+  `--rayon-threads`, `[performance].rayon_threads`, or `RAYON_NUM_THREADS`
+  for explicit reproduction/debug overrides.
   **No cargo feature is required.** The historic `--features simd`
   flag is retained as a deprecated no-op so existing build scripts keep
   working.
@@ -541,7 +540,7 @@ The Rust crate (`rust-engine/`) is organised into single-responsibility modules:
 | `gating` | Production routing path: `LinearGate` computes `softmax(W_gate · x) → top-K` exactly the way Mixtral does. `Router` is an enum the engine holds polymorphically, `Router::Linear` in the real-transformer path, `Router::Markov` for the benchmark / `--io-only` path. |
 | `inference` | SwiGLU expert FFN (`y = down · (silu(gate·x) ⊙ (up·x))`), executed through the **`candle-core`** tensor backend. Implemented per dtype: `run_inference` (F32, zero-copy reinterpret + Candle matmul), `run_inference_f16` / `_int8` / `_q8_0` (dequantise to `f32` then the same Candle SwiGLU kernel), and `run_inference_partial` (load only the top-M input columns by magnitude). For homogeneous GGUF block-quantised dtypes the engine prefers a **`QMatMul` fast path** (`run_inference_q4_0_qmm` / `run_inference_q4k_qmm` / `run_inference_q8_0_qmm`) that hands the on-disk quantised blocks straight to candle's GGML kernels, no F32 dequantise of the weights. For `dtype=mixed`, UTH2 supplies independent gate/up/down dtype+range metadata and the CPU path executes each projection directly from its quantised bytes (`Q4_0`, `Q4_K`, `Q5_K`, `Q6_K`, `Q8_0`, plus float projections) without materialising full F32 matrices per activation. The legacy dequant kernels remain as reference/debug paths. All variants run directly over the bytes streamed off NVMe; the proprietary `ExpertResident` / `BufferPool` / `expert_cache` / O_DIRECT I/O substrate is untouched. |
 | `transformer` | Scalar `f32` dense pieces of the Mixtral / Llama decoder layer: `RmsNorm`, `apply_rope_inplace`, `MultiHeadSelfAttention` (with **GQA** when `num_kv_heads < num_heads` and optional **sliding-window** attention, resolved **per layer** so hybrid SWA/global families like MiMo-V2 and GPT-OSS mix modes within one model), `TransformerLayer`, `KvCache` (16-token blocks, can be backed by the `block_pool` slab; `evict_before` drops leading blocks to bound sliding-window caches), `LMHead`, and the `matmul_row_major` dispatch. `matmul_row_major` auto-escalates: scalar → runtime row-parallel (always compiled, via `parallel::par_row_chunks`) → `matrixmultiply` SGEMV under `--features blas`. |
-| `parallel` | Architecture-agnostic **row-parallel execution helper** shared by every dense kernel across every supported family (`matmul_row_major`, the per-expert `gate_up_swiglu` / `down_proj`, the MoE router gate, DeepSeek MLA projections, the LM head). `par_row_chunks` fans disjoint output-row chunks onto a **shared, process-wide `rayon` work-stealing pool** that is created once and reused, so the per-token hot path never spawns/joins OS threads per call (the previous `std::thread::scope` design spawned fresh threads on every matmul), and concurrent requests under continuous batching contend for **one bounded pool** instead of each oversubscribing the box by `N × cores`. The pool is sized at startup by `init_global_pool` to the host's logical cores **minus a small reservation** (`default_compute_threads`: 0 on ≤4-core hosts, 1 on 5–8, two from 9 up, growing by one per extra 16 cores) so a saturated fan-out cannot starve the tokio async runtime; `RAYON_NUM_THREADS` overrides it. Matmuls below an element threshold run inline on the caller; output is bit-identical to the serial reference. |
+| `parallel` | Architecture-agnostic **row-parallel execution helper** shared by every dense kernel across every supported family (`matmul_row_major`, the per-expert `gate_up_swiglu` / `down_proj`, the MoE router gate, DeepSeek MLA projections, the LM head). `par_row_chunks` fans disjoint output-row chunks onto a **shared, process-wide `rayon` work-stealing pool** that is created once and reused, so the per-token hot path never spawns/joins OS threads per call (the previous `std::thread::scope` design spawned fresh threads on every matmul), and concurrent requests under continuous batching contend for **one bounded pool** instead of each oversubscribing the box by `N × cores`. The pool is sized at startup by `init_global_pool` from the effective logical cores visible after affinity/cpuset placement **minus a small reservation** (`default_compute_threads`: 0 on ≤4-core hosts, 1 on 5–8, two from 9 up, growing by one per extra 16 cores) so a saturated fan-out cannot starve the tokio async runtime; `--autotune-rayon` can probe the current placement, while `--rayon-threads`, `performance.rayon_threads`, or `RAYON_NUM_THREADS` can override it. Matmuls below an element threshold run inline on the caller; output is bit-identical to the serial reference. |
 | `model` | `RealModel`, full multi-layer decoder built on top of `transformer`. Owns the dense (resident) weights, drives the per-token forward (`embedding → stacked layers → final RMSNorm → LM head`), and addresses experts as `global_id = layer * num_experts + local_id` so the existing single-namespace cache + storage layers work unchanged. Loads dense weights from per-tensor `.bin` files (`from_dir`) **or** HuggingFace `.safetensors` shards (`from_safetensors`); `from_dir_auto` picks the right one. Missing tensors fall back to a deterministic seeded init. Also exposes `peek_experts` (cheap, side-effect-free routing pre-pass) and `step_speculative` (verify K draft tokens with a unified expert prefetch, gist Phase 2; the preview KV growth for positions `k ≥ 1` is now seeded from a layer-0 draft-token embedding + RoPE projection rather than zero vectors so the verifier's lookahead is not routed on garbage activations, gist Part 2 fix #3). |
 | `draft` | Speculative-decoding "draft" model (gist Phase 2). `DraftLike` trait + `DraftEngine` (a small, deterministic, RAM-resident dense head tied to the main model's embedding). `predict_next` runs through `kernels::dot_f32` over a 64-byte-aligned hidden-state scratch (gist Part 2 fix #1) so the draft path auto-escalates AVX-512 → AVX2 → scalar exactly like the main matmul; the K-token loop reuses one allocation. Generates K candidate tokens with no SSD I/O so `RealModel::step_speculative` can verify them in a single batched-prefetch wave. |
 | `sampling` | OpenAI-compatible next-token sampler, temperature, top-K, top-P (nucleus), `(seed, position)`-driven RNG. `temperature == 0.0` short-circuits to greedy `argmax`. |
@@ -555,9 +554,9 @@ The Rust crate (`rust-engine/`) is organised into single-responsibility modules:
 | `kernels` | Runtime CPU-feature dispatcher (`mod.rs::detect()` + `current()` + `cpu_features()`), with `scalar.rs` (always on, also home of the `swiglu_f32` reference oracle plus the `dot_int8_int8` scalar reference for VNNI), `avx2.rs` (always compiled on x86_64, no cargo feature; the `#[target_feature]` entry points are gated on the runtime probe), `avx512.rs` (`--features avx512`, `#[target_feature]` fused int8 dequant + dot, the 4×-unrolled `dot_f32_avx512`, the fused per-row `swiglu_f32_avx512` kernel, **and** the AVX-512 VNNI int8×int8 dot `dot_int8_int8_avx512_vnni` built on `_mm512_dpbusd_epi32`, gist Part 2 fix #8, with the i8→u8 bias-trick correction so the inner reduction stays in i32 integer registers), and `amx.rs` (`--features amx`, skeleton until tile intrinsics stabilise on stable Rust). The dispatcher also exposes `swiglu_f32_into(gate_w, up_w, x, rows, cols, y)` which routes to the AVX-512 fused kernel on capable hosts and the scalar reference elsewhere, caller owns `y`, no allocation on the hot path. The probe reads `/proc/cpuinfo` to recognise Sapphire-Rapids-class Xeons so AMX can be preferred on the chips it ships on. The selected backend is logged once at startup. |
 | `backend` | Plugin-system math `Backend` trait (`matmul`, `matmul_into`, `swiglu_into`, `softmax`, `silu_inplace`) with three built-in implementations: `ScalarBackend` (pure Rust reference), `CandleBackend` (default CPU executor, dispatches through `kernels::dot_f32` / `kernels::swiglu_f32_into`, no `candle_core::Tensor` rebuild on the hot path, **zero allocation** in either call), and `GpuBackend` (gist Part 2 fix #5, budget-GPU executor selected by `[real_transformer].compute_offload = "gpu"`; both the integration seam and the `wgpu` compute pipeline compile on every build, the `gpu` cargo feature is now a no-op kept only for backwards compatibility). Both CPU backends override `matmul_into` to dispatch through `kernels::dot_f32` (auto-escalates AVX-512 → AVX2 → scalar). The active backend is installed once at startup via `backend::install_default()` (or, when `compute_offload = "gpu"`, `set_backend(GpuBackend::try_new())` runs first) and resolved on the hot path through `backend::current()`, a single `OnceLock` load, no `cfg!` dispatch. New executors (Burn, Tract, custom CUDA) implement `Backend` and call `set_backend(Arc<dyn Backend>)` before the first token is generated. |
 | `io_reactor` | **Actor-pattern I/O reactor** (gist Part 5 doc fix). Wraps an `NvmeStorage` behind a single-owner tokio task that runs a **bounded serial loop**: it dequeues read requests from a bounded `mpsc` channel one at a time, `await`s the read inline, replies over the per-request `oneshot`, and only then pulls the next request, the bounded queue therefore also bounds active I/O concurrency. `IoReactorHandle` is cheaply cloneable (the sender side is reference-counted by tokio); workers issue `read_expert(id, buf)` without ever touching a shared `DashMap` shard / `RwLock` write guard. Backpressure is automatic, when the I/O substrate saturates, callers park on `mpsc::send` instead of overflowing a per-thread queue. Exposed as a standalone helper alongside the legacy `engine` path so the in-flight `DashMap<u32, Notify>` deduplicator can retire one subsystem at a time. |
-| `numa` | Startup CPU placement. `--cpu-mask 0-24` / `[performance].cpu_mask = "0-24"` applies an explicit Linux `sched_setaffinity(2)` cpulist before tokio and Rayon workers are created; legacy `MER_PIN_CORES=N` still pins the first `N` CPUs when no explicit mask is set. The effective mask is logged for production diagnosis. |
+| `numa` | Startup CPU placement helpers. By default MER applies no artificial CPU mask. Operators can opt in with global `--cpu-mask <CPULIST>` or `[performance].cpu_mask`; legacy `MER_PIN_CORES=N` remains a lower-precedence fallback. On Linux this uses `sched_setaffinity(2)` best-effort; elsewhere MER logs and continues. |
 | `metrics` | Prometheus `Registry` + handles for every counter / histogram exported on `/metrics`. |
-| `config` | TOML schema for `serve --config`: `[server]`, `[security]`, `[sampling]`, `[model]`, `[storage]`, `[tokenizer]`, `[real_transformer]`, `[predictive]`, `[performance]`, `[gpu_cache]`. Validated at startup. |
+| `config` | TOML schema for `serve --config`: `[server]`, `[security]`, `[sampling]`, `[model]`, `[storage]`, `[tokenizer]`, `[real_transformer]`, `[predictive]`, `[gpu_cache]`. Validated at startup. |
 | `tui` (with `--features tui`) | Native "Amalgafy"-style terminal dashboard rendered with `ratatui` + `crossterm`. The `monitor` subcommand (`micro-expert-router monitor --url http://127.0.0.1:8080 --refresh-ms 250`) polls `/v1/admin/health/experts` and draws a header (status / uptime / TPS, with restart-recovery: TPS resets to zero on a backwards jump of `tokens_generated`), a 3-tier hit grid with one **delta-calculated** sparkline per tier (VRAM / RAM / SSD, pulse per refresh tick, not a cumulative staircase), a VRAM/RAM utilisation gauge, and an I/O reactor stall pulse driven by the per-tick SSD-miss delta. All sparkline histories are capped at 60 points to bound memory growth. Uses a hand-rolled minimal HTTP/1.1 client over `tokio::net::TcpStream` to avoid pulling in `reqwest`. |
 | `server` | OpenAI-compatible HTTP server (`axum`): `/health`, `/metrics`, `/v1/completions`, `/v1/chat/completions` (both streaming SSE and one-shot), `DELETE /v1/sessions/{id}`, plus the operator endpoints `GET /v1/admin/health/experts` and `POST /v1/admin/evict`. Calls `run_engine_warmup` before binding the listener so the first user token never pays the cold-start cost (best-effort; failures only `tracing::warn!`). |
 | `middleware` | Production-readiness HTTP middleware layered onto the `server` router via `axum::middleware::from_fn_with_state`: per-request UUID tracing span, optional **API-key gate** (`[security].api_keys`; `401` when configured and missing/unknown), optional **per-key token-bucket rate limit** (`rate_limit_rps` / `rate_limit_burst`; `429` on overflow), and **admission control** (`[server].max_concurrent_requests`, `[server].admission_min_free_blocks` against the paged-KV pool; `503` when saturated). Defaults are fully permissive so legacy benchmark / development flows are byte-identical. |
@@ -1415,9 +1414,10 @@ without recompilation:
    amortise the fork-join. The pool is created once and reused, so the
    per-token hot path never spawns OS threads per call and concurrent
    requests share one bounded pool instead of oversubscribing the
-   machine. It is sized at startup from a matching CPU/Rayon autotune
-   profile when one exists, otherwise to the host's logical cores minus a
-   small async-runtime reservation (`RAYON_NUM_THREADS` overrides both).
+   machine. It is sized at startup to the effective logical cores after
+   affinity/cpuset placement minus a small async-runtime reservation
+   (`--autotune-rayon` can probe; `RAYON_NUM_THREADS`, `--rayon-threads`,
+   or `performance.rayon_threads` can override).
    **Replaces the old `--features simd` build-time flag**;
    that feature is now a no-op kept for backwards compatibility.
 3. **Scalar fallback**, single-threaded fused loop, the validation
@@ -1434,105 +1434,6 @@ on. The selected backend is logged once at startup:
 ```
 INFO auto-escalation selected math kernel backend backend=avx2 vendor=GenuineIntel ... avx2=true avx512=true amx_int8=true sapphire_rapids=true
 ```
-
-#### CPU/Rayon autotune
-
-Using every visible vCPU is not always the fastest CPU setting. The Rayon
-pool competes with tokio scheduler workers, SSD completion handling, cache
-traffic, and quantized kernel placement. The fixed
-`default_compute_threads(logical)` fallback keeps async headroom, but VM
-tests showed that a fixed heuristic can still land in a slow regime on a
-new host.
-
-Run the autotuner on the same host, data directory, dtype, cache size, and
-backend path you plan to benchmark:
-
-```bash
-./target/release/micro-expert-router run \
-  --data-dir ./data \
-  --dtype q4_0 \
-  --cache-slots 124 \
-  --tokens 10000 \
-  --autotune-rayon \
-  --autotune-tokens 256
-```
-
-`--autotune-rayon` launches short child-process probes, one per candidate,
-with `RAYON_NUM_THREADS=<candidate>`. The parent process does not build
-Rayon's global pool during probing; after it selects the winner, it builds
-the pool exactly once for the real run. By default the candidate set is a
-window around `parallel::default_compute_threads(logical)` plus the full
-visible logical-core count. On a 32-vCPU host this includes at least
-`24, 26, 27, 28, 29, 30, 31, 32`.
-
-Each child emits JSON with the candidate thread count, `sustained_tps`,
-`compute_p50_us`, `compute_p95_us`, hit rate, token count, cache slots,
-dtype, backend/quant path, and success/failure. The parent avoids
-bimodal candidates by first preferring probes whose tail compute latency
-stays below the slow-regime threshold (`compute_p95_us < 80000`), then
-chooses the lowest `compute_p50_us` and breaks ties with higher
-`sustained_tps`. If every valid candidate has slow-tail p95, it falls
-back to the p50/tps rule rather than claiming the lowest-p50 candidate
-is always best. Failed or invalid probes are ignored.
-
-The selected profile is saved under:
-
-```text
-~/.cache/mer/autotune/<machine-and-model-fingerprint>.json
-```
-
-If `XDG_CACHE_HOME` is set, MER uses
-`$XDG_CACHE_HOME/mer/autotune/` instead. Normal `run`, `serve`, and
-`bench-real` startups use a matching saved profile automatically. An
-explicit `RAYON_NUM_THREADS` still wins over a saved profile. Re-run
-`run --autotune-rayon` to force a fresh measurement and replace the saved
-profile for that host/model/backend fingerprint.
-
-The strongest fast/slow evidence so far came from Mixtral 8x7B Q4_0
-expert-streaming runs using the QMatMul path. Do not read any selected
-thread count, including 30, as universal. Qwen-MoE, OLMoE, Q8_0, mixed
-projection dtypes, dense matvec backend choices, and other quant kernels
-should be benchmarked independently because the best count can vary with
-host shape, model shape, dtype, quant kernel, cache size, and runtime
-placement.
-
-#### CPU placement and progress watchdog
-
-Autotune chooses the Rayon thread count; CPU mask/pinning controls where
-those workers and the async runtime are allowed to run. On VMs, both can
-matter for stable FFN performance. For example, the strongest current
-evidence is still Mixtral Q4_0/QMatMul on GCP `g2-standard-32`: autotune
-found useful thread-count bands, but manual placement such as
-`RAYON_NUM_THREADS=25` plus `--cpu-mask 0-24` was needed to avoid VM
-placement variance in repeated long runs. Do not treat a one-time autotune
-profile as proof that placement variance is gone on every host.
-
-Use the global CLI flag for one-off runs:
-
-```bash
-RAYON_NUM_THREADS=25 ./target/release/micro-expert-router \
-  --cpu-mask 0-24 \
-  --progress-timeout-secs 300 \
-  run --data-dir ./data --dtype q4_0 --cache-slots 124 --tokens 10000
-```
-
-Or configure serving/`bench-real` in TOML:
-
-```toml
-[performance]
-cpu_mask = "0-24"
-progress_timeout_secs = 300
-```
-
-CPU affinity is applied before tokio runtime creation and before the
-process-wide Rayon pool is initialized, so worker threads inherit the
-intended placement. Startup logs include the requested mask, effective
-allowed mask, visible logical cores, selected Rayon thread count, Rayon
-source (`env`, `profile`, `autotune`, or `default`), and whether pinning
-succeeded. The watchdog timeout is disabled by default; when set for
-benchmark runs, a token-progress stall logs the last token index, cache
-and I/O counters, compute latency summary, Rayon settings, CPU mask, and
-stage, then exits non-zero instead of hanging indefinitely.
 
 ```bash
 cargo build --release                # default, auto-escalation only
@@ -1653,8 +1554,8 @@ cargo build --release --features tokenizer
 
 Configuration lives in TOML, see [`config.toml`](./config.toml) for
 the full annotated schema (server bind address, model dimensions, cache
-slots, `O_DIRECT` block alignment, predictive prefetch fanout, CPU
-placement, benchmark watchdog timeout, optional tokenizer path).
+slots, `O_DIRECT` block alignment, predictive prefetch fanout, optional
+tokenizer path).
 
 To **isolate pure I/O cost** (skip the SwiGLU FFN; XOR every byte read
 to force the page in):
@@ -1674,6 +1575,81 @@ To run on a filesystem that doesn't support `O_DIRECT` (CI, tmpfs, macOS dev):
 
 ```bash
 ./target/release/micro-expert-router run --no-direct ...
+```
+
+#### Portable CPU/Rayon Autotune
+
+MER's CPU dense paths use one process-wide Rayon pool for row-parallel
+matmul and expert FFN work. The pool is initialized once at startup, so
+CPU placement and thread-count selection must be resolved before the
+first CPU compute path touches Rayon.
+
+`--autotune-rayon` chooses the Rayon worker count for the current
+machine, model/config, backend, and effective CPU affinity. `--cpu-mask`
+controls CPU placement/visibility. They solve different problems:
+autotune decides how many Rayon workers to use; a CPU mask bounds where
+the process and its workers may run.
+
+On most machines, start with no CPU mask and use autotune:
+
+```bash
+env -u RAYON_NUM_THREADS ./target/release/micro-expert-router \
+  --progress-timeout-secs 300 \
+  run \
+  --autotune-rayon \
+  --autotune-tokens 2000 \
+  ...
+```
+
+On noisy cloud VMs, NUMA hosts, or container/cpuset deployments where you
+need placement control, bound placement first and autotune inside that
+mask:
+
+```bash
+env -u RAYON_NUM_THREADS ./target/release/micro-expert-router \
+  --cpu-mask 0-24 \
+  --progress-timeout-secs 300 \
+  run \
+  --autotune-rayon \
+  --autotune-tokens 2000 \
+  ...
+```
+
+For exact benchmark reproduction, pin both the placement and the worker
+count:
+
+```bash
+RAYON_NUM_THREADS=25 ./target/release/micro-expert-router \
+  --cpu-mask 0-24 \
+  --progress-timeout-secs 300 \
+  run \
+  ...
+```
+
+Selection precedence is:
+
+1. `RAYON_NUM_THREADS`
+2. `--rayon-threads <N>`
+3. `performance.rayon_threads = N`
+4. `--autotune-rayon` result
+5. saved placement-aware autotune profile
+6. MER's default startup sizing under the effective affinity mask
+
+`RAYON_NUM_THREADS` is mainly for debugging or exact benchmark
+reproduction. A known-good setting on one VM, such as `25` Rayon threads
+inside CPU mask `0-24`, is not a universal recommendation for other
+cloud shapes, bare-metal hosts, containers, models, quantization types,
+or backends.
+
+For config-driven `serve` and `bench-real` runs, placement and watchdog
+controls live under `[performance]`:
+
+```toml
+[performance]
+# Optional; unset means no artificial CPU mask.
+cpu_mask = "0-24"
+# Optional; 0/unset disables the watchdog.
+progress_timeout_secs = 300
 ```
 
 Increase log verbosity:
@@ -1795,14 +1771,6 @@ for a given model size.
 ### CLI reference
 
 ```
-micro-expert-router [global options] <subcommand>
-  --cpu-mask <CPULIST>       Best-effort Linux CPU affinity before tokio
-                              and Rayon startup, e.g. 0-24 or 0-7,16-23.
-                              Overrides [performance].cpu_mask and legacy
-                              MER_PIN_CORES.
-  --progress-timeout-secs <N> Fail benchmark token-progress stalls after N
-                              seconds. 0/unset disables the watchdog.
-
 micro-expert-router gen-data
   --data-dir <PATH>          Output directory (default ./data)
   --num-experts <N>          Number of expert files (default 64)
@@ -1830,6 +1798,11 @@ micro-expert-router repack    # Tier 2: build a packed expert blob + manifest
                               --profile; only the listed experts are packed.
 
 micro-expert-router run
+  --cpu-mask <CPULIST>      Optional global CPU placement mask, e.g. 0-24.
+                              Leave unset for no artificial placement.
+  --progress-timeout-secs <S>  Optional global progress watchdog. 0 disables.
+  --rayon-threads <N>       Worker count for the process-wide CPU Rayon pool.
+                              Global flag; may also be written before `run`.
   --data-dir <PATH>          Directory with expert_<id>.bin files
                               (auto-loads metadata.json if present).
                               Accepts a comma-separated list to shard
@@ -1844,14 +1817,9 @@ micro-expert-router run
                               runs tested 16, 64, and 128 slots.
   --top-k <K>                Active experts per token (default 2, distinct)
   --tokens <N>               Stream length
-  --autotune-rayon           Probe candidate Rayon thread counts in child
-                              processes, save the best profile, then run
-                              the real benchmark with the selected pool size.
-  --autotune-tokens <N>      Tokens per child probe (default 256)
-  --autotune-candidates <N,..>  Optional comma-separated candidate counts.
-                              Defaults to a window around
-                              default_compute_threads(logical), plus the
-                              full visible logical-core count.
+  --autotune-rayon           Probe Rayon worker counts before startup pool
+                              initialization and run with the winner.
+  --autotune-tokens <N>      Tokens per autotune probe (default 2000).
   --dtype <DTYPE>            f32 | f16 | bf16 | int8 | q4k | q4_0 | q5k
                               | q6k | q8_0 | mxfp4 | mixed (default f32).
                               Must match gen-data / gguf-convert / the
@@ -1905,12 +1873,11 @@ micro-expert-router run
                               selected experts still streamed from the SSD
                               by Engine::moe_step.
   --io-uring                 Probe the IoUringStorage backend (Linux,
-                              --features io_uring); also pins the process
-                              to NUMA-local cores (min(8, available
-                              parallelism)). To override the pin count,
-                              set the MER_PIN_CORES env var, it is
-                              honoured globally at startup before any
-                              subcommand-specific pinning runs.
+                              --features io_uring). It inherits startup
+                              CPU placement if `--cpu-mask`,
+                              `[performance].cpu_mask`, or legacy
+                              MER_PIN_CORES was provided; otherwise it
+                              does not apply a late process repin.
   --token-pause-us <N>       Sleep between tokens to throttle the stream
   --seed <U64>               PRNG seed for reproducibility
   --trace-out <PATH>         Append a JSONL routing trace (one record per
@@ -2041,9 +2008,8 @@ micro-expert-router serve
                               metrics on `GET /metrics`. All engine flags
                               that `run` accepts on the CLI are configured
                               here under `[server]`, `[model]`, `[storage]`,
-                              `[tokenizer]`, `[real_transformer]`,
-                              `[predictive]`, `[performance]`, and
-                              `[gpu_cache]`.
+                              `[performance]`, `[tokenizer]`, `[real_transformer]`,
+                              `[predictive]`, and `[gpu_cache]`.
 
 micro-expert-router monitor          # requires `--features tui` (on by default)
   --url <URL>                Base URL of a running `serve` instance
@@ -3291,12 +3257,13 @@ The genuinely open items are:
   kernel. The runtime dispatcher already selects between the scalar
   reference path, AVX2+FMA (always compiled on x86_64), and AVX-512
   (`--features avx512`); AMX slots into the same dispatcher.
-- **Per-NUMA-node io_uring rings.** `MER_PIN_CORES=N` is honoured at
-  startup to `sched_setaffinity(2)` the process to the first `N`
-  CPUs of NUMA node 0 (Linux only, best-effort; no-op + warn
-  elsewhere, see `src/numa.rs`). Real per-ring per-node pinning
-  would still need one io_uring ring per node and per-node buffer
-  pools, a deeper refactor of `IoUringStorage` and `BufferPool`.
+- **Per-NUMA-node io_uring rings.** Startup placement is explicit:
+  `--cpu-mask <CPULIST>` or `[performance].cpu_mask` bounds the whole
+  process before Tokio/Rayon/io_uring setup, while legacy
+  `MER_PIN_CORES=N` remains a lower-precedence fallback. Real per-ring
+  per-node pinning would still need one io_uring ring per node and
+  per-node buffer pools, a deeper refactor of `IoUringStorage` and
+  `BufferPool`.
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ The previous June 25 results remain available as a
     - [Real-transformer pipeline](#real-transformer-pipeline)
     - [Hardware auto-escalation](#hardware-auto-escalation)
     - [CPU/Rayon autotune](#cpurayon-autotune)
+    - [CPU placement and progress watchdog](#cpu-placement-and-progress-watchdog)
     - [Decoupled math backend](#decoupled-math-backend)
     - [Speculative engine warm-up](#speculative-engine-warm-up)
     - [Distributed expert sharding](#distributed-expert-sharding)
@@ -554,9 +555,9 @@ The Rust crate (`rust-engine/`) is organised into single-responsibility modules:
 | `kernels` | Runtime CPU-feature dispatcher (`mod.rs::detect()` + `current()` + `cpu_features()`), with `scalar.rs` (always on, also home of the `swiglu_f32` reference oracle plus the `dot_int8_int8` scalar reference for VNNI), `avx2.rs` (always compiled on x86_64, no cargo feature; the `#[target_feature]` entry points are gated on the runtime probe), `avx512.rs` (`--features avx512`, `#[target_feature]` fused int8 dequant + dot, the 4×-unrolled `dot_f32_avx512`, the fused per-row `swiglu_f32_avx512` kernel, **and** the AVX-512 VNNI int8×int8 dot `dot_int8_int8_avx512_vnni` built on `_mm512_dpbusd_epi32`, gist Part 2 fix #8, with the i8→u8 bias-trick correction so the inner reduction stays in i32 integer registers), and `amx.rs` (`--features amx`, skeleton until tile intrinsics stabilise on stable Rust). The dispatcher also exposes `swiglu_f32_into(gate_w, up_w, x, rows, cols, y)` which routes to the AVX-512 fused kernel on capable hosts and the scalar reference elsewhere, caller owns `y`, no allocation on the hot path. The probe reads `/proc/cpuinfo` to recognise Sapphire-Rapids-class Xeons so AMX can be preferred on the chips it ships on. The selected backend is logged once at startup. |
 | `backend` | Plugin-system math `Backend` trait (`matmul`, `matmul_into`, `swiglu_into`, `softmax`, `silu_inplace`) with three built-in implementations: `ScalarBackend` (pure Rust reference), `CandleBackend` (default CPU executor, dispatches through `kernels::dot_f32` / `kernels::swiglu_f32_into`, no `candle_core::Tensor` rebuild on the hot path, **zero allocation** in either call), and `GpuBackend` (gist Part 2 fix #5, budget-GPU executor selected by `[real_transformer].compute_offload = "gpu"`; both the integration seam and the `wgpu` compute pipeline compile on every build, the `gpu` cargo feature is now a no-op kept only for backwards compatibility). Both CPU backends override `matmul_into` to dispatch through `kernels::dot_f32` (auto-escalates AVX-512 → AVX2 → scalar). The active backend is installed once at startup via `backend::install_default()` (or, when `compute_offload = "gpu"`, `set_backend(GpuBackend::try_new())` runs first) and resolved on the hot path through `backend::current()`, a single `OnceLock` load, no `cfg!` dispatch. New executors (Burn, Tract, custom CUDA) implement `Backend` and call `set_backend(Arc<dyn Backend>)` before the first token is generated. |
 | `io_reactor` | **Actor-pattern I/O reactor** (gist Part 5 doc fix). Wraps an `NvmeStorage` behind a single-owner tokio task that runs a **bounded serial loop**: it dequeues read requests from a bounded `mpsc` channel one at a time, `await`s the read inline, replies over the per-request `oneshot`, and only then pulls the next request, the bounded queue therefore also bounds active I/O concurrency. `IoReactorHandle` is cheaply cloneable (the sender side is reference-counted by tokio); workers issue `read_expert(id, buf)` without ever touching a shared `DashMap` shard / `RwLock` write guard. Backpressure is automatic, when the I/O substrate saturates, callers park on `mpsc::send` instead of overflowing a per-thread queue. Exposed as a standalone helper alongside the legacy `engine` path so the in-flight `DashMap<u32, Notify>` deduplicator can retire one subsystem at a time. |
-| `numa` | `MER_PIN_CORES=N` env honoured at startup → `sched_setaffinity(2)` first `N` CPUs of NUMA node 0 (Linux only, best-effort; no-op + warn elsewhere). |
+| `numa` | Startup CPU placement. `--cpu-mask 0-24` / `[performance].cpu_mask = "0-24"` applies an explicit Linux `sched_setaffinity(2)` cpulist before tokio and Rayon workers are created; legacy `MER_PIN_CORES=N` still pins the first `N` CPUs when no explicit mask is set. The effective mask is logged for production diagnosis. |
 | `metrics` | Prometheus `Registry` + handles for every counter / histogram exported on `/metrics`. |
-| `config` | TOML schema for `serve --config`: `[server]`, `[security]`, `[sampling]`, `[model]`, `[storage]`, `[tokenizer]`, `[real_transformer]`, `[predictive]`, `[gpu_cache]`. Validated at startup. |
+| `config` | TOML schema for `serve --config`: `[server]`, `[security]`, `[sampling]`, `[model]`, `[storage]`, `[tokenizer]`, `[real_transformer]`, `[predictive]`, `[performance]`, `[gpu_cache]`. Validated at startup. |
 | `tui` (with `--features tui`) | Native "Amalgafy"-style terminal dashboard rendered with `ratatui` + `crossterm`. The `monitor` subcommand (`micro-expert-router monitor --url http://127.0.0.1:8080 --refresh-ms 250`) polls `/v1/admin/health/experts` and draws a header (status / uptime / TPS, with restart-recovery: TPS resets to zero on a backwards jump of `tokens_generated`), a 3-tier hit grid with one **delta-calculated** sparkline per tier (VRAM / RAM / SSD, pulse per refresh tick, not a cumulative staircase), a VRAM/RAM utilisation gauge, and an I/O reactor stall pulse driven by the per-tick SSD-miss delta. All sparkline histories are capped at 60 points to bound memory growth. Uses a hand-rolled minimal HTTP/1.1 client over `tokio::net::TcpStream` to avoid pulling in `reqwest`. |
 | `server` | OpenAI-compatible HTTP server (`axum`): `/health`, `/metrics`, `/v1/completions`, `/v1/chat/completions` (both streaming SSE and one-shot), `DELETE /v1/sessions/{id}`, plus the operator endpoints `GET /v1/admin/health/experts` and `POST /v1/admin/evict`. Calls `run_engine_warmup` before binding the listener so the first user token never pays the cold-start cost (best-effort; failures only `tracing::warn!`). |
 | `middleware` | Production-readiness HTTP middleware layered onto the `server` router via `axum::middleware::from_fn_with_state`: per-request UUID tracing span, optional **API-key gate** (`[security].api_keys`; `401` when configured and missing/unknown), optional **per-key token-bucket rate limit** (`rate_limit_rps` / `rate_limit_burst`; `429` on overflow), and **admission control** (`[server].max_concurrent_requests`, `[server].admission_min_free_blocks` against the paged-KV pool; `503` when saturated). Defaults are fully permissive so legacy benchmark / development flows are byte-identical. |
@@ -1495,6 +1496,44 @@ should be benchmarked independently because the best count can vary with
 host shape, model shape, dtype, quant kernel, cache size, and runtime
 placement.
 
+#### CPU placement and progress watchdog
+
+Autotune chooses the Rayon thread count; CPU mask/pinning controls where
+those workers and the async runtime are allowed to run. On VMs, both can
+matter for stable FFN performance. For example, the strongest current
+evidence is still Mixtral Q4_0/QMatMul on GCP `g2-standard-32`: autotune
+found useful thread-count bands, but manual placement such as
+`RAYON_NUM_THREADS=25` plus `--cpu-mask 0-24` was needed to avoid VM
+placement variance in repeated long runs. Do not treat a one-time autotune
+profile as proof that placement variance is gone on every host.
+
+Use the global CLI flag for one-off runs:
+
+```bash
+RAYON_NUM_THREADS=25 ./target/release/micro-expert-router \
+  --cpu-mask 0-24 \
+  --progress-timeout-secs 300 \
+  run --data-dir ./data --dtype q4_0 --cache-slots 124 --tokens 10000
+```
+
+Or configure serving/`bench-real` in TOML:
+
+```toml
+[performance]
+cpu_mask = "0-24"
+progress_timeout_secs = 300
+```
+
+CPU affinity is applied before tokio runtime creation and before the
+process-wide Rayon pool is initialized, so worker threads inherit the
+intended placement. Startup logs include the requested mask, effective
+allowed mask, visible logical cores, selected Rayon thread count, Rayon
+source (`env`, `profile`, `autotune`, or `default`), and whether pinning
+succeeded. The watchdog timeout is disabled by default; when set for
+benchmark runs, a token-progress stall logs the last token index, cache
+and I/O counters, compute latency summary, Rayon settings, CPU mask, and
+stage, then exits non-zero instead of hanging indefinitely.
+
 ```bash
 cargo build --release                # default, auto-escalation only
 cargo build --release --features blas      # opt-in BLAS-shaped matmul
@@ -1614,8 +1653,8 @@ cargo build --release --features tokenizer
 
 Configuration lives in TOML, see [`config.toml`](./config.toml) for
 the full annotated schema (server bind address, model dimensions, cache
-slots, `O_DIRECT` block alignment, predictive prefetch fanout, optional
-tokenizer path).
+slots, `O_DIRECT` block alignment, predictive prefetch fanout, CPU
+placement, benchmark watchdog timeout, optional tokenizer path).
 
 To **isolate pure I/O cost** (skip the SwiGLU FFN; XOR every byte read
 to force the page in):
@@ -1756,6 +1795,14 @@ for a given model size.
 ### CLI reference
 
 ```
+micro-expert-router [global options] <subcommand>
+  --cpu-mask <CPULIST>       Best-effort Linux CPU affinity before tokio
+                              and Rayon startup, e.g. 0-24 or 0-7,16-23.
+                              Overrides [performance].cpu_mask and legacy
+                              MER_PIN_CORES.
+  --progress-timeout-secs <N> Fail benchmark token-progress stalls after N
+                              seconds. 0/unset disables the watchdog.
+
 micro-expert-router gen-data
   --data-dir <PATH>          Output directory (default ./data)
   --num-experts <N>          Number of expert files (default 64)
@@ -1995,7 +2042,8 @@ micro-expert-router serve
                               that `run` accepts on the CLI are configured
                               here under `[server]`, `[model]`, `[storage]`,
                               `[tokenizer]`, `[real_transformer]`,
-                              `[predictive]`, and `[gpu_cache]`.
+                              `[predictive]`, `[performance]`, and
+                              `[gpu_cache]`.
 
 micro-expert-router monitor          # requires `--features tui` (on by default)
   --url <URL>                Base URL of a running `serve` instance

--- a/config.toml
+++ b/config.toml
@@ -9,8 +9,8 @@
 # subcommand exposes, but driven from one place instead of a long-tail of
 # CLI flags.
 #
-# All sections are required except `[tokenizer]`, which falls back to a
-# byte-level tokenizer when omitted.
+# Optional sections include `[security]`, `[performance]`, and
+# `[tokenizer]`, which falls back to a byte-level tokenizer when omitted.
 
 [server]
 # Address to listen on. `0.0.0.0:8080` to expose to the network.
@@ -57,6 +57,13 @@ admission_min_free_blocks = 0
 # validation error.
 # tls_cert = "/etc/mer/tls/cert.pem"
 # tls_key = "/etc/mer/tls/key.pem"
+
+# Optional CPU placement and benchmark stall diagnostics. CPU affinity is
+# applied at process startup before tokio and Rayon workers are created, so
+# those threads inherit the mask. The timeout is disabled when unset or 0.
+# [performance]
+# cpu_mask = "0-24"
+# progress_timeout_secs = 300
 
 [sampling]
 # Server-wide defaults for the next-token sampler. Each request can

--- a/config.toml
+++ b/config.toml
@@ -9,8 +9,8 @@
 # subcommand exposes, but driven from one place instead of a long-tail of
 # CLI flags.
 #
-# Optional sections include `[security]`, `[performance]`, and
-# `[tokenizer]`, which falls back to a byte-level tokenizer when omitted.
+# All sections are required except `[tokenizer]`, which falls back to a
+# byte-level tokenizer when omitted.
 
 [server]
 # Address to listen on. `0.0.0.0:8080` to expose to the network.
@@ -36,6 +36,22 @@ max_concurrent_requests = 0
 # configured with a block pool. `0` (default) disables.
 admission_min_free_blocks = 0
 
+[performance]
+# Optional CPU placement mask in Linux cpulist syntax. Leave unset for the
+# portable default: MER does not apply an artificial CPU mask. Use this only
+# when you need to bound placement for a noisy VM, NUMA domain, or container.
+# cpu_mask = "0-24"
+
+# Optional explicit worker count for MER's process-wide CPU Rayon compute
+# pool. Leave unset to preserve portable behavior: `RAYON_NUM_THREADS` wins
+# when supplied, otherwise CLI `--rayon-threads`, otherwise autotune/profile,
+# otherwise MER sizes the pool at startup with async-runtime headroom.
+# rayon_threads = 30
+
+# Optional progress watchdog. `0` or unset disables. A positive value makes
+# `run` and `bench-real` fail loudly if a token/probe stops making progress.
+# progress_timeout_secs = 300
+
 # Optional API-key gate + simple in-process rate limiting. The whole
 # section is optional; when omitted (or when `api_keys` is empty) the
 # server runs with no auth, matching the legacy behaviour. See
@@ -57,13 +73,6 @@ admission_min_free_blocks = 0
 # validation error.
 # tls_cert = "/etc/mer/tls/cert.pem"
 # tls_key = "/etc/mer/tls/key.pem"
-
-# Optional CPU placement and benchmark stall diagnostics. CPU affinity is
-# applied at process startup before tokio and Rayon workers are created, so
-# those threads inherit the mask. The timeout is disabled when unset or 0.
-# [performance]
-# cpu_mask = "0-24"
-# progress_timeout_secs = 300
 
 [sampling]
 # Server-wide defaults for the next-token sampler. Each request can

--- a/rust-engine/src/batch_scheduler.rs
+++ b/rust-engine/src/batch_scheduler.rs
@@ -1323,7 +1323,9 @@ async fn scheduler_loop(
         }
         if prepass_ran {
             let prepass_ns = prepass_started.elapsed().as_nanos() as u64;
-            prepass.time_ns_total.fetch_add(prepass_ns, Ordering::Relaxed);
+            prepass
+                .time_ns_total
+                .fetch_add(prepass_ns, Ordering::Relaxed);
             prepass_gate.record(useful_fetches, prepass_ns);
         }
 
@@ -1458,7 +1460,7 @@ mod tests {
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::Instant;
 
-    static TEMP_DIR_SEQ: AtomicU64 = AtomicU64::new(0);
+    static TEMP_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
 
     struct TempDir {
         path: PathBuf,
@@ -1470,10 +1472,10 @@ mod tests {
                 .duration_since(std::time::UNIX_EPOCH)
                 .map(|d| d.as_nanos())
                 .unwrap_or(0);
-            let seq = TEMP_DIR_SEQ.fetch_add(1, Ordering::Relaxed);
+            let unique = TEMP_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
             path.push(format!(
-                "mer-batch-test-{tag}-{}-{nanos}-{seq}",
-                std::process::id(),
+                "mer-batch-test-{tag}-{}-{nanos}-{unique}",
+                std::process::id()
             ));
             std::fs::create_dir_all(&path).unwrap();
             Self { path }

--- a/rust-engine/src/batch_scheduler.rs
+++ b/rust-engine/src/batch_scheduler.rs
@@ -1455,7 +1455,10 @@ mod tests {
     use crate::multi_layer_cache::MultiLayerExpertCache;
     use crate::router::{PredictiveLoader, TopKRouter};
     use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::Instant;
+
+    static TEMP_DIR_SEQ: AtomicU64 = AtomicU64::new(0);
 
     struct TempDir {
         path: PathBuf,
@@ -1467,9 +1470,10 @@ mod tests {
                 .duration_since(std::time::UNIX_EPOCH)
                 .map(|d| d.as_nanos())
                 .unwrap_or(0);
+            let seq = TEMP_DIR_SEQ.fetch_add(1, Ordering::Relaxed);
             path.push(format!(
-                "mer-batch-test-{tag}-{}-{nanos}",
-                std::process::id()
+                "mer-batch-test-{tag}-{}-{nanos}-{seq}",
+                std::process::id(),
             ));
             std::fs::create_dir_all(&path).unwrap();
             Self { path }

--- a/rust-engine/src/config.rs
+++ b/rust-engine/src/config.rs
@@ -94,6 +94,31 @@ pub struct SecurityConfig {
     pub tls_key: Option<PathBuf>,
 }
 
+/// Restart-time performance controls.
+///
+/// These options are consumed before Tokio and Rayon are initialized, so
+/// they cannot be hot-reloaded. Keep request-level/runtime knobs out of
+/// this section.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PerformanceConfig {
+    /// Linux cpulist mask applied at process startup, before Tokio and
+    /// Rayon workers are created. Example: `"0-24"`.
+    #[serde(default)]
+    pub cpu_mask: Option<String>,
+
+    /// Benchmark watchdog timeout. `None` or `0` disables the watchdog;
+    /// positive values make `run` / `bench-real` fail closed if a token
+    /// step makes no progress for this many seconds.
+    #[serde(default)]
+    pub progress_timeout_secs: Option<u64>,
+}
+
+impl PerformanceConfig {
+    pub fn normalized_progress_timeout_secs(&self) -> Option<u64> {
+        self.progress_timeout_secs.filter(|&secs| secs > 0)
+    }
+}
+
 /// Server-wide sampling defaults. Each request can override these via
 /// the `temperature` / `top_p` / `top_k` / `seed` JSON fields.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -957,6 +982,10 @@ pub struct Config {
     /// HTTP) to preserve the legacy behaviour bit-for-bit.
     #[serde(default)]
     pub security: SecurityConfig,
+    /// Optional `[performance]` section for startup CPU placement and
+    /// benchmark watchdog settings. Defaults are disabled.
+    #[serde(default)]
+    pub performance: PerformanceConfig,
     /// Optional `[gpu_cache]` section — Phase 1/2 of the 3-tier
     /// heterogeneous memory orchestrator (SSD → RAM → VRAM). Off by
     /// default; the binary behaves identically to the 2-tier engine
@@ -1254,6 +1283,16 @@ impl Config {
                 "security.rate_limit_burst requires rate_limit_rps > 0".into(),
             ));
         }
+        if let Some(mask) = self.performance.cpu_mask.as_ref() {
+            let cpus = crate::numa::parse_cpulist(mask).map_err(|e| {
+                ConfigError::Invalid(format!("performance.cpu_mask is invalid: {e}"))
+            })?;
+            if cpus.is_empty() {
+                return Err(ConfigError::Invalid(
+                    "performance.cpu_mask must name at least one CPU".into(),
+                ));
+            }
+        }
         Ok(())
     }
 }
@@ -1461,6 +1500,7 @@ mod tests {
             sampling: SamplingConfig::default(),
             predictive: PredictiveConfig::default(),
             security: SecurityConfig::default(),
+            performance: PerformanceConfig::default(),
             gpu_cache: GpuCacheConfig::default(),
             distributed: DistributedConfig::default(),
         }
@@ -1469,6 +1509,26 @@ mod tests {
     #[test]
     fn valid_config_passes_validation() {
         minimal_cfg().validate().expect("valid");
+    }
+
+    #[test]
+    fn performance_config_accepts_cpu_mask_and_timeout() {
+        let mut c = minimal_cfg();
+        c.performance.cpu_mask = Some("0-2,4".to_string());
+        c.performance.progress_timeout_secs = Some(300);
+        c.validate().expect("valid performance placement config");
+        assert_eq!(c.performance.normalized_progress_timeout_secs(), Some(300));
+    }
+
+    #[test]
+    fn performance_config_rejects_invalid_cpu_mask() {
+        let mut c = minimal_cfg();
+        c.performance.cpu_mask = Some("4-1".to_string());
+        let err = c.validate().expect_err("descending mask must fail");
+        assert!(
+            err.to_string().contains("performance.cpu_mask"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/rust-engine/src/config.rs
+++ b/rust-engine/src/config.rs
@@ -94,29 +94,28 @@ pub struct SecurityConfig {
     pub tls_key: Option<PathBuf>,
 }
 
-/// Restart-time performance controls.
-///
-/// These options are consumed before Tokio and Rayon are initialized, so
-/// they cannot be hot-reloaded. Keep request-level/runtime knobs out of
-/// this section.
+/// Process-level runtime/performance controls applied at startup.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct PerformanceConfig {
-    /// Linux cpulist mask applied at process startup, before Tokio and
-    /// Rayon workers are created. Example: `"0-24"`.
+    /// Optional process CPU placement mask in Linux cpulist syntax, e.g.
+    /// `"0-24"` or `"0-15,32-47"`. Leave unset for portable default
+    /// behavior: MER does not apply an artificial placement mask.
     #[serde(default)]
     pub cpu_mask: Option<String>,
 
-    /// Benchmark watchdog timeout. `None` or `0` disables the watchdog;
-    /// positive values make `run` / `bench-real` fail closed if a token
-    /// step makes no progress for this many seconds.
+    /// Explicit worker count for MER's process-wide Rayon compute pool.
+    ///
+    /// `None` preserves portable startup behavior: honor
+    /// `RAYON_NUM_THREADS` when set, otherwise allow autotune/profile/default
+    /// selection under the effective affinity mask.
+    #[serde(default)]
+    pub rayon_threads: Option<usize>,
+
+    /// Progress watchdog timeout in seconds. `0` or unset disables the
+    /// watchdog. A positive value wraps long-running run/bench-real progress
+    /// steps so hangs fail loudly instead of remaining silent.
     #[serde(default)]
     pub progress_timeout_secs: Option<u64>,
-}
-
-impl PerformanceConfig {
-    pub fn normalized_progress_timeout_secs(&self) -> Option<u64> {
-        self.progress_timeout_secs.filter(|&secs| secs > 0)
-    }
 }
 
 /// Server-wide sampling defaults. Each request can override these via
@@ -594,12 +593,10 @@ impl RealTransformerConfig {
     /// inference.
     pub fn resolve_weight_policy(&self) -> Result<RealWeightPolicy, String> {
         if !self.strict_weights && !self.allow_seeded_fallback {
-            return Err(
-                "real_transformer.strict_weights = false requires \
+            return Err("real_transformer.strict_weights = false requires \
                  real_transformer.allow_seeded_fallback = true (development-only). \
                  Production real-model serving must load a strict, complete checkpoint."
-                    .into(),
-            );
+                .into());
         }
         match self.weights_dir.as_ref() {
             Some(_) if self.strict_weights => Ok(RealWeightPolicy::StrictReal),
@@ -967,6 +964,8 @@ impl Default for DistributedConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
     pub server: ServerConfig,
+    #[serde(default)]
+    pub performance: PerformanceConfig,
     pub model: ModelConfig,
     pub storage: StorageConfigToml,
     #[serde(default)]
@@ -982,10 +981,6 @@ pub struct Config {
     /// HTTP) to preserve the legacy behaviour bit-for-bit.
     #[serde(default)]
     pub security: SecurityConfig,
-    /// Optional `[performance]` section for startup CPU placement and
-    /// benchmark watchdog settings. Defaults are disabled.
-    #[serde(default)]
-    pub performance: PerformanceConfig,
     /// Optional `[gpu_cache]` section — Phase 1/2 of the 3-tier
     /// heterogeneous memory orchestrator (SSD → RAM → VRAM). Off by
     /// default; the binary behaves identically to the 2-tier engine
@@ -1012,6 +1007,21 @@ impl Config {
     }
 
     pub fn validate(&self) -> Result<(), ConfigError> {
+        if self.performance.rayon_threads == Some(0) {
+            return Err(ConfigError::Invalid(
+                "performance.rayon_threads must be > 0".into(),
+            ));
+        }
+        if let Some(mask) = self.performance.cpu_mask.as_deref() {
+            let parsed = crate::numa::parse_cpulist(mask).map_err(|e| {
+                ConfigError::Invalid(format!("performance.cpu_mask is invalid: {e}"))
+            })?;
+            if parsed.is_empty() {
+                return Err(ConfigError::Invalid(
+                    "performance.cpu_mask must contain at least one CPU".into(),
+                ));
+            }
+        }
         if self.model.num_experts == 0 {
             return Err(ConfigError::Invalid("model.num_experts must be > 0".into()));
         }
@@ -1283,16 +1293,6 @@ impl Config {
                 "security.rate_limit_burst requires rate_limit_rps > 0".into(),
             ));
         }
-        if let Some(mask) = self.performance.cpu_mask.as_ref() {
-            let cpus = crate::numa::parse_cpulist(mask).map_err(|e| {
-                ConfigError::Invalid(format!("performance.cpu_mask is invalid: {e}"))
-            })?;
-            if cpus.is_empty() {
-                return Err(ConfigError::Invalid(
-                    "performance.cpu_mask must name at least one CPU".into(),
-                ));
-            }
-        }
         Ok(())
     }
 }
@@ -1473,6 +1473,7 @@ mod tests {
                 max_concurrent_requests: 0,
                 admission_min_free_blocks: 0,
             },
+            performance: PerformanceConfig::default(),
             model: ModelConfig {
                 data_dir: PathBuf::from("./data"),
                 num_experts: 8,
@@ -1500,7 +1501,6 @@ mod tests {
             sampling: SamplingConfig::default(),
             predictive: PredictiveConfig::default(),
             security: SecurityConfig::default(),
-            performance: PerformanceConfig::default(),
             gpu_cache: GpuCacheConfig::default(),
             distributed: DistributedConfig::default(),
         }
@@ -1512,30 +1512,48 @@ mod tests {
     }
 
     #[test]
-    fn performance_config_accepts_cpu_mask_and_timeout() {
+    fn rejects_top_k_greater_than_num_experts() {
         let mut c = minimal_cfg();
-        c.performance.cpu_mask = Some("0-2,4".to_string());
-        c.performance.progress_timeout_secs = Some(300);
-        c.validate().expect("valid performance placement config");
-        assert_eq!(c.performance.normalized_progress_timeout_secs(), Some(300));
+        c.model.top_k = 99;
+        assert!(c.validate().is_err());
     }
 
     #[test]
-    fn performance_config_rejects_invalid_cpu_mask() {
+    fn performance_rayon_threads_parses_from_toml() {
+        let perf: PerformanceConfig = toml::from_str(
+            r#"
+            cpu_mask = "0-24"
+            rayon_threads = 30
+            progress_timeout_secs = 300
+            "#,
+        )
+        .unwrap();
+        assert_eq!(perf.cpu_mask.as_deref(), Some("0-24"));
+        assert_eq!(perf.rayon_threads, Some(30));
+        assert_eq!(perf.progress_timeout_secs, Some(300));
+    }
+
+    #[test]
+    fn rejects_zero_performance_rayon_threads() {
         let mut c = minimal_cfg();
-        c.performance.cpu_mask = Some("4-1".to_string());
-        let err = c.validate().expect_err("descending mask must fail");
+        c.performance.rayon_threads = Some(0);
+        let err = c.validate().expect_err("zero rayon_threads must fail");
         assert!(
-            err.to_string().contains("performance.cpu_mask"),
+            err.to_string()
+                .contains("performance.rayon_threads must be > 0"),
             "unexpected error: {err}"
         );
     }
 
     #[test]
-    fn rejects_top_k_greater_than_num_experts() {
+    fn rejects_invalid_performance_cpu_mask() {
         let mut c = minimal_cfg();
-        c.model.top_k = 99;
-        assert!(c.validate().is_err());
+        c.performance.cpu_mask = Some("4-1".to_string());
+        let err = c.validate().expect_err("descending cpu mask must fail");
+        assert!(
+            err.to_string().contains("performance.cpu_mask is invalid"),
+            "unexpected error: {err}"
+        );
     }
 
     /// Part A6: the flat u32 global expert-id namespace
@@ -1602,10 +1620,16 @@ mod tests {
 
     #[test]
     fn round_trips_through_toml() {
-        let c = minimal_cfg();
+        let mut c = minimal_cfg();
+        c.performance.cpu_mask = Some("0-3".to_string());
+        c.performance.rayon_threads = Some(30);
+        c.performance.progress_timeout_secs = Some(300);
         let s = toml::to_string(&c).unwrap();
         let back: Config = toml::from_str(&s).unwrap();
         back.validate().unwrap();
+        assert_eq!(back.performance.cpu_mask.as_deref(), Some("0-3"));
+        assert_eq!(back.performance.rayon_threads, Some(30));
+        assert_eq!(back.performance.progress_timeout_secs, Some(300));
         assert_eq!(back.model.num_experts, c.model.num_experts);
         assert_eq!(back.server.bind, c.server.bind);
     }

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -409,6 +409,29 @@ enum Cmd {
         /// Print a concise coarse/fine Rayon autotune result table.
         #[arg(long)]
         autotune_print_table: bool,
+        /// Slow-regime cutoff for the worst fine-probe p95.
+        #[arg(
+            long,
+            default_value_t = crate::rayon_autotune::DEFAULT_SLOW_P95_THRESHOLD_MS,
+            value_name = "MS",
+            value_parser = parse_positive_f64_value
+        )]
+        autotune_slow_p95_ms: f64,
+        /// Slow-regime cutoff for the worst fine-probe p99.
+        #[arg(
+            long,
+            default_value_t = crate::rayon_autotune::DEFAULT_SLOW_P99_THRESHOLD_MS,
+            value_name = "MS",
+            value_parser = parse_positive_f64_value
+        )]
+        autotune_slow_p99_ms: f64,
+        /// Use a low-confidence autotune result for this run.
+        ///
+        /// Without this flag, low-confidence results are treated as failed
+        /// selection and the startup thread resolver falls back to a saved
+        /// profile or MER's default sizing.
+        #[arg(long)]
+        allow_low_confidence_rayon_autotune: bool,
         /// Predictive prefetch fanout (how many candidates to issue per token).
         #[arg(long, default_value_t = 2)]
         predict_fanout: usize,
@@ -941,6 +964,17 @@ fn parse_positive_u64_value(s: &str) -> Result<u64, String> {
     }
 }
 
+fn parse_positive_f64_value(s: &str) -> Result<f64, String> {
+    let n = s
+        .parse::<f64>()
+        .map_err(|_| format!("expected a positive number, got {s:?}"))?;
+    if n.is_finite() && n > 0.0 {
+        Ok(n)
+    } else {
+        Err("value must be a finite number > 0".to_string())
+    }
+}
+
 fn init_logging(filter: &str) {
     let env_filter = EnvFilter::try_new(filter).unwrap_or_else(|_| EnvFilter::new("info"));
     let _ = tracing_subscriber::fmt()
@@ -1047,6 +1081,17 @@ fn load_profiled_rayon_threads(
     Some(profile.threads)
 }
 
+fn load_high_confidence_profile_threads(
+    cli: &Cli,
+    key: Option<&crate::rayon_autotune::CpuAutotuneKey>,
+) -> Option<usize> {
+    let key = key?;
+    let path = run_profile_path(cli)?;
+    let profile = crate::rayon_autotune::load_profile(&path, key)?;
+    (profile.confidence == crate::rayon_autotune::RayonAutotuneConfidence::High)
+        .then_some(profile.threads)
+}
+
 fn maybe_run_startup_rayon_autotune(
     cli: &Cli,
     raw_args: &[OsString],
@@ -1061,6 +1106,9 @@ fn maybe_run_startup_rayon_autotune(
         autotune_coarse_tokens,
         autotune_top_candidates,
         autotune_print_table,
+        autotune_slow_p95_ms,
+        autotune_slow_p99_ms,
+        allow_low_confidence_rayon_autotune,
         ..
     } = &cli.cmd
     else {
@@ -1091,6 +1139,8 @@ fn maybe_run_startup_rayon_autotune(
         fine_tokens = autotune_tokens,
         repeats = autotune_repeats,
         top_candidates = autotune_top_candidates,
+        slow_p95_threshold_ms = autotune_slow_p95_ms,
+        slow_p99_threshold_ms = autotune_slow_p99_ms,
         "starting Rayon autotune probes"
     );
 
@@ -1107,8 +1157,8 @@ fn maybe_run_startup_rayon_autotune(
         probes.push(probe);
     }
 
-    let slow_p95_threshold_ms = crate::rayon_autotune::DEFAULT_SLOW_P95_THRESHOLD_MS;
-    let slow_p99_threshold_ms = crate::rayon_autotune::DEFAULT_SLOW_P99_THRESHOLD_MS;
+    let slow_p95_threshold_ms = *autotune_slow_p95_ms;
+    let slow_p99_threshold_ms = *autotune_slow_p99_ms;
     let coarse_summaries = crate::rayon_autotune::summarize_candidate_results(
         &candidates,
         1,
@@ -1116,13 +1166,13 @@ fn maybe_run_startup_rayon_autotune(
         slow_p95_threshold_ms,
         slow_p99_threshold_ms,
     );
-    let fine_candidates: Vec<usize> =
-        crate::rayon_autotune::ranked_candidate_summaries(&coarse_summaries)
-            .into_iter()
-            .filter(|c| c.successful_repeats > 0)
-            .take(*autotune_top_candidates)
-            .map(|c| c.threads)
-            .collect();
+    let previous_profile_threads = load_high_confidence_profile_threads(cli, key);
+    let fine_candidates = crate::rayon_autotune::fine_thread_candidates(
+        affinity.logical_cores,
+        *autotune_top_candidates,
+        previous_profile_threads,
+        &coarse_summaries,
+    );
     if fine_candidates.is_empty() {
         if *autotune_print_table {
             let table = crate::rayon_autotune::format_autotune_table(&probes, &coarse_summaries);
@@ -1132,6 +1182,7 @@ fn maybe_run_startup_rayon_autotune(
     }
     info!(
         fine_candidates = ?fine_candidates,
+        previous_high_confidence_profile_threads = ?previous_profile_threads,
         repeats = autotune_repeats,
         fine_tokens = autotune_tokens,
         "Rayon autotune coarse pass selected fine candidates"
@@ -1183,47 +1234,80 @@ fn maybe_run_startup_rayon_autotune(
         "Rayon autotune selected worker count"
     );
 
-    if let (Some(path), Some(key)) = (run_profile_path(cli), key) {
-        let median_p50_ms = best.median_p50_ms.unwrap_or(0.0);
-        let worst_p95_ms = best.worst_p95_ms.unwrap_or(0.0);
-        let median_sustained_tps = best.median_sustained_tps.unwrap_or(0.0);
-        let profile = crate::rayon_autotune::RayonAutotuneProfile {
-            threads: best.threads,
-            effective_cpu_mask: affinity.cpus.clone(),
-            effective_cpu_mask_display: Some(affinity.display.clone()),
-            logical_cores: affinity.logical_cores,
-            repeats: *autotune_repeats,
-            p50_ms: median_p50_ms,
-            p95_ms: worst_p95_ms,
-            p99_ms: best.worst_p99_ms,
-            sustained_tps: median_sustained_tps,
-            median_p50_ms,
-            worst_p95_ms,
-            worst_p99_ms: best.worst_p99_ms,
-            median_sustained_tps,
-            confidence: selection.confidence,
-            selection_reason: selection.reason.clone(),
-            candidate_results: candidate_summaries.clone(),
-            probe_results: probes.clone(),
-        };
-        if let Err(e) = crate::rayon_autotune::save_profile(&path, key, profile) {
-            warn!(path = %path.display(), error = %e, "failed to save Rayon autotune profile");
-        } else if selection.confidence == crate::rayon_autotune::RayonAutotuneConfidence::Low {
-            warn!(
-                path = %path.display(),
-                confidence = selection.confidence.as_str(),
-                "saved low-confidence Rayon autotune profile; normal runs will not reuse it without --reuse-low-confidence-rayon-profile"
-            );
-        } else {
-            info!(
-                path = %path.display(),
-                confidence = selection.confidence.as_str(),
-                "saved placement-aware Rayon autotune profile"
-            );
-        }
+    let use_selected = selected_autotune_threads(
+        &selection,
+        *allow_low_confidence_rayon_autotune,
+    );
+    if use_selected.is_none() {
+        warn!(
+            threads = best.threads,
+            confidence = selection.confidence.as_str(),
+            "Rayon autotune result is low-confidence; falling back to saved profile/default threads unless --allow-low-confidence-rayon-autotune is passed"
+        );
     }
 
-    Ok(Some(best.threads))
+    if use_selected.is_some() {
+        if let (Some(path), Some(key)) = (run_profile_path(cli), key) {
+            let median_p50_ms = best.median_p50_ms.unwrap_or(0.0);
+            let worst_p95_ms = best.worst_p95_ms.unwrap_or(0.0);
+            let median_sustained_tps = best.median_sustained_tps.unwrap_or(0.0);
+            let profile = crate::rayon_autotune::RayonAutotuneProfile {
+                threads: best.threads,
+                effective_cpu_mask: affinity.cpus.clone(),
+                effective_cpu_mask_display: Some(affinity.display.clone()),
+                logical_cores: affinity.logical_cores,
+                repeats: *autotune_repeats,
+                p50_ms: median_p50_ms,
+                p95_ms: worst_p95_ms,
+                p99_ms: best.worst_p99_ms,
+                sustained_tps: median_sustained_tps,
+                median_p50_ms,
+                worst_p95_ms,
+                worst_p99_ms: best.worst_p99_ms,
+                median_sustained_tps,
+                confidence: selection.confidence,
+                selection_reason: selection.reason.clone(),
+                candidate_results: candidate_summaries.clone(),
+                probe_results: probes.clone(),
+            };
+            if let Err(e) = crate::rayon_autotune::save_profile(&path, key, profile) {
+                warn!(path = %path.display(), error = %e, "failed to save Rayon autotune profile");
+            } else if selection.confidence == crate::rayon_autotune::RayonAutotuneConfidence::Low {
+                warn!(
+                    path = %path.display(),
+                    confidence = selection.confidence.as_str(),
+                    "saved low-confidence Rayon autotune profile; normal runs will not reuse it without --reuse-low-confidence-rayon-profile"
+                );
+            } else {
+                info!(
+                    path = %path.display(),
+                    confidence = selection.confidence.as_str(),
+                    "saved placement-aware Rayon autotune profile"
+                );
+            }
+        }
+    } else if let Some(path) = run_profile_path(cli) {
+        warn!(
+            path = %path.display(),
+            confidence = selection.confidence.as_str(),
+            "not saving low-confidence Rayon autotune result as the default profile"
+        );
+    }
+
+    Ok(use_selected)
+}
+
+fn selected_autotune_threads(
+    selection: &crate::rayon_autotune::RayonAutotuneSelection,
+    allow_low_confidence: bool,
+) -> Option<usize> {
+    if selection.confidence == crate::rayon_autotune::RayonAutotuneConfidence::Low
+        && !allow_low_confidence
+    {
+        None
+    } else {
+        Some(selection.selected.threads)
+    }
 }
 
 fn run_rayon_autotune_probe_observation(
@@ -1326,7 +1410,10 @@ fn autotune_child_args(
             || s.starts_with("--autotune-repeats=")
             || s.starts_with("--autotune-coarse-tokens=")
             || s.starts_with("--autotune-top-candidates=")
+            || s.starts_with("--autotune-slow-p95-ms=")
+            || s.starts_with("--autotune-slow-p99-ms=")
             || s == "--autotune-print-table"
+            || s == "--allow-low-confidence-rayon-autotune"
             || s.starts_with("--tokens=")
             || s.starts_with("--rayon-threads=")
         {
@@ -1336,6 +1423,8 @@ fn autotune_child_args(
             || s == "--autotune-repeats"
             || s == "--autotune-coarse-tokens"
             || s == "--autotune-top-candidates"
+            || s == "--autotune-slow-p95-ms"
+            || s == "--autotune-slow-p99-ms"
             || s == "--tokens"
             || s == "--rayon-threads"
         {
@@ -5759,6 +5848,7 @@ async fn cmd_run(
         "streaming tokens (latency / throughput logs follow)"
     );
     let mut token_cycle_us = Vec::with_capacity(args.tokens.min(1_000_000) as usize);
+    let autotune_probe = std::env::var_os(crate::rayon_autotune::AUTOTUNE_PROBE_ENV).is_some();
 
     // Optional production gating network. When present, every token's
     // expert ids come from `softmax(W_gate · x) → top-K` (real Mixtral
@@ -5900,16 +5990,18 @@ async fn cmd_run(
         } else {
             f64::INFINITY
         };
-        info!(
-            token = t,
-            cycle_us = elapsed.as_micros() as u64,
-            tps = format!("{throughput:.1}"),
-            hits = stats.hits,
-            misses = stats.misses,
-            kib = stats.bytes_read / 1024,
-            resident = ?cache.resident_ids(),
-            "tick"
-        );
+        if !autotune_probe {
+            info!(
+                token = t,
+                cycle_us = elapsed.as_micros() as u64,
+                tps = format!("{throughput:.1}"),
+                hits = stats.hits,
+                misses = stats.misses,
+                kib = stats.bytes_read / 1024,
+                resident = ?cache.resident_ids(),
+                "tick"
+            );
+        }
         if args.token_pause_us > 0 {
             tokio::time::sleep(Duration::from_micros(args.token_pause_us)).await;
         }
@@ -5925,7 +6017,7 @@ async fn cmd_run(
         hit_rate_pct = (r.hits as f64 / total_lookups as f64) * 100.0,
         "stream complete"
     );
-    if std::env::var_os(crate::rayon_autotune::AUTOTUNE_PROBE_ENV).is_some() {
+    if autotune_probe {
         token_cycle_us.sort_unstable();
         let report = crate::rayon_autotune::RayonAutotuneProbeResult {
             threads: crate::parallel::num_threads(),
@@ -6657,7 +6749,12 @@ mod tests {
             OsString::from("512"),
             OsString::from("--autotune-top-candidates"),
             OsString::from("2"),
+            OsString::from("--autotune-slow-p95-ms"),
+            OsString::from("110"),
+            OsString::from("--autotune-slow-p99-ms"),
+            OsString::from("150"),
             OsString::from("--autotune-print-table"),
+            OsString::from("--allow-low-confidence-rayon-autotune"),
             OsString::from("--tokens"),
             OsString::from("10000"),
         ];
@@ -6674,7 +6771,12 @@ mod tests {
         assert!(!rendered.iter().any(|s| s == "--autotune-repeats"));
         assert!(!rendered.iter().any(|s| s == "--autotune-coarse-tokens"));
         assert!(!rendered.iter().any(|s| s == "--autotune-top-candidates"));
+        assert!(!rendered.iter().any(|s| s == "--autotune-slow-p95-ms"));
+        assert!(!rendered.iter().any(|s| s == "--autotune-slow-p99-ms"));
         assert!(!rendered.iter().any(|s| s == "--autotune-print-table"));
+        assert!(!rendered
+            .iter()
+            .any(|s| s == "--allow-low-confidence-rayon-autotune"));
         assert!(rendered
             .windows(2)
             .any(|w| w[0] == "--tokens" && w[1] == "123"));
@@ -6697,7 +6799,12 @@ mod tests {
             "512",
             "--autotune-top-candidates",
             "2",
+            "--autotune-slow-p95-ms",
+            "110",
+            "--autotune-slow-p99-ms",
+            "150",
             "--autotune-print-table",
+            "--allow-low-confidence-rayon-autotune",
         ])
         .expect("autotune stability flags should parse");
         let Cmd::Run {
@@ -6706,7 +6813,10 @@ mod tests {
             autotune_repeats,
             autotune_coarse_tokens,
             autotune_top_candidates,
+            autotune_slow_p95_ms,
+            autotune_slow_p99_ms,
             autotune_print_table,
+            allow_low_confidence_rayon_autotune,
             ..
         } = cli.cmd
         else {
@@ -6717,7 +6827,10 @@ mod tests {
         assert_eq!(autotune_repeats, 3);
         assert_eq!(autotune_coarse_tokens, 512);
         assert_eq!(autotune_top_candidates, 2);
+        assert_eq!(autotune_slow_p95_ms, 110.0);
+        assert_eq!(autotune_slow_p99_ms, 150.0);
         assert!(autotune_print_table);
+        assert!(allow_low_confidence_rayon_autotune);
     }
 
     #[test]
@@ -6786,6 +6899,31 @@ mod tests {
         .unwrap();
         assert_eq!(load_profiled_rayon_threads(&cli, Some(&key)), Some(25));
         let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn low_confidence_autotune_selection_requires_current_run_opt_in() {
+        let selection = crate::rayon_autotune::RayonAutotuneSelection {
+            selected: crate::rayon_autotune::RayonAutotuneCandidateSummary {
+                threads: 25,
+                requested_repeats: 2,
+                successful_repeats: 2,
+                all_repeats_successful: true,
+                p95_below_slow_threshold: false,
+                p99_below_slow_threshold: true,
+                median_p50_ms: Some(99.0),
+                worst_p95_ms: Some(101.0),
+                worst_p99_ms: Some(120.0),
+                median_sustained_tps: Some(10.0),
+                p50_cv: Some(0.0),
+                confidence: crate::rayon_autotune::RayonAutotuneConfidence::Low,
+                rejection_reason: Some("worst p95 exceeds threshold".to_string()),
+            },
+            confidence: crate::rayon_autotune::RayonAutotuneConfidence::Low,
+            reason: "low confidence".to_string(),
+        };
+        assert_eq!(selected_autotune_threads(&selection, false), None);
+        assert_eq!(selected_autotune_threads(&selection, true), Some(25));
     }
 
     // ---- Item 4: bench-real fail-open policy rejection matrix ----

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -1505,6 +1505,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // `MER_PIN_CORES` is now consumed centrally at process start via the
     // `numa` module. Clear it so later code cannot re-apply affinity and
     // drift from this startup contract.
+    // SAFETY: this runs during single-threaded startup, before the Tokio
+    // runtime or Rayon worker pool is created and before this process
+    // introduces any concurrent environment access.
     unsafe {
         std::env::remove_var(crate::numa::MER_PIN_CORES_ENV);
     }
@@ -5847,8 +5850,9 @@ async fn cmd_run(
         tokens = args.tokens,
         "streaming tokens (latency / throughput logs follow)"
     );
-    let mut token_cycle_us = Vec::with_capacity(args.tokens.min(1_000_000) as usize);
     let autotune_probe = std::env::var_os(crate::rayon_autotune::AUTOTUNE_PROBE_ENV).is_some();
+    let mut token_cycle_us =
+        autotune_probe.then(|| Vec::with_capacity(args.tokens.min(1_000_000) as usize));
 
     // Optional production gating network. When present, every token's
     // expert ids come from `softmax(W_gate · x) → top-K` (real Mixtral
@@ -5984,7 +5988,9 @@ async fn cmd_run(
         })
         .await?;
         let elapsed = start.elapsed();
-        token_cycle_us.push(elapsed.as_micros() as u64);
+        if let Some(samples) = token_cycle_us.as_mut() {
+            samples.push(elapsed.as_micros() as u64);
+        }
         let throughput = if elapsed.as_secs_f64() > 0.0 {
             1.0 / elapsed.as_secs_f64()
         } else {
@@ -6018,6 +6024,9 @@ async fn cmd_run(
         "stream complete"
     );
     if autotune_probe {
+        let token_cycle_us = token_cycle_us
+            .as_mut()
+            .expect("autotune probe samples initialized");
         token_cycle_us.sort_unstable();
         let report = crate::rayon_autotune::RayonAutotuneProbeResult {
             threads: crate::parallel::num_threads(),

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -210,7 +210,7 @@ struct Cli {
     ///
     /// Precedence: RAYON_NUM_THREADS > CLI > performance.rayon_threads >
     /// autotune/profile > MER's startup default.
-    #[arg(long, global = true, value_name = "N", value_parser = parse_positive_usize)]
+    #[arg(long, global = true, value_name = "N", value_parser = parse_positive_rayon_threads)]
     rayon_threads: Option<usize>,
 
     /// Optional CPU placement mask in Linux cpulist syntax, e.g. `0-24`.
@@ -224,6 +224,13 @@ struct Cli {
     /// Progress watchdog timeout in seconds. `0` disables the watchdog.
     #[arg(long, global = true, value_name = "SECS")]
     progress_timeout_secs: Option<u64>,
+
+    /// Reuse a saved low-confidence Rayon autotune profile.
+    ///
+    /// By default low-confidence profiles are kept for auditability but are
+    /// not applied to normal runs.
+    #[arg(long, global = true)]
+    reuse_low_confidence_rayon_profile: bool,
 
     #[command(subcommand)]
     cmd: Cmd,
@@ -368,8 +375,40 @@ enum Cmd {
         #[arg(long)]
         autotune_rayon: bool,
         /// Number of tokens each Rayon autotune probe runs.
-        #[arg(long, default_value_t = crate::rayon_autotune::DEFAULT_AUTOTUNE_TOKENS)]
+        #[arg(
+            long,
+            default_value_t = crate::rayon_autotune::DEFAULT_AUTOTUNE_TOKENS,
+            value_name = "N",
+            value_parser = parse_positive_u64_value
+        )]
         autotune_tokens: u64,
+        /// Number of repeated fine probes for each finalist candidate.
+        #[arg(
+            long,
+            default_value_t = crate::rayon_autotune::DEFAULT_AUTOTUNE_REPEATS,
+            value_name = "N",
+            value_parser = parse_positive_usize_value
+        )]
+        autotune_repeats: usize,
+        /// Number of tokens for the cheap coarse autotune pass.
+        #[arg(
+            long,
+            default_value_t = crate::rayon_autotune::DEFAULT_AUTOTUNE_COARSE_TOKENS,
+            value_name = "N",
+            value_parser = parse_positive_u64_value
+        )]
+        autotune_coarse_tokens: u64,
+        /// Number of coarse winners promoted to repeated fine probes.
+        #[arg(
+            long,
+            default_value_t = crate::rayon_autotune::DEFAULT_AUTOTUNE_TOP_CANDIDATES,
+            value_name = "N",
+            value_parser = parse_positive_usize_value
+        )]
+        autotune_top_candidates: usize,
+        /// Print a concise coarse/fine Rayon autotune result table.
+        #[arg(long)]
+        autotune_print_table: bool,
         /// Predictive prefetch fanout (how many candidates to issue per token).
         #[arg(long, default_value_t = 2)]
         predict_fanout: usize,
@@ -870,12 +909,33 @@ fn resolve_predict_min_prob(configured: f64, num_experts: u32) -> f64 {
     }
 }
 
-fn parse_positive_usize(s: &str) -> Result<usize, String> {
+fn parse_positive_rayon_threads(s: &str) -> Result<usize, String> {
+    parse_positive_usize_value(s).map_err(|e| {
+        if e == "value must be > 0" {
+            "--rayon-threads must be > 0".to_string()
+        } else {
+            e
+        }
+    })
+}
+
+fn parse_positive_usize_value(s: &str) -> Result<usize, String> {
     let n = s
         .parse::<usize>()
         .map_err(|_| format!("expected a positive integer, got {s:?}"))?;
     if n == 0 {
-        Err("--rayon-threads must be > 0".to_string())
+        Err("value must be > 0".to_string())
+    } else {
+        Ok(n)
+    }
+}
+
+fn parse_positive_u64_value(s: &str) -> Result<u64, String> {
+    let n = s
+        .parse::<u64>()
+        .map_err(|_| format!("expected a positive integer, got {s:?}"))?;
+    if n == 0 {
+        Err("value must be > 0".to_string())
     } else {
         Ok(n)
     }
@@ -964,12 +1024,24 @@ fn load_profiled_rayon_threads(
     let key = key?;
     let path = run_profile_path(cli)?;
     let profile = crate::rayon_autotune::load_profile(&path, key)?;
+    if !profile.reusable_by_default() && !cli.reuse_low_confidence_rayon_profile {
+        warn!(
+            path = %path.display(),
+            threads = profile.threads,
+            confidence = profile.confidence.as_str(),
+            reason = %profile.selection_reason,
+            "skipping low-confidence Rayon autotune profile; pass --reuse-low-confidence-rayon-profile to opt in"
+        );
+        return None;
+    }
     info!(
         path = %path.display(),
         threads = profile.threads,
-        p50_ms = profile.p50_ms,
-        p95_ms = profile.p95_ms,
-        sustained_tps = profile.sustained_tps,
+        confidence = profile.confidence.as_str(),
+        median_p50_ms = profile.median_p50_ms,
+        worst_p95_ms = profile.worst_p95_ms,
+        worst_p99_ms = ?profile.worst_p99_ms,
+        median_sustained_tps = profile.median_sustained_tps,
         "loaded placement-aware Rayon autotune profile"
     );
     Some(profile.threads)
@@ -985,6 +1057,10 @@ fn maybe_run_startup_rayon_autotune(
     let Cmd::Run {
         autotune_rayon,
         autotune_tokens,
+        autotune_repeats,
+        autotune_coarse_tokens,
+        autotune_top_candidates,
+        autotune_print_table,
         ..
     } = &cli.cmd
     else {
@@ -1011,64 +1087,203 @@ fn maybe_run_startup_rayon_autotune(
         effective_cpu_mask = %affinity.display,
         logical_cores = affinity.logical_cores,
         candidates = ?candidates,
-        autotune_tokens,
+        coarse_tokens = autotune_coarse_tokens,
+        fine_tokens = autotune_tokens,
+        repeats = autotune_repeats,
+        top_candidates = autotune_top_candidates,
         "starting Rayon autotune probes"
     );
 
     let mut probes = Vec::new();
-    for threads in candidates {
-        match run_rayon_autotune_probe(raw_args, *autotune_tokens, threads) {
-            Ok(Some(result)) => {
-                info!(
-                    threads = result.threads,
-                    p50_ms = result.p50_ms,
-                    p95_ms = result.p95_ms,
-                    sustained_tps = result.sustained_tps,
-                    "Rayon autotune probe complete"
-                );
-                probes.push(result);
-            }
-            Ok(None) => warn!(threads, "Rayon autotune probe produced no parseable result"),
-            Err(e) => warn!(threads, error = %e, "Rayon autotune probe failed"),
+    for threads in candidates.iter().copied() {
+        let probe = run_rayon_autotune_probe_observation(
+            raw_args,
+            *autotune_coarse_tokens,
+            threads,
+            crate::rayon_autotune::RayonAutotuneProbeStage::Coarse,
+            1,
+        );
+        log_rayon_autotune_probe_observation(&probe);
+        probes.push(probe);
+    }
+
+    let slow_p95_threshold_ms = crate::rayon_autotune::DEFAULT_SLOW_P95_THRESHOLD_MS;
+    let slow_p99_threshold_ms = crate::rayon_autotune::DEFAULT_SLOW_P99_THRESHOLD_MS;
+    let coarse_summaries = crate::rayon_autotune::summarize_candidate_results(
+        &candidates,
+        1,
+        &probes,
+        slow_p95_threshold_ms,
+        slow_p99_threshold_ms,
+    );
+    let fine_candidates: Vec<usize> =
+        crate::rayon_autotune::ranked_candidate_summaries(&coarse_summaries)
+            .into_iter()
+            .filter(|c| c.successful_repeats > 0)
+            .take(*autotune_top_candidates)
+            .map(|c| c.threads)
+            .collect();
+    if fine_candidates.is_empty() {
+        if *autotune_print_table {
+            let table = crate::rayon_autotune::format_autotune_table(&probes, &coarse_summaries);
+            info!("Rayon autotune table\n{table}");
+        }
+        return Err("Rayon autotune coarse pass did not produce any successful probe".into());
+    }
+    info!(
+        fine_candidates = ?fine_candidates,
+        repeats = autotune_repeats,
+        fine_tokens = autotune_tokens,
+        "Rayon autotune coarse pass selected fine candidates"
+    );
+
+    for threads in fine_candidates.iter().copied() {
+        for repeat in 1..=*autotune_repeats {
+            let probe = run_rayon_autotune_probe_observation(
+                raw_args,
+                *autotune_tokens,
+                threads,
+                crate::rayon_autotune::RayonAutotuneProbeStage::Fine,
+                repeat,
+            );
+            log_rayon_autotune_probe_observation(&probe);
+            probes.push(probe);
         }
     }
 
-    let fastest_p50 = probes
+    let fine_probes: Vec<_> = probes
         .iter()
-        .filter(|p| p.valid)
-        .map(|p| p.p50_ms)
-        .fold(f64::INFINITY, f64::min);
-    let slow_threshold = if fastest_p50.is_finite() {
-        (fastest_p50 * 4.0).max(1.0)
-    } else {
-        f64::INFINITY
-    };
-    let best = crate::rayon_autotune::select_best_probe(&probes, slow_threshold)
-        .ok_or("Rayon autotune did not produce any successful probe")?;
+        .filter(|p| p.stage == crate::rayon_autotune::RayonAutotuneProbeStage::Fine)
+        .cloned()
+        .collect();
+    let candidate_summaries = crate::rayon_autotune::summarize_candidate_results(
+        &fine_candidates,
+        *autotune_repeats,
+        &fine_probes,
+        slow_p95_threshold_ms,
+        slow_p99_threshold_ms,
+    );
+    let selection = crate::rayon_autotune::select_best_candidate(&candidate_summaries)
+        .ok_or("Rayon autotune did not produce any successful fine probe")?;
+    if *autotune_print_table {
+        let table = crate::rayon_autotune::format_autotune_table(&probes, &candidate_summaries);
+        info!("Rayon autotune table\n{table}");
+    }
+    let best = selection.selected.clone();
     info!(
         threads = best.threads,
-        p50_ms = best.p50_ms,
-        p95_ms = best.p95_ms,
-        sustained_tps = best.sustained_tps,
-        slow_p95_threshold_ms = slow_threshold,
+        confidence = selection.confidence.as_str(),
+        median_p50_ms = ?best.median_p50_ms,
+        worst_p95_ms = ?best.worst_p95_ms,
+        worst_p99_ms = ?best.worst_p99_ms,
+        median_sustained_tps = ?best.median_sustained_tps,
+        slow_p95_threshold_ms,
+        slow_p99_threshold_ms,
+        reason = %selection.reason,
         "Rayon autotune selected worker count"
     );
 
     if let (Some(path), Some(key)) = (run_profile_path(cli), key) {
+        let median_p50_ms = best.median_p50_ms.unwrap_or(0.0);
+        let worst_p95_ms = best.worst_p95_ms.unwrap_or(0.0);
+        let median_sustained_tps = best.median_sustained_tps.unwrap_or(0.0);
         let profile = crate::rayon_autotune::RayonAutotuneProfile {
             threads: best.threads,
-            p50_ms: best.p50_ms,
-            p95_ms: best.p95_ms,
-            sustained_tps: best.sustained_tps,
+            effective_cpu_mask: affinity.cpus.clone(),
+            effective_cpu_mask_display: Some(affinity.display.clone()),
+            logical_cores: affinity.logical_cores,
+            repeats: *autotune_repeats,
+            p50_ms: median_p50_ms,
+            p95_ms: worst_p95_ms,
+            p99_ms: best.worst_p99_ms,
+            sustained_tps: median_sustained_tps,
+            median_p50_ms,
+            worst_p95_ms,
+            worst_p99_ms: best.worst_p99_ms,
+            median_sustained_tps,
+            confidence: selection.confidence,
+            selection_reason: selection.reason.clone(),
+            candidate_results: candidate_summaries.clone(),
+            probe_results: probes.clone(),
         };
         if let Err(e) = crate::rayon_autotune::save_profile(&path, key, profile) {
             warn!(path = %path.display(), error = %e, "failed to save Rayon autotune profile");
+        } else if selection.confidence == crate::rayon_autotune::RayonAutotuneConfidence::Low {
+            warn!(
+                path = %path.display(),
+                confidence = selection.confidence.as_str(),
+                "saved low-confidence Rayon autotune profile; normal runs will not reuse it without --reuse-low-confidence-rayon-profile"
+            );
         } else {
-            info!(path = %path.display(), "saved placement-aware Rayon autotune profile");
+            info!(
+                path = %path.display(),
+                confidence = selection.confidence.as_str(),
+                "saved placement-aware Rayon autotune profile"
+            );
         }
     }
 
     Ok(Some(best.threads))
+}
+
+fn run_rayon_autotune_probe_observation(
+    raw_args: &[OsString],
+    autotune_tokens: u64,
+    threads: usize,
+    stage: crate::rayon_autotune::RayonAutotuneProbeStage,
+    repeat: usize,
+) -> crate::rayon_autotune::RayonAutotuneProbeObservation {
+    match run_rayon_autotune_probe(raw_args, autotune_tokens, threads) {
+        Ok(Some(result)) => {
+            crate::rayon_autotune::RayonAutotuneProbeObservation::from_probe_result(
+                stage,
+                repeat,
+                autotune_tokens,
+                result,
+            )
+        }
+        Ok(None) => crate::rayon_autotune::RayonAutotuneProbeObservation::invalid(
+            threads,
+            stage,
+            repeat,
+            autotune_tokens,
+            "probe produced no parseable result",
+        ),
+        Err(e) => crate::rayon_autotune::RayonAutotuneProbeObservation::invalid(
+            threads,
+            stage,
+            repeat,
+            autotune_tokens,
+            e.to_string(),
+        ),
+    }
+}
+
+fn log_rayon_autotune_probe_observation(
+    probe: &crate::rayon_autotune::RayonAutotuneProbeObservation,
+) {
+    if probe.valid {
+        info!(
+            stage = probe.stage.as_str(),
+            threads = probe.threads,
+            repeat = probe.repeat,
+            tokens = probe.tokens,
+            p50_ms = ?probe.p50_ms,
+            p95_ms = ?probe.p95_ms,
+            p99_ms = ?probe.p99_ms,
+            sustained_tps = ?probe.sustained_tps,
+            "Rayon autotune probe complete"
+        );
+    } else {
+        warn!(
+            stage = probe.stage.as_str(),
+            threads = probe.threads,
+            repeat = probe.repeat,
+            tokens = probe.tokens,
+            reason = %probe.reason.as_deref().unwrap_or("invalid"),
+            "Rayon autotune probe failed"
+        );
+    }
 }
 
 fn run_rayon_autotune_probe(
@@ -1108,12 +1323,22 @@ fn autotune_child_args(
         if s == "--autotune-rayon"
             || s.starts_with("--autotune-rayon=")
             || s.starts_with("--autotune-tokens=")
+            || s.starts_with("--autotune-repeats=")
+            || s.starts_with("--autotune-coarse-tokens=")
+            || s.starts_with("--autotune-top-candidates=")
+            || s == "--autotune-print-table"
             || s.starts_with("--tokens=")
             || s.starts_with("--rayon-threads=")
         {
             continue;
         }
-        if s == "--autotune-tokens" || s == "--tokens" || s == "--rayon-threads" {
+        if s == "--autotune-tokens"
+            || s == "--autotune-repeats"
+            || s == "--autotune-coarse-tokens"
+            || s == "--autotune-top-candidates"
+            || s == "--tokens"
+            || s == "--rayon-threads"
+        {
             let _ = iter.next();
             continue;
         }
@@ -1395,6 +1620,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     num_experts_per_layer,
                     packed_blob,
                     packed_manifest,
+                    ..
                 } = cli.cmd
                 {
                     let dtype =
@@ -5706,6 +5932,7 @@ async fn cmd_run(
             valid: true,
             p50_ms: crate::rayon_autotune::percentile_ms(&token_cycle_us, 0.50),
             p95_ms: crate::rayon_autotune::percentile_ms(&token_cycle_us, 0.95),
+            p99_ms: Some(crate::rayon_autotune::percentile_ms(&token_cycle_us, 0.99)),
             sustained_tps: args.tokens as f64 / wall.as_secs_f64(),
         };
         println!(
@@ -6424,6 +6651,13 @@ mod tests {
             OsString::from("--autotune-rayon"),
             OsString::from("--autotune-tokens"),
             OsString::from("2000"),
+            OsString::from("--autotune-repeats"),
+            OsString::from("3"),
+            OsString::from("--autotune-coarse-tokens"),
+            OsString::from("512"),
+            OsString::from("--autotune-top-candidates"),
+            OsString::from("2"),
+            OsString::from("--autotune-print-table"),
             OsString::from("--tokens"),
             OsString::from("10000"),
         ];
@@ -6437,12 +6671,53 @@ mod tests {
             .any(|w| w[0] == "--cpu-mask" && w[1] == "0-24"));
         assert!(!rendered.iter().any(|s| s == "--autotune-rayon"));
         assert!(!rendered.iter().any(|s| s == "--autotune-tokens"));
+        assert!(!rendered.iter().any(|s| s == "--autotune-repeats"));
+        assert!(!rendered.iter().any(|s| s == "--autotune-coarse-tokens"));
+        assert!(!rendered.iter().any(|s| s == "--autotune-top-candidates"));
+        assert!(!rendered.iter().any(|s| s == "--autotune-print-table"));
         assert!(rendered
             .windows(2)
             .any(|w| w[0] == "--tokens" && w[1] == "123"));
         assert!(rendered
             .windows(2)
             .any(|w| w[0] == "--rayon-threads" && w[1] == "25"));
+    }
+
+    #[test]
+    fn cli_parses_autotune_stability_flags() {
+        let cli = <Cli as clap::Parser>::try_parse_from([
+            "micro-expert-router",
+            "run",
+            "--autotune-rayon",
+            "--autotune-tokens",
+            "2000",
+            "--autotune-repeats",
+            "3",
+            "--autotune-coarse-tokens",
+            "512",
+            "--autotune-top-candidates",
+            "2",
+            "--autotune-print-table",
+        ])
+        .expect("autotune stability flags should parse");
+        let Cmd::Run {
+            autotune_rayon,
+            autotune_tokens,
+            autotune_repeats,
+            autotune_coarse_tokens,
+            autotune_top_candidates,
+            autotune_print_table,
+            ..
+        } = cli.cmd
+        else {
+            panic!("expected run command");
+        };
+        assert!(autotune_rayon);
+        assert_eq!(autotune_tokens, 2000);
+        assert_eq!(autotune_repeats, 3);
+        assert_eq!(autotune_coarse_tokens, 512);
+        assert_eq!(autotune_top_candidates, 2);
+        assert!(autotune_print_table);
     }
 
     #[test]
@@ -6458,6 +6733,59 @@ mod tests {
             err.to_string().contains("--rayon-threads must be > 0"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn low_confidence_rayon_profile_is_not_reused_without_opt_in() {
+        let dir = tempdir_unique("rayon-low-confidence-profile");
+        std::fs::create_dir_all(&dir).unwrap();
+        let key = crate::rayon_autotune::CpuAutotuneKey {
+            machine_fingerprint: "machine".to_string(),
+            model_fingerprint: "model".to_string(),
+            backend_fingerprint: "backend".to_string(),
+        };
+        let profile = crate::rayon_autotune::RayonAutotuneProfile {
+            threads: 25,
+            effective_cpu_mask: Some((0..25).collect()),
+            effective_cpu_mask_display: Some("0-24".to_string()),
+            logical_cores: 25,
+            repeats: 1,
+            p50_ms: 99.0,
+            p95_ms: 101.0,
+            p99_ms: Some(120.0),
+            sustained_tps: 10.0,
+            median_p50_ms: 99.0,
+            worst_p95_ms: 101.0,
+            worst_p99_ms: Some(120.0),
+            median_sustained_tps: 10.0,
+            confidence: crate::rayon_autotune::RayonAutotuneConfidence::Low,
+            selection_reason: "slow-regime profile".to_string(),
+            candidate_results: Vec::new(),
+            probe_results: Vec::new(),
+        };
+        let path = crate::rayon_autotune::default_profile_path(&dir);
+        crate::rayon_autotune::save_profile(&path, &key, profile).unwrap();
+
+        let dir_arg = dir.to_string_lossy().to_string();
+        let cli = <Cli as clap::Parser>::try_parse_from([
+            "micro-expert-router",
+            "run",
+            "--data-dir",
+            dir_arg.as_str(),
+        ])
+        .unwrap();
+        assert_eq!(load_profiled_rayon_threads(&cli, Some(&key)), None);
+
+        let cli = <Cli as clap::Parser>::try_parse_from([
+            "micro-expert-router",
+            "--reuse-low-confidence-rayon-profile",
+            "run",
+            "--data-dir",
+            dir_arg.as_str(),
+        ])
+        .unwrap();
+        assert_eq!(load_profiled_rayon_threads(&cli, Some(&key)), Some(25));
+        let _ = std::fs::remove_dir_all(dir);
     }
 
     // ---- Item 4: bench-real fail-open policy rejection matrix ----

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -176,8 +176,9 @@ mod workload;
 
 use clap::{Parser, Subcommand, ValueEnum};
 use serde::Serialize;
-use std::future::Future;
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tracing::{info, warn};
@@ -205,32 +206,27 @@ struct Cli {
     #[arg(long, global = true, default_value = "info", env = "RUST_LOG")]
     log: String,
 
-    /// Linux cpulist CPU mask applied before Tokio and Rayon start
-    /// (for example, `--cpu-mask 0-24`). Overrides
-    /// `[performance].cpu_mask` and legacy `MER_PIN_CORES`.
-    #[arg(long, global = true, value_parser = parse_cpu_mask_arg)]
+    /// Worker count for MER's process-wide CPU Rayon compute pool.
+    ///
+    /// Precedence: RAYON_NUM_THREADS > CLI > performance.rayon_threads >
+    /// autotune/profile > MER's startup default.
+    #[arg(long, global = true, value_name = "N", value_parser = parse_positive_usize)]
+    rayon_threads: Option<usize>,
+
+    /// Optional CPU placement mask in Linux cpulist syntax, e.g. `0-24`.
+    ///
+    /// Leave unset for portable default behavior: MER does not apply an
+    /// artificial CPU mask. Precedence: CLI > performance.cpu_mask >
+    /// legacy MER_PIN_CORES.
+    #[arg(long, global = true, value_name = "CPULIST")]
     cpu_mask: Option<String>,
 
-    /// Fail closed if benchmark token progress stalls for this many
-    /// seconds. `0` disables. Overrides
-    /// `[performance].progress_timeout_secs`.
-    #[arg(long, global = true)]
+    /// Progress watchdog timeout in seconds. `0` disables the watchdog.
+    #[arg(long, global = true, value_name = "SECS")]
     progress_timeout_secs: Option<u64>,
 
     #[command(subcommand)]
     cmd: Cmd,
-}
-
-fn parse_cpu_mask_arg(s: &str) -> Result<String, String> {
-    let trimmed = s.trim();
-    if trimmed.is_empty() {
-        return Err("CPU mask must not be empty".to_string());
-    }
-    let cpus = crate::numa::parse_cpulist(trimmed)?;
-    if cpus.is_empty() {
-        return Err("CPU mask must name at least one CPU".to_string());
-    }
-    Ok(trimmed.to_string())
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, ValueEnum)]
@@ -367,24 +363,13 @@ enum Cmd {
         /// Number of tokens to simulate.
         #[arg(long, default_value_t = 200)]
         tokens: u64,
-        /// Run short child-process probes to select the best Rayon worker
-        /// count for this host/model/backend before the real benchmark.
+        /// Probe Rayon worker counts on this machine/model/backend before
+        /// initializing the process-wide pool, then run with the winner.
         #[arg(long)]
         autotune_rayon: bool,
-        /// Number of tokens each child-process Rayon autotune probe runs.
-        #[arg(long, default_value_t = crate::rayon_autotune::DEFAULT_PROBE_TOKENS)]
+        /// Number of tokens each Rayon autotune probe runs.
+        #[arg(long, default_value_t = crate::rayon_autotune::DEFAULT_AUTOTUNE_TOKENS)]
         autotune_tokens: u64,
-        /// Optional comma-separated candidate Rayon thread counts. When
-        /// omitted, MER derives a window around default_compute_threads()
-        /// and includes the full visible logical-core count.
-        #[arg(long, value_delimiter = ',')]
-        autotune_candidates: Vec<usize>,
-        /// Hidden child-probe mode used by `--autotune-rayon`.
-        #[arg(long, hide = true)]
-        rayon_autotune_probe: bool,
-        /// Candidate thread count reported by a hidden child probe.
-        #[arg(long, hide = true)]
-        rayon_autotune_candidate: Option<usize>,
         /// Predictive prefetch fanout (how many candidates to issue per token).
         #[arg(long, default_value_t = 2)]
         predict_fanout: usize,
@@ -885,6 +870,17 @@ fn resolve_predict_min_prob(configured: f64, num_experts: u32) -> f64 {
     }
 }
 
+fn parse_positive_usize(s: &str) -> Result<usize, String> {
+    let n = s
+        .parse::<usize>()
+        .map_err(|_| format!("expected a positive integer, got {s:?}"))?;
+    if n == 0 {
+        Err("--rayon-threads must be > 0".to_string())
+    } else {
+        Ok(n)
+    }
+}
+
 fn init_logging(filter: &str) {
     let env_filter = EnvFilter::try_new(filter).unwrap_or_else(|_| EnvFilter::new("info"));
     let _ = tracing_subscriber::fmt()
@@ -894,403 +890,356 @@ fn init_logging(filter: &str) {
         .try_init();
 }
 
-#[derive(Clone, Debug)]
-struct RayonAutotuneStartupContext {
-    key: crate::rayon_autotune::CpuAutotuneKey,
-    cache_slots: usize,
-    dtype: String,
+fn rayon_env_override_present() -> bool {
+    std::env::var("RAYON_NUM_THREADS")
+        .ok()
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .is_some_and(|n| n > 0)
 }
 
-#[derive(Clone, Debug)]
-struct StartupDiagnostics {
-    requested_cpu_mask: Option<String>,
-    effective_cpu_mask: Option<String>,
-    pin_result: crate::numa::PinResult,
-    logical_cores: usize,
-    rayon_threads: usize,
-    rayon_source: &'static str,
+fn rayon_hard_override_present(cli: Option<usize>, config: Option<usize>) -> bool {
+    rayon_env_override_present() || cli.is_some() || config.is_some()
 }
 
-impl StartupDiagnostics {
-    fn startup_pinned(&self) -> bool {
-        matches!(self.pin_result, crate::numa::PinResult::Pinned { .. })
-    }
-
-    fn progress_cpu_mask(&self) -> &str {
-        self.effective_cpu_mask
-            .as_deref()
-            .or(self.requested_cpu_mask.as_deref())
-            .unwrap_or("unknown")
-    }
-}
-
-fn performance_config_for_cmd(
-    cmd: &Cmd,
-) -> Result<Option<crate::config::PerformanceConfig>, Box<dyn std::error::Error>> {
-    match cmd {
-        Cmd::Serve { config } | Cmd::BenchReal { config, .. } => {
-            Ok(Some(crate::config::Config::from_file(config)?.performance))
-        }
-        _ => Ok(None),
-    }
-}
-
-fn requested_cpu_mask(
+fn rayon_autotune_key_for_cli(
     cli: &Cli,
-    performance: Option<&crate::config::PerformanceConfig>,
-) -> Option<String> {
-    cli.cpu_mask
-        .clone()
-        .or_else(|| performance.and_then(|p| p.cpu_mask.clone()))
-        .or_else(|| {
-            std::env::var(crate::numa::MER_PIN_CORES_ENV)
-                .ok()
-                .filter(|s| !s.trim().is_empty())
-                .map(|s| format!("{}={}", crate::numa::MER_PIN_CORES_ENV, s.trim()))
-        })
-}
-
-fn explicit_cpu_mask<'a>(
-    cli: &'a Cli,
-    performance: Option<&'a crate::config::PerformanceConfig>,
-) -> Option<&'a str> {
-    cli.cpu_mask
-        .as_deref()
-        .or_else(|| performance.and_then(|p| p.cpu_mask.as_deref()))
-}
-
-fn progress_timeout_secs(
-    cli: &Cli,
-    performance: Option<&crate::config::PerformanceConfig>,
-) -> Option<u64> {
-    cli.progress_timeout_secs
-        .or_else(|| performance.and_then(|p| p.normalized_progress_timeout_secs()))
-        .filter(|&secs| secs > 0)
-}
-
-fn rayon_source_label(source: &crate::parallel::RayonThreadSource) -> &'static str {
-    match source {
-        crate::parallel::RayonThreadSource::EnvOverride => "env",
-        crate::parallel::RayonThreadSource::AutotuneProfile { .. } => "profile",
-        crate::parallel::RayonThreadSource::FreshAutotune { .. } => "autotune",
-        crate::parallel::RayonThreadSource::DefaultHeuristic => "default",
-    }
-}
-
-fn log_startup_placement(diagnostics: &StartupDiagnostics) {
-    info!(
-        requested_cpu_mask = diagnostics.requested_cpu_mask.as_deref().unwrap_or("none"),
-        effective_cpu_mask = diagnostics.effective_cpu_mask.as_deref().unwrap_or("unknown"),
-        logical_cores = diagnostics.logical_cores,
-        rayon_threads = diagnostics.rayon_threads,
-        rayon_source = diagnostics.rayon_source,
-        pinning_succeeded = diagnostics.startup_pinned(),
-        pinning_status = %diagnostics.pin_result.as_log_line(),
-        "startup CPU placement"
-    );
-}
-
-fn resolve_startup_rayon_threads(
-    cmd: &Cmd,
-    logical: usize,
-) -> Result<crate::parallel::RayonThreadSelection, Box<dyn std::error::Error>> {
-    if let Cmd::Run {
-        autotune_rayon: true,
-        rayon_autotune_probe: false,
-        autotune_tokens,
-        autotune_candidates,
-        ..
-    } = cmd
-    {
-        let ctx = rayon_autotune_context_for_cmd(cmd, logical).ok_or_else(|| {
-            "run --autotune-rayon could not build a model/backend fingerprint".to_string()
-        })?;
-        let candidates = sanitize_autotune_candidates(logical, autotune_candidates);
-        info!(
-            logical,
-            candidates = ?candidates,
-            probe_tokens = *autotune_tokens,
-            profile = %ctx.key.profile_path().display(),
-            "CPU/Rayon autotune: probing candidate thread counts in child processes"
-        );
-        let tuned = crate::rayon_autotune::run_cpu_autotune(
-            &ctx.key,
-            logical,
-            &candidates,
-            *autotune_tokens,
-            ctx.cache_slots,
-            &ctx.dtype,
-        )?;
-        info!(
-            selected_rayon_threads = tuned.profile.selected_rayon_threads,
-            profile = %tuned.profile_path.display(),
-            "CPU/Rayon autotune complete; saved selected profile"
-        );
-        return Ok(crate::parallel::RayonThreadSelection::fresh_autotune(
-            logical,
-            tuned.profile.selected_rayon_threads,
-            tuned.profile_path,
-        ));
-    }
-
-    let profile = if crate::parallel::env_thread_override().is_some()
-        || matches!(
-            cmd,
-            Cmd::Run {
-                rayon_autotune_probe: true,
-                ..
-            }
-        ) {
-        None
-    } else {
-        rayon_autotune_context_for_cmd(cmd, logical)
-            .and_then(|ctx| crate::rayon_autotune::load_matching_profile(&ctx.key))
-            .map(|(path, profile)| (profile.selected_rayon_threads, path))
-    };
-    Ok(crate::parallel::resolve_thread_selection(logical, profile))
-}
-
-fn sanitize_autotune_candidates(logical: usize, configured: &[usize]) -> Vec<usize> {
-    let mut candidates: Vec<usize> = if configured.is_empty() {
-        crate::rayon_autotune::candidate_thread_counts(logical)
-    } else {
-        configured.iter().copied().filter(|&n| n > 0).collect()
-    };
-    candidates.sort_unstable();
-    candidates.dedup();
-    if candidates.is_empty() {
-        crate::rayon_autotune::candidate_thread_counts(logical)
-    } else {
-        candidates
-    }
-}
-
-fn rayon_autotune_context_for_cmd(
-    cmd: &Cmd,
-    logical: usize,
-) -> Option<RayonAutotuneStartupContext> {
-    match cmd {
+    affinity: &crate::numa::EffectiveCpuAffinity,
+) -> Option<crate::rayon_autotune::CpuAutotuneKey> {
+    match &cli.cmd {
         Cmd::Run {
             data_dir,
             num_experts,
             expert_size,
             d_model,
             d_ff,
-            cache_slots,
             top_k,
             dtype,
+            workload,
+            gate_weights,
             gpu,
-            num_layers,
-            block_align,
-            packed_blob,
-            packed_manifest,
+            pipeline_depth,
             ..
-        } => Some(run_rayon_autotune_context(
-            logical,
-            data_dir,
-            *num_experts,
-            *expert_size,
-            *d_model,
-            *d_ff,
-            *cache_slots,
-            *top_k,
-            dtype,
-            *gpu,
-            *num_layers,
-            *block_align,
-            packed_blob.as_deref(),
-            packed_manifest.as_deref(),
-        )),
-        Cmd::Serve { config } => config_rayon_autotune_context(logical, config, "serve").ok(),
-        Cmd::BenchReal { config, .. } => {
-            config_rayon_autotune_context(logical, config, "bench-real").ok()
-        }
+        } => Some(crate::rayon_autotune::CpuAutotuneKey {
+            machine_fingerprint: crate::rayon_autotune::machine_fingerprint_from_affinity(
+                affinity,
+            ),
+            model_fingerprint: format!(
+                "run;data_dir={};experts={};expert_size={};d_model={};d_ff={};top_k={};dtype={};workload={};gate={};pipeline_depth={}",
+                data_dir.display(),
+                num_experts,
+                expert_size,
+                d_model,
+                d_ff,
+                top_k,
+                dtype,
+                workload,
+                gate_weights
+                    .as_ref()
+                    .map(|p| p.display().to_string())
+                    .unwrap_or_else(|| "none".to_string()),
+                pipeline_depth,
+            ),
+            backend_fingerprint: format!(
+                "dense={};gpu={};features={}",
+                crate::parallel::default_dense_matvec_backend(),
+                gpu,
+                build_features().join(",")
+            ),
+        }),
         _ => None,
     }
 }
 
-#[allow(clippy::too_many_arguments)]
-fn run_rayon_autotune_context(
-    logical: usize,
-    data_dir: &Path,
-    num_experts: u32,
-    expert_size: usize,
-    d_model: usize,
-    d_ff: usize,
-    cache_slots: usize,
-    top_k: usize,
-    dtype: &str,
-    gpu: bool,
-    num_layers: u32,
-    block_align: usize,
-    packed_blob: Option<&Path>,
-    packed_manifest: Option<&Path>,
-) -> RayonAutotuneStartupContext {
-    let mut num_experts = num_experts;
-    let mut expert_size = expert_size;
-    let mut d_model = d_model;
-    let mut d_ff = d_ff;
-    let mut top_k = top_k;
-    let mut dtype = dtype.to_ascii_lowercase();
-    let mut block_align = block_align;
-
-    if let Ok(body) = std::fs::read_to_string(data_dir.join("metadata.json")) {
-        if num_experts == cli_defaults::NUM_EXPERTS {
-            if let Some(v) = parse_json_number(&body, "num_experts") {
-                num_experts = v as u32;
-            }
-        }
-        if d_model == cli_defaults::D_MODEL {
-            if let Some(v) = parse_json_number(&body, "d_model") {
-                d_model = v as usize;
-            }
-        }
-        if d_ff == cli_defaults::D_FF {
-            if let Some(v) = parse_json_number(&body, "d_ff") {
-                d_ff = v as usize;
-            }
-        }
-        if top_k == cli_defaults::TOP_K {
-            if let Some(v) = parse_json_number(&body, "top_k") {
-                top_k = v as usize;
-            }
-        }
-        if expert_size == cli_defaults::EXPERT_SIZE {
-            if let Some(v) = parse_json_number(&body, "expert_size") {
-                expert_size = v as usize;
-            }
-        }
-        if block_align == cli_defaults::BLOCK_ALIGN {
-            if let Some(v) = parse_json_number(&body, "block_align") {
-                block_align = v as usize;
-            }
-        }
-        if dtype == "f32" {
-            if let Some(v) = parse_json_string(&body, "dtype") {
-                dtype = v.to_ascii_lowercase();
-            }
-        }
-    }
-
-    let data_dir_fingerprint = crate::rayon_autotune::make_data_dir_fingerprint(data_dir);
-    let model_fingerprint = crate::rayon_autotune::make_model_fingerprint(
-        data_dir,
-        num_experts,
-        top_k,
-        d_model,
-        d_ff,
-        expert_size,
-        num_layers,
-        &dtype,
-        packed_blob,
-        packed_manifest,
-    );
-    let backend = format!(
-        "run:compute_plane={}:dense_matvec={}:expert_policy=auto:qmm=on:block_align={}",
-        if gpu { "gpu" } else { "cpu" },
-        crate::parallel::default_dense_matvec_backend(),
-        block_align
-    );
-    RayonAutotuneStartupContext {
-        key: crate::rayon_autotune::CpuAutotuneKey {
-            machine_fingerprint: crate::rayon_autotune::make_machine_fingerprint(logical),
-            model_fingerprint,
-            data_dir_fingerprint,
-            dtype: dtype.clone(),
-            cache_slots,
-            backend,
-        },
-        cache_slots,
-        dtype,
+fn run_profile_path(cli: &Cli) -> Option<PathBuf> {
+    match &cli.cmd {
+        Cmd::Run { data_dir, .. } => Some(crate::rayon_autotune::default_profile_path(data_dir)),
+        _ => None,
     }
 }
 
-fn config_rayon_autotune_context(
-    logical: usize,
-    config: &Path,
-    command: &str,
-) -> Result<RayonAutotuneStartupContext, crate::config::ConfigError> {
-    let cfg = crate::config::Config::from_file(config)?;
-    let dtype = cfg.model.dtype.as_str().to_string();
-    let data_dir_fingerprint =
-        crate::rayon_autotune::make_data_dir_fingerprint(&cfg.model.data_dir);
-    let model_fingerprint = crate::rayon_autotune::make_model_fingerprint(
-        &cfg.model.data_dir,
-        cfg.model.num_experts,
-        cfg.model.top_k,
-        cfg.model.d_model,
-        cfg.model.d_ff,
-        cfg.model.expert_size,
-        cfg.model.num_layers as u32,
-        &dtype,
-        cfg.storage.packed_blob.as_deref(),
-        cfg.storage.packed_manifest.as_deref(),
+fn load_profiled_rayon_threads(
+    cli: &Cli,
+    key: Option<&crate::rayon_autotune::CpuAutotuneKey>,
+) -> Option<usize> {
+    let key = key?;
+    let path = run_profile_path(cli)?;
+    let profile = crate::rayon_autotune::load_profile(&path, key)?;
+    info!(
+        path = %path.display(),
+        threads = profile.threads,
+        p50_ms = profile.p50_ms,
+        p95_ms = profile.p95_ms,
+        sustained_tps = profile.sustained_tps,
+        "loaded placement-aware Rayon autotune profile"
     );
-    let backend = format!(
-        "{}:compute_offload={:?}:dense_matvec={}:expert_policy={:?}:real_transformer={}",
-        command,
-        cfg.real_transformer.compute_offload,
-        cfg.real_transformer.dense_matvec_backend,
-        cfg.real_transformer.expert_execution_policy,
-        cfg.real_transformer.enabled
+    Some(profile.threads)
+}
+
+fn maybe_run_startup_rayon_autotune(
+    cli: &Cli,
+    raw_args: &[OsString],
+    affinity: &crate::numa::EffectiveCpuAffinity,
+    key: Option<&crate::rayon_autotune::CpuAutotuneKey>,
+    config_threads: Option<usize>,
+) -> Result<Option<usize>, Box<dyn std::error::Error>> {
+    let Cmd::Run {
+        autotune_rayon,
+        autotune_tokens,
+        ..
+    } = &cli.cmd
+    else {
+        return Ok(None);
+    };
+    if !*autotune_rayon {
+        return Ok(None);
+    }
+    if std::env::var_os(crate::rayon_autotune::AUTOTUNE_PROBE_ENV).is_some() {
+        return Ok(None);
+    }
+    if rayon_hard_override_present(cli.rayon_threads, config_threads) {
+        info!(
+            "Rayon autotune requested, but an explicit thread-count override is present; skipping probes"
+        );
+        return Ok(None);
+    }
+
+    let candidates = crate::rayon_autotune::default_thread_candidates(affinity.logical_cores);
+    if candidates.is_empty() {
+        return Ok(None);
+    }
+    info!(
+        effective_cpu_mask = %affinity.display,
+        logical_cores = affinity.logical_cores,
+        candidates = ?candidates,
+        autotune_tokens,
+        "starting Rayon autotune probes"
     );
-    Ok(RayonAutotuneStartupContext {
-        key: crate::rayon_autotune::CpuAutotuneKey {
-            machine_fingerprint: crate::rayon_autotune::make_machine_fingerprint(logical),
-            model_fingerprint,
-            data_dir_fingerprint,
-            dtype: dtype.clone(),
-            cache_slots: cfg.storage.cache_slots,
-            backend,
-        },
-        cache_slots: cfg.storage.cache_slots,
-        dtype,
-    })
+
+    let mut probes = Vec::new();
+    for threads in candidates {
+        match run_rayon_autotune_probe(raw_args, *autotune_tokens, threads) {
+            Ok(Some(result)) => {
+                info!(
+                    threads = result.threads,
+                    p50_ms = result.p50_ms,
+                    p95_ms = result.p95_ms,
+                    sustained_tps = result.sustained_tps,
+                    "Rayon autotune probe complete"
+                );
+                probes.push(result);
+            }
+            Ok(None) => warn!(threads, "Rayon autotune probe produced no parseable result"),
+            Err(e) => warn!(threads, error = %e, "Rayon autotune probe failed"),
+        }
+    }
+
+    let fastest_p50 = probes
+        .iter()
+        .filter(|p| p.valid)
+        .map(|p| p.p50_ms)
+        .fold(f64::INFINITY, f64::min);
+    let slow_threshold = if fastest_p50.is_finite() {
+        (fastest_p50 * 4.0).max(1.0)
+    } else {
+        f64::INFINITY
+    };
+    let best = crate::rayon_autotune::select_best_probe(&probes, slow_threshold)
+        .ok_or("Rayon autotune did not produce any successful probe")?;
+    info!(
+        threads = best.threads,
+        p50_ms = best.p50_ms,
+        p95_ms = best.p95_ms,
+        sustained_tps = best.sustained_tps,
+        slow_p95_threshold_ms = slow_threshold,
+        "Rayon autotune selected worker count"
+    );
+
+    if let (Some(path), Some(key)) = (run_profile_path(cli), key) {
+        let profile = crate::rayon_autotune::RayonAutotuneProfile {
+            threads: best.threads,
+            p50_ms: best.p50_ms,
+            p95_ms: best.p95_ms,
+            sustained_tps: best.sustained_tps,
+        };
+        if let Err(e) = crate::rayon_autotune::save_profile(&path, key, profile) {
+            warn!(path = %path.display(), error = %e, "failed to save Rayon autotune profile");
+        } else {
+            info!(path = %path.display(), "saved placement-aware Rayon autotune profile");
+        }
+    }
+
+    Ok(Some(best.threads))
+}
+
+fn run_rayon_autotune_probe(
+    raw_args: &[OsString],
+    autotune_tokens: u64,
+    threads: usize,
+) -> Result<Option<crate::rayon_autotune::RayonAutotuneProbeResult>, Box<dyn std::error::Error>> {
+    let exe = raw_args
+        .first()
+        .ok_or("missing argv[0] for Rayon autotune probe")?;
+    let child_args = autotune_child_args(raw_args, autotune_tokens, threads);
+    let output = Command::new(exe)
+        .args(&child_args)
+        .env(crate::rayon_autotune::AUTOTUNE_PROBE_ENV, "1")
+        .env("RAYON_NUM_THREADS", threads.to_string())
+        .output()?;
+    if !output.status.success() {
+        return Err(format!(
+            "probe exited with status {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        )
+        .into());
+    }
+    Ok(parse_autotune_probe_output(&output.stdout))
+}
+
+fn autotune_child_args(
+    raw_args: &[OsString],
+    autotune_tokens: u64,
+    threads: usize,
+) -> Vec<OsString> {
+    let mut out = Vec::new();
+    let mut iter = raw_args.iter().skip(1).peekable();
+    while let Some(arg) = iter.next() {
+        let s = arg.to_string_lossy();
+        if s == "--autotune-rayon"
+            || s.starts_with("--autotune-rayon=")
+            || s.starts_with("--autotune-tokens=")
+            || s.starts_with("--tokens=")
+            || s.starts_with("--rayon-threads=")
+        {
+            continue;
+        }
+        if s == "--autotune-tokens" || s == "--tokens" || s == "--rayon-threads" {
+            let _ = iter.next();
+            continue;
+        }
+        out.push(arg.clone());
+    }
+    out.push(OsString::from("--tokens"));
+    out.push(OsString::from(autotune_tokens.to_string()));
+    out.push(OsString::from("--rayon-threads"));
+    out.push(OsString::from(threads.to_string()));
+    out
+}
+
+fn parse_autotune_probe_output(
+    stdout: &[u8],
+) -> Option<crate::rayon_autotune::RayonAutotuneProbeResult> {
+    let body = String::from_utf8_lossy(stdout);
+    for line in body.lines() {
+        let Some(json) = line.strip_prefix("MER_RAYON_AUTOTUNE_RESULT ") else {
+            continue;
+        };
+        if let Ok(result) = serde_json::from_str(json) {
+            return Some(result);
+        }
+    }
+    None
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let raw_args: Vec<OsString> = std::env::args_os().collect();
     let cli = Cli::parse();
     init_logging(&cli.log);
-    let performance = performance_config_for_cmd(&cli.cmd)?;
-    let requested_cpu_mask = requested_cpu_mask(&cli, performance.as_ref());
-    let progress_timeout_secs = progress_timeout_secs(&cli, performance.as_ref());
 
-    // Best-effort CPU placement: honoured before any tokio runtime or
-    // background thread spawns so child threads inherit the affinity
-    // mask. Explicit `--cpu-mask` / `[performance].cpu_mask` wins over
-    // legacy `MER_PIN_CORES`.
-    let pin = crate::numa::apply_startup_cpu_mask(explicit_cpu_mask(&cli, performance.as_ref()));
+    // Load only enough startup configuration to resolve process-level
+    // runtime controls before CPU placement / Rayon exist. The command
+    // handlers still own their normal config reconciliation and runtime
+    // construction below.
+    let startup_config = match &cli.cmd {
+        Cmd::Serve { config } | Cmd::BenchReal { config, .. } => {
+            Some(crate::config::Config::from_file(config)?)
+        }
+        _ => None,
+    };
+
+    let config_cpu_mask = startup_config
+        .as_ref()
+        .and_then(|cfg| cfg.performance.cpu_mask.as_deref());
+    let legacy_mer_pin_cores = std::env::var(crate::numa::MER_PIN_CORES_ENV).ok();
+    let cpu_mask_request = crate::numa::resolve_cpu_mask_request(
+        cli.cpu_mask.as_deref(),
+        config_cpu_mask,
+        legacy_mer_pin_cores.as_deref(),
+    )
+    .map_err(|e| format!("CPU mask selection: {e}"))?;
+
+    // Apply explicit placement before any Tokio runtime or Rayon worker is
+    // spawned, then read the effective affinity that the OS actually gave us.
+    let pin = crate::numa::apply_cpu_mask_request(cpu_mask_request.as_ref());
+    let startup_pinned = matches!(pin, crate::numa::PinResult::Pinned { .. });
+    let effective_affinity = crate::numa::effective_cpu_affinity();
+    info!(
+        requested_cpu_mask = cpu_mask_request
+            .as_ref()
+            .map(|r| r.display.as_str())
+            .unwrap_or("none"),
+        requested_cpu_mask_source = cpu_mask_request
+            .as_ref()
+            .map(|r| r.source.as_str())
+            .unwrap_or("none"),
+        effective_cpu_mask = %effective_affinity.display,
+        logical_cores = effective_affinity.logical_cores,
+        pinning_result = %pin.as_log_line(),
+        "startup CPU placement"
+    );
 
     // `MER_PIN_CORES` is now consumed centrally at process start via the
-    // `numa` module. Clear it so any legacy later parsing in subcommands
-    // (for example, `cmd_serve`) does not attempt to re-apply affinity
-    // and drift from the startup contract.
-    std::env::remove_var("MER_PIN_CORES");
+    // `numa` module. Clear it so later code cannot re-apply affinity and
+    // drift from this startup contract.
+    unsafe {
+        std::env::remove_var(crate::numa::MER_PIN_CORES_ENV);
+    }
+
+    let progress_config_secs = startup_config
+        .as_ref()
+        .and_then(|cfg| cfg.performance.progress_timeout_secs);
+    let progress_watchdog = crate::rayon_autotune::normalize_progress_timeout_secs(
+        cli.progress_timeout_secs,
+        progress_config_secs,
+    );
+    match progress_watchdog.timeout {
+        Some(timeout) => info!(
+            progress_timeout_secs = timeout.as_secs(),
+            "progress watchdog enabled"
+        ),
+        None => info!("progress watchdog disabled"),
+    }
 
     // Size the shared compute (`rayon`) pool now: after affinity pinning so
-    // its workers inherit the startup mask, and before any matmul touches
-    // it. By default it spans the host's logical cores *minus a small
-    // reservation* (`parallel::default_compute_threads`) so a saturated
-    // compute fan-out can't starve the async runtime under continuous
-    // batching; an explicit `RAYON_NUM_THREADS` overrides saved autotune
-    // profiles. `run --autotune-rayon` is the dedicated force-refresh path:
-    // it probes candidates in child processes first, then builds this
-    // process's global pool exactly once with the selected result.
-    let logical = std::thread::available_parallelism()
-        .map(|n| n.get())
-        .unwrap_or(1);
-    let rayon_selection = resolve_startup_rayon_threads(&cli.cmd, logical)?;
-    let rayon_source = rayon_source_label(&rayon_selection.source);
-    let rayon_threads = crate::parallel::init_global_pool_with_selection(rayon_selection);
-    let startup = StartupDiagnostics {
-        requested_cpu_mask,
-        effective_cpu_mask: crate::numa::current_affinity_cpulist(),
-        pin_result: pin,
-        logical_cores: logical,
-        rayon_threads,
-        rayon_source,
+    // its workers inherit the startup mask, after CLI/config/env precedence
+    // is resolved, and before any matmul touches it. By default it preserves
+    // MER's existing logical-core-minus-headroom policy under the effective
+    // affinity mask; `RAYON_NUM_THREADS` remains the hard reproduction
+    // override above autotune/profile/default selection.
+    let rayon_config_threads = startup_config
+        .as_ref()
+        .and_then(|cfg| cfg.performance.rayon_threads);
+    let run_autotune_key = rayon_autotune_key_for_cli(&cli, &effective_affinity);
+    let profile_threads = if rayon_hard_override_present(cli.rayon_threads, rayon_config_threads) {
+        None
+    } else {
+        load_profiled_rayon_threads(&cli, run_autotune_key.as_ref())
     };
-    log_startup_placement(&startup);
+    let autotuned_threads = maybe_run_startup_rayon_autotune(
+        &cli,
+        &raw_args,
+        &effective_affinity,
+        run_autotune_key.as_ref(),
+        rayon_config_threads,
+    )?;
+    let rayon_selection = crate::parallel::resolve_rayon_threads_from_env(
+        cli.rayon_threads,
+        rayon_config_threads,
+        autotuned_threads,
+        profile_threads,
+    )
+    .map_err(|e| format!("rayon thread selection: {e}"))?;
+    crate::parallel::init_global_pool(rayon_selection, effective_affinity.logical_cores);
 
     // Log the selected math kernel backend once. The dispatcher itself
     // is lazy, but emitting this at startup gives ops a single line in
@@ -1397,9 +1346,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     tokens,
                     autotune_rayon: _,
                     autotune_tokens: _,
-                    autotune_candidates: _,
-                    rayon_autotune_probe,
-                    rayon_autotune_candidate,
                     predict_fanout,
                     predict_min_prob,
                     no_direct,
@@ -1457,91 +1403,69 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 "--dtype: unknown value {dtype:?} (supported: {SUPPORTED_RUNTIME_DTYPES})"
                             )
                         })?;
-                    let run_args = RunArgs {
-                        data_dir,
-                        num_experts,
-                        expert_size,
-                        d_model,
-                        d_ff,
-                        cache_slots,
-                        top_k,
-                        tokens,
-                        rayon_autotune_probe,
-                        rayon_autotune_candidate,
-                        predict_fanout,
-                        predict_min_prob,
-                        no_direct,
-                        block_align,
-                        seed,
-                        dtype,
-                        partial_load_fraction,
-                        pin_after_observations,
-                        alias_map_path: alias_map,
-                        io_uring,
-                        token_pause_us,
-                        first_token,
-                        no_prefetch,
-                        io_only,
-                        force_ssd,
-                        router_clusters,
-                        router_intra_p,
-                        router_matrix,
-                        gate_weights,
-                        trace_out,
-                        gpu_expert_cache: if gpu { run_gpu_cache.clone() } else { None },
-                        pipeline_depth,
-                        speculator,
-                        speculator_hidden_dim,
-                        speculator_top_k,
-                        locality,
-                        locality_window,
-                        locality_threshold_pct,
-                        affinity,
-                        affinity_neighbors_k,
-                        affinity_decay_epoch,
-                        prefetch_governor,
-                        prefetch_precision_floor,
-                        prefetch_contention_weight,
-                        cost_aware_eviction,
-                        pregate,
-                        static_residency_fraction,
-                        static_residency_warmup_tokens,
-                        static_residency_profile,
-                        profile_out,
-                        workload,
-                        zipf_s,
-                        workload_correlation,
-                        replay_trace,
-                        num_layers,
-                        num_experts_per_layer,
-                        packed_blob,
-                        packed_manifest,
-                    };
-                    let probe_mode = run_args.rayon_autotune_probe;
-                    let failure_candidate = run_args
-                        .rayon_autotune_candidate
-                        .or_else(crate::parallel::env_thread_override)
-                        .unwrap_or(0);
-                    let failure_tokens = run_args.tokens;
-                    let failure_cache_slots = run_args.cache_slots;
-                    let failure_dtype = run_args.dtype.as_str().to_string();
-                    let result =
-                        cmd_run(run_args, startup.clone(), progress_timeout_secs).await;
-                    if probe_mode {
-                        if let Err(e) = result {
-                            let failure = crate::rayon_autotune::CpuAutotuneProbeResult::failure(
-                                failure_candidate,
-                                failure_tokens,
-                                failure_cache_slots,
-                                failure_dtype,
-                                e.to_string(),
-                            );
-                            println!("{}", serde_json::to_string(&failure)?);
-                        }
-                        Ok(())
-                    } else {
-                        result
-                    }
+                    cmd_run(
+                        RunArgs {
+                            data_dir,
+                            num_experts,
+                            expert_size,
+                            d_model,
+                            d_ff,
+                            cache_slots,
+                            top_k,
+                            tokens,
+                            predict_fanout,
+                            predict_min_prob,
+                            no_direct,
+                            block_align,
+                            seed,
+                            dtype,
+                            partial_load_fraction,
+                            pin_after_observations,
+                            alias_map_path: alias_map,
+                            io_uring,
+                            token_pause_us,
+                            first_token,
+                            no_prefetch,
+                            io_only,
+                            force_ssd,
+                            router_clusters,
+                            router_intra_p,
+                            router_matrix,
+                            gate_weights,
+                            trace_out,
+                            gpu_expert_cache: if gpu { run_gpu_cache.clone() } else { None },
+                            pipeline_depth,
+                            speculator,
+                            speculator_hidden_dim,
+                            speculator_top_k,
+                            locality,
+                            locality_window,
+                            locality_threshold_pct,
+                            affinity,
+                            affinity_neighbors_k,
+                            affinity_decay_epoch,
+                            prefetch_governor,
+                            prefetch_precision_floor,
+                            prefetch_contention_weight,
+                            cost_aware_eviction,
+                            pregate,
+                            static_residency_fraction,
+                            static_residency_warmup_tokens,
+                            static_residency_profile,
+                            profile_out,
+                            workload,
+                            zipf_s,
+                            workload_correlation,
+                            replay_trace,
+                            num_layers,
+                            num_experts_per_layer,
+                            packed_blob,
+                            packed_manifest,
+                        },
+                        startup_pinned,
+                        progress_watchdog,
+                    )
+                    .await
                 } else {
                     unreachable!()
                 }
@@ -1577,8 +1501,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 cache_reset,
                 greedy,
                 format,
-                progress_timeout_secs,
-                startup: startup.clone(),
+                progress_watchdog,
             }))
         }
         Cmd::MatvecMicrobench {
@@ -1700,10 +1623,12 @@ fn install_run_gpu_backend(
         0,
     );
     if !backend_box.is_gpu() {
-        return Err("explicit --gpu request failed: GPU backend initialization did not \
+        return Err(
+            "explicit --gpu request failed: GPU backend initialization did not \
                     produce a GPU device; refusing to run on CPU (use serving \
                     compute_offload = \"auto\" for best-effort GPU with CPU fallback)"
-            .into());
+                .into(),
+        );
     }
     let device_name = backend_box.device_name().to_string();
     let compute_plane = backend_box.compute_plane().to_string();
@@ -1774,8 +1699,7 @@ struct BenchRealArgs {
     cache_reset: BenchRealCacheReset,
     greedy: bool,
     format: BenchRealOutputFormat,
-    progress_timeout_secs: Option<u64>,
-    startup: StartupDiagnostics,
+    progress_watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
 }
 
 struct MatvecMicrobenchArgs {
@@ -1973,14 +1897,10 @@ async fn cmd_bench_real(args: BenchRealArgs) -> Result<(), Box<dyn std::error::E
         let runtime = build_bench_real_runtime(&args.config).await?;
         let params = bench_sampling_params(&runtime.cfg, args.greedy);
         for i in 0..args.warmup_runs {
-            let _ = run_bench_real_once(
-                &runtime,
-                &input.prompt,
-                input.output_tokens,
-                params,
-                i,
-                args.progress_timeout_secs,
-                &args.startup,
+            let _ = with_progress_timeout(
+                format!("bench-real warmup run {i}"),
+                args.progress_watchdog,
+                run_bench_real_once(&runtime, &input.prompt, input.output_tokens, params, i),
             )
             .await?;
         }
@@ -1988,14 +1908,10 @@ async fn cmd_bench_real(args: BenchRealArgs) -> Result<(), Box<dyn std::error::E
         let mut runs = Vec::with_capacity(args.measured_runs);
         for i in 0..args.measured_runs {
             runs.push(
-                run_bench_real_once(
-                    &runtime,
-                    &input.prompt,
-                    input.output_tokens,
-                    params,
-                    i,
-                    args.progress_timeout_secs,
-                    &args.startup,
+                with_progress_timeout(
+                    format!("bench-real measured run {i}"),
+                    args.progress_watchdog,
+                    run_bench_real_once(&runtime, &input.prompt, input.output_tokens, params, i),
                 )
                 .await?,
             );
@@ -2006,14 +1922,10 @@ async fn cmd_bench_real(args: BenchRealArgs) -> Result<(), Box<dyn std::error::E
         for i in 0..args.warmup_runs {
             let runtime = build_bench_real_runtime(&args.config).await?;
             let params = bench_sampling_params(&runtime.cfg, args.greedy);
-            let _ = run_bench_real_once(
-                &runtime,
-                &input.prompt,
-                input.output_tokens,
-                params,
-                i,
-                args.progress_timeout_secs,
-                &args.startup,
+            let _ = with_progress_timeout(
+                format!("bench-real warmup run {i}"),
+                args.progress_watchdog,
+                run_bench_real_once(&runtime, &input.prompt, input.output_tokens, params, i),
             )
             .await?;
         }
@@ -2023,14 +1935,10 @@ async fn cmd_bench_real(args: BenchRealArgs) -> Result<(), Box<dyn std::error::E
             let runtime = build_bench_real_runtime(&args.config).await?;
             let params = bench_sampling_params(&runtime.cfg, args.greedy);
             runs.push(
-                run_bench_real_once(
-                    &runtime,
-                    &input.prompt,
-                    input.output_tokens,
-                    params,
-                    i,
-                    args.progress_timeout_secs,
-                    &args.startup,
+                with_progress_timeout(
+                    format!("bench-real measured run {i}"),
+                    args.progress_watchdog,
+                    run_bench_real_once(&runtime, &input.prompt, input.output_tokens, params, i),
                 )
                 .await?,
             );
@@ -2039,6 +1947,28 @@ async fn cmd_bench_real(args: BenchRealArgs) -> Result<(), Box<dyn std::error::E
         emit_bench_real_report(&args, input, runs)?;
     }
     Ok(())
+}
+
+async fn with_progress_timeout<T, F>(
+    label: String,
+    watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+    fut: F,
+) -> Result<T, Box<dyn std::error::Error>>
+where
+    F: std::future::Future<Output = Result<T, Box<dyn std::error::Error>>>,
+{
+    if let Some(timeout) = watchdog.timeout {
+        match tokio::time::timeout(timeout, fut).await {
+            Ok(result) => result,
+            Err(_) => Err(format!(
+                "progress watchdog fired after {}s while waiting for {label}",
+                timeout.as_secs()
+            )
+            .into()),
+        }
+    } else {
+        fut.await
+    }
 }
 
 /// Strict real-model benchmarks must not emit attention-softmax non-finite
@@ -2215,16 +2145,8 @@ fn cmd_scratch_alloc_microbench(
 
         let backend = crate::backend::current();
         let results = vec![
-            run_scratch_alloc_variant(
-                &args,
-                ScratchAllocVariant::CompatibilityWrappers,
-                &backend,
-            ),
-            run_scratch_alloc_variant(
-                &args,
-                ScratchAllocVariant::ScratchBuffers,
-                &backend,
-            ),
+            run_scratch_alloc_variant(&args, ScratchAllocVariant::CompatibilityWrappers, &backend),
+            run_scratch_alloc_variant(&args, ScratchAllocVariant::ScratchBuffers, &backend),
         ];
 
         let report = ScratchAllocMicrobenchReport {
@@ -2977,11 +2899,9 @@ async fn build_bench_real_runtime(
         Some(p) => match Tokenizer::from_file(p) {
             Ok(t) => Arc::new(t),
             Err(e) => {
-                return Err(format!(
-                    "bench-real failed to load tokenizer {}: {e}",
-                    p.display()
-                )
-                .into());
+                return Err(
+                    format!("bench-real failed to load tokenizer {}: {e}", p.display()).into(),
+                );
             }
         },
         None => {
@@ -3288,9 +3208,7 @@ fn validate_resolved_real_model_config(
         ));
     }
     if num_experts > u32::MAX as usize {
-        errs.push(format!(
-            "num_experts ({num_experts}) does not fit in u32"
-        ));
+        errs.push(format!("num_experts ({num_experts}) does not fit in u32"));
     }
 
     if errs.is_empty() {
@@ -3319,8 +3237,6 @@ async fn run_bench_real_once(
     output_tokens: usize,
     params: crate::sampling::SamplingParams,
     run_index: usize,
-    progress_timeout_secs: Option<u64>,
-    startup: &StartupDiagnostics,
 ) -> Result<BenchRealRunReport, Box<dyn std::error::Error>> {
     let prompt_ids = runtime.tokenizer.encode(prompt)?;
     if prompt_ids.is_empty() {
@@ -3338,24 +3254,16 @@ async fn run_bench_real_once(
     let mut decode_latencies_us = Vec::with_capacity(output_tokens.saturating_sub(1));
 
     for &tid in &prompt_ids[..prompt_ids.len().saturating_sub(1)] {
-        let future = runtime.model.forward_token_hidden_with_timing(
-            &runtime.engine,
-            tid,
-            pos,
-            &mut kv,
-            Some(&stage_timings),
-        );
-        await_with_progress_watchdog(
-            future,
-            progress_timeout_secs,
-            "bench-real:prompt",
-            pos as u64,
-            pos.checked_sub(1).map(|v| v as u64),
-            &runtime.engine,
-            None,
-            startup,
-        )
-        .await?;
+        runtime
+            .model
+            .forward_token_hidden_with_timing(
+                &runtime.engine,
+                tid,
+                pos,
+                &mut kv,
+                Some(&stage_timings),
+            )
+            .await?;
         forward_evaluations += 1;
         pos += 1;
     }
@@ -3363,23 +3271,16 @@ async fn run_bench_real_once(
     let final_prompt = *prompt_ids.last().expect("prompt_ids checked non-empty");
     let final_prompt_pos = pos;
     let first_started = Instant::now();
-    let final_hidden = await_with_progress_watchdog(
-        runtime.model.forward_token_hidden_with_timing(
+    let final_hidden = runtime
+        .model
+        .forward_token_hidden_with_timing(
             &runtime.engine,
             final_prompt,
             final_prompt_pos,
             &mut kv,
             Some(&stage_timings),
-        ),
-        progress_timeout_secs,
-        "bench-real:prompt-final",
-        final_prompt_pos as u64,
-        final_prompt_pos.checked_sub(1).map(|v| v as u64),
-        &runtime.engine,
-        None,
-        startup,
-    )
-    .await?;
+        )
+        .await?;
     forward_evaluations += 1;
     pos += 1;
     let prompt_elapsed = prompt_started.elapsed();
@@ -3400,25 +3301,17 @@ async fn run_bench_real_once(
     let mut last = first;
     while completion_ids.len() < output_tokens {
         let step_started = Instant::now();
-        let current_completion_index = completion_ids.len() as u64;
-        let next = await_with_progress_watchdog(
-            runtime.model.decode_step_with_timing(
+        let next = runtime
+            .model
+            .decode_step_with_timing(
                 &runtime.engine,
                 last,
                 pos,
                 &mut kv,
                 &params,
                 Some(&stage_timings),
-            ),
-            progress_timeout_secs,
-            "bench-real:decode",
-            current_completion_index,
-            current_completion_index.checked_sub(1),
-            &runtime.engine,
-            None,
-            startup,
-        )
-        .await?;
+            )
+            .await?;
         forward_evaluations += 1;
         lm_head_evaluations += 1;
         decode_latencies_us.push(step_started.elapsed().as_micros() as u64);
@@ -5049,8 +4942,6 @@ struct RunArgs {
     cache_slots: usize,
     top_k: usize,
     tokens: u64,
-    rayon_autotune_probe: bool,
-    rayon_autotune_candidate: Option<usize>,
     predict_fanout: usize,
     predict_min_prob: f64,
     no_direct: bool,
@@ -5101,99 +4992,10 @@ struct RunArgs {
     packed_manifest: Option<PathBuf>,
 }
 
-async fn await_with_progress_watchdog<T, E, F>(
-    future: F,
-    timeout_secs: Option<u64>,
-    stage: &'static str,
-    current_token_index: u64,
-    last_completed_token_index: Option<u64>,
-    engine: &Engine,
-    cache: Option<&MultiLayerExpertCache>,
-    startup: &StartupDiagnostics,
-) -> Result<T, Box<dyn std::error::Error>>
-where
-    F: Future<Output = Result<T, E>>,
-    E: Into<Box<dyn std::error::Error>>,
-{
-    let Some(timeout_secs) = timeout_secs.filter(|&secs| secs > 0) else {
-        return future.await.map_err(Into::into);
-    };
-    match tokio::time::timeout(Duration::from_secs(timeout_secs), future).await {
-        Ok(result) => result.map_err(Into::into),
-        Err(_) => {
-            log_progress_watchdog_timeout(
-                timeout_secs,
-                stage,
-                current_token_index,
-                last_completed_token_index,
-                engine,
-                cache,
-                startup,
-            );
-            Err(format!(
-                "progress watchdog: no token progress for {timeout_secs}s \
-                 at stage {stage} (current_token_index={current_token_index}, \
-                 last_completed_token_index={})",
-                last_completed_token_index
-                    .map(|v| v.to_string())
-                    .unwrap_or_else(|| "none".to_string())
-            )
-            .into())
-        }
-    }
-}
-
-fn log_progress_watchdog_timeout(
-    timeout_secs: u64,
-    stage: &'static str,
-    current_token_index: u64,
-    last_completed_token_index: Option<u64>,
-    engine: &Engine,
-    cache: Option<&MultiLayerExpertCache>,
-    startup: &StartupDiagnostics,
-) {
-    let report = engine.report();
-    let resident_ids = cache.map(|c| c.resident_ids()).unwrap_or_default();
-    warn!(
-        progress_timeout_secs = timeout_secs,
-        stage,
-        current_token_index,
-        last_completed_token_index = last_completed_token_index
-            .map(|v| v.to_string())
-            .unwrap_or_else(|| "none".to_string()),
-        cache_hits = report.hits,
-        cache_misses = report.misses,
-        cache_capacity = report.cache_capacity,
-        pool_capacity = report.pool_capacity,
-        resident = ?resident_ids,
-        prefetch_completed = report.prefetch_completed,
-        prefetch_used = report.prefetch_used,
-        prefetch_dropped_concurrency = report.prefetch_dropped_concurrency,
-        prefetch_dropped_pool_starved = report.prefetch_dropped_pool_starved,
-        prefetch_dropped_governor = report.prefetch_dropped_governor,
-        governor_admitted = report.governor_admitted,
-        governor_throttled = report.governor_throttled,
-        singleflight_followers = report.singleflight_followers,
-        bytes_read = report.bytes_read,
-        io_count = report.io_count,
-        io_p50_us = report.io_p50_us,
-        io_p95_us = report.io_p95_us,
-        compute_p50_us = report.compute_p50_us,
-        compute_p95_us = report.compute_p95_us,
-        avg_compute_us = report.avg_compute_us,
-        pct_time_io = report.pct_time_io,
-        engine_tokens_processed = report.tokens_processed,
-        rayon_threads = startup.rayon_threads,
-        rayon_source = startup.rayon_source,
-        cpu_mask = startup.progress_cpu_mask(),
-        "progress watchdog timeout: token generation appears stalled"
-    );
-}
-
 async fn cmd_run(
     mut args: RunArgs,
-    startup: StartupDiagnostics,
-    progress_timeout_secs: Option<u64>,
+    startup_pinned: bool,
+    progress_watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // 0) If `metadata.json` exists alongside the expert blobs (e.g. as
     //    written by `scripts/extract_mixtral_experts.py`), use it to fill
@@ -5332,22 +5134,16 @@ async fn cmd_run(
     args.data_dir = primary_dir.clone();
 
     if args.io_uring {
-        // Best-effort affinity: keep the engine on the NUMA node that
-        // owns CPU 0 to avoid cross-socket DRAM hops on every io_uring
-        // completion. Honored only on Linux.
-        //
-        // Respect startup `MER_PIN_CORES` affinity if it already pinned
-        // the process; otherwise fall back to the io_uring default.
-        if startup.startup_pinned() {
-            info!("startup affinity already applied; skipping io_uring repin");
+        // CPU placement is a startup-level decision now. If the operator
+        // supplied `--cpu-mask` / `[performance].cpu_mask` / legacy
+        // `MER_PIN_CORES`, Rayon, Tokio, and io_uring setup all inherit that
+        // same mask. With no startup mask, do not repin here: a late repin
+        // would make the already-created Rayon pool disagree with the main
+        // thread's placement.
+        if startup_pinned {
+            info!("startup CPU placement already applied; io_uring inherits it");
         } else {
-            let n = std::thread::available_parallelism()
-                .map(|n| n.get())
-                .unwrap_or(1)
-                .min(8);
-            if let Err(e) = pin_to_local_cores(n) {
-                warn!(error = %e, "could not set CPU affinity (continuing without pinning)");
-            }
+            info!("no startup CPU mask requested; io_uring will not apply a late process repin");
         }
         #[cfg(all(target_os = "linux", feature = "io_uring"))]
         {
@@ -5736,6 +5532,7 @@ async fn cmd_run(
         tokens = args.tokens,
         "streaming tokens (latency / throughput logs follow)"
     );
+    let mut token_cycle_us = Vec::with_capacity(args.tokens.min(1_000_000) as usize);
 
     // Optional production gating network. When present, every token's
     // expert ids come from `softmax(W_gate · x) → top-K` (real Mixtral
@@ -5806,7 +5603,7 @@ async fn cmd_run(
 
     for t in 0..args.tokens {
         let start = Instant::now();
-        let token_future = async {
+        let stats = with_progress_timeout(format!("run token {t}"), progress_watchdog, async {
             let stats = match workload {
                 // Structured workloads: drive `moe_step` with the harness's
                 // explicit expert set and measure the engine-counter delta.
@@ -5868,19 +5665,10 @@ async fn cmd_run(
                 }
             };
             Ok::<crate::engine::CycleStats, Box<dyn std::error::Error>>(stats)
-        };
-        let stats = await_with_progress_watchdog(
-            token_future,
-            progress_timeout_secs,
-            "run:token",
-            t,
-            t.checked_sub(1),
-            &engine,
-            Some(&cache),
-            &startup,
-        )
+        })
         .await?;
         let elapsed = start.elapsed();
+        token_cycle_us.push(elapsed.as_micros() as u64);
         let throughput = if elapsed.as_secs_f64() > 0.0 {
             1.0 / elapsed.as_secs_f64()
         } else {
@@ -5911,13 +5699,23 @@ async fn cmd_run(
         hit_rate_pct = (r.hits as f64 / total_lookups as f64) * 100.0,
         "stream complete"
     );
-    if args.rayon_autotune_probe {
-        emit_rayon_autotune_probe_result(&args, &r, wall)?;
-    } else {
-        engine.print_summary();
+    if std::env::var_os(crate::rayon_autotune::AUTOTUNE_PROBE_ENV).is_some() {
+        token_cycle_us.sort_unstable();
+        let report = crate::rayon_autotune::RayonAutotuneProbeResult {
+            threads: crate::parallel::num_threads(),
+            valid: true,
+            p50_ms: crate::rayon_autotune::percentile_ms(&token_cycle_us, 0.50),
+            p95_ms: crate::rayon_autotune::percentile_ms(&token_cycle_us, 0.95),
+            sustained_tps: args.tokens as f64 / wall.as_secs_f64(),
+        };
+        println!(
+            "MER_RAYON_AUTOTUNE_RESULT {}",
+            serde_json::to_string(&report)?
+        );
     }
+    engine.print_summary();
 
-    if !args.rayon_autotune_probe && r.misses > 0 && r.io_p50_us == 0 {
+    if r.misses > 0 && r.io_p50_us == 0 {
         warn!(
             "I/O latency histogram is empty despite cache misses; check that \
              tracing is enabled and runs are long enough to produce samples."
@@ -5939,54 +5737,6 @@ async fn cmd_run(
     }
 
     Ok(())
-}
-
-fn emit_rayon_autotune_probe_result(
-    args: &RunArgs,
-    report: &crate::engine::EngineReport,
-    wall: Duration,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let total_lookups = (report.hits + report.misses).max(1);
-    let backend = crate::backend::current();
-    let result = crate::rayon_autotune::CpuAutotuneProbeResult {
-        candidate_threads: args
-            .rayon_autotune_candidate
-            .or_else(crate::parallel::env_thread_override)
-            .unwrap_or_else(crate::parallel::num_threads),
-        sustained_tps: Some(args.tokens as f64 / wall.as_secs_f64()),
-        compute_p50_us: Some(report.compute_p50_us),
-        compute_p95_us: Some(report.compute_p95_us),
-        hit_rate_pct: Some((report.hits as f64 / total_lookups as f64) * 100.0),
-        tokens: args.tokens,
-        cache_slots: args.cache_slots,
-        dtype: args.dtype.as_str().to_string(),
-        backend: Some(format!(
-            "{}:{}",
-            backend.compute_plane(),
-            backend.device_name()
-        )),
-        quant_path: Some(quant_path_label(args.dtype).to_string()),
-        success: true,
-        error: None,
-    };
-    println!("{}", serde_json::to_string(&result)?);
-    Ok(())
-}
-
-fn quant_path_label(dtype: crate::inference::WeightDtype) -> &'static str {
-    match dtype {
-        crate::inference::WeightDtype::Q4_0 => "qmatmul-q4_0",
-        crate::inference::WeightDtype::Q4K => "qmatmul-q4k",
-        crate::inference::WeightDtype::Q8_0 => "qmatmul-q8_0",
-        crate::inference::WeightDtype::Mixed => "mixed-direct-dispatch",
-        crate::inference::WeightDtype::F32 => "f32-candle",
-        crate::inference::WeightDtype::F16 => "f16-dequant-candle",
-        crate::inference::WeightDtype::BF16 => "bf16-dequant-candle",
-        crate::inference::WeightDtype::Int8 => "int8-dequant-candle",
-        crate::inference::WeightDtype::Q5K => "q5k-direct-or-dequant",
-        crate::inference::WeightDtype::Q6K => "q6k-direct-or-dequant",
-        crate::inference::WeightDtype::MXFP4 => "mxfp4-dequant-candle",
-    }
 }
 
 /// Per-CLI defaults. We compare an `args` value to its default to detect
@@ -6322,98 +6072,6 @@ fn total_ram_bytes() -> Option<u64> {
     }
 }
 
-/// Best-effort NUMA / CPU-affinity hint.
-///
-/// On Linux, when `num_cores > 0`, pin the current process to the first
-/// `num_cores` CPUs of the NUMA node owning CPU 0 (via
-/// `sched_setaffinity(2)`). The intent is to keep io_uring completion
-/// processing, the engine's matmul threads, and the tokio runtime on
-/// the same memory controller — for an SSD-streaming MoE this avoids
-/// cross-socket DRAM hops on every cache fill, which dominate latency
-/// at high QPS.
-///
-/// We deliberately don't pull in a NUMA crate: this function picks the
-/// CPUs from `/sys/devices/system/node/node0/cpulist` (a kernel-exposed
-/// comma+dash list). When that file isn't available we fall back to
-/// CPUs `0..num_cores`. On non-Linux targets this is a no-op that
-/// returns `Ok(())` so callers can always invoke it unconditionally.
-fn pin_to_local_cores(num_cores: usize) -> std::io::Result<()> {
-    if num_cores == 0 {
-        return Ok(());
-    }
-    #[cfg(target_os = "linux")]
-    {
-        let cpus = read_local_node_cpus().unwrap_or_else(|| (0..num_cores).collect());
-        let chosen: Vec<usize> = cpus.into_iter().take(num_cores).collect();
-        if chosen.is_empty() {
-            return Ok(());
-        }
-        // SAFETY: `cpu_set_t` is a POD bitset; we zero it with
-        // `mem::zeroed`, fill in valid CPU bits with the libc helpers,
-        // then hand it to `sched_setaffinity` which only reads.
-        unsafe {
-            let mut set: libc::cpu_set_t = std::mem::zeroed();
-            libc::CPU_ZERO(&mut set);
-            for cpu in &chosen {
-                libc::CPU_SET(*cpu, &mut set);
-            }
-            let rc = libc::sched_setaffinity(
-                0, // current process
-                std::mem::size_of::<libc::cpu_set_t>(),
-                &set as *const _,
-            );
-            if rc != 0 {
-                return Err(std::io::Error::last_os_error());
-            }
-        }
-        info!(
-            cores = ?chosen,
-            "pinned process to NUMA-local CPU set (best-effort; sched_setaffinity)"
-        );
-        Ok(())
-    }
-    #[cfg(not(target_os = "linux"))]
-    {
-        warn!(
-            "core affinity hint requested ({} cores) but pinning is Linux-only; \
-             continuing without affinity",
-            num_cores
-        );
-        Ok(())
-    }
-}
-
-/// Parse `/sys/devices/system/node/node0/cpulist` into an ordered
-/// `Vec<usize>` of CPU ids (e.g. `"0-3,8,10-11"` -> `[0,1,2,3,8,10,11]`).
-/// Returns `None` if the file is missing / unparseable — callers fall
-/// back to a contiguous `0..N` range in that case.
-#[cfg(target_os = "linux")]
-fn read_local_node_cpus() -> Option<Vec<usize>> {
-    let body = std::fs::read_to_string("/sys/devices/system/node/node0/cpulist").ok()?;
-    let mut out: Vec<usize> = Vec::new();
-    for part in body.trim().split(',') {
-        let part = part.trim();
-        if part.is_empty() {
-            continue;
-        }
-        if let Some((lo, hi)) = part.split_once('-') {
-            let lo: usize = lo.parse().ok()?;
-            let hi: usize = hi.parse().ok()?;
-            if hi < lo {
-                return None;
-            }
-            out.extend(lo..=hi);
-        } else {
-            out.push(part.parse().ok()?);
-        }
-    }
-    if out.is_empty() {
-        None
-    } else {
-        Some(out)
-    }
-}
-
 /// Detect the NUMA node of the block device backing `data_dir`.
 ///
 /// Returns `Some(node)` when both probes succeed:
@@ -6730,88 +6388,76 @@ fn json_get_u32_array(line: &str, key: &str) -> Vec<u32> {
 mod tests {
     use super::*;
 
-    fn test_startup_diagnostics() -> StartupDiagnostics {
-        StartupDiagnostics {
-            requested_cpu_mask: None,
-            effective_cpu_mask: None,
-            pin_result: crate::numa::PinResult::NotRequested,
-            logical_cores: 1,
-            rayon_threads: 1,
-            rayon_source: "default",
-        }
+    #[test]
+    fn cli_parses_rayon_threads_after_run_subcommand() {
+        let cli = <Cli as clap::Parser>::try_parse_from([
+            "micro-expert-router",
+            "run",
+            "--rayon-threads",
+            "30",
+        ])
+        .expect("global --rayon-threads should parse after subcommand");
+        assert_eq!(cli.rayon_threads, Some(30));
     }
 
     #[test]
-    fn cpu_mask_cli_overrides_config_for_startup_selection() {
-        let cli = Cli::parse_from(["micro-expert-router", "--cpu-mask", "0-24", "gen-data"]);
-        let performance = crate::config::PerformanceConfig {
-            cpu_mask: Some("4-8".to_string()),
-            progress_timeout_secs: None,
-        };
-
-        assert_eq!(
-            requested_cpu_mask(&cli, Some(&performance)).as_deref(),
-            Some("0-24")
-        );
-        assert_eq!(
-            explicit_cpu_mask(&cli, Some(&performance)).as_deref(),
-            Some("0-24")
-        );
+    fn cli_parses_cpu_mask_after_run_subcommand() {
+        let cli = <Cli as clap::Parser>::try_parse_from([
+            "micro-expert-router",
+            "run",
+            "--cpu-mask",
+            "0-24",
+        ])
+        .expect("global --cpu-mask should parse after subcommand");
+        assert_eq!(cli.cpu_mask.as_deref(), Some("0-24"));
     }
 
     #[test]
-    fn cpu_mask_cli_rejects_invalid_cpulist() {
-        let err = Cli::try_parse_from(["micro-expert-router", "--cpu-mask", "8-4", "gen-data"])
-            .expect_err("descending CPU mask must be rejected");
+    fn autotune_child_args_preserve_cpu_mask_and_strip_recursive_flags() {
+        let raw = vec![
+            OsString::from("micro-expert-router"),
+            OsString::from("--log"),
+            OsString::from("info"),
+            OsString::from("run"),
+            OsString::from("--cpu-mask"),
+            OsString::from("0-24"),
+            OsString::from("--autotune-rayon"),
+            OsString::from("--autotune-tokens"),
+            OsString::from("2000"),
+            OsString::from("--tokens"),
+            OsString::from("10000"),
+        ];
+        let args = autotune_child_args(&raw, 123, 25);
+        let rendered: Vec<String> = args
+            .iter()
+            .map(|s| s.to_string_lossy().to_string())
+            .collect();
+        assert!(rendered
+            .windows(2)
+            .any(|w| w[0] == "--cpu-mask" && w[1] == "0-24"));
+        assert!(!rendered.iter().any(|s| s == "--autotune-rayon"));
+        assert!(!rendered.iter().any(|s| s == "--autotune-tokens"));
+        assert!(rendered
+            .windows(2)
+            .any(|w| w[0] == "--tokens" && w[1] == "123"));
+        assert!(rendered
+            .windows(2)
+            .any(|w| w[0] == "--rayon-threads" && w[1] == "25"));
+    }
 
+    #[test]
+    fn cli_rejects_zero_rayon_threads() {
+        let err = <Cli as clap::Parser>::try_parse_from([
+            "micro-expert-router",
+            "run",
+            "--rayon-threads",
+            "0",
+        ])
+        .expect_err("zero rayon threads must be rejected");
         assert!(
-            err.to_string().contains("descending cpulist range"),
+            err.to_string().contains("--rayon-threads must be > 0"),
             "unexpected error: {err}"
         );
-    }
-
-    #[test]
-    fn performance_cpu_mask_used_when_cli_omits_it() {
-        let cli = Cli::parse_from(["micro-expert-router", "gen-data"]);
-        let performance = crate::config::PerformanceConfig {
-            cpu_mask: Some("2-5".to_string()),
-            progress_timeout_secs: None,
-        };
-
-        assert_eq!(
-            requested_cpu_mask(&cli, Some(&performance)).as_deref(),
-            Some("2-5")
-        );
-        assert_eq!(
-            explicit_cpu_mask(&cli, Some(&performance)).as_deref(),
-            Some("2-5")
-        );
-    }
-
-    #[test]
-    fn progress_timeout_cli_zero_disables_config_timeout() {
-        let cli = Cli::parse_from([
-            "micro-expert-router",
-            "--progress-timeout-secs",
-            "0",
-            "gen-data",
-        ]);
-        let performance = crate::config::PerformanceConfig {
-            cpu_mask: None,
-            progress_timeout_secs: Some(300),
-        };
-
-        assert_eq!(progress_timeout_secs(&cli, Some(&performance)), None);
-    }
-
-    #[test]
-    fn startup_diagnostics_reports_effective_mask_before_requested_mask() {
-        let mut diagnostics = test_startup_diagnostics();
-        diagnostics.requested_cpu_mask = Some("0-24".to_string());
-        assert_eq!(diagnostics.progress_cpu_mask(), "0-24");
-
-        diagnostics.effective_cpu_mask = Some("0-23".to_string());
-        assert_eq!(diagnostics.progress_cpu_mask(), "0-23");
     }
 
     // ---- Item 4: bench-real fail-open policy rejection matrix ----
@@ -6829,6 +6475,7 @@ mod tests {
                 max_concurrent_requests: 0,
                 admission_min_free_blocks: 0,
             },
+            performance: crate::config::PerformanceConfig::default(),
             model: crate::config::ModelConfig {
                 data_dir: PathBuf::from("./data"),
                 num_experts: 8,
@@ -6861,7 +6508,6 @@ mod tests {
             sampling: crate::config::SamplingConfig::default(),
             predictive: crate::config::PredictiveConfig::default(),
             security: crate::config::SecurityConfig::default(),
-            performance: crate::config::PerformanceConfig::default(),
             gpu_cache: crate::config::GpuCacheConfig::default(),
             distributed: crate::config::DistributedConfig::default(),
         }
@@ -6962,7 +6608,9 @@ mod tests {
         // Share the transformer softmax-fallback test lock so this mutation of
         // the process-wide counter cannot race with the transformer tests that
         // assert exact before/after deltas.
-        let _g = crate::transformer::SOFTMAX_FALLBACK_TEST_LOCK.lock().unwrap();
+        let _g = crate::transformer::SOFTMAX_FALLBACK_TEST_LOCK
+            .lock()
+            .unwrap();
         let snapshot = crate::transformer::nonfinite_softmax_fallbacks();
         crate::transformer::record_nonfinite_softmax_fallback();
         assert!(
@@ -6996,7 +6644,11 @@ mod tests {
             Ok(t) => t,
             Err(_) => panic!("synthetic mode must keep the byte-tokenizer fallback"),
         };
-        assert_eq!(tok.vocab_size(), 256, "byte tokenizer expected in synthetic mode");
+        assert_eq!(
+            tok.vocab_size(),
+            256,
+            "byte tokenizer expected in synthetic mode"
+        );
     }
 
     #[test]
@@ -7148,8 +6800,7 @@ mod tests {
             cache_reset: BenchRealCacheReset::Keep,
             greedy: true,
             format: BenchRealOutputFormat::Json,
-            progress_timeout_secs: None,
-            startup: test_startup_diagnostics(),
+            progress_watchdog: crate::rayon_autotune::ProgressWatchdogConfig::disabled(),
         };
         let input = load_bench_real_input(&args).unwrap();
         assert_eq!(input.output_tokens, 7);
@@ -7172,8 +6823,7 @@ mod tests {
             cache_reset: BenchRealCacheReset::Keep,
             greedy: true,
             format: BenchRealOutputFormat::Json,
-            progress_timeout_secs: None,
-            startup: test_startup_diagnostics(),
+            progress_watchdog: crate::rayon_autotune::ProgressWatchdogConfig::disabled(),
         };
         let input = load_bench_real_input(&args).unwrap();
         assert_eq!(input.prompt, "hello");
@@ -7204,6 +6854,7 @@ mod tests {
                 max_concurrent_requests: 0,
                 admission_min_free_blocks: 0,
             },
+            performance: PerformanceConfig::default(),
             model: ModelConfig {
                 data_dir: PathBuf::from("./data"),
                 num_experts: 8,
@@ -7231,7 +6882,6 @@ mod tests {
             sampling: SamplingConfig::default(),
             predictive: PredictiveConfig::default(),
             security: SecurityConfig::default(),
-            performance: PerformanceConfig::default(),
             gpu_cache: GpuCacheConfig::default(),
             distributed: DistributedConfig::default(),
         }

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -130,8 +130,8 @@ mod batch_scheduler;
 mod block_pool;
 mod buffer_pool;
 mod config;
-mod dequant;
 mod dense_tensor;
+mod dequant;
 mod distributed;
 mod draft;
 mod engine;
@@ -159,6 +159,7 @@ mod packed_storage;
 mod parallel;
 mod prefetch_governor;
 mod pregate;
+mod rayon_autotune;
 mod residency;
 mod router;
 mod rpc;
@@ -341,6 +342,24 @@ enum Cmd {
         /// Number of tokens to simulate.
         #[arg(long, default_value_t = 200)]
         tokens: u64,
+        /// Run short child-process probes to select the best Rayon worker
+        /// count for this host/model/backend before the real benchmark.
+        #[arg(long)]
+        autotune_rayon: bool,
+        /// Number of tokens each child-process Rayon autotune probe runs.
+        #[arg(long, default_value_t = crate::rayon_autotune::DEFAULT_PROBE_TOKENS)]
+        autotune_tokens: u64,
+        /// Optional comma-separated candidate Rayon thread counts. When
+        /// omitted, MER derives a window around default_compute_threads()
+        /// and includes the full visible logical-core count.
+        #[arg(long, value_delimiter = ',')]
+        autotune_candidates: Vec<usize>,
+        /// Hidden child-probe mode used by `--autotune-rayon`.
+        #[arg(long, hide = true)]
+        rayon_autotune_probe: bool,
+        /// Candidate thread count reported by a hidden child probe.
+        #[arg(long, hide = true)]
+        rayon_autotune_candidate: Option<usize>,
         /// Predictive prefetch fanout (how many candidates to issue per token).
         #[arg(long, default_value_t = 2)]
         predict_fanout: usize,
@@ -850,6 +869,271 @@ fn init_logging(filter: &str) {
         .try_init();
 }
 
+#[derive(Clone, Debug)]
+struct RayonAutotuneStartupContext {
+    key: crate::rayon_autotune::CpuAutotuneKey,
+    cache_slots: usize,
+    dtype: String,
+}
+
+fn resolve_startup_rayon_threads(
+    cmd: &Cmd,
+    logical: usize,
+) -> Result<crate::parallel::RayonThreadSelection, Box<dyn std::error::Error>> {
+    if let Cmd::Run {
+        autotune_rayon: true,
+        rayon_autotune_probe: false,
+        autotune_tokens,
+        autotune_candidates,
+        ..
+    } = cmd
+    {
+        let ctx = rayon_autotune_context_for_cmd(cmd, logical).ok_or_else(|| {
+            "run --autotune-rayon could not build a model/backend fingerprint".to_string()
+        })?;
+        let candidates = sanitize_autotune_candidates(logical, autotune_candidates);
+        info!(
+            logical,
+            candidates = ?candidates,
+            probe_tokens = *autotune_tokens,
+            profile = %ctx.key.profile_path().display(),
+            "CPU/Rayon autotune: probing candidate thread counts in child processes"
+        );
+        let tuned = crate::rayon_autotune::run_cpu_autotune(
+            &ctx.key,
+            logical,
+            &candidates,
+            *autotune_tokens,
+            ctx.cache_slots,
+            &ctx.dtype,
+        )?;
+        info!(
+            selected_rayon_threads = tuned.profile.selected_rayon_threads,
+            profile = %tuned.profile_path.display(),
+            "CPU/Rayon autotune complete; saved selected profile"
+        );
+        return Ok(crate::parallel::RayonThreadSelection::fresh_autotune(
+            logical,
+            tuned.profile.selected_rayon_threads,
+            tuned.profile_path,
+        ));
+    }
+
+    let profile = if crate::parallel::env_thread_override().is_some()
+        || matches!(
+            cmd,
+            Cmd::Run {
+                rayon_autotune_probe: true,
+                ..
+            }
+        ) {
+        None
+    } else {
+        rayon_autotune_context_for_cmd(cmd, logical)
+            .and_then(|ctx| crate::rayon_autotune::load_matching_profile(&ctx.key))
+            .map(|(path, profile)| (profile.selected_rayon_threads, path))
+    };
+    Ok(crate::parallel::resolve_thread_selection(logical, profile))
+}
+
+fn sanitize_autotune_candidates(logical: usize, configured: &[usize]) -> Vec<usize> {
+    let mut candidates: Vec<usize> = if configured.is_empty() {
+        crate::rayon_autotune::candidate_thread_counts(logical)
+    } else {
+        configured.iter().copied().filter(|&n| n > 0).collect()
+    };
+    candidates.sort_unstable();
+    candidates.dedup();
+    if candidates.is_empty() {
+        crate::rayon_autotune::candidate_thread_counts(logical)
+    } else {
+        candidates
+    }
+}
+
+fn rayon_autotune_context_for_cmd(
+    cmd: &Cmd,
+    logical: usize,
+) -> Option<RayonAutotuneStartupContext> {
+    match cmd {
+        Cmd::Run {
+            data_dir,
+            num_experts,
+            expert_size,
+            d_model,
+            d_ff,
+            cache_slots,
+            top_k,
+            dtype,
+            gpu,
+            num_layers,
+            block_align,
+            packed_blob,
+            packed_manifest,
+            ..
+        } => Some(run_rayon_autotune_context(
+            logical,
+            data_dir,
+            *num_experts,
+            *expert_size,
+            *d_model,
+            *d_ff,
+            *cache_slots,
+            *top_k,
+            dtype,
+            *gpu,
+            *num_layers,
+            *block_align,
+            packed_blob.as_deref(),
+            packed_manifest.as_deref(),
+        )),
+        Cmd::Serve { config } => config_rayon_autotune_context(logical, config, "serve").ok(),
+        Cmd::BenchReal { config, .. } => {
+            config_rayon_autotune_context(logical, config, "bench-real").ok()
+        }
+        _ => None,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_rayon_autotune_context(
+    logical: usize,
+    data_dir: &Path,
+    num_experts: u32,
+    expert_size: usize,
+    d_model: usize,
+    d_ff: usize,
+    cache_slots: usize,
+    top_k: usize,
+    dtype: &str,
+    gpu: bool,
+    num_layers: u32,
+    block_align: usize,
+    packed_blob: Option<&Path>,
+    packed_manifest: Option<&Path>,
+) -> RayonAutotuneStartupContext {
+    let mut num_experts = num_experts;
+    let mut expert_size = expert_size;
+    let mut d_model = d_model;
+    let mut d_ff = d_ff;
+    let mut top_k = top_k;
+    let mut dtype = dtype.to_ascii_lowercase();
+    let mut block_align = block_align;
+
+    if let Ok(body) = std::fs::read_to_string(data_dir.join("metadata.json")) {
+        if num_experts == cli_defaults::NUM_EXPERTS {
+            if let Some(v) = parse_json_number(&body, "num_experts") {
+                num_experts = v as u32;
+            }
+        }
+        if d_model == cli_defaults::D_MODEL {
+            if let Some(v) = parse_json_number(&body, "d_model") {
+                d_model = v as usize;
+            }
+        }
+        if d_ff == cli_defaults::D_FF {
+            if let Some(v) = parse_json_number(&body, "d_ff") {
+                d_ff = v as usize;
+            }
+        }
+        if top_k == cli_defaults::TOP_K {
+            if let Some(v) = parse_json_number(&body, "top_k") {
+                top_k = v as usize;
+            }
+        }
+        if expert_size == cli_defaults::EXPERT_SIZE {
+            if let Some(v) = parse_json_number(&body, "expert_size") {
+                expert_size = v as usize;
+            }
+        }
+        if block_align == cli_defaults::BLOCK_ALIGN {
+            if let Some(v) = parse_json_number(&body, "block_align") {
+                block_align = v as usize;
+            }
+        }
+        if dtype == "f32" {
+            if let Some(v) = parse_json_string(&body, "dtype") {
+                dtype = v.to_ascii_lowercase();
+            }
+        }
+    }
+
+    let data_dir_fingerprint = crate::rayon_autotune::make_data_dir_fingerprint(data_dir);
+    let model_fingerprint = crate::rayon_autotune::make_model_fingerprint(
+        data_dir,
+        num_experts,
+        top_k,
+        d_model,
+        d_ff,
+        expert_size,
+        num_layers,
+        &dtype,
+        packed_blob,
+        packed_manifest,
+    );
+    let backend = format!(
+        "run:compute_plane={}:dense_matvec={}:expert_policy=auto:qmm=on:block_align={}",
+        if gpu { "gpu" } else { "cpu" },
+        crate::parallel::default_dense_matvec_backend(),
+        block_align
+    );
+    RayonAutotuneStartupContext {
+        key: crate::rayon_autotune::CpuAutotuneKey {
+            machine_fingerprint: crate::rayon_autotune::make_machine_fingerprint(logical),
+            model_fingerprint,
+            data_dir_fingerprint,
+            dtype: dtype.clone(),
+            cache_slots,
+            backend,
+        },
+        cache_slots,
+        dtype,
+    }
+}
+
+fn config_rayon_autotune_context(
+    logical: usize,
+    config: &Path,
+    command: &str,
+) -> Result<RayonAutotuneStartupContext, crate::config::ConfigError> {
+    let cfg = crate::config::Config::from_file(config)?;
+    let dtype = cfg.model.dtype.as_str().to_string();
+    let data_dir_fingerprint =
+        crate::rayon_autotune::make_data_dir_fingerprint(&cfg.model.data_dir);
+    let model_fingerprint = crate::rayon_autotune::make_model_fingerprint(
+        &cfg.model.data_dir,
+        cfg.model.num_experts,
+        cfg.model.top_k,
+        cfg.model.d_model,
+        cfg.model.d_ff,
+        cfg.model.expert_size,
+        cfg.model.num_layers as u32,
+        &dtype,
+        cfg.storage.packed_blob.as_deref(),
+        cfg.storage.packed_manifest.as_deref(),
+    );
+    let backend = format!(
+        "{}:compute_offload={:?}:dense_matvec={}:expert_policy={:?}:real_transformer={}",
+        command,
+        cfg.real_transformer.compute_offload,
+        cfg.real_transformer.dense_matvec_backend,
+        cfg.real_transformer.expert_execution_policy,
+        cfg.real_transformer.enabled
+    );
+    Ok(RayonAutotuneStartupContext {
+        key: crate::rayon_autotune::CpuAutotuneKey {
+            machine_fingerprint: crate::rayon_autotune::make_machine_fingerprint(logical),
+            model_fingerprint,
+            data_dir_fingerprint,
+            dtype: dtype.clone(),
+            cache_slots: cfg.storage.cache_slots,
+            backend,
+        },
+        cache_slots: cfg.storage.cache_slots,
+        dtype,
+    })
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
     init_logging(&cli.log);
@@ -872,8 +1156,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // it. By default it spans the host's logical cores *minus a small
     // reservation* (`parallel::default_compute_threads`) so a saturated
     // compute fan-out can't starve the async runtime under continuous
-    // batching; an explicit `RAYON_NUM_THREADS` overrides the default.
-    crate::parallel::init_global_pool();
+    // batching; an explicit `RAYON_NUM_THREADS` overrides saved autotune
+    // profiles. `run --autotune-rayon` is the dedicated force-refresh path:
+    // it probes candidates in child processes first, then builds this
+    // process's global pool exactly once with the selected result.
+    let logical = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1);
+    let rayon_selection = resolve_startup_rayon_threads(&cli.cmd, logical)?;
+    crate::parallel::init_global_pool_with_selection(rayon_selection);
 
     // Log the selected math kernel backend once. The dispatcher itself
     // is lazy, but emitting this at startup gives ops a single line in
@@ -978,6 +1269,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     cache_slots,
                     top_k,
                     tokens,
+                    autotune_rayon: _,
+                    autotune_tokens: _,
+                    autotune_candidates: _,
+                    rayon_autotune_probe,
+                    rayon_autotune_candidate,
                     predict_fanout,
                     predict_min_prob,
                     no_direct,
@@ -1035,68 +1331,90 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 "--dtype: unknown value {dtype:?} (supported: {SUPPORTED_RUNTIME_DTYPES})"
                             )
                         })?;
-                    cmd_run(
-                        RunArgs {
-                            data_dir,
-                            num_experts,
-                            expert_size,
-                            d_model,
-                            d_ff,
-                            cache_slots,
-                            top_k,
-                            tokens,
-                            predict_fanout,
-                            predict_min_prob,
-                            no_direct,
-                            block_align,
-                            seed,
-                            dtype,
-                            partial_load_fraction,
-                            pin_after_observations,
-                            alias_map_path: alias_map,
-                            io_uring,
-                            token_pause_us,
-                            first_token,
-                            no_prefetch,
-                            io_only,
-                            force_ssd,
-                            router_clusters,
-                            router_intra_p,
-                            router_matrix,
-                            gate_weights,
-                            trace_out,
-                            gpu_expert_cache: if gpu { run_gpu_cache.clone() } else { None },
-                            pipeline_depth,
-                            speculator,
-                            speculator_hidden_dim,
-                            speculator_top_k,
-                            locality,
-                            locality_window,
-                            locality_threshold_pct,
-                            affinity,
-                            affinity_neighbors_k,
-                            affinity_decay_epoch,
-                            prefetch_governor,
-                            prefetch_precision_floor,
-                            prefetch_contention_weight,
-                            cost_aware_eviction,
-                            pregate,
-                            static_residency_fraction,
-                            static_residency_warmup_tokens,
-                            static_residency_profile,
-                            profile_out,
-                            workload,
-                            zipf_s,
-                            workload_correlation,
-                            replay_trace,
-                            num_layers,
-                            num_experts_per_layer,
-                            packed_blob,
-                            packed_manifest,
-                        },
-                        startup_pinned,
-                    )
-                    .await
+                    let run_args = RunArgs {
+                        data_dir,
+                        num_experts,
+                        expert_size,
+                        d_model,
+                        d_ff,
+                        cache_slots,
+                        top_k,
+                        tokens,
+                        rayon_autotune_probe,
+                        rayon_autotune_candidate,
+                        predict_fanout,
+                        predict_min_prob,
+                        no_direct,
+                        block_align,
+                        seed,
+                        dtype,
+                        partial_load_fraction,
+                        pin_after_observations,
+                        alias_map_path: alias_map,
+                        io_uring,
+                        token_pause_us,
+                        first_token,
+                        no_prefetch,
+                        io_only,
+                        force_ssd,
+                        router_clusters,
+                        router_intra_p,
+                        router_matrix,
+                        gate_weights,
+                        trace_out,
+                        gpu_expert_cache: if gpu { run_gpu_cache.clone() } else { None },
+                        pipeline_depth,
+                        speculator,
+                        speculator_hidden_dim,
+                        speculator_top_k,
+                        locality,
+                        locality_window,
+                        locality_threshold_pct,
+                        affinity,
+                        affinity_neighbors_k,
+                        affinity_decay_epoch,
+                        prefetch_governor,
+                        prefetch_precision_floor,
+                        prefetch_contention_weight,
+                        cost_aware_eviction,
+                        pregate,
+                        static_residency_fraction,
+                        static_residency_warmup_tokens,
+                        static_residency_profile,
+                        profile_out,
+                        workload,
+                        zipf_s,
+                        workload_correlation,
+                        replay_trace,
+                        num_layers,
+                        num_experts_per_layer,
+                        packed_blob,
+                        packed_manifest,
+                    };
+                    let probe_mode = run_args.rayon_autotune_probe;
+                    let failure_candidate = run_args
+                        .rayon_autotune_candidate
+                        .or_else(crate::parallel::env_thread_override)
+                        .unwrap_or(0);
+                    let failure_tokens = run_args.tokens;
+                    let failure_cache_slots = run_args.cache_slots;
+                    let failure_dtype = run_args.dtype.as_str().to_string();
+                    let result = cmd_run(run_args, startup_pinned).await;
+                    if probe_mode {
+                        if let Err(e) = result {
+                            let failure = crate::rayon_autotune::CpuAutotuneProbeResult::failure(
+                                failure_candidate,
+                                failure_tokens,
+                                failure_cache_slots,
+                                failure_dtype,
+                                e.to_string(),
+                            );
+                            println!("{}", serde_json::to_string(&failure)?);
+                        }
+                        Ok(())
+                    } else {
+                        result
+                    }
                 } else {
                     unreachable!()
                 }
@@ -4543,6 +4861,8 @@ struct RunArgs {
     cache_slots: usize,
     top_k: usize,
     tokens: u64,
+    rayon_autotune_probe: bool,
+    rayon_autotune_candidate: Option<usize>,
     predict_fanout: usize,
     predict_min_prob: f64,
     no_direct: bool,
@@ -5297,9 +5617,13 @@ async fn cmd_run(
         hit_rate_pct = (r.hits as f64 / total_lookups as f64) * 100.0,
         "stream complete"
     );
-    engine.print_summary();
+    if args.rayon_autotune_probe {
+        emit_rayon_autotune_probe_result(&args, &r, wall)?;
+    } else {
+        engine.print_summary();
+    }
 
-    if r.misses > 0 && r.io_p50_us == 0 {
+    if !args.rayon_autotune_probe && r.misses > 0 && r.io_p50_us == 0 {
         warn!(
             "I/O latency histogram is empty despite cache misses; check that \
              tracing is enabled and runs are long enough to produce samples."
@@ -5321,6 +5645,54 @@ async fn cmd_run(
     }
 
     Ok(())
+}
+
+fn emit_rayon_autotune_probe_result(
+    args: &RunArgs,
+    report: &crate::engine::EngineReport,
+    wall: Duration,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let total_lookups = (report.hits + report.misses).max(1);
+    let backend = crate::backend::current();
+    let result = crate::rayon_autotune::CpuAutotuneProbeResult {
+        candidate_threads: args
+            .rayon_autotune_candidate
+            .or_else(crate::parallel::env_thread_override)
+            .unwrap_or_else(crate::parallel::num_threads),
+        sustained_tps: Some(args.tokens as f64 / wall.as_secs_f64()),
+        compute_p50_us: Some(report.compute_p50_us),
+        compute_p95_us: Some(report.compute_p95_us),
+        hit_rate_pct: Some((report.hits as f64 / total_lookups as f64) * 100.0),
+        tokens: args.tokens,
+        cache_slots: args.cache_slots,
+        dtype: args.dtype.as_str().to_string(),
+        backend: Some(format!(
+            "{}:{}",
+            backend.compute_plane(),
+            backend.device_name()
+        )),
+        quant_path: Some(quant_path_label(args.dtype).to_string()),
+        success: true,
+        error: None,
+    };
+    println!("{}", serde_json::to_string(&result)?);
+    Ok(())
+}
+
+fn quant_path_label(dtype: crate::inference::WeightDtype) -> &'static str {
+    match dtype {
+        crate::inference::WeightDtype::Q4_0 => "qmatmul-q4_0",
+        crate::inference::WeightDtype::Q4K => "qmatmul-q4k",
+        crate::inference::WeightDtype::Q8_0 => "qmatmul-q8_0",
+        crate::inference::WeightDtype::Mixed => "mixed-direct-dispatch",
+        crate::inference::WeightDtype::F32 => "f32-candle",
+        crate::inference::WeightDtype::F16 => "f16-dequant-candle",
+        crate::inference::WeightDtype::BF16 => "bf16-dequant-candle",
+        crate::inference::WeightDtype::Int8 => "int8-dequant-candle",
+        crate::inference::WeightDtype::Q5K => "q5k-direct-or-dequant",
+        crate::inference::WeightDtype::Q6K => "q6k-direct-or-dequant",
+        crate::inference::WeightDtype::MXFP4 => "mxfp4-dequant-candle",
+    }
 }
 
 /// Per-CLI defaults. We compare an `args` value to its default to detect

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -176,6 +176,7 @@ mod workload;
 
 use clap::{Parser, Subcommand, ValueEnum};
 use serde::Serialize;
+use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -204,8 +205,32 @@ struct Cli {
     #[arg(long, global = true, default_value = "info", env = "RUST_LOG")]
     log: String,
 
+    /// Linux cpulist CPU mask applied before Tokio and Rayon start
+    /// (for example, `--cpu-mask 0-24`). Overrides
+    /// `[performance].cpu_mask` and legacy `MER_PIN_CORES`.
+    #[arg(long, global = true, value_parser = parse_cpu_mask_arg)]
+    cpu_mask: Option<String>,
+
+    /// Fail closed if benchmark token progress stalls for this many
+    /// seconds. `0` disables. Overrides
+    /// `[performance].progress_timeout_secs`.
+    #[arg(long, global = true)]
+    progress_timeout_secs: Option<u64>,
+
     #[command(subcommand)]
     cmd: Cmd,
+}
+
+fn parse_cpu_mask_arg(s: &str) -> Result<String, String> {
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        return Err("CPU mask must not be empty".to_string());
+    }
+    let cpus = crate::numa::parse_cpulist(trimmed)?;
+    if cpus.is_empty() {
+        return Err("CPU mask must name at least one CPU".to_string());
+    }
+    Ok(trimmed.to_string())
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, ValueEnum)]
@@ -876,6 +901,95 @@ struct RayonAutotuneStartupContext {
     dtype: String,
 }
 
+#[derive(Clone, Debug)]
+struct StartupDiagnostics {
+    requested_cpu_mask: Option<String>,
+    effective_cpu_mask: Option<String>,
+    pin_result: crate::numa::PinResult,
+    logical_cores: usize,
+    rayon_threads: usize,
+    rayon_source: &'static str,
+}
+
+impl StartupDiagnostics {
+    fn startup_pinned(&self) -> bool {
+        matches!(self.pin_result, crate::numa::PinResult::Pinned { .. })
+    }
+
+    fn progress_cpu_mask(&self) -> &str {
+        self.effective_cpu_mask
+            .as_deref()
+            .or(self.requested_cpu_mask.as_deref())
+            .unwrap_or("unknown")
+    }
+}
+
+fn performance_config_for_cmd(
+    cmd: &Cmd,
+) -> Result<Option<crate::config::PerformanceConfig>, Box<dyn std::error::Error>> {
+    match cmd {
+        Cmd::Serve { config } | Cmd::BenchReal { config, .. } => {
+            Ok(Some(crate::config::Config::from_file(config)?.performance))
+        }
+        _ => Ok(None),
+    }
+}
+
+fn requested_cpu_mask(
+    cli: &Cli,
+    performance: Option<&crate::config::PerformanceConfig>,
+) -> Option<String> {
+    cli.cpu_mask
+        .clone()
+        .or_else(|| performance.and_then(|p| p.cpu_mask.clone()))
+        .or_else(|| {
+            std::env::var(crate::numa::MER_PIN_CORES_ENV)
+                .ok()
+                .filter(|s| !s.trim().is_empty())
+                .map(|s| format!("{}={}", crate::numa::MER_PIN_CORES_ENV, s.trim()))
+        })
+}
+
+fn explicit_cpu_mask<'a>(
+    cli: &'a Cli,
+    performance: Option<&'a crate::config::PerformanceConfig>,
+) -> Option<&'a str> {
+    cli.cpu_mask
+        .as_deref()
+        .or_else(|| performance.and_then(|p| p.cpu_mask.as_deref()))
+}
+
+fn progress_timeout_secs(
+    cli: &Cli,
+    performance: Option<&crate::config::PerformanceConfig>,
+) -> Option<u64> {
+    cli.progress_timeout_secs
+        .or_else(|| performance.and_then(|p| p.normalized_progress_timeout_secs()))
+        .filter(|&secs| secs > 0)
+}
+
+fn rayon_source_label(source: &crate::parallel::RayonThreadSource) -> &'static str {
+    match source {
+        crate::parallel::RayonThreadSource::EnvOverride => "env",
+        crate::parallel::RayonThreadSource::AutotuneProfile { .. } => "profile",
+        crate::parallel::RayonThreadSource::FreshAutotune { .. } => "autotune",
+        crate::parallel::RayonThreadSource::DefaultHeuristic => "default",
+    }
+}
+
+fn log_startup_placement(diagnostics: &StartupDiagnostics) {
+    info!(
+        requested_cpu_mask = diagnostics.requested_cpu_mask.as_deref().unwrap_or("none"),
+        effective_cpu_mask = diagnostics.effective_cpu_mask.as_deref().unwrap_or("unknown"),
+        logical_cores = diagnostics.logical_cores,
+        rayon_threads = diagnostics.rayon_threads,
+        rayon_source = diagnostics.rayon_source,
+        pinning_succeeded = diagnostics.startup_pinned(),
+        pinning_status = %diagnostics.pin_result.as_log_line(),
+        "startup CPU placement"
+    );
+}
+
 fn resolve_startup_rayon_threads(
     cmd: &Cmd,
     logical: usize,
@@ -1137,13 +1251,15 @@ fn config_rayon_autotune_context(
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
     init_logging(&cli.log);
+    let performance = performance_config_for_cmd(&cli.cmd)?;
+    let requested_cpu_mask = requested_cpu_mask(&cli, performance.as_ref());
+    let progress_timeout_secs = progress_timeout_secs(&cli, performance.as_ref());
 
-    // Best-effort NUMA pinning: honoured before any tokio runtime or
+    // Best-effort CPU placement: honoured before any tokio runtime or
     // background thread spawns so child threads inherit the affinity
-    // mask. See `numa::apply_mer_pin_cores_env` for the contract.
-    let pin = crate::numa::apply_mer_pin_cores_env();
-    let startup_pinned = matches!(pin, crate::numa::PinResult::Pinned { .. });
-    info!("{}", pin.as_log_line());
+    // mask. Explicit `--cpu-mask` / `[performance].cpu_mask` wins over
+    // legacy `MER_PIN_CORES`.
+    let pin = crate::numa::apply_startup_cpu_mask(explicit_cpu_mask(&cli, performance.as_ref()));
 
     // `MER_PIN_CORES` is now consumed centrally at process start via the
     // `numa` module. Clear it so any legacy later parsing in subcommands
@@ -1164,7 +1280,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .map(|n| n.get())
         .unwrap_or(1);
     let rayon_selection = resolve_startup_rayon_threads(&cli.cmd, logical)?;
-    crate::parallel::init_global_pool_with_selection(rayon_selection);
+    let rayon_source = rayon_source_label(&rayon_selection.source);
+    let rayon_threads = crate::parallel::init_global_pool_with_selection(rayon_selection);
+    let startup = StartupDiagnostics {
+        requested_cpu_mask,
+        effective_cpu_mask: crate::numa::current_affinity_cpulist(),
+        pin_result: pin,
+        logical_cores: logical,
+        rayon_threads,
+        rayon_source,
+    };
+    log_startup_placement(&startup);
 
     // Log the selected math kernel backend once. The dispatcher itself
     // is lazy, but emitting this at startup gives ops a single line in
@@ -1399,7 +1525,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     let failure_tokens = run_args.tokens;
                     let failure_cache_slots = run_args.cache_slots;
                     let failure_dtype = run_args.dtype.as_str().to_string();
-                    let result = cmd_run(run_args, startup_pinned).await;
+                    let result =
+                        cmd_run(run_args, startup.clone(), progress_timeout_secs).await;
                     if probe_mode {
                         if let Err(e) = result {
                             let failure = crate::rayon_autotune::CpuAutotuneProbeResult::failure(
@@ -1450,6 +1577,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 cache_reset,
                 greedy,
                 format,
+                progress_timeout_secs,
+                startup: startup.clone(),
             }))
         }
         Cmd::MatvecMicrobench {
@@ -1645,6 +1774,8 @@ struct BenchRealArgs {
     cache_reset: BenchRealCacheReset,
     greedy: bool,
     format: BenchRealOutputFormat,
+    progress_timeout_secs: Option<u64>,
+    startup: StartupDiagnostics,
 }
 
 struct MatvecMicrobenchArgs {
@@ -1842,15 +1973,31 @@ async fn cmd_bench_real(args: BenchRealArgs) -> Result<(), Box<dyn std::error::E
         let runtime = build_bench_real_runtime(&args.config).await?;
         let params = bench_sampling_params(&runtime.cfg, args.greedy);
         for i in 0..args.warmup_runs {
-            let _ = run_bench_real_once(&runtime, &input.prompt, input.output_tokens, params, i)
-                .await?;
+            let _ = run_bench_real_once(
+                &runtime,
+                &input.prompt,
+                input.output_tokens,
+                params,
+                i,
+                args.progress_timeout_secs,
+                &args.startup,
+            )
+            .await?;
         }
         let softmax_before = crate::transformer::nonfinite_softmax_fallbacks();
         let mut runs = Vec::with_capacity(args.measured_runs);
         for i in 0..args.measured_runs {
             runs.push(
-                run_bench_real_once(&runtime, &input.prompt, input.output_tokens, params, i)
-                    .await?,
+                run_bench_real_once(
+                    &runtime,
+                    &input.prompt,
+                    input.output_tokens,
+                    params,
+                    i,
+                    args.progress_timeout_secs,
+                    &args.startup,
+                )
+                .await?,
             );
         }
         assert_no_softmax_fallbacks(softmax_before)?;
@@ -1859,8 +2006,16 @@ async fn cmd_bench_real(args: BenchRealArgs) -> Result<(), Box<dyn std::error::E
         for i in 0..args.warmup_runs {
             let runtime = build_bench_real_runtime(&args.config).await?;
             let params = bench_sampling_params(&runtime.cfg, args.greedy);
-            let _ = run_bench_real_once(&runtime, &input.prompt, input.output_tokens, params, i)
-                .await?;
+            let _ = run_bench_real_once(
+                &runtime,
+                &input.prompt,
+                input.output_tokens,
+                params,
+                i,
+                args.progress_timeout_secs,
+                &args.startup,
+            )
+            .await?;
         }
         let softmax_before = crate::transformer::nonfinite_softmax_fallbacks();
         let mut runs = Vec::with_capacity(args.measured_runs);
@@ -1868,8 +2023,16 @@ async fn cmd_bench_real(args: BenchRealArgs) -> Result<(), Box<dyn std::error::E
             let runtime = build_bench_real_runtime(&args.config).await?;
             let params = bench_sampling_params(&runtime.cfg, args.greedy);
             runs.push(
-                run_bench_real_once(&runtime, &input.prompt, input.output_tokens, params, i)
-                    .await?,
+                run_bench_real_once(
+                    &runtime,
+                    &input.prompt,
+                    input.output_tokens,
+                    params,
+                    i,
+                    args.progress_timeout_secs,
+                    &args.startup,
+                )
+                .await?,
             );
         }
         assert_no_softmax_fallbacks(softmax_before)?;
@@ -3156,6 +3319,8 @@ async fn run_bench_real_once(
     output_tokens: usize,
     params: crate::sampling::SamplingParams,
     run_index: usize,
+    progress_timeout_secs: Option<u64>,
+    startup: &StartupDiagnostics,
 ) -> Result<BenchRealRunReport, Box<dyn std::error::Error>> {
     let prompt_ids = runtime.tokenizer.encode(prompt)?;
     if prompt_ids.is_empty() {
@@ -3173,16 +3338,24 @@ async fn run_bench_real_once(
     let mut decode_latencies_us = Vec::with_capacity(output_tokens.saturating_sub(1));
 
     for &tid in &prompt_ids[..prompt_ids.len().saturating_sub(1)] {
-        runtime
-            .model
-            .forward_token_hidden_with_timing(
-                &runtime.engine,
-                tid,
-                pos,
-                &mut kv,
-                Some(&stage_timings),
-            )
-            .await?;
+        let future = runtime.model.forward_token_hidden_with_timing(
+            &runtime.engine,
+            tid,
+            pos,
+            &mut kv,
+            Some(&stage_timings),
+        );
+        await_with_progress_watchdog(
+            future,
+            progress_timeout_secs,
+            "bench-real:prompt",
+            pos as u64,
+            pos.checked_sub(1).map(|v| v as u64),
+            &runtime.engine,
+            None,
+            startup,
+        )
+        .await?;
         forward_evaluations += 1;
         pos += 1;
     }
@@ -3190,16 +3363,23 @@ async fn run_bench_real_once(
     let final_prompt = *prompt_ids.last().expect("prompt_ids checked non-empty");
     let final_prompt_pos = pos;
     let first_started = Instant::now();
-    let final_hidden = runtime
-        .model
-        .forward_token_hidden_with_timing(
+    let final_hidden = await_with_progress_watchdog(
+        runtime.model.forward_token_hidden_with_timing(
             &runtime.engine,
             final_prompt,
             final_prompt_pos,
             &mut kv,
             Some(&stage_timings),
-        )
-        .await?;
+        ),
+        progress_timeout_secs,
+        "bench-real:prompt-final",
+        final_prompt_pos as u64,
+        final_prompt_pos.checked_sub(1).map(|v| v as u64),
+        &runtime.engine,
+        None,
+        startup,
+    )
+    .await?;
     forward_evaluations += 1;
     pos += 1;
     let prompt_elapsed = prompt_started.elapsed();
@@ -3220,17 +3400,25 @@ async fn run_bench_real_once(
     let mut last = first;
     while completion_ids.len() < output_tokens {
         let step_started = Instant::now();
-        let next = runtime
-            .model
-            .decode_step_with_timing(
+        let current_completion_index = completion_ids.len() as u64;
+        let next = await_with_progress_watchdog(
+            runtime.model.decode_step_with_timing(
                 &runtime.engine,
                 last,
                 pos,
                 &mut kv,
                 &params,
                 Some(&stage_timings),
-            )
-            .await?;
+            ),
+            progress_timeout_secs,
+            "bench-real:decode",
+            current_completion_index,
+            current_completion_index.checked_sub(1),
+            &runtime.engine,
+            None,
+            startup,
+        )
+        .await?;
         forward_evaluations += 1;
         lm_head_evaluations += 1;
         decode_latencies_us.push(step_started.elapsed().as_micros() as u64);
@@ -4913,9 +5101,99 @@ struct RunArgs {
     packed_manifest: Option<PathBuf>,
 }
 
+async fn await_with_progress_watchdog<T, E, F>(
+    future: F,
+    timeout_secs: Option<u64>,
+    stage: &'static str,
+    current_token_index: u64,
+    last_completed_token_index: Option<u64>,
+    engine: &Engine,
+    cache: Option<&MultiLayerExpertCache>,
+    startup: &StartupDiagnostics,
+) -> Result<T, Box<dyn std::error::Error>>
+where
+    F: Future<Output = Result<T, E>>,
+    E: Into<Box<dyn std::error::Error>>,
+{
+    let Some(timeout_secs) = timeout_secs.filter(|&secs| secs > 0) else {
+        return future.await.map_err(Into::into);
+    };
+    match tokio::time::timeout(Duration::from_secs(timeout_secs), future).await {
+        Ok(result) => result.map_err(Into::into),
+        Err(_) => {
+            log_progress_watchdog_timeout(
+                timeout_secs,
+                stage,
+                current_token_index,
+                last_completed_token_index,
+                engine,
+                cache,
+                startup,
+            );
+            Err(format!(
+                "progress watchdog: no token progress for {timeout_secs}s \
+                 at stage {stage} (current_token_index={current_token_index}, \
+                 last_completed_token_index={})",
+                last_completed_token_index
+                    .map(|v| v.to_string())
+                    .unwrap_or_else(|| "none".to_string())
+            )
+            .into())
+        }
+    }
+}
+
+fn log_progress_watchdog_timeout(
+    timeout_secs: u64,
+    stage: &'static str,
+    current_token_index: u64,
+    last_completed_token_index: Option<u64>,
+    engine: &Engine,
+    cache: Option<&MultiLayerExpertCache>,
+    startup: &StartupDiagnostics,
+) {
+    let report = engine.report();
+    let resident_ids = cache.map(|c| c.resident_ids()).unwrap_or_default();
+    warn!(
+        progress_timeout_secs = timeout_secs,
+        stage,
+        current_token_index,
+        last_completed_token_index = last_completed_token_index
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "none".to_string()),
+        cache_hits = report.hits,
+        cache_misses = report.misses,
+        cache_capacity = report.cache_capacity,
+        pool_capacity = report.pool_capacity,
+        resident = ?resident_ids,
+        prefetch_completed = report.prefetch_completed,
+        prefetch_used = report.prefetch_used,
+        prefetch_dropped_concurrency = report.prefetch_dropped_concurrency,
+        prefetch_dropped_pool_starved = report.prefetch_dropped_pool_starved,
+        prefetch_dropped_governor = report.prefetch_dropped_governor,
+        governor_admitted = report.governor_admitted,
+        governor_throttled = report.governor_throttled,
+        singleflight_followers = report.singleflight_followers,
+        bytes_read = report.bytes_read,
+        io_count = report.io_count,
+        io_p50_us = report.io_p50_us,
+        io_p95_us = report.io_p95_us,
+        compute_p50_us = report.compute_p50_us,
+        compute_p95_us = report.compute_p95_us,
+        avg_compute_us = report.avg_compute_us,
+        pct_time_io = report.pct_time_io,
+        engine_tokens_processed = report.tokens_processed,
+        rayon_threads = startup.rayon_threads,
+        rayon_source = startup.rayon_source,
+        cpu_mask = startup.progress_cpu_mask(),
+        "progress watchdog timeout: token generation appears stalled"
+    );
+}
+
 async fn cmd_run(
     mut args: RunArgs,
-    startup_pinned: bool,
+    startup: StartupDiagnostics,
+    progress_timeout_secs: Option<u64>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // 0) If `metadata.json` exists alongside the expert blobs (e.g. as
     //    written by `scripts/extract_mixtral_experts.py`), use it to fill
@@ -5060,7 +5338,7 @@ async fn cmd_run(
         //
         // Respect startup `MER_PIN_CORES` affinity if it already pinned
         // the process; otherwise fall back to the io_uring default.
-        if startup_pinned {
+        if startup.startup_pinned() {
             info!("startup affinity already applied; skipping io_uring repin");
         } else {
             let n = std::thread::available_parallelism()
@@ -5528,52 +5806,36 @@ async fn cmd_run(
 
     for t in 0..args.tokens {
         let start = Instant::now();
-        let stats = match workload {
-            // Structured workloads: drive `moe_step` with the harness's
-            // explicit expert set and measure the engine-counter delta.
-            crate::workload::Workload::Skewed | crate::workload::Workload::Replay => {
-                let (tok_idx, layer_idx, experts): (u64, u32, Vec<u32>) = match workload {
-                    crate::workload::Workload::Skewed => (
-                        t,
-                        0,
-                        skewed_stream
-                            .as_mut()
-                            .expect("skewed stream")
-                            .next_experts(),
-                    ),
-                    _ => {
-                        let record = replay_stream
-                            .as_mut()
-                            .expect("replay stream")
-                            .next_record()
-                            .expect("replay stream non-empty");
-                        let layer = u32::try_from(record.layer).map_err(|_| {
-                            format!("replay layer {} does not fit in u32", record.layer)
-                        })?;
-                        (record.token, layer, record.experts)
-                    }
-                };
-                let hidden = crate::inference::synth_hidden_state(tok_idx, args.d_model, args.seed);
-                let pre = engine.report();
-                let _ = engine.moe_step(tok_idx, layer_idx, &hidden, &experts).await;
-                let post = engine.report();
-                crate::engine::CycleStats {
-                    hits: post.hits.saturating_sub(pre.hits),
-                    misses: post.misses.saturating_sub(pre.misses),
-                    prefetch_hits: 0,
-                    bytes_read: post.bytes_read.saturating_sub(pre.bytes_read),
-                }
-            }
-            crate::workload::Workload::Synthetic => {
-                if let Some(gate) = gate.as_ref() {
-                    // Real gating-network path. Hidden state is the same
-                    // synthetic activation `Engine::generate` would have
-                    // used, so the only difference relative to the legacy
-                    // path is *which* experts are selected.
-                    let hidden = crate::inference::synth_hidden_state(t, args.d_model, args.seed);
-                    let dec = gate.route(&hidden);
+        let token_future = async {
+            let stats = match workload {
+                // Structured workloads: drive `moe_step` with the harness's
+                // explicit expert set and measure the engine-counter delta.
+                crate::workload::Workload::Skewed | crate::workload::Workload::Replay => {
+                    let (tok_idx, layer_idx, experts): (u64, u32, Vec<u32>) = match workload {
+                        crate::workload::Workload::Skewed => (
+                            t,
+                            0,
+                            skewed_stream
+                                .as_mut()
+                                .expect("skewed stream")
+                                .next_experts(),
+                        ),
+                        _ => {
+                            let record = replay_stream
+                                .as_mut()
+                                .expect("replay stream")
+                                .next_record()
+                                .expect("replay stream non-empty");
+                            let layer = u32::try_from(record.layer).map_err(|_| {
+                                format!("replay layer {} does not fit in u32", record.layer)
+                            })?;
+                            (record.token, layer, record.experts)
+                        }
+                    };
+                    let hidden =
+                        crate::inference::synth_hidden_state(tok_idx, args.d_model, args.seed);
                     let pre = engine.report();
-                    let _ = engine.moe_step(t, 0, &hidden, &dec.experts).await;
+                    let _ = engine.moe_step(tok_idx, layer_idx, &hidden, &experts).await;
                     let post = engine.report();
                     crate::engine::CycleStats {
                         hits: post.hits.saturating_sub(pre.hits),
@@ -5581,11 +5843,43 @@ async fn cmd_run(
                         prefetch_hits: 0,
                         bytes_read: post.bytes_read.saturating_sub(pre.bytes_read),
                     }
-                } else {
-                    engine.generate(t).await?
                 }
-            }
+                crate::workload::Workload::Synthetic => {
+                    if let Some(gate) = gate.as_ref() {
+                        // Real gating-network path. Hidden state is the same
+                        // synthetic activation `Engine::generate` would have
+                        // used, so the only difference relative to the legacy
+                        // path is *which* experts are selected.
+                        let hidden =
+                            crate::inference::synth_hidden_state(t, args.d_model, args.seed);
+                        let dec = gate.route(&hidden);
+                        let pre = engine.report();
+                        let _ = engine.moe_step(t, 0, &hidden, &dec.experts).await;
+                        let post = engine.report();
+                        crate::engine::CycleStats {
+                            hits: post.hits.saturating_sub(pre.hits),
+                            misses: post.misses.saturating_sub(pre.misses),
+                            prefetch_hits: 0,
+                            bytes_read: post.bytes_read.saturating_sub(pre.bytes_read),
+                        }
+                    } else {
+                        engine.generate(t).await?
+                    }
+                }
+            };
+            Ok::<crate::engine::CycleStats, Box<dyn std::error::Error>>(stats)
         };
+        let stats = await_with_progress_watchdog(
+            token_future,
+            progress_timeout_secs,
+            "run:token",
+            t,
+            t.checked_sub(1),
+            &engine,
+            Some(&cache),
+            &startup,
+        )
+        .await?;
         let elapsed = start.elapsed();
         let throughput = if elapsed.as_secs_f64() > 0.0 {
             1.0 / elapsed.as_secs_f64()
@@ -6436,6 +6730,90 @@ fn json_get_u32_array(line: &str, key: &str) -> Vec<u32> {
 mod tests {
     use super::*;
 
+    fn test_startup_diagnostics() -> StartupDiagnostics {
+        StartupDiagnostics {
+            requested_cpu_mask: None,
+            effective_cpu_mask: None,
+            pin_result: crate::numa::PinResult::NotRequested,
+            logical_cores: 1,
+            rayon_threads: 1,
+            rayon_source: "default",
+        }
+    }
+
+    #[test]
+    fn cpu_mask_cli_overrides_config_for_startup_selection() {
+        let cli = Cli::parse_from(["micro-expert-router", "--cpu-mask", "0-24", "gen-data"]);
+        let performance = crate::config::PerformanceConfig {
+            cpu_mask: Some("4-8".to_string()),
+            progress_timeout_secs: None,
+        };
+
+        assert_eq!(
+            requested_cpu_mask(&cli, Some(&performance)).as_deref(),
+            Some("0-24")
+        );
+        assert_eq!(
+            explicit_cpu_mask(&cli, Some(&performance)).as_deref(),
+            Some("0-24")
+        );
+    }
+
+    #[test]
+    fn cpu_mask_cli_rejects_invalid_cpulist() {
+        let err = Cli::try_parse_from(["micro-expert-router", "--cpu-mask", "8-4", "gen-data"])
+            .expect_err("descending CPU mask must be rejected");
+
+        assert!(
+            err.to_string().contains("descending cpulist range"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn performance_cpu_mask_used_when_cli_omits_it() {
+        let cli = Cli::parse_from(["micro-expert-router", "gen-data"]);
+        let performance = crate::config::PerformanceConfig {
+            cpu_mask: Some("2-5".to_string()),
+            progress_timeout_secs: None,
+        };
+
+        assert_eq!(
+            requested_cpu_mask(&cli, Some(&performance)).as_deref(),
+            Some("2-5")
+        );
+        assert_eq!(
+            explicit_cpu_mask(&cli, Some(&performance)).as_deref(),
+            Some("2-5")
+        );
+    }
+
+    #[test]
+    fn progress_timeout_cli_zero_disables_config_timeout() {
+        let cli = Cli::parse_from([
+            "micro-expert-router",
+            "--progress-timeout-secs",
+            "0",
+            "gen-data",
+        ]);
+        let performance = crate::config::PerformanceConfig {
+            cpu_mask: None,
+            progress_timeout_secs: Some(300),
+        };
+
+        assert_eq!(progress_timeout_secs(&cli, Some(&performance)), None);
+    }
+
+    #[test]
+    fn startup_diagnostics_reports_effective_mask_before_requested_mask() {
+        let mut diagnostics = test_startup_diagnostics();
+        diagnostics.requested_cpu_mask = Some("0-24".to_string());
+        assert_eq!(diagnostics.progress_cpu_mask(), "0-24");
+
+        diagnostics.effective_cpu_mask = Some("0-23".to_string());
+        assert_eq!(diagnostics.progress_cpu_mask(), "0-23");
+    }
+
     // ---- Item 4: bench-real fail-open policy rejection matrix ----
 
     /// A minimal config that passes every `bench-real` policy gate:
@@ -6483,6 +6861,7 @@ mod tests {
             sampling: crate::config::SamplingConfig::default(),
             predictive: crate::config::PredictiveConfig::default(),
             security: crate::config::SecurityConfig::default(),
+            performance: crate::config::PerformanceConfig::default(),
             gpu_cache: crate::config::GpuCacheConfig::default(),
             distributed: crate::config::DistributedConfig::default(),
         }
@@ -6769,6 +7148,8 @@ mod tests {
             cache_reset: BenchRealCacheReset::Keep,
             greedy: true,
             format: BenchRealOutputFormat::Json,
+            progress_timeout_secs: None,
+            startup: test_startup_diagnostics(),
         };
         let input = load_bench_real_input(&args).unwrap();
         assert_eq!(input.output_tokens, 7);
@@ -6791,6 +7172,8 @@ mod tests {
             cache_reset: BenchRealCacheReset::Keep,
             greedy: true,
             format: BenchRealOutputFormat::Json,
+            progress_timeout_secs: None,
+            startup: test_startup_diagnostics(),
         };
         let input = load_bench_real_input(&args).unwrap();
         assert_eq!(input.prompt, "hello");
@@ -6848,6 +7231,7 @@ mod tests {
             sampling: SamplingConfig::default(),
             predictive: PredictiveConfig::default(),
             security: SecurityConfig::default(),
+            performance: PerformanceConfig::default(),
             gpu_cache: GpuCacheConfig::default(),
             distributed: DistributedConfig::default(),
         }

--- a/rust-engine/src/numa.rs
+++ b/rust-engine/src/numa.rs
@@ -8,14 +8,11 @@
 //! advertises. This module wires the bare minimum we need to keep that
 //! hop out of the inference critical path:
 //!
-//! * [`apply_startup_cpu_mask`] honours an explicit kernel cpulist such
-//!   as `0-24` at startup and calls `sched_setaffinity(2)` before
-//!   tokio/Rayon worker threads are created. If no explicit mask is
-//!   supplied, [`apply_mer_pin_cores_env`] keeps the legacy
-//!   `MER_PIN_CORES=N` behaviour and pins **the whole process** to the
-//!   first `N` CPUs of NUMA node 0. Best-effort and Linux-only:
-//!   anywhere else this is a logged no-op so dev machines (macOS,
-//!   Windows) still boot.
+//! * `--cpu-mask <CPULIST>` and `[performance].cpu_mask` can pin **the
+//!   whole process** before Tokio/Rayon startup. `MER_PIN_CORES=N`
+//!   remains as a lower-precedence compatibility fallback. Best-effort
+//!   and Linux-only: anywhere else this is a logged no-op so dev machines
+//!   (macOS, Windows) still boot.
 //! * [`pin_current_thread_to_core`] is the lower-level primitive for
 //!   future per-thread pinning (e.g. the io_uring completion thread).
 //!
@@ -39,15 +36,112 @@ use std::{fs, path::Path};
 /// the process to the first `N` CPUs of NUMA node 0 at startup.
 pub const MER_PIN_CORES_ENV: &str = "MER_PIN_CORES";
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CpuMaskSource {
+    Cli,
+    Config,
+    LegacyMerPinCores,
+}
+
+impl CpuMaskSource {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Cli => "cli",
+            Self::Config => "config",
+            Self::LegacyMerPinCores => "MER_PIN_CORES",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CpuMaskRequest {
+    pub source: CpuMaskSource,
+    pub cpus: Vec<usize>,
+    pub display: String,
+}
+
+/// Effective CPU-affinity context observed after startup placement.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EffectiveCpuAffinity {
+    pub cpus: Option<Vec<usize>>,
+    pub logical_cores: usize,
+    pub display: String,
+}
+
+/// Resolve CPU placement precedence without applying it.
+///
+/// No mask is selected by default. Operators can opt in with `--cpu-mask`,
+/// `[performance].cpu_mask`, or the legacy `MER_PIN_CORES=N` fallback, in
+/// that order.
+pub fn resolve_cpu_mask_request(
+    cli_mask: Option<&str>,
+    config_mask: Option<&str>,
+    legacy_mer_pin_cores: Option<&str>,
+) -> Result<Option<CpuMaskRequest>, String> {
+    if let Some(mask) = cli_mask.and_then(nonempty) {
+        return parse_explicit_cpu_mask(mask, CpuMaskSource::Cli).map(Some);
+    }
+    if let Some(mask) = config_mask.and_then(nonempty) {
+        return parse_explicit_cpu_mask(mask, CpuMaskSource::Config).map(Some);
+    }
+    if let Some(raw) = legacy_mer_pin_cores.and_then(nonempty) {
+        let n = raw
+            .parse::<usize>()
+            .map_err(|_| format!("{MER_PIN_CORES_ENV}={raw:?} must be a positive integer"))?;
+        if n == 0 {
+            return Err(format!("{MER_PIN_CORES_ENV}={raw:?} must be > 0"));
+        }
+        let cpus = first_n_node0_or_online_cpus(n);
+        if cpus.is_empty() {
+            return Err(format!(
+                "{MER_PIN_CORES_ENV}={raw:?} resolved to an empty CPU set"
+            ));
+        }
+        let display = format_cpulist(&cpus);
+        return Ok(Some(CpuMaskRequest {
+            source: CpuMaskSource::LegacyMerPinCores,
+            cpus,
+            display,
+        }));
+    }
+    Ok(None)
+}
+
+fn nonempty(s: &str) -> Option<&str> {
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed)
+    }
+}
+
+pub fn parse_explicit_cpu_mask(
+    mask: &str,
+    source: CpuMaskSource,
+) -> Result<CpuMaskRequest, String> {
+    let cpus = normalize_cpus(parse_cpulist(mask)?);
+    if cpus.is_empty() {
+        return Err("cpu mask must contain at least one CPU".to_string());
+    }
+    let display = format_cpulist(&cpus);
+    Ok(CpuMaskRequest {
+        source,
+        cpus,
+        display,
+    })
+}
+
 /// Outcome of an `apply_mer_pin_cores_env` call. Public so the caller
 /// can log a single human-readable line at startup.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PinResult {
-    /// No explicit mask or legacy `MER_PIN_CORES` value was provided.
+    /// `MER_PIN_CORES` was unset or empty — no pinning was attempted.
     NotRequested,
-    /// A requested CPU mask or legacy `MER_PIN_CORES` value was invalid.
+    /// `MER_PIN_CORES` was set but invalid (non-numeric or `<= 0`).
     BadValue(String),
-    /// Linux only: pinned to the listed CPUs (already de-duplicated).
+    /// Linux only: pinned to the listed CPUs (already de-duplicated
+    /// and clamped to what node 0 actually exposes).
     Pinned { cpus: Vec<usize> },
     /// Pinning was requested but the kernel / OS does not support the
     /// primitive (non-Linux, or `sched_setaffinity` returned an error).
@@ -58,13 +152,11 @@ pub enum PinResult {
 impl PinResult {
     pub fn as_log_line(&self) -> String {
         match self {
-            PinResult::NotRequested => "no CPU affinity pinning requested".to_string(),
-            PinResult::BadValue(s) => format!("CPU affinity value \"{s}\" invalid, ignored"),
-            PinResult::Pinned { cpus } => {
-                format!("pinned process to CPUs {:?}", cpus)
-            }
+            PinResult::NotRequested => format!("{MER_PIN_CORES_ENV} unset, no NUMA pinning"),
+            PinResult::BadValue(s) => format!("{MER_PIN_CORES_ENV}=\"{s}\" invalid, ignored"),
+            PinResult::Pinned { cpus } => format!("pinned process to CPUs {:?}", cpus),
             PinResult::Unsupported(why) => {
-                format!("CPU affinity pinning unsupported on this platform: {why}")
+                format!("NUMA pinning unsupported on this platform: {why}")
             }
         }
     }
@@ -78,84 +170,69 @@ impl PinResult {
 /// is reported as [`PinResult::Unsupported`] rather than aborting
 /// startup.
 pub fn apply_mer_pin_cores_env() -> PinResult {
-    let raw = match env::var(MER_PIN_CORES_ENV) {
-        Ok(s) if !s.trim().is_empty() => s,
+    let raw = env::var(MER_PIN_CORES_ENV).ok();
+    apply_mer_pin_cores_value(raw.as_deref())
+}
+
+fn apply_mer_pin_cores_value(raw: Option<&str>) -> PinResult {
+    let raw = match raw {
+        Some(s) if !s.trim().is_empty() => s,
         _ => return PinResult::NotRequested,
     };
     let n: i64 = match raw.trim().parse() {
         Ok(v) => v,
-        Err(_) => return PinResult::BadValue(raw),
+        Err(_) => return PinResult::BadValue(raw.to_string()),
     };
     if n <= 0 {
-        return PinResult::BadValue(raw);
+        return PinResult::BadValue(raw.to_string());
     }
     let n = n as usize;
     pin_first_n_to_node0(n)
 }
 
-/// Apply an explicit kernel cpulist such as `"0-24"` or `"0-7,16-23"`.
-///
-/// When `requested` is `None`, this falls back to the legacy
-/// [`MER_PIN_CORES_ENV`] behaviour. The explicit mask path is the
-/// first-class production placement knob; it runs at process startup so
-/// Tokio and Rayon workers inherit the selected affinity.
-pub fn apply_startup_cpu_mask(requested: Option<&str>) -> PinResult {
-    let raw = match requested {
-        Some(s) if !s.trim().is_empty() => s.trim(),
-        Some(s) => return PinResult::BadValue(s.to_string()),
-        None => return apply_mer_pin_cores_env(),
+pub fn apply_cpu_mask_request(request: Option<&CpuMaskRequest>) -> PinResult {
+    let Some(request) = request else {
+        return PinResult::NotRequested;
     };
-    let mut cpus = match parse_cpulist(raw) {
-        Ok(cpus) => cpus,
-        Err(_) => return PinResult::BadValue(raw.to_string()),
-    };
-    cpus.sort_unstable();
-    cpus.dedup();
+    apply_cpu_mask(&request.cpus)
+}
+
+#[cfg(target_os = "linux")]
+pub fn apply_cpu_mask(cpus: &[usize]) -> PinResult {
+    let cpus = normalize_cpus(cpus.to_vec());
     if cpus.is_empty() {
-        return PinResult::BadValue(raw.to_string());
+        return PinResult::BadValue("empty CPU mask".to_string());
     }
-    pin_cpu_set(&cpus)
+    match set_affinity(&cpus) {
+        Ok(()) => PinResult::Pinned { cpus },
+        Err(e) => PinResult::Unsupported(format!("sched_setaffinity: {e}")),
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn apply_cpu_mask(cpus: &[usize]) -> PinResult {
+    let _ = cpus;
+    PinResult::Unsupported("sched_setaffinity(2) is Linux-only".into())
 }
 
 /// Pin the calling process to the first `n` CPUs of NUMA node 0.
 /// On non-Linux this is a logged no-op.
 #[cfg(target_os = "linux")]
 pub fn pin_first_n_to_node0(n: usize) -> PinResult {
-    let mut cpus = node0_cpus().unwrap_or_else(|_| {
-        // Fall back to all online CPUs in ascending order if sysfs is
-        // unavailable (containers, exotic kernels). The "first N"
-        // ordering still matches the user's intent.
-        let max = num_cpus_online();
-        (0..max).collect()
-    });
-    cpus.sort_unstable();
-    cpus.dedup();
-    cpus.truncate(n);
+    let cpus = first_n_node0_or_online_cpus(n);
     if cpus.is_empty() {
         return PinResult::Unsupported(
             "no CPUs reported for NUMA node 0 and /proc/cpuinfo empty".into(),
         );
     }
-    pin_cpu_set(&cpus)
-}
-
-#[cfg(not(target_os = "linux"))]
-pub fn pin_first_n_to_node0(_n: usize) -> PinResult {
-    PinResult::Unsupported("sched_setaffinity(2) is Linux-only".into())
-}
-
-#[cfg(target_os = "linux")]
-pub fn pin_cpu_set(cpus: &[usize]) -> PinResult {
-    match set_affinity(cpus) {
-        Ok(()) => PinResult::Pinned {
-            cpus: cpus.to_vec(),
-        },
+    match set_affinity(&cpus) {
+        Ok(()) => PinResult::Pinned { cpus },
         Err(e) => PinResult::Unsupported(format!("sched_setaffinity: {e}")),
     }
 }
 
 #[cfg(not(target_os = "linux"))]
-pub fn pin_cpu_set(_cpus: &[usize]) -> PinResult {
+pub fn pin_first_n_to_node0(_n: usize) -> PinResult {
     PinResult::Unsupported("sched_setaffinity(2) is Linux-only".into())
 }
 
@@ -189,7 +266,30 @@ fn num_cpus_online() -> usize {
     // takes a single integer constant and returns an integer. It has
     // no memory-safety preconditions and is thread-safe per POSIX.
     let n = unsafe { libc::sysconf(libc::_SC_NPROCESSORS_ONLN) };
-    if n > 0 { n as usize } else { 1 }
+    if n > 0 {
+        n as usize
+    } else {
+        1
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn first_n_node0_or_online_cpus(n: usize) -> Vec<usize> {
+    let mut cpus = node0_cpus().unwrap_or_else(|_| {
+        // Fall back to all online CPUs in ascending order if sysfs is
+        // unavailable (containers, exotic kernels). The "first N"
+        // ordering still matches the user's intent.
+        let max = num_cpus_online();
+        (0..max).collect()
+    });
+    cpus = normalize_cpus(cpus);
+    cpus.truncate(n);
+    cpus
+}
+
+#[cfg(not(target_os = "linux"))]
+fn first_n_node0_or_online_cpus(n: usize) -> Vec<usize> {
+    (0..n).collect()
 }
 
 /// Parse a kernel cpulist string (e.g. `"0-3,8,10-11"`).
@@ -225,14 +325,18 @@ pub fn parse_cpulist(s: &str) -> Result<Vec<usize>, String> {
     Ok(out)
 }
 
+pub fn normalize_cpus(mut cpus: Vec<usize>) -> Vec<usize> {
+    cpus.sort_unstable();
+    cpus.dedup();
+    cpus
+}
+
 pub fn format_cpulist(cpus: &[usize]) -> String {
+    let cpus = normalize_cpus(cpus.to_vec());
     if cpus.is_empty() {
         return String::new();
     }
-    let mut cpus = cpus.to_vec();
-    cpus.sort_unstable();
-    cpus.dedup();
-    let mut ranges = Vec::new();
+    let mut parts = Vec::new();
     let mut start = cpus[0];
     let mut prev = cpus[0];
     for &cpu in cpus.iter().skip(1) {
@@ -240,48 +344,54 @@ pub fn format_cpulist(cpus: &[usize]) -> String {
             prev = cpu;
             continue;
         }
-        ranges.push(format_cpu_range(start, prev));
+        push_cpulist_range(&mut parts, start, prev);
         start = cpu;
         prev = cpu;
     }
-    ranges.push(format_cpu_range(start, prev));
-    ranges.join(",")
+    push_cpulist_range(&mut parts, start, prev);
+    parts.join(",")
 }
 
-fn format_cpu_range(start: usize, end: usize) -> String {
+fn push_cpulist_range(parts: &mut Vec<String>, start: usize, end: usize) {
     if start == end {
-        start.to_string()
+        parts.push(start.to_string());
     } else {
-        format!("{start}-{end}")
+        parts.push(format!("{start}-{end}"));
     }
 }
 
-#[cfg(target_os = "linux")]
-pub fn current_affinity() -> Result<Vec<usize>, String> {
-    unsafe {
-        let mut set: libc::cpu_set_t = std::mem::zeroed();
-        libc::CPU_ZERO(&mut set);
-        let rc = libc::sched_getaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &mut set);
-        if rc != 0 {
-            return Err(std::io::Error::last_os_error().to_string());
-        }
-        let mut cpus = Vec::new();
-        for cpu in 0..libc::CPU_SETSIZE as usize {
-            if libc::CPU_ISSET(cpu, &set) {
-                cpus.push(cpu);
+pub fn effective_cpu_affinity() -> EffectiveCpuAffinity {
+    #[cfg(target_os = "linux")]
+    {
+        match get_affinity() {
+            Ok(cpus) if !cpus.is_empty() => {
+                let cpus = normalize_cpus(cpus);
+                let display = format_cpulist(&cpus);
+                let logical_cores = cpus.len().max(1);
+                EffectiveCpuAffinity {
+                    cpus: Some(cpus),
+                    logical_cores,
+                    display,
+                }
             }
+            Ok(_) | Err(_) => effective_cpu_affinity_unavailable(),
         }
-        Ok(cpus)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        effective_cpu_affinity_unavailable()
     }
 }
 
-#[cfg(not(target_os = "linux"))]
-pub fn current_affinity() -> Result<Vec<usize>, String> {
-    Err("sched_getaffinity(2) is Linux-only".into())
-}
-
-pub fn current_affinity_cpulist() -> Option<String> {
-    current_affinity().ok().map(|cpus| format_cpulist(&cpus))
+fn effective_cpu_affinity_unavailable() -> EffectiveCpuAffinity {
+    let logical_cores = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1);
+    EffectiveCpuAffinity {
+        cpus: None,
+        logical_cores,
+        display: "unavailable".to_string(),
+    }
 }
 
 #[cfg(target_os = "linux")]
@@ -319,6 +429,26 @@ fn set_affinity_pid(pid: libc::pid_t, cpus: &[usize]) -> Result<(), String> {
     Ok(())
 }
 
+#[cfg(target_os = "linux")]
+fn get_affinity() -> Result<Vec<usize>, String> {
+    unsafe {
+        let mut set: libc::cpu_set_t = std::mem::zeroed();
+        libc::CPU_ZERO(&mut set);
+        let rc = libc::sched_getaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &mut set);
+        if rc != 0 {
+            let e = std::io::Error::last_os_error();
+            return Err(format!("{e}"));
+        }
+        let mut cpus = Vec::new();
+        for cpu in 0..libc::CPU_SETSIZE as usize {
+            if libc::CPU_ISSET(cpu, &set) {
+                cpus.push(cpu);
+            }
+        }
+        Ok(cpus)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -333,14 +463,43 @@ mod tests {
     }
 
     #[test]
-    fn parses_cpulist_with_whitespace() {
-        assert_eq!(parse_cpulist("0-1, 4 , 6-7\n").unwrap(), vec![0, 1, 4, 6, 7]);
+    fn formats_cpulist_as_ranges() {
+        assert_eq!(format_cpulist(&[0, 1, 2, 4, 7, 8]), "0-2,4,7-8");
+        assert_eq!(format_cpulist(&[4, 2, 2, 3]), "2-4");
     }
 
     #[test]
-    fn formats_cpulist_compactly() {
-        assert_eq!(format_cpulist(&[0, 1, 2, 4, 8, 7, 7]), "0-2,4,7-8");
-        assert_eq!(format_cpulist(&[]), "");
+    fn no_cpu_mask_means_no_startup_placement_request() {
+        let request = resolve_cpu_mask_request(None, None, None).unwrap();
+        assert_eq!(request, None);
+    }
+
+    #[test]
+    fn cli_cpu_mask_overrides_config() {
+        let request = resolve_cpu_mask_request(Some("0-1"), Some("4-5"), None)
+            .unwrap()
+            .expect("mask");
+        assert_eq!(request.source, CpuMaskSource::Cli);
+        assert_eq!(request.display, "0-1");
+        assert_eq!(request.cpus, vec![0, 1]);
+    }
+
+    #[test]
+    fn config_cpu_mask_overrides_legacy_mer_pin_cores() {
+        let request = resolve_cpu_mask_request(None, Some("2-3"), Some("8"))
+            .unwrap()
+            .expect("mask");
+        assert_eq!(request.source, CpuMaskSource::Config);
+        assert_eq!(request.display, "2-3");
+        assert_eq!(request.cpus, vec![2, 3]);
+    }
+
+    #[test]
+    fn parses_cpulist_with_whitespace() {
+        assert_eq!(
+            parse_cpulist("0-1, 4 , 6-7\n").unwrap(),
+            vec![0, 1, 4, 6, 7]
+        );
     }
 
     #[test]
@@ -358,7 +517,7 @@ mod tests {
     fn pin_result_log_line_is_descriptive() {
         assert!(PinResult::NotRequested
             .as_log_line()
-            .contains("no CPU affinity pinning requested"));
+            .contains(MER_PIN_CORES_ENV));
         assert!(PinResult::BadValue("xyz".into())
             .as_log_line()
             .contains("xyz"));
@@ -372,18 +531,13 @@ mod tests {
 
     #[test]
     fn apply_with_unset_env_is_not_requested() {
-        // SAFETY: tests in this module are single-threaded relative to
-        // this env var. We deliberately remove it before calling.
-        // SAFETY (Rust 2024 set/remove_var are unsafe due to multi-thread races): single-thread tests.
-        unsafe { env::remove_var(MER_PIN_CORES_ENV); }
-        assert_eq!(apply_mer_pin_cores_env(), PinResult::NotRequested);
+        assert_eq!(apply_mer_pin_cores_value(None), PinResult::NotRequested);
+        assert_eq!(apply_mer_pin_cores_value(Some("")), PinResult::NotRequested);
     }
 
     #[test]
     fn apply_with_bad_env_reports_bad_value() {
-        unsafe { env::set_var(MER_PIN_CORES_ENV, "abc"); }
-        let r = apply_mer_pin_cores_env();
-        unsafe { env::remove_var(MER_PIN_CORES_ENV); }
+        let r = apply_mer_pin_cores_value(Some("abc"));
         assert!(matches!(r, PinResult::BadValue(_)));
     }
 }

--- a/rust-engine/src/numa.rs
+++ b/rust-engine/src/numa.rs
@@ -8,9 +8,12 @@
 //! advertises. This module wires the bare minimum we need to keep that
 //! hop out of the inference critical path:
 //!
-//! * [`apply_mer_pin_cores_env`] honours `MER_PIN_CORES=N` at startup
-//!   and calls `sched_setaffinity(2)` to pin **the whole process** to
-//!   the first `N` CPUs of NUMA node 0. Best-effort and Linux-only:
+//! * [`apply_startup_cpu_mask`] honours an explicit kernel cpulist such
+//!   as `0-24` at startup and calls `sched_setaffinity(2)` before
+//!   tokio/Rayon worker threads are created. If no explicit mask is
+//!   supplied, [`apply_mer_pin_cores_env`] keeps the legacy
+//!   `MER_PIN_CORES=N` behaviour and pins **the whole process** to the
+//!   first `N` CPUs of NUMA node 0. Best-effort and Linux-only:
 //!   anywhere else this is a logged no-op so dev machines (macOS,
 //!   Windows) still boot.
 //! * [`pin_current_thread_to_core`] is the lower-level primitive for
@@ -40,12 +43,11 @@ pub const MER_PIN_CORES_ENV: &str = "MER_PIN_CORES";
 /// can log a single human-readable line at startup.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PinResult {
-    /// `MER_PIN_CORES` was unset or empty — no pinning was attempted.
+    /// No explicit mask or legacy `MER_PIN_CORES` value was provided.
     NotRequested,
-    /// `MER_PIN_CORES` was set but invalid (non-numeric or `<= 0`).
+    /// A requested CPU mask or legacy `MER_PIN_CORES` value was invalid.
     BadValue(String),
-    /// Linux only: pinned to the listed CPUs (already de-duplicated
-    /// and clamped to what node 0 actually exposes).
+    /// Linux only: pinned to the listed CPUs (already de-duplicated).
     Pinned { cpus: Vec<usize> },
     /// Pinning was requested but the kernel / OS does not support the
     /// primitive (non-Linux, or `sched_setaffinity` returned an error).
@@ -56,13 +58,13 @@ pub enum PinResult {
 impl PinResult {
     pub fn as_log_line(&self) -> String {
         match self {
-            PinResult::NotRequested => format!("{MER_PIN_CORES_ENV} unset, no NUMA pinning"),
-            PinResult::BadValue(s) => format!("{MER_PIN_CORES_ENV}=\"{s}\" invalid, ignored"),
+            PinResult::NotRequested => "no CPU affinity pinning requested".to_string(),
+            PinResult::BadValue(s) => format!("CPU affinity value \"{s}\" invalid, ignored"),
             PinResult::Pinned { cpus } => {
-                format!("pinned process to NUMA node 0 CPUs {:?}", cpus)
+                format!("pinned process to CPUs {:?}", cpus)
             }
             PinResult::Unsupported(why) => {
-                format!("NUMA pinning unsupported on this platform: {why}")
+                format!("CPU affinity pinning unsupported on this platform: {why}")
             }
         }
     }
@@ -91,6 +93,30 @@ pub fn apply_mer_pin_cores_env() -> PinResult {
     pin_first_n_to_node0(n)
 }
 
+/// Apply an explicit kernel cpulist such as `"0-24"` or `"0-7,16-23"`.
+///
+/// When `requested` is `None`, this falls back to the legacy
+/// [`MER_PIN_CORES_ENV`] behaviour. The explicit mask path is the
+/// first-class production placement knob; it runs at process startup so
+/// Tokio and Rayon workers inherit the selected affinity.
+pub fn apply_startup_cpu_mask(requested: Option<&str>) -> PinResult {
+    let raw = match requested {
+        Some(s) if !s.trim().is_empty() => s.trim(),
+        Some(s) => return PinResult::BadValue(s.to_string()),
+        None => return apply_mer_pin_cores_env(),
+    };
+    let mut cpus = match parse_cpulist(raw) {
+        Ok(cpus) => cpus,
+        Err(_) => return PinResult::BadValue(raw.to_string()),
+    };
+    cpus.sort_unstable();
+    cpus.dedup();
+    if cpus.is_empty() {
+        return PinResult::BadValue(raw.to_string());
+    }
+    pin_cpu_set(&cpus)
+}
+
 /// Pin the calling process to the first `n` CPUs of NUMA node 0.
 /// On non-Linux this is a logged no-op.
 #[cfg(target_os = "linux")]
@@ -110,14 +136,26 @@ pub fn pin_first_n_to_node0(n: usize) -> PinResult {
             "no CPUs reported for NUMA node 0 and /proc/cpuinfo empty".into(),
         );
     }
-    match set_affinity(&cpus) {
-        Ok(()) => PinResult::Pinned { cpus },
+    pin_cpu_set(&cpus)
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn pin_first_n_to_node0(_n: usize) -> PinResult {
+    PinResult::Unsupported("sched_setaffinity(2) is Linux-only".into())
+}
+
+#[cfg(target_os = "linux")]
+pub fn pin_cpu_set(cpus: &[usize]) -> PinResult {
+    match set_affinity(cpus) {
+        Ok(()) => PinResult::Pinned {
+            cpus: cpus.to_vec(),
+        },
         Err(e) => PinResult::Unsupported(format!("sched_setaffinity: {e}")),
     }
 }
 
 #[cfg(not(target_os = "linux"))]
-pub fn pin_first_n_to_node0(_n: usize) -> PinResult {
+pub fn pin_cpu_set(_cpus: &[usize]) -> PinResult {
     PinResult::Unsupported("sched_setaffinity(2) is Linux-only".into())
 }
 
@@ -187,6 +225,65 @@ pub fn parse_cpulist(s: &str) -> Result<Vec<usize>, String> {
     Ok(out)
 }
 
+pub fn format_cpulist(cpus: &[usize]) -> String {
+    if cpus.is_empty() {
+        return String::new();
+    }
+    let mut cpus = cpus.to_vec();
+    cpus.sort_unstable();
+    cpus.dedup();
+    let mut ranges = Vec::new();
+    let mut start = cpus[0];
+    let mut prev = cpus[0];
+    for &cpu in cpus.iter().skip(1) {
+        if cpu == prev + 1 {
+            prev = cpu;
+            continue;
+        }
+        ranges.push(format_cpu_range(start, prev));
+        start = cpu;
+        prev = cpu;
+    }
+    ranges.push(format_cpu_range(start, prev));
+    ranges.join(",")
+}
+
+fn format_cpu_range(start: usize, end: usize) -> String {
+    if start == end {
+        start.to_string()
+    } else {
+        format!("{start}-{end}")
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub fn current_affinity() -> Result<Vec<usize>, String> {
+    unsafe {
+        let mut set: libc::cpu_set_t = std::mem::zeroed();
+        libc::CPU_ZERO(&mut set);
+        let rc = libc::sched_getaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &mut set);
+        if rc != 0 {
+            return Err(std::io::Error::last_os_error().to_string());
+        }
+        let mut cpus = Vec::new();
+        for cpu in 0..libc::CPU_SETSIZE as usize {
+            if libc::CPU_ISSET(cpu, &set) {
+                cpus.push(cpu);
+            }
+        }
+        Ok(cpus)
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn current_affinity() -> Result<Vec<usize>, String> {
+    Err("sched_getaffinity(2) is Linux-only".into())
+}
+
+pub fn current_affinity_cpulist() -> Option<String> {
+    current_affinity().ok().map(|cpus| format_cpulist(&cpus))
+}
+
 #[cfg(target_os = "linux")]
 fn set_affinity(cpus: &[usize]) -> Result<(), String> {
     set_affinity_pid(0, cpus)
@@ -241,6 +338,12 @@ mod tests {
     }
 
     #[test]
+    fn formats_cpulist_compactly() {
+        assert_eq!(format_cpulist(&[0, 1, 2, 4, 8, 7, 7]), "0-2,4,7-8");
+        assert_eq!(format_cpulist(&[]), "");
+    }
+
+    #[test]
     fn rejects_descending_range() {
         assert!(parse_cpulist("4-1").is_err());
     }
@@ -253,8 +356,12 @@ mod tests {
 
     #[test]
     fn pin_result_log_line_is_descriptive() {
-        assert!(PinResult::NotRequested.as_log_line().contains(MER_PIN_CORES_ENV));
-        assert!(PinResult::BadValue("xyz".into()).as_log_line().contains("xyz"));
+        assert!(PinResult::NotRequested
+            .as_log_line()
+            .contains("no CPU affinity pinning requested"));
+        assert!(PinResult::BadValue("xyz".into())
+            .as_log_line()
+            .contains("xyz"));
         assert!(PinResult::Pinned { cpus: vec![0, 1] }
             .as_log_line()
             .contains("[0, 1]"));

--- a/rust-engine/src/numa.rs
+++ b/rust-engine/src/numa.rs
@@ -32,6 +32,11 @@ use std::env;
 #[cfg(target_os = "linux")]
 use std::{fs, path::Path};
 
+#[cfg(target_os = "linux")]
+const MAX_CPULIST_CPUS: usize = libc::CPU_SETSIZE as usize;
+#[cfg(not(target_os = "linux"))]
+const MAX_CPULIST_CPUS: usize = 4096;
+
 /// Environment variable that, if set to a positive integer `N`, pins
 /// the process to the first `N` CPUs of NUMA node 0 at startup.
 pub const MER_PIN_CORES_ENV: &str = "MER_PIN_CORES";
@@ -312,6 +317,21 @@ pub fn parse_cpulist(s: &str) -> Result<Vec<usize>, String> {
             if b < a {
                 return Err(format!("descending cpulist range: {a}-{b}"));
             }
+            let len = b
+                .checked_sub(a)
+                .and_then(|delta| delta.checked_add(1))
+                .ok_or_else(|| format!("cpulist range is too large: {a}-{b}"))?;
+            if len > MAX_CPULIST_CPUS {
+                return Err(format!(
+                    "cpulist range {a}-{b} expands to {len} CPUs, exceeding supported maximum {MAX_CPULIST_CPUS}"
+                ));
+            }
+            if b >= MAX_CPULIST_CPUS {
+                return Err(format!(
+                    "cpu {b} exceeds supported maximum CPU id {}",
+                    MAX_CPULIST_CPUS - 1
+                ));
+            }
             for c in a..=b {
                 out.push(c);
             }
@@ -319,6 +339,12 @@ pub fn parse_cpulist(s: &str) -> Result<Vec<usize>, String> {
             let c: usize = part
                 .parse()
                 .map_err(|_| format!("bad cpulist cpu: {part:?}"))?;
+            if c >= MAX_CPULIST_CPUS {
+                return Err(format!(
+                    "cpu {c} exceeds supported maximum CPU id {}",
+                    MAX_CPULIST_CPUS - 1
+                ));
+            }
             out.push(c);
         }
     }
@@ -505,6 +531,12 @@ mod tests {
     #[test]
     fn rejects_descending_range() {
         assert!(parse_cpulist("4-1").is_err());
+    }
+
+    #[test]
+    fn rejects_oversized_range_before_expansion() {
+        let err = parse_cpulist("0-999999999").unwrap_err();
+        assert!(err.contains("exceeding supported maximum"));
     }
 
     #[test]

--- a/rust-engine/src/parallel.rs
+++ b/rust-engine/src/parallel.rs
@@ -57,8 +57,9 @@
 
 use serde::{Deserialize, Serialize};
 use std::fmt;
+use std::path::PathBuf;
 use std::str::FromStr;
-use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use tracing::{info, warn};
 
 /// Dense matrix-vector backend selected for `transformer::matmul_row_major`.
@@ -133,6 +134,7 @@ impl FromStr for DenseMatvecBackend {
 }
 
 static DENSE_MATVEC_BACKEND: AtomicU8 = AtomicU8::new(DenseMatvecBackend::Auto.code());
+static GLOBAL_POOL_INIT_ATTEMPTED: AtomicBool = AtomicBool::new(false);
 
 pub fn set_dense_matvec_backend(backend: DenseMatvecBackend) {
     DENSE_MATVEC_BACKEND.store(backend.code(), Ordering::Relaxed);
@@ -210,11 +212,72 @@ pub fn default_compute_threads(logical: usize) -> usize {
 /// A valid, positive `RAYON_NUM_THREADS` is an explicit operator override.
 /// Zero or unparseable values are ignored so the smart default applies
 /// (rayon itself treats `RAYON_NUM_THREADS=0` as "use the default").
-fn env_thread_override() -> Option<usize> {
+pub(crate) fn env_thread_override() -> Option<usize> {
     std::env::var("RAYON_NUM_THREADS")
         .ok()
         .and_then(|v| v.trim().parse::<usize>().ok())
         .filter(|&n| n > 0)
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RayonThreadSource {
+    EnvOverride,
+    AutotuneProfile { path: PathBuf },
+    FreshAutotune { path: PathBuf },
+    DefaultHeuristic,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RayonThreadSelection {
+    pub logical: usize,
+    pub threads: usize,
+    pub source: RayonThreadSource,
+}
+
+impl RayonThreadSelection {
+    pub fn fresh_autotune(logical: usize, threads: usize, path: PathBuf) -> Self {
+        Self {
+            logical: logical.max(1),
+            threads: threads.max(1),
+            source: RayonThreadSource::FreshAutotune { path },
+        }
+    }
+}
+
+pub fn resolve_thread_selection(
+    logical: usize,
+    profile: Option<(usize, PathBuf)>,
+) -> RayonThreadSelection {
+    resolve_thread_selection_from_parts(logical, env_thread_override(), profile)
+}
+
+pub(crate) fn resolve_thread_selection_from_parts(
+    logical: usize,
+    env_override: Option<usize>,
+    profile: Option<(usize, PathBuf)>,
+) -> RayonThreadSelection {
+    let logical = logical.max(1);
+    if let Some(threads) = env_override {
+        return RayonThreadSelection {
+            logical,
+            threads: threads.max(1),
+            source: RayonThreadSource::EnvOverride,
+        };
+    }
+    if let Some((threads, path)) = profile {
+        if threads > 0 {
+            return RayonThreadSelection {
+                logical,
+                threads,
+                source: RayonThreadSource::AutotuneProfile { path },
+            };
+        }
+    }
+    RayonThreadSelection {
+        logical,
+        threads: default_compute_threads(logical),
+        source: RayonThreadSource::DefaultHeuristic,
+    }
 }
 
 /// Initialise the shared compute pool once, reserving headroom for the
@@ -236,31 +299,51 @@ pub fn init_global_pool() -> usize {
     let logical = std::thread::available_parallelism()
         .map(|n| n.get())
         .unwrap_or(1);
+    let selection = resolve_thread_selection(logical, None);
+    init_global_pool_with_selection(selection)
+}
 
-    // Resolve the worker count: an explicit, valid `RAYON_NUM_THREADS` wins,
-    // otherwise fall back to the reserved async-runtime-headroom default.
-    let threads = match env_thread_override() {
-        Some(n) => {
+pub fn init_global_pool_with_selection(selection: RayonThreadSelection) -> usize {
+    let logical = selection.logical.max(1);
+    let threads = selection.threads.max(1);
+
+    match &selection.source {
+        RayonThreadSource::EnvOverride => {
             info!(
-                threads = n,
+                threads,
                 logical,
                 source = "RAYON_NUM_THREADS",
                 "compute pool: honoring explicit thread-count override"
             );
-            n
         }
-        None => {
-            let t = default_compute_threads(logical);
+        RayonThreadSource::AutotuneProfile { path } => {
             info!(
                 logical,
-                threads = t,
-                reserved = logical - t,
+                threads,
+                profile = %path.display(),
+                source = "autotune-profile",
+                "compute pool: sizing from saved CPU/Rayon autotune profile"
+            );
+        }
+        RayonThreadSource::FreshAutotune { path } => {
+            info!(
+                logical,
+                threads,
+                profile = %path.display(),
+                source = "fresh-autotune",
+                "compute pool: sizing from freshly measured CPU/Rayon autotune result"
+            );
+        }
+        RayonThreadSource::DefaultHeuristic => {
+            info!(
+                logical,
+                threads,
+                reserved = logical.saturating_sub(threads),
                 source = "auto",
                 "compute pool: sizing with reserved async-runtime headroom"
             );
-            t
         }
-    };
+    }
 
     // Build the global pool *now* — after startup affinity pinning and before
     // the first matmul — for BOTH the override and auto paths, so the workers
@@ -268,21 +351,36 @@ pub fn init_global_pool() -> usize {
     // on the override path (deferring to rayon's lazy init) would instead
     // spawn them at first use, inheriting whatever affinity the triggering
     // thread carries by then (e.g. a later io_uring repin onto ≤8 cores).
-    if let Err(e) = rayon::ThreadPoolBuilder::new()
-        .num_threads(threads)
-        .thread_name(|i| format!("mer-compute-{i}"))
-        .build_global()
-    {
-        // `build_global` only errors if the global pool was already built
-        // (a prior call, or a rayon use before init). Keep what exists.
+    if mark_pool_init_attempted() {
+        if let Err(e) = rayon::ThreadPoolBuilder::new()
+            .num_threads(threads)
+            .thread_name(|i| format!("mer-compute-{i}"))
+            .build_global()
+        {
+            // `build_global` only errors if the global pool was already built
+            // by a rayon use before init. Keep what exists.
+            warn!(
+                error = %e,
+                current_threads = rayon::current_num_threads().max(1),
+                "compute pool already initialised; keeping existing configuration"
+            );
+        }
+    } else {
         warn!(
-            error = %e,
             current_threads = rayon::current_num_threads().max(1),
-            "compute pool already initialised; keeping existing configuration"
+            "compute pool init was already attempted; not rebuilding Rayon global pool"
         );
     }
 
     num_threads()
+}
+
+fn mark_pool_init_attempted() -> bool {
+    mark_pool_init_attempted_with(&GLOBAL_POOL_INIT_ATTEMPTED)
+}
+
+fn mark_pool_init_attempted_with(flag: &AtomicBool) -> bool {
+    !flag.swap(true, Ordering::AcqRel)
 }
 
 /// Fill `out` in parallel by computing disjoint row-chunks on the shared
@@ -502,5 +600,33 @@ mod tests {
             );
             prev = t;
         }
+    }
+
+    #[test]
+    fn thread_resolution_precedence_is_env_profile_default() {
+        let profile_path = std::path::PathBuf::from("/tmp/profile.json");
+        let env =
+            resolve_thread_selection_from_parts(32, Some(17), Some((30, profile_path.clone())));
+        assert_eq!(env.threads, 17);
+        assert_eq!(env.source, RayonThreadSource::EnvOverride);
+
+        let profile =
+            resolve_thread_selection_from_parts(32, None, Some((30, profile_path.clone())));
+        assert_eq!(profile.threads, 30);
+        assert_eq!(
+            profile.source,
+            RayonThreadSource::AutotuneProfile { path: profile_path }
+        );
+
+        let fallback = resolve_thread_selection_from_parts(32, None, None);
+        assert_eq!(fallback.threads, default_compute_threads(32));
+        assert_eq!(fallback.source, RayonThreadSource::DefaultHeuristic);
+    }
+
+    #[test]
+    fn global_pool_init_attempt_guard_allows_only_one_attempt() {
+        let flag = AtomicBool::new(false);
+        assert!(mark_pool_init_attempted_with(&flag));
+        assert!(!mark_pool_init_attempted_with(&flag));
     }
 }

--- a/rust-engine/src/parallel.rs
+++ b/rust-engine/src/parallel.rs
@@ -53,13 +53,13 @@
 //! once at startup with [`default_compute_threads`] — logical cores minus
 //! a small, bounded reservation — so the engine keeps a couple of cores
 //! free for async work by default. An explicit `RAYON_NUM_THREADS` is
-//! treated as an operator override and wins.
+//! treated as a hard operator override and wins over profile/autotune/default
+//! selection.
 
 use serde::{Deserialize, Serialize};
 use std::fmt;
-use std::path::PathBuf;
 use std::str::FromStr;
-use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+use std::sync::atomic::{AtomicU8, Ordering};
 use tracing::{info, warn};
 
 /// Dense matrix-vector backend selected for `transformer::matmul_row_major`.
@@ -134,7 +134,6 @@ impl FromStr for DenseMatvecBackend {
 }
 
 static DENSE_MATVEC_BACKEND: AtomicU8 = AtomicU8::new(DenseMatvecBackend::Auto.code());
-static GLOBAL_POOL_INIT_ATTEMPTED: AtomicBool = AtomicBool::new(false);
 
 pub fn set_dense_matvec_backend(backend: DenseMatvecBackend) {
     DENSE_MATVEC_BACKEND.store(backend.code(), Ordering::Relaxed);
@@ -212,71 +211,142 @@ pub fn default_compute_threads(logical: usize) -> usize {
 /// A valid, positive `RAYON_NUM_THREADS` is an explicit operator override.
 /// Zero or unparseable values are ignored so the smart default applies
 /// (rayon itself treats `RAYON_NUM_THREADS=0` as "use the default").
-pub(crate) fn env_thread_override() -> Option<usize> {
-    std::env::var("RAYON_NUM_THREADS")
-        .ok()
+fn parse_env_thread_override(value: Option<&str>) -> Option<usize> {
+    value
         .and_then(|v| v.trim().parse::<usize>().ok())
         .filter(|&n| n > 0)
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum RayonThreadSource {
-    EnvOverride,
-    AutotuneProfile { path: PathBuf },
-    FreshAutotune { path: PathBuf },
-    DefaultHeuristic,
+    Env,
+    Cli,
+    Config,
+    Autotune,
+    Profile,
+    RayonDefault,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+impl RayonThreadSource {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Env => "env",
+            Self::Cli => "cli",
+            Self::Config => "config",
+            Self::Autotune => "autotune",
+            Self::Profile => "profile",
+            Self::RayonDefault => "rayon_default",
+        }
+    }
+}
+
+/// Resolved Rayon worker-count selection before the global pool exists.
+///
+/// `threads = None` means keep MER's existing default pool sizing policy
+/// (`default_compute_threads`) instead of forcing an explicit worker count.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct RayonThreadSelection {
-    pub logical: usize,
-    pub threads: usize,
+    pub threads: Option<usize>,
     pub source: RayonThreadSource,
 }
 
 impl RayonThreadSelection {
-    pub fn fresh_autotune(logical: usize, threads: usize, path: PathBuf) -> Self {
+    pub const fn default() -> Self {
         Self {
-            logical: logical.max(1),
-            threads: threads.max(1),
-            source: RayonThreadSource::FreshAutotune { path },
+            threads: None,
+            source: RayonThreadSource::RayonDefault,
         }
     }
 }
 
-pub fn resolve_thread_selection(
-    logical: usize,
-    profile: Option<(usize, PathBuf)>,
-) -> RayonThreadSelection {
-    resolve_thread_selection_from_parts(logical, env_thread_override(), profile)
+fn validate_positive_threads(value: Option<usize>, name: &str) -> Result<Option<usize>, String> {
+    match value {
+        Some(0) => Err(format!("{name} must be > 0")),
+        other => Ok(other),
+    }
 }
 
-pub(crate) fn resolve_thread_selection_from_parts(
-    logical: usize,
-    env_override: Option<usize>,
-    profile: Option<(usize, PathBuf)>,
-) -> RayonThreadSelection {
-    let logical = logical.max(1);
-    if let Some(threads) = env_override {
-        return RayonThreadSelection {
-            logical,
-            threads: threads.max(1),
-            source: RayonThreadSource::EnvOverride,
-        };
+pub fn resolve_rayon_threads(
+    cli: Option<usize>,
+    config: Option<usize>,
+    env_value: Option<&str>,
+    autotune: Option<usize>,
+    profile: Option<usize>,
+) -> Result<RayonThreadSelection, String> {
+    if let Some(n) = parse_env_thread_override(env_value) {
+        return Ok(RayonThreadSelection {
+            threads: Some(n),
+            source: RayonThreadSource::Env,
+        });
     }
-    if let Some((threads, path)) = profile {
-        if threads > 0 {
-            return RayonThreadSelection {
-                logical,
-                threads,
-                source: RayonThreadSource::AutotuneProfile { path },
-            };
-        }
+    if let Some(n) = validate_positive_threads(cli, "--rayon-threads")? {
+        return Ok(RayonThreadSelection {
+            threads: Some(n),
+            source: RayonThreadSource::Cli,
+        });
     }
-    RayonThreadSelection {
+    if let Some(n) = validate_positive_threads(config, "performance.rayon_threads")? {
+        return Ok(RayonThreadSelection {
+            threads: Some(n),
+            source: RayonThreadSource::Config,
+        });
+    }
+    if let Some(n) = validate_positive_threads(autotune, "autotuned rayon threads")? {
+        return Ok(RayonThreadSelection {
+            threads: Some(n),
+            source: RayonThreadSource::Autotune,
+        });
+    }
+    if let Some(n) = validate_positive_threads(profile, "profile rayon threads")? {
+        return Ok(RayonThreadSelection {
+            threads: Some(n),
+            source: RayonThreadSource::Profile,
+        });
+    }
+    Ok(RayonThreadSelection::default())
+}
+
+pub fn resolve_rayon_threads_from_env(
+    cli: Option<usize>,
+    config: Option<usize>,
+    autotune: Option<usize>,
+    profile: Option<usize>,
+) -> Result<RayonThreadSelection, String> {
+    resolve_rayon_threads(
+        cli,
+        config,
+        std::env::var("RAYON_NUM_THREADS").ok().as_deref(),
+        autotune,
+        profile,
+    )
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RayonPoolInitPlan {
+    pub threads: usize,
+    pub selection: RayonThreadSelection,
+    pub logical: usize,
+}
+
+pub fn rayon_pool_init_plan(selection: RayonThreadSelection, logical: usize) -> RayonPoolInitPlan {
+    let threads = selection
+        .threads
+        .unwrap_or_else(|| default_compute_threads(logical));
+    RayonPoolInitPlan {
+        threads,
+        selection,
         logical,
-        threads: default_compute_threads(logical),
-        source: RayonThreadSource::DefaultHeuristic,
+    }
+}
+
+fn log_rayon_selection(selection: RayonThreadSelection) {
+    match selection.threads {
+        Some(n) => info!(
+            "CPU Rayon threads: {} source={}",
+            n,
+            selection.source.as_str()
+        ),
+        None => info!("CPU Rayon threads: default source=rayon_default"),
     }
 }
 
@@ -287,58 +357,35 @@ pub(crate) fn resolve_thread_selection_from_parts(
 /// Call exactly once at process start — *after* any NUMA/affinity pinning
 /// so the workers inherit the startup affinity mask, and *before* the first
 /// [`par_row_chunks`] touches the pool. The global pool is built eagerly
-/// here in *both* cases: a valid `RAYON_NUM_THREADS` sets the worker count
-/// as an explicit operator override, otherwise the reserved
+/// here in *both* cases: a valid env/CLI/config/autotune/profile selection
+/// sets the worker count explicitly, otherwise the reserved
 /// [`default_compute_threads`] count is used. Building now — rather than
 /// letting rayon lazily initialise on first use — is what guarantees the
 /// workers are spawned at this point and inherit the startup affinity mask.
 /// Deferring (e.g. returning early on the override path) would spawn them at
 /// the first matmul, inheriting whatever affinity the triggering thread
-/// happens to carry by then (such as a later io_uring repin onto ≤8 cores).
-pub fn init_global_pool() -> usize {
-    let logical = std::thread::available_parallelism()
-        .map(|n| n.get())
-        .unwrap_or(1);
-    let selection = resolve_thread_selection(logical, None);
-    init_global_pool_with_selection(selection)
-}
+/// happens to carry by then.
+pub fn init_global_pool(selection: RayonThreadSelection, logical: usize) -> usize {
+    let logical = logical.max(1);
+    let plan = rayon_pool_init_plan(selection, logical);
+    log_rayon_selection(plan.selection);
 
-pub fn init_global_pool_with_selection(selection: RayonThreadSelection) -> usize {
-    let logical = selection.logical.max(1);
-    let threads = selection.threads.max(1);
-
-    match &selection.source {
-        RayonThreadSource::EnvOverride => {
+    // Resolve the worker count: an explicit env/CLI/config/autotune/profile
+    // selection wins, otherwise fall back to the reserved headroom default.
+    match plan.selection.threads {
+        Some(n) => {
             info!(
-                threads,
+                threads = n,
                 logical,
-                source = "RAYON_NUM_THREADS",
+                source = plan.selection.source.as_str(),
                 "compute pool: honoring explicit thread-count override"
             );
         }
-        RayonThreadSource::AutotuneProfile { path } => {
+        None => {
             info!(
                 logical,
-                threads,
-                profile = %path.display(),
-                source = "autotune-profile",
-                "compute pool: sizing from saved CPU/Rayon autotune profile"
-            );
-        }
-        RayonThreadSource::FreshAutotune { path } => {
-            info!(
-                logical,
-                threads,
-                profile = %path.display(),
-                source = "fresh-autotune",
-                "compute pool: sizing from freshly measured CPU/Rayon autotune result"
-            );
-        }
-        RayonThreadSource::DefaultHeuristic => {
-            info!(
-                logical,
-                threads,
-                reserved = logical.saturating_sub(threads),
+                threads = plan.threads,
+                reserved = logical - plan.threads,
                 source = "auto",
                 "compute pool: sizing with reserved async-runtime headroom"
             );
@@ -350,37 +397,22 @@ pub fn init_global_pool_with_selection(selection: RayonThreadSelection) -> usize
     // are spawned here and inherit the startup affinity mask. Returning early
     // on the override path (deferring to rayon's lazy init) would instead
     // spawn them at first use, inheriting whatever affinity the triggering
-    // thread carries by then (e.g. a later io_uring repin onto ≤8 cores).
-    if mark_pool_init_attempted() {
-        if let Err(e) = rayon::ThreadPoolBuilder::new()
-            .num_threads(threads)
-            .thread_name(|i| format!("mer-compute-{i}"))
-            .build_global()
-        {
-            // `build_global` only errors if the global pool was already built
-            // by a rayon use before init. Keep what exists.
-            warn!(
-                error = %e,
-                current_threads = rayon::current_num_threads().max(1),
-                "compute pool already initialised; keeping existing configuration"
-            );
-        }
-    } else {
+    // thread carries by then.
+    if let Err(e) = rayon::ThreadPoolBuilder::new()
+        .num_threads(plan.threads)
+        .thread_name(|i| format!("mer-compute-{i}"))
+        .build_global()
+    {
+        // `build_global` only errors if the global pool was already built
+        // (a prior call, or a rayon use before init). Keep what exists.
         warn!(
+            error = %e,
             current_threads = rayon::current_num_threads().max(1),
-            "compute pool init was already attempted; not rebuilding Rayon global pool"
+            "compute pool already initialised; keeping existing configuration"
         );
     }
 
     num_threads()
-}
-
-fn mark_pool_init_attempted() -> bool {
-    mark_pool_init_attempted_with(&GLOBAL_POOL_INIT_ATTEMPTED)
-}
-
-fn mark_pool_init_attempted_with(flag: &AtomicBool) -> bool {
-    !flag.swap(true, Ordering::AcqRel)
 }
 
 /// Fill `out` in parallel by computing disjoint row-chunks on the shared
@@ -603,30 +635,102 @@ mod tests {
     }
 
     #[test]
-    fn thread_resolution_precedence_is_env_profile_default() {
-        let profile_path = std::path::PathBuf::from("/tmp/profile.json");
-        let env =
-            resolve_thread_selection_from_parts(32, Some(17), Some((30, profile_path.clone())));
-        assert_eq!(env.threads, 17);
-        assert_eq!(env.source, RayonThreadSource::EnvOverride);
-
-        let profile =
-            resolve_thread_selection_from_parts(32, None, Some((30, profile_path.clone())));
-        assert_eq!(profile.threads, 30);
+    fn rayon_thread_selection_precedence_is_env_cli_config_autotune_profile_default() {
         assert_eq!(
-            profile.source,
-            RayonThreadSource::AutotuneProfile { path: profile_path }
+            resolve_rayon_threads(Some(30), Some(28), Some("26"), Some(24), Some(22)).unwrap(),
+            RayonThreadSelection {
+                threads: Some(26),
+                source: RayonThreadSource::Env,
+            }
         );
-
-        let fallback = resolve_thread_selection_from_parts(32, None, None);
-        assert_eq!(fallback.threads, default_compute_threads(32));
-        assert_eq!(fallback.source, RayonThreadSource::DefaultHeuristic);
+        assert_eq!(
+            resolve_rayon_threads(Some(30), Some(28), None, Some(24), Some(22)).unwrap(),
+            RayonThreadSelection {
+                threads: Some(30),
+                source: RayonThreadSource::Cli,
+            }
+        );
+        assert_eq!(
+            resolve_rayon_threads(None, Some(28), None, Some(24), Some(22)).unwrap(),
+            RayonThreadSelection {
+                threads: Some(28),
+                source: RayonThreadSource::Config,
+            }
+        );
+        assert_eq!(
+            resolve_rayon_threads(None, None, None, Some(24), Some(22)).unwrap(),
+            RayonThreadSelection {
+                threads: Some(24),
+                source: RayonThreadSource::Autotune,
+            }
+        );
+        assert_eq!(
+            resolve_rayon_threads(None, None, None, None, Some(22)).unwrap(),
+            RayonThreadSelection {
+                threads: Some(22),
+                source: RayonThreadSource::Profile,
+            }
+        );
+        assert_eq!(
+            resolve_rayon_threads(None, None, None, None, None).unwrap(),
+            RayonThreadSelection::default()
+        );
     }
 
     #[test]
-    fn global_pool_init_attempt_guard_allows_only_one_attempt() {
-        let flag = AtomicBool::new(false);
-        assert!(mark_pool_init_attempted_with(&flag));
-        assert!(!mark_pool_init_attempted_with(&flag));
+    fn rayon_thread_selection_rejects_invalid_cli_and_config_zero() {
+        let err = resolve_rayon_threads(Some(0), Some(28), None, None, None).unwrap_err();
+        assert!(
+            err.contains("--rayon-threads must be > 0"),
+            "unexpected error: {err}"
+        );
+        let err = resolve_rayon_threads(None, Some(0), None, None, None).unwrap_err();
+        assert!(
+            err.contains("performance.rayon_threads must be > 0"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn rayon_thread_selection_preserves_existing_env_default_behavior() {
+        // Existing behavior ignores invalid/zero env overrides and falls
+        // through to the engine's startup default sizing policy.
+        assert_eq!(
+            resolve_rayon_threads(None, None, Some("0"), None, None).unwrap(),
+            RayonThreadSelection::default()
+        );
+        assert_eq!(
+            resolve_rayon_threads(None, None, Some("not-a-number"), None, None).unwrap(),
+            RayonThreadSelection::default()
+        );
+    }
+
+    #[test]
+    fn rayon_num_threads_overrides_autotune_profile_and_default() {
+        assert_eq!(
+            resolve_rayon_threads(None, None, Some("25"), Some(23), Some(22)).unwrap(),
+            RayonThreadSelection {
+                threads: Some(25),
+                source: RayonThreadSource::Env,
+            }
+        );
+    }
+
+    #[test]
+    fn selected_thread_count_feeds_pool_init_plan_before_creation() {
+        let selected = RayonThreadSelection {
+            threads: Some(30),
+            source: RayonThreadSource::Cli,
+        };
+        let plan = rayon_pool_init_plan(selected, 32);
+        assert_eq!(plan.threads, 30);
+        assert_eq!(plan.selection, selected);
+
+        let default_plan = rayon_pool_init_plan(RayonThreadSelection::default(), 32);
+        assert_eq!(default_plan.threads, default_compute_threads(32));
+        assert_eq!(
+            default_plan.selection.source,
+            RayonThreadSource::RayonDefault
+        );
     }
 }

--- a/rust-engine/src/rayon_autotune.rs
+++ b/rust-engine/src/rayon_autotune.rs
@@ -402,11 +402,13 @@ pub fn default_profile_dir() -> PathBuf {
 
 pub fn make_machine_fingerprint(logical: usize) -> String {
     let cpu = cpu_model().unwrap_or_else(|| "unknown-cpu".to_string());
+    let affinity = crate::numa::current_affinity_cpulist().unwrap_or_else(|| "unknown".into());
     format!(
-        "{}-{}-logical{}-{}",
+        "{}-{}-logical{}-affinity{}-{}",
         std::env::consts::OS,
         std::env::consts::ARCH,
         logical.max(1),
+        affinity,
         cpu
     )
 }

--- a/rust-engine/src/rayon_autotune.rs
+++ b/rust-engine/src/rayon_autotune.rs
@@ -1,0 +1,596 @@
+//! CPU/Rayon thread-count autotuning.
+//!
+//! Rayon can build its global pool only once per process, so the tuner runs
+//! each candidate in a child process with `RAYON_NUM_THREADS=<candidate>`.
+//! The parent process never touches Rayon during probing; after it selects a
+//! winner it initialises the global pool exactly once for the real run.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub const PROFILE_VERSION: u32 = 1;
+pub const DEFAULT_PROBE_TOKENS: u64 = 96;
+pub const SLOW_REGIME_P50_US: u64 = 80_000;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CpuAutotuneKey {
+    pub machine_fingerprint: String,
+    pub model_fingerprint: String,
+    pub data_dir_fingerprint: String,
+    pub dtype: String,
+    pub cache_slots: usize,
+    pub backend: String,
+}
+
+impl CpuAutotuneKey {
+    pub fn profile_path(&self) -> PathBuf {
+        default_profile_dir().join(format!("{}.json", self.stable_id()))
+    }
+
+    pub fn stable_id(&self) -> String {
+        stable_hash_hex(&format!(
+            "v{}|machine={}|model={}|data={}|dtype={}|cache={}|backend={}",
+            PROFILE_VERSION,
+            self.machine_fingerprint,
+            self.model_fingerprint,
+            self.data_dir_fingerprint,
+            self.dtype,
+            self.cache_slots,
+            self.backend
+        ))
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CpuAutotuneProfile {
+    pub version: u32,
+    pub selected_rayon_threads: usize,
+    pub candidate_results: Vec<CpuAutotuneProbeResult>,
+    pub logical_cores: usize,
+    pub cpu_model: Option<String>,
+    pub machine_fingerprint: String,
+    pub model_fingerprint: String,
+    pub data_dir_fingerprint: String,
+    pub dtype: String,
+    pub cache_slots: usize,
+    pub backend: String,
+    pub selection_rule: String,
+    pub created_at: String,
+    pub created_at_unix_secs: u64,
+}
+
+impl CpuAutotuneProfile {
+    pub fn new(
+        key: &CpuAutotuneKey,
+        logical_cores: usize,
+        selected_rayon_threads: usize,
+        candidate_results: Vec<CpuAutotuneProbeResult>,
+    ) -> Self {
+        let created_at_unix_secs = unix_now_secs();
+        Self {
+            version: PROFILE_VERSION,
+            selected_rayon_threads,
+            candidate_results,
+            logical_cores,
+            cpu_model: cpu_model(),
+            machine_fingerprint: key.machine_fingerprint.clone(),
+            model_fingerprint: key.model_fingerprint.clone(),
+            data_dir_fingerprint: key.data_dir_fingerprint.clone(),
+            dtype: key.dtype.clone(),
+            cache_slots: key.cache_slots,
+            backend: key.backend.clone(),
+            selection_rule:
+                "lowest compute_p50_us; tie-break highest sustained_tps; ignore failed/invalid probes; prefer sub-80000us p50 when any candidate reaches it"
+                    .to_string(),
+            created_at: format!("unix:{created_at_unix_secs}"),
+            created_at_unix_secs,
+        }
+    }
+
+    pub fn matches_key(&self, key: &CpuAutotuneKey) -> bool {
+        self.version == PROFILE_VERSION
+            && self.machine_fingerprint == key.machine_fingerprint
+            && self.model_fingerprint == key.model_fingerprint
+            && self.data_dir_fingerprint == key.data_dir_fingerprint
+            && self.dtype == key.dtype
+            && self.cache_slots == key.cache_slots
+            && self.backend == key.backend
+    }
+
+    pub fn save(&self, path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let json = serde_json::to_string_pretty(self)?;
+        std::fs::write(path, json)?;
+        Ok(())
+    }
+
+    pub fn load(path: &Path) -> Result<Self, Box<dyn std::error::Error>> {
+        let body = std::fs::read_to_string(path)?;
+        Ok(serde_json::from_str(&body)?)
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CpuAutotuneProbeResult {
+    pub candidate_threads: usize,
+    pub sustained_tps: Option<f64>,
+    pub compute_p50_us: Option<u64>,
+    pub compute_p95_us: Option<u64>,
+    pub hit_rate_pct: Option<f64>,
+    pub tokens: u64,
+    pub cache_slots: usize,
+    pub dtype: String,
+    pub backend: Option<String>,
+    pub quant_path: Option<String>,
+    pub success: bool,
+    pub error: Option<String>,
+}
+
+impl CpuAutotuneProbeResult {
+    pub fn failure(
+        candidate_threads: usize,
+        tokens: u64,
+        cache_slots: usize,
+        dtype: impl Into<String>,
+        error: impl Into<String>,
+    ) -> Self {
+        Self {
+            candidate_threads,
+            sustained_tps: None,
+            compute_p50_us: None,
+            compute_p95_us: None,
+            hit_rate_pct: None,
+            tokens,
+            cache_slots,
+            dtype: dtype.into(),
+            backend: None,
+            quant_path: None,
+            success: false,
+            error: Some(error.into()),
+        }
+    }
+
+    fn valid_for_selection(&self) -> bool {
+        self.success
+            && self.compute_p50_us.is_some()
+            && self
+                .sustained_tps
+                .is_some_and(|v| v.is_finite() && v >= 0.0)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct CpuAutotuneRun {
+    pub profile: CpuAutotuneProfile,
+    pub profile_path: PathBuf,
+}
+
+/// Candidate window around the existing smart fallback, plus the full visible
+/// core count. For a 32-vCPU VM this returns 24..=32, covering the previously
+/// observed fast band without assuming it is universal.
+pub fn candidate_thread_counts(logical: usize) -> Vec<usize> {
+    let logical = logical.max(1);
+    let fallback = crate::parallel::default_compute_threads(logical);
+    let radius = match logical {
+        0..=8 => 2,
+        9..=15 => 3,
+        16..=31 => 4,
+        _ => 6,
+    };
+    let lo = fallback.saturating_sub(radius).max(1);
+    let hi = fallback.saturating_add(radius).min(logical);
+    let mut set = BTreeSet::new();
+    set.extend(lo..=hi);
+    set.insert(fallback.min(logical).max(1));
+    set.insert(logical);
+    set.into_iter().collect()
+}
+
+pub fn select_best_candidate(
+    results: &[CpuAutotuneProbeResult],
+) -> Option<&CpuAutotuneProbeResult> {
+    let mut valid: Vec<&CpuAutotuneProbeResult> =
+        results.iter().filter(|r| r.valid_for_selection()).collect();
+    if valid.is_empty() {
+        return None;
+    }
+    if valid
+        .iter()
+        .any(|r| r.compute_p50_us.unwrap_or(u64::MAX) < SLOW_REGIME_P50_US)
+    {
+        valid.retain(|r| r.compute_p50_us.unwrap_or(u64::MAX) < SLOW_REGIME_P50_US);
+    }
+    valid.into_iter().min_by(|a, b| {
+        let p50_cmp = a.compute_p50_us.cmp(&b.compute_p50_us);
+        if p50_cmp != std::cmp::Ordering::Equal {
+            return p50_cmp;
+        }
+        let a_tps = a.sustained_tps.unwrap_or(0.0);
+        let b_tps = b.sustained_tps.unwrap_or(0.0);
+        b_tps
+            .partial_cmp(&a_tps)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    })
+}
+
+pub fn load_matching_profile(key: &CpuAutotuneKey) -> Option<(PathBuf, CpuAutotuneProfile)> {
+    let path = key.profile_path();
+    let profile = CpuAutotuneProfile::load(&path).ok()?;
+    profile.matches_key(key).then_some((path, profile))
+}
+
+pub fn run_cpu_autotune(
+    key: &CpuAutotuneKey,
+    logical: usize,
+    candidates: &[usize],
+    probe_tokens: u64,
+    cache_slots: usize,
+    dtype: &str,
+) -> Result<CpuAutotuneRun, Box<dyn std::error::Error>> {
+    let mut results = Vec::new();
+    let probe_tokens = probe_tokens.max(1);
+    for &candidate in candidates {
+        results.push(run_probe_child(candidate, probe_tokens, cache_slots, dtype));
+    }
+    let selected = select_best_candidate(&results).ok_or_else(|| {
+        let failures = results
+            .iter()
+            .filter_map(|r| r.error.as_deref())
+            .take(5)
+            .collect::<Vec<_>>()
+            .join("; ");
+        if failures.is_empty() {
+            "CPU/Rayon autotune produced no valid child probe results".to_string()
+        } else {
+            format!("CPU/Rayon autotune produced no valid child probe results: {failures}")
+        }
+    })?;
+    let profile = CpuAutotuneProfile::new(key, logical, selected.candidate_threads, results);
+    let profile_path = key.profile_path();
+    profile.save(&profile_path)?;
+    Ok(CpuAutotuneRun {
+        profile,
+        profile_path,
+    })
+}
+
+fn run_probe_child(
+    candidate: usize,
+    probe_tokens: u64,
+    cache_slots: usize,
+    dtype: &str,
+) -> CpuAutotuneProbeResult {
+    let exe = match std::env::current_exe() {
+        Ok(path) => path,
+        Err(e) => {
+            return CpuAutotuneProbeResult::failure(
+                candidate,
+                probe_tokens,
+                cache_slots,
+                dtype,
+                format!("failed to resolve current executable: {e}"),
+            );
+        }
+    };
+    let mut cmd = Command::new(exe);
+    cmd.args(child_probe_args(probe_tokens, candidate))
+        .env("RAYON_NUM_THREADS", candidate.to_string())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let output = match cmd.output() {
+        Ok(output) => output,
+        Err(e) => {
+            return CpuAutotuneProbeResult::failure(
+                candidate,
+                probe_tokens,
+                cache_slots,
+                dtype,
+                format!("failed to spawn child probe: {e}"),
+            );
+        }
+    };
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    match parse_probe_stdout(&stdout) {
+        Ok(mut result) => {
+            result.candidate_threads = candidate;
+            if !output.status.success() && result.success {
+                result.success = false;
+                result.error = Some(format!("child exited with status {}", output.status));
+            }
+            result
+        }
+        Err(e) => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let mut msg = format!("failed to parse child probe JSON: {e}");
+            if !output.status.success() {
+                msg.push_str(&format!("; status={}", output.status));
+            }
+            let trimmed = stderr.trim();
+            if !trimmed.is_empty() {
+                msg.push_str("; stderr=");
+                msg.push_str(&trimmed.chars().take(600).collect::<String>());
+            }
+            CpuAutotuneProbeResult::failure(candidate, probe_tokens, cache_slots, dtype, msg)
+        }
+    }
+}
+
+fn parse_probe_stdout(stdout: &str) -> Result<CpuAutotuneProbeResult, serde_json::Error> {
+    let trimmed = stdout.trim();
+    if let Some(line) = trimmed
+        .lines()
+        .rev()
+        .map(str::trim)
+        .find(|line| line.starts_with('{'))
+    {
+        serde_json::from_str(line)
+    } else {
+        serde_json::from_str(trimmed)
+    }
+}
+
+fn child_probe_args(probe_tokens: u64, candidate: usize) -> Vec<OsString> {
+    let mut out = Vec::new();
+    let mut args = std::env::args_os().skip(1).peekable();
+    while let Some(arg) = args.next() {
+        if arg == OsStr::new("--autotune-rayon") {
+            continue;
+        }
+        if arg == OsStr::new("--autotune-tokens") {
+            let _ = args.next();
+            continue;
+        }
+        if os_arg_has_prefix(&arg, "--autotune-tokens=") {
+            continue;
+        }
+        if arg == OsStr::new("--autotune-candidates") {
+            let _ = args.next();
+            continue;
+        }
+        if os_arg_has_prefix(&arg, "--autotune-candidates=") {
+            continue;
+        }
+        if arg == OsStr::new("--tokens") {
+            let _ = args.next();
+            continue;
+        }
+        if os_arg_has_prefix(&arg, "--tokens=") {
+            continue;
+        }
+        if arg == OsStr::new("--rayon-autotune-probe") {
+            continue;
+        }
+        if arg == OsStr::new("--rayon-autotune-candidate") {
+            let _ = args.next();
+            continue;
+        }
+        if os_arg_has_prefix(&arg, "--rayon-autotune-candidate=") {
+            continue;
+        }
+        out.push(arg);
+    }
+    out.push(OsString::from("--tokens"));
+    out.push(OsString::from(probe_tokens.to_string()));
+    out.push(OsString::from("--rayon-autotune-probe"));
+    out.push(OsString::from("--rayon-autotune-candidate"));
+    out.push(OsString::from(candidate.to_string()));
+    out
+}
+
+fn os_arg_has_prefix(arg: &OsStr, prefix: &str) -> bool {
+    arg.to_str().is_some_and(|s| s.starts_with(prefix))
+}
+
+pub fn default_profile_dir() -> PathBuf {
+    if let Some(xdg) = std::env::var_os("XDG_CACHE_HOME") {
+        return PathBuf::from(xdg).join("mer").join("autotune");
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        return PathBuf::from(home)
+            .join(".cache")
+            .join("mer")
+            .join("autotune");
+    }
+    std::env::temp_dir().join("mer").join("autotune")
+}
+
+pub fn make_machine_fingerprint(logical: usize) -> String {
+    let cpu = cpu_model().unwrap_or_else(|| "unknown-cpu".to_string());
+    format!(
+        "{}-{}-logical{}-{}",
+        std::env::consts::OS,
+        std::env::consts::ARCH,
+        logical.max(1),
+        cpu
+    )
+}
+
+pub fn make_data_dir_fingerprint(path: &Path) -> String {
+    let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    let mut parts = vec![canonical.display().to_string()];
+    if let Ok(md) = std::fs::metadata(&canonical) {
+        parts.push(format!("mtime={:?}", md.modified().ok()));
+    }
+    stable_hash_hex(&parts.join("|"))
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn make_model_fingerprint(
+    data_dir: &Path,
+    num_experts: u32,
+    top_k: usize,
+    d_model: usize,
+    d_ff: usize,
+    expert_size: usize,
+    num_layers: u32,
+    dtype: &str,
+    packed_blob: Option<&Path>,
+    packed_manifest: Option<&Path>,
+) -> String {
+    let raw = format!(
+        "data={}|experts={}|top_k={}|d_model={}|d_ff={}|expert_size={}|layers={}|dtype={}|packed_blob={}|packed_manifest={}",
+        make_data_dir_fingerprint(data_dir),
+        num_experts,
+        top_k,
+        d_model,
+        d_ff,
+        expert_size,
+        num_layers,
+        dtype,
+        packed_blob
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|| "none".to_string()),
+        packed_manifest
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|| "none".to_string())
+    );
+    stable_hash_hex(&raw)
+}
+
+pub fn cpu_model() -> Option<String> {
+    #[cfg(target_os = "linux")]
+    {
+        let body = std::fs::read_to_string("/proc/cpuinfo").ok()?;
+        for line in body.lines() {
+            if let Some(rest) = line.strip_prefix("model name") {
+                let model = rest.split_once(':')?.1.trim();
+                if !model.is_empty() {
+                    return Some(model.to_string());
+                }
+            }
+        }
+        None
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let out = Command::new("sysctl")
+            .args(["-n", "machdep.cpu.brand_string"])
+            .output()
+            .ok()?;
+        let model = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        (!model.is_empty()).then_some(model)
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        None
+    }
+}
+
+pub fn stable_hash_hex(input: &str) -> String {
+    // FNV-1a 64-bit: small, deterministic, and good enough for cache-file
+    // names where collisions are inconvenient but not security-sensitive.
+    let mut hash = 0xcbf2_9ce4_8422_2325u64;
+    for byte in input.as_bytes() {
+        hash ^= *byte as u64;
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    format!("{hash:016x}")
+}
+
+fn unix_now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ok(candidate: usize, p50: u64, tps: f64) -> CpuAutotuneProbeResult {
+        CpuAutotuneProbeResult {
+            candidate_threads: candidate,
+            sustained_tps: Some(tps),
+            compute_p50_us: Some(p50),
+            compute_p95_us: Some(p50 + 1000),
+            hit_rate_pct: Some(95.0),
+            tokens: 64,
+            cache_slots: 124,
+            dtype: "q4_0".to_string(),
+            backend: Some("cpu".to_string()),
+            quant_path: Some("qmatmul-q4_0".to_string()),
+            success: true,
+            error: None,
+        }
+    }
+
+    #[test]
+    fn candidates_for_32_vcpus_cover_observed_fast_band() {
+        let candidates = candidate_thread_counts(32);
+        for expected in [24, 26, 27, 28, 29, 30, 31, 32] {
+            assert!(
+                candidates.contains(&expected),
+                "missing candidate {expected}: {candidates:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn selection_prefers_lowest_p50_then_highest_tps() {
+        let results = vec![
+            ok(28, 55_000, 12.0),
+            ok(29, 54_000, 11.0),
+            ok(30, 54_000, 13.0),
+        ];
+        let selected = select_best_candidate(&results).unwrap();
+        assert_eq!(selected.candidate_threads, 30);
+    }
+
+    #[test]
+    fn selection_ignores_failed_invalid_and_slow_when_fast_exists() {
+        let mut failed = ok(24, 40_000, 99.0);
+        failed.success = false;
+        let mut invalid = ok(26, 39_000, f64::NAN);
+        invalid.sustained_tps = Some(f64::NAN);
+        let results = vec![failed, invalid, ok(32, 98_000, 20.0), ok(30, 56_000, 12.0)];
+        let selected = select_best_candidate(&results).unwrap();
+        assert_eq!(selected.candidate_threads, 30);
+    }
+
+    #[test]
+    fn selection_uses_slow_results_when_all_candidates_are_slow() {
+        let results = vec![ok(31, 99_000, 11.0), ok(32, 97_000, 10.0)];
+        let selected = select_best_candidate(&results).unwrap();
+        assert_eq!(selected.candidate_threads, 32);
+    }
+
+    #[test]
+    fn profile_round_trips_json() {
+        let dir =
+            std::env::temp_dir().join(format!("mer-autotune-profile-test-{}", unix_now_secs()));
+        let key = CpuAutotuneKey {
+            machine_fingerprint: "machine".to_string(),
+            model_fingerprint: "model".to_string(),
+            data_dir_fingerprint: "data".to_string(),
+            dtype: "q4_0".to_string(),
+            cache_slots: 124,
+            backend: "cpu:rayon".to_string(),
+        };
+        let profile = CpuAutotuneProfile::new(&key, 32, 30, vec![ok(30, 55_000, 13.0)]);
+        let path = dir.join("profile.json");
+        profile.save(&path).unwrap();
+        let loaded = CpuAutotuneProfile::load(&path).unwrap();
+        assert!(loaded.matches_key(&key));
+        assert_eq!(loaded.selected_rayon_threads, 30);
+        assert_eq!(loaded.candidate_results.len(), 1);
+        let _ = std::fs::remove_file(path);
+        let _ = std::fs::remove_dir(dir);
+    }
+
+    #[test]
+    fn probe_stdout_parser_uses_last_json_line_after_logs() {
+        let stdout = "2026-07-08T00:00:00Z INFO child starting\n\
+                      {\"candidate_threads\":2,\"sustained_tps\":10.0,\"compute_p50_us\":5,\"compute_p95_us\":7,\"hit_rate_pct\":100.0,\"tokens\":2,\"cache_slots\":2,\"dtype\":\"f32\",\"backend\":\"cpu\",\"quant_path\":\"f32-candle\",\"success\":true,\"error\":null}\n";
+        let parsed = parse_probe_stdout(stdout).unwrap();
+        assert_eq!(parsed.candidate_threads, 2);
+        assert!(parsed.success);
+    }
+}

--- a/rust-engine/src/rayon_autotune.rs
+++ b/rust-engine/src/rayon_autotune.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
+use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use crate::numa::{format_cpulist, EffectiveCpuAffinity};
 
@@ -737,14 +738,51 @@ pub fn save_profile(
     key: &CpuAutotuneKey,
     profile: RayonAutotuneProfile,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    std::fs::create_dir_all(parent)?;
     let mut store = match std::fs::read_to_string(path) {
-        Ok(body) => serde_json::from_str::<RayonAutotuneProfileStore>(&body).unwrap_or_default(),
-        Err(_) => RayonAutotuneProfileStore::default(),
+        Ok(body) => serde_json::from_str::<RayonAutotuneProfileStore>(&body).map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "failed to parse existing Rayon autotune profile store {}: {e}; refusing to overwrite",
+                    path.display()
+                ),
+            )
+        })?,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => RayonAutotuneProfileStore::default(),
+        Err(e) => return Err(e.into()),
     };
     store.profiles.insert(key.cache_key(), profile);
-    let body = serde_json::to_string_pretty(&store)?;
-    std::fs::write(path, body)?;
-    Ok(())
+    let body = serde_json::to_vec_pretty(&store)?;
+    let file_name = path.file_name().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("profile path {} has no file name", path.display()),
+        )
+    })?;
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let tmp_path = parent.join(format!(
+        ".{}.{}.{}.tmp",
+        file_name.to_string_lossy(),
+        std::process::id(),
+        nonce
+    ));
+    let write_result = (|| -> Result<(), Box<dyn std::error::Error>> {
+        let mut tmp = std::fs::File::create(&tmp_path)?;
+        tmp.write_all(&body)?;
+        tmp.sync_all()?;
+        drop(tmp);
+        std::fs::rename(&tmp_path, path)?;
+        Ok(())
+    })();
+    if write_result.is_err() {
+        let _ = std::fs::remove_file(&tmp_path);
+    }
+    write_result
 }
 
 pub fn percentile_ms(sorted_us: &[u64], q: f64) -> f64 {
@@ -961,6 +999,52 @@ mod tests {
         let profile: RayonAutotuneProfile = serde_json::from_str(legacy).unwrap();
         assert_eq!(profile.confidence, RayonAutotuneConfidence::Low);
         assert!(!profile.reusable_by_default());
+    }
+
+    #[test]
+    fn save_profile_refuses_to_clobber_unparseable_store() {
+        let dir = std::env::temp_dir().join(format!(
+            "mer-rayon-autotune-save-test-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("profile.json");
+        std::fs::write(&path, "{not-json").unwrap();
+        let key = CpuAutotuneKey {
+            machine_fingerprint: "machine".to_string(),
+            model_fingerprint: "model".to_string(),
+            backend_fingerprint: "backend".to_string(),
+        };
+        let probes = vec![probe(25, 1, 58.0, 61.0, 70.0, 17.0)];
+        let candidates = summarize_candidate_results(&[25], 1, &probes, 80.0, 120.0);
+        let profile = RayonAutotuneProfile {
+            threads: 25,
+            effective_cpu_mask: Some((0..25).collect()),
+            effective_cpu_mask_display: Some("0-24".to_string()),
+            logical_cores: 25,
+            repeats: 1,
+            p50_ms: 58.0,
+            p95_ms: 61.0,
+            p99_ms: Some(70.0),
+            sustained_tps: 17.0,
+            median_p50_ms: 58.0,
+            worst_p95_ms: 61.0,
+            worst_p99_ms: Some(70.0),
+            median_sustained_tps: 17.0,
+            confidence: RayonAutotuneConfidence::Low,
+            selection_reason: "test".to_string(),
+            candidate_results: candidates,
+            probe_results: probes,
+        };
+
+        assert!(save_profile(&path, &key, profile).is_err());
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "{not-json");
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_dir(&dir);
     }
 
     #[test]

--- a/rust-engine/src/rayon_autotune.rs
+++ b/rust-engine/src/rayon_autotune.rs
@@ -13,8 +13,9 @@ use std::process::{Command, Stdio};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 pub const PROFILE_VERSION: u32 = 1;
-pub const DEFAULT_PROBE_TOKENS: u64 = 96;
-pub const SLOW_REGIME_P50_US: u64 = 80_000;
+pub const DEFAULT_PROBE_TOKENS: u64 = 256;
+pub const SLOW_REGIME_COMPUTE_US: u64 = 80_000;
+pub const SELECTION_RULE: &str = "prefer candidates with compute_p95_us below slow threshold; then lowest compute_p50_us; tie-break highest sustained_tps; ignore failed/invalid probes";
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CpuAutotuneKey {
@@ -83,9 +84,7 @@ impl CpuAutotuneProfile {
             dtype: key.dtype.clone(),
             cache_slots: key.cache_slots,
             backend: key.backend.clone(),
-            selection_rule:
-                "lowest compute_p50_us; tie-break highest sustained_tps; ignore failed/invalid probes; prefer sub-80000us p50 when any candidate reaches it"
-                    .to_string(),
+            selection_rule: SELECTION_RULE.to_string(),
             created_at: format!("unix:{created_at_unix_secs}"),
             created_at_unix_secs,
         }
@@ -202,9 +201,9 @@ pub fn select_best_candidate(
     }
     if valid
         .iter()
-        .any(|r| r.compute_p50_us.unwrap_or(u64::MAX) < SLOW_REGIME_P50_US)
+        .any(|r| r.compute_p95_us.unwrap_or(u64::MAX) < SLOW_REGIME_COMPUTE_US)
     {
-        valid.retain(|r| r.compute_p50_us.unwrap_or(u64::MAX) < SLOW_REGIME_P50_US);
+        valid.retain(|r| r.compute_p95_us.unwrap_or(u64::MAX) < SLOW_REGIME_COMPUTE_US);
     }
     valid.into_iter().min_by(|a, b| {
         let p50_cmp = a.compute_p50_us.cmp(&b.compute_p50_us);
@@ -506,11 +505,15 @@ mod tests {
     use super::*;
 
     fn ok(candidate: usize, p50: u64, tps: f64) -> CpuAutotuneProbeResult {
+        ok_with_p95(candidate, p50, p50 + 1000, tps)
+    }
+
+    fn ok_with_p95(candidate: usize, p50: u64, p95: u64, tps: f64) -> CpuAutotuneProbeResult {
         CpuAutotuneProbeResult {
             candidate_threads: candidate,
             sustained_tps: Some(tps),
             compute_p50_us: Some(p50),
-            compute_p95_us: Some(p50 + 1000),
+            compute_p95_us: Some(p95),
             hit_rate_pct: Some(95.0),
             tokens: 64,
             cache_slots: 124,
@@ -534,7 +537,17 @@ mod tests {
     }
 
     #[test]
-    fn selection_prefers_lowest_p50_then_highest_tps() {
+    fn selection_prefers_stable_p95_over_slightly_lower_p50() {
+        let results = vec![
+            ok_with_p95(31, 55_711, 99_775, 12.0),
+            ok_with_p95(24, 56_063, 59_007, 11.0),
+        ];
+        let selected = select_best_candidate(&results).unwrap();
+        assert_eq!(selected.candidate_threads, 24);
+    }
+
+    #[test]
+    fn stable_selection_prefers_lowest_p50_then_highest_tps() {
         let results = vec![
             ok(28, 55_000, 12.0),
             ok(29, 54_000, 11.0),
@@ -545,21 +558,25 @@ mod tests {
     }
 
     #[test]
-    fn selection_ignores_failed_invalid_and_slow_when_fast_exists() {
-        let mut failed = ok(24, 40_000, 99.0);
+    fn selection_ignores_failed_invalid_candidates() {
+        let mut failed = ok_with_p95(24, 40_000, 41_000, 99.0);
         failed.success = false;
         let mut invalid = ok(26, 39_000, f64::NAN);
         invalid.sustained_tps = Some(f64::NAN);
-        let results = vec![failed, invalid, ok(32, 98_000, 20.0), ok(30, 56_000, 12.0)];
+        let results = vec![failed, invalid, ok(30, 56_000, 12.0)];
         let selected = select_best_candidate(&results).unwrap();
         assert_eq!(selected.candidate_threads, 30);
     }
 
     #[test]
-    fn selection_uses_slow_results_when_all_candidates_are_slow() {
-        let results = vec![ok(31, 99_000, 11.0), ok(32, 97_000, 10.0)];
+    fn selection_falls_back_to_p50_and_tps_when_all_candidates_have_slow_p95() {
+        let results = vec![
+            ok_with_p95(24, 56_063, 90_000, 15.0),
+            ok_with_p95(31, 55_711, 99_775, 9.0),
+            ok_with_p95(30, 55_711, 95_000, 11.0),
+        ];
         let selected = select_best_candidate(&results).unwrap();
-        assert_eq!(selected.candidate_threads, 32);
+        assert_eq!(selected.candidate_threads, 30);
     }
 
     #[test]
@@ -581,6 +598,7 @@ mod tests {
         assert!(loaded.matches_key(&key));
         assert_eq!(loaded.selected_rayon_threads, 30);
         assert_eq!(loaded.candidate_results.len(), 1);
+        assert_eq!(loaded.selection_rule, SELECTION_RULE);
         let _ = std::fs::remove_file(path);
         let _ = std::fs::remove_dir(dir);
     }

--- a/rust-engine/src/rayon_autotune.rs
+++ b/rust-engine/src/rayon_autotune.rs
@@ -1,616 +1,318 @@
-//! CPU/Rayon thread-count autotuning.
-//!
-//! Rayon can build its global pool only once per process, so the tuner runs
-//! each candidate in a child process with `RAYON_NUM_THREADS=<candidate>`.
-//! The parent process never touches Rayon during probing; after it selects a
-//! winner it initialises the global pool exactly once for the real run.
-
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeSet;
-use std::ffi::{OsStr, OsString};
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
-pub const PROFILE_VERSION: u32 = 1;
-pub const DEFAULT_PROBE_TOKENS: u64 = 256;
-pub const SLOW_REGIME_COMPUTE_US: u64 = 80_000;
-pub const SELECTION_RULE: &str = "prefer candidates with compute_p95_us below slow threshold; then lowest compute_p50_us; tie-break highest sustained_tps; ignore failed/invalid probes";
+use crate::numa::{format_cpulist, EffectiveCpuAffinity};
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+pub const AUTOTUNE_PROBE_ENV: &str = "MER_RAYON_AUTOTUNE_PROBE";
+pub const DEFAULT_AUTOTUNE_TOKENS: u64 = 2_000;
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct CpuAutotuneKey {
     pub machine_fingerprint: String,
     pub model_fingerprint: String,
-    pub data_dir_fingerprint: String,
-    pub dtype: String,
-    pub cache_slots: usize,
-    pub backend: String,
+    pub backend_fingerprint: String,
 }
 
 impl CpuAutotuneKey {
-    pub fn profile_path(&self) -> PathBuf {
-        default_profile_dir().join(format!("{}.json", self.stable_id()))
-    }
-
-    pub fn stable_id(&self) -> String {
-        stable_hash_hex(&format!(
-            "v{}|machine={}|model={}|data={}|dtype={}|cache={}|backend={}",
-            PROFILE_VERSION,
-            self.machine_fingerprint,
-            self.model_fingerprint,
-            self.data_dir_fingerprint,
-            self.dtype,
-            self.cache_slots,
-            self.backend
-        ))
+    pub fn cache_key(&self) -> String {
+        format!(
+            "{}|{}|{}",
+            self.machine_fingerprint, self.model_fingerprint, self.backend_fingerprint
+        )
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct CpuAutotuneProfile {
-    pub version: u32,
-    pub selected_rayon_threads: usize,
-    pub candidate_results: Vec<CpuAutotuneProbeResult>,
-    pub logical_cores: usize,
-    pub cpu_model: Option<String>,
-    pub machine_fingerprint: String,
-    pub model_fingerprint: String,
-    pub data_dir_fingerprint: String,
-    pub dtype: String,
-    pub cache_slots: usize,
-    pub backend: String,
-    pub selection_rule: String,
-    pub created_at: String,
-    pub created_at_unix_secs: u64,
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CpuAutotuneMachine {
+    pub os: String,
+    pub arch: String,
+    pub cpu_features: Vec<&'static str>,
+    pub available_logical_cores: usize,
+    pub effective_cpu_mask: Option<Vec<usize>>,
 }
 
-impl CpuAutotuneProfile {
-    pub fn new(
-        key: &CpuAutotuneKey,
-        logical_cores: usize,
-        selected_rayon_threads: usize,
-        candidate_results: Vec<CpuAutotuneProbeResult>,
-    ) -> Self {
-        let created_at_unix_secs = unix_now_secs();
+impl CpuAutotuneMachine {
+    pub fn from_effective_affinity(affinity: &EffectiveCpuAffinity) -> Self {
         Self {
-            version: PROFILE_VERSION,
-            selected_rayon_threads,
-            candidate_results,
-            logical_cores,
-            cpu_model: cpu_model(),
-            machine_fingerprint: key.machine_fingerprint.clone(),
-            model_fingerprint: key.model_fingerprint.clone(),
-            data_dir_fingerprint: key.data_dir_fingerprint.clone(),
-            dtype: key.dtype.clone(),
-            cache_slots: key.cache_slots,
-            backend: key.backend.clone(),
-            selection_rule: SELECTION_RULE.to_string(),
-            created_at: format!("unix:{created_at_unix_secs}"),
-            created_at_unix_secs,
+            os: std::env::consts::OS.to_string(),
+            arch: std::env::consts::ARCH.to_string(),
+            cpu_features: detected_cpu_features(),
+            available_logical_cores: affinity.logical_cores,
+            effective_cpu_mask: affinity.cpus.clone(),
         }
     }
 
-    pub fn matches_key(&self, key: &CpuAutotuneKey) -> bool {
-        self.version == PROFILE_VERSION
-            && self.machine_fingerprint == key.machine_fingerprint
-            && self.model_fingerprint == key.model_fingerprint
-            && self.data_dir_fingerprint == key.data_dir_fingerprint
-            && self.dtype == key.dtype
-            && self.cache_slots == key.cache_slots
-            && self.backend == key.backend
+    pub fn fingerprint(&self) -> String {
+        let mask = self
+            .effective_cpu_mask
+            .as_deref()
+            .map(format_cpulist)
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| "unavailable".to_string());
+        let features = if self.cpu_features.is_empty() {
+            "none".to_string()
+        } else {
+            self.cpu_features.join("+")
+        };
+        format!(
+            "os={};arch={};features={};logical={};affinity={}",
+            self.os, self.arch, features, self.available_logical_cores, mask
+        )
+    }
+}
+
+pub fn machine_fingerprint_from_affinity(affinity: &EffectiveCpuAffinity) -> String {
+    CpuAutotuneMachine::from_effective_affinity(affinity).fingerprint()
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+fn detected_cpu_features() -> Vec<&'static str> {
+    let mut features = Vec::new();
+    if std::is_x86_feature_detected!("avx2") {
+        features.push("avx2");
+    }
+    if std::is_x86_feature_detected!("avx512f") {
+        features.push("avx512f");
+    }
+    if std::is_x86_feature_detected!("fma") {
+        features.push("fma");
+    }
+    if std::is_x86_feature_detected!("amx-tile") {
+        features.push("amx-tile");
+    }
+    features
+}
+
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+fn detected_cpu_features() -> Vec<&'static str> {
+    Vec::new()
+}
+
+pub fn default_thread_candidates(effective_logical_cores: usize) -> Vec<usize> {
+    let n = effective_logical_cores.max(1);
+    let mut candidates = BTreeSet::new();
+    candidates.insert(1);
+    candidates.insert(n);
+    candidates.insert(crate::parallel::default_compute_threads(n));
+
+    for divisor in [2usize, 3, 4] {
+        let lower = (n / divisor).max(1);
+        let upper = n.div_ceil(divisor).max(1);
+        candidates.insert(lower);
+        candidates.insert(upper);
     }
 
-    pub fn save(&self, path: &Path) -> Result<(), Box<dyn std::error::Error>> {
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
+    for delta in [1usize, 2, 4, 8] {
+        if n > delta {
+            candidates.insert(n - delta);
         }
-        let json = serde_json::to_string_pretty(self)?;
-        std::fs::write(path, json)?;
-        Ok(())
     }
 
-    pub fn load(path: &Path) -> Result<Self, Box<dyn std::error::Error>> {
-        let body = std::fs::read_to_string(path)?;
-        Ok(serde_json::from_str(&body)?)
-    }
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct CpuAutotuneProbeResult {
-    pub candidate_threads: usize,
-    pub sustained_tps: Option<f64>,
-    pub compute_p50_us: Option<u64>,
-    pub compute_p95_us: Option<u64>,
-    pub hit_rate_pct: Option<f64>,
-    pub tokens: u64,
-    pub cache_slots: usize,
-    pub dtype: String,
-    pub backend: Option<String>,
-    pub quant_path: Option<String>,
-    pub success: bool,
-    pub error: Option<String>,
-}
-
-impl CpuAutotuneProbeResult {
-    pub fn failure(
-        candidate_threads: usize,
-        tokens: u64,
-        cache_slots: usize,
-        dtype: impl Into<String>,
-        error: impl Into<String>,
-    ) -> Self {
-        Self {
-            candidate_threads,
-            sustained_tps: None,
-            compute_p50_us: None,
-            compute_p95_us: None,
-            hit_rate_pct: None,
-            tokens,
-            cache_slots,
-            dtype: dtype.into(),
-            backend: None,
-            quant_path: None,
-            success: false,
-            error: Some(error.into()),
+    let default = crate::parallel::default_compute_threads(n);
+    for delta in [1usize, 2] {
+        if default > delta {
+            candidates.insert(default - delta);
+        }
+        let plus = default.saturating_add(delta);
+        if plus <= n {
+            candidates.insert(plus);
         }
     }
 
-    fn valid_for_selection(&self) -> bool {
-        self.success
-            && self.compute_p50_us.is_some()
-            && self
-                .sustained_tps
-                .is_some_and(|v| v.is_finite() && v >= 0.0)
-    }
+    candidates.into_iter().filter(|&c| c <= n).collect()
 }
 
-#[derive(Clone, Debug)]
-pub struct CpuAutotuneRun {
-    pub profile: CpuAutotuneProfile,
-    pub profile_path: PathBuf,
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+pub struct RayonAutotuneProbeResult {
+    pub threads: usize,
+    pub valid: bool,
+    pub p50_ms: f64,
+    pub p95_ms: f64,
+    pub sustained_tps: f64,
 }
 
-/// Candidate window around the existing smart fallback, plus the full visible
-/// core count. For a 32-vCPU VM this returns 24..=32, covering the previously
-/// observed fast band without assuming it is universal.
-pub fn candidate_thread_counts(logical: usize) -> Vec<usize> {
-    let logical = logical.max(1);
-    let fallback = crate::parallel::default_compute_threads(logical);
-    let radius = match logical {
-        0..=8 => 2,
-        9..=15 => 3,
-        16..=31 => 4,
-        _ => 6,
-    };
-    let lo = fallback.saturating_sub(radius).max(1);
-    let hi = fallback.saturating_add(radius).min(logical);
-    let mut set = BTreeSet::new();
-    set.extend(lo..=hi);
-    set.insert(fallback.min(logical).max(1));
-    set.insert(logical);
-    set.into_iter().collect()
-}
-
-pub fn select_best_candidate(
-    results: &[CpuAutotuneProbeResult],
-) -> Option<&CpuAutotuneProbeResult> {
-    let mut valid: Vec<&CpuAutotuneProbeResult> =
-        results.iter().filter(|r| r.valid_for_selection()).collect();
+pub fn select_best_probe(
+    probes: &[RayonAutotuneProbeResult],
+    slow_p95_threshold_ms: f64,
+) -> Option<RayonAutotuneProbeResult> {
+    let mut valid: Vec<RayonAutotuneProbeResult> =
+        probes.iter().copied().filter(|p| p.valid).collect();
     if valid.is_empty() {
         return None;
     }
-    if valid
+    let under_threshold: Vec<RayonAutotuneProbeResult> = valid
         .iter()
-        .any(|r| r.compute_p95_us.unwrap_or(u64::MAX) < SLOW_REGIME_COMPUTE_US)
-    {
-        valid.retain(|r| r.compute_p95_us.unwrap_or(u64::MAX) < SLOW_REGIME_COMPUTE_US);
+        .copied()
+        .filter(|p| p.p95_ms <= slow_p95_threshold_ms)
+        .collect();
+    if !under_threshold.is_empty() {
+        valid = under_threshold;
     }
-    valid.into_iter().min_by(|a, b| {
-        let p50_cmp = a.compute_p50_us.cmp(&b.compute_p50_us);
-        if p50_cmp != std::cmp::Ordering::Equal {
-            return p50_cmp;
-        }
-        let a_tps = a.sustained_tps.unwrap_or(0.0);
-        let b_tps = b.sustained_tps.unwrap_or(0.0);
-        b_tps
-            .partial_cmp(&a_tps)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    })
+    valid.sort_by(|a, b| {
+        a.p50_ms
+            .total_cmp(&b.p50_ms)
+            .then_with(|| b.sustained_tps.total_cmp(&a.sustained_tps))
+            .then_with(|| a.threads.cmp(&b.threads))
+    });
+    valid.into_iter().next()
 }
 
-pub fn load_matching_profile(key: &CpuAutotuneKey) -> Option<(PathBuf, CpuAutotuneProfile)> {
-    let path = key.profile_path();
-    let profile = CpuAutotuneProfile::load(&path).ok()?;
-    profile.matches_key(key).then_some((path, profile))
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ProgressWatchdogConfig {
+    pub timeout: Option<Duration>,
 }
 
-pub fn run_cpu_autotune(
+impl ProgressWatchdogConfig {
+    pub const fn disabled() -> Self {
+        Self { timeout: None }
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.timeout.is_some()
+    }
+}
+
+pub fn normalize_progress_timeout_secs(
+    cli: Option<u64>,
+    config: Option<u64>,
+) -> ProgressWatchdogConfig {
+    match cli.or(config) {
+        Some(0) | None => ProgressWatchdogConfig::disabled(),
+        Some(secs) => ProgressWatchdogConfig {
+            timeout: Some(Duration::from_secs(secs)),
+        },
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RayonAutotuneProfile {
+    pub threads: usize,
+    pub p50_ms: f64,
+    pub p95_ms: f64,
+    pub sustained_tps: f64,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct RayonAutotuneProfileStore {
+    profiles: BTreeMap<String, RayonAutotuneProfile>,
+}
+
+pub fn default_profile_path(data_dir: &Path) -> PathBuf {
+    data_dir.join(".mer-rayon-autotune.json")
+}
+
+pub fn load_profile(path: &Path, key: &CpuAutotuneKey) -> Option<RayonAutotuneProfile> {
+    let body = std::fs::read_to_string(path).ok()?;
+    let store: RayonAutotuneProfileStore = serde_json::from_str(&body).ok()?;
+    store.profiles.get(&key.cache_key()).cloned()
+}
+
+pub fn save_profile(
+    path: &Path,
     key: &CpuAutotuneKey,
-    logical: usize,
-    candidates: &[usize],
-    probe_tokens: u64,
-    cache_slots: usize,
-    dtype: &str,
-) -> Result<CpuAutotuneRun, Box<dyn std::error::Error>> {
-    let mut results = Vec::new();
-    let probe_tokens = probe_tokens.max(1);
-    for &candidate in candidates {
-        results.push(run_probe_child(candidate, probe_tokens, cache_slots, dtype));
-    }
-    let selected = select_best_candidate(&results).ok_or_else(|| {
-        let failures = results
-            .iter()
-            .filter_map(|r| r.error.as_deref())
-            .take(5)
-            .collect::<Vec<_>>()
-            .join("; ");
-        if failures.is_empty() {
-            "CPU/Rayon autotune produced no valid child probe results".to_string()
-        } else {
-            format!("CPU/Rayon autotune produced no valid child probe results: {failures}")
-        }
-    })?;
-    let profile = CpuAutotuneProfile::new(key, logical, selected.candidate_threads, results);
-    let profile_path = key.profile_path();
-    profile.save(&profile_path)?;
-    Ok(CpuAutotuneRun {
-        profile,
-        profile_path,
-    })
-}
-
-fn run_probe_child(
-    candidate: usize,
-    probe_tokens: u64,
-    cache_slots: usize,
-    dtype: &str,
-) -> CpuAutotuneProbeResult {
-    let exe = match std::env::current_exe() {
-        Ok(path) => path,
-        Err(e) => {
-            return CpuAutotuneProbeResult::failure(
-                candidate,
-                probe_tokens,
-                cache_slots,
-                dtype,
-                format!("failed to resolve current executable: {e}"),
-            );
-        }
+    profile: RayonAutotuneProfile,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut store = match std::fs::read_to_string(path) {
+        Ok(body) => serde_json::from_str::<RayonAutotuneProfileStore>(&body).unwrap_or_default(),
+        Err(_) => RayonAutotuneProfileStore::default(),
     };
-    let mut cmd = Command::new(exe);
-    cmd.args(child_probe_args(probe_tokens, candidate))
-        .env("RAYON_NUM_THREADS", candidate.to_string())
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-    let output = match cmd.output() {
-        Ok(output) => output,
-        Err(e) => {
-            return CpuAutotuneProbeResult::failure(
-                candidate,
-                probe_tokens,
-                cache_slots,
-                dtype,
-                format!("failed to spawn child probe: {e}"),
-            );
-        }
-    };
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    match parse_probe_stdout(&stdout) {
-        Ok(mut result) => {
-            result.candidate_threads = candidate;
-            if !output.status.success() && result.success {
-                result.success = false;
-                result.error = Some(format!("child exited with status {}", output.status));
-            }
-            result
-        }
-        Err(e) => {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            let mut msg = format!("failed to parse child probe JSON: {e}");
-            if !output.status.success() {
-                msg.push_str(&format!("; status={}", output.status));
-            }
-            let trimmed = stderr.trim();
-            if !trimmed.is_empty() {
-                msg.push_str("; stderr=");
-                msg.push_str(&trimmed.chars().take(600).collect::<String>());
-            }
-            CpuAutotuneProbeResult::failure(candidate, probe_tokens, cache_slots, dtype, msg)
-        }
-    }
+    store.profiles.insert(key.cache_key(), profile);
+    let body = serde_json::to_string_pretty(&store)?;
+    std::fs::write(path, body)?;
+    Ok(())
 }
 
-fn parse_probe_stdout(stdout: &str) -> Result<CpuAutotuneProbeResult, serde_json::Error> {
-    let trimmed = stdout.trim();
-    if let Some(line) = trimmed
-        .lines()
-        .rev()
-        .map(str::trim)
-        .find(|line| line.starts_with('{'))
-    {
-        serde_json::from_str(line)
-    } else {
-        serde_json::from_str(trimmed)
+pub fn percentile_ms(sorted_us: &[u64], q: f64) -> f64 {
+    if sorted_us.is_empty() {
+        return 0.0;
     }
-}
-
-fn child_probe_args(probe_tokens: u64, candidate: usize) -> Vec<OsString> {
-    let mut out = Vec::new();
-    let mut args = std::env::args_os().skip(1).peekable();
-    while let Some(arg) = args.next() {
-        if arg == OsStr::new("--autotune-rayon") {
-            continue;
-        }
-        if arg == OsStr::new("--autotune-tokens") {
-            let _ = args.next();
-            continue;
-        }
-        if os_arg_has_prefix(&arg, "--autotune-tokens=") {
-            continue;
-        }
-        if arg == OsStr::new("--autotune-candidates") {
-            let _ = args.next();
-            continue;
-        }
-        if os_arg_has_prefix(&arg, "--autotune-candidates=") {
-            continue;
-        }
-        if arg == OsStr::new("--tokens") {
-            let _ = args.next();
-            continue;
-        }
-        if os_arg_has_prefix(&arg, "--tokens=") {
-            continue;
-        }
-        if arg == OsStr::new("--rayon-autotune-probe") {
-            continue;
-        }
-        if arg == OsStr::new("--rayon-autotune-candidate") {
-            let _ = args.next();
-            continue;
-        }
-        if os_arg_has_prefix(&arg, "--rayon-autotune-candidate=") {
-            continue;
-        }
-        out.push(arg);
-    }
-    out.push(OsString::from("--tokens"));
-    out.push(OsString::from(probe_tokens.to_string()));
-    out.push(OsString::from("--rayon-autotune-probe"));
-    out.push(OsString::from("--rayon-autotune-candidate"));
-    out.push(OsString::from(candidate.to_string()));
-    out
-}
-
-fn os_arg_has_prefix(arg: &OsStr, prefix: &str) -> bool {
-    arg.to_str().is_some_and(|s| s.starts_with(prefix))
-}
-
-pub fn default_profile_dir() -> PathBuf {
-    if let Some(xdg) = std::env::var_os("XDG_CACHE_HOME") {
-        return PathBuf::from(xdg).join("mer").join("autotune");
-    }
-    if let Some(home) = std::env::var_os("HOME") {
-        return PathBuf::from(home)
-            .join(".cache")
-            .join("mer")
-            .join("autotune");
-    }
-    std::env::temp_dir().join("mer").join("autotune")
-}
-
-pub fn make_machine_fingerprint(logical: usize) -> String {
-    let cpu = cpu_model().unwrap_or_else(|| "unknown-cpu".to_string());
-    let affinity = crate::numa::current_affinity_cpulist().unwrap_or_else(|| "unknown".into());
-    format!(
-        "{}-{}-logical{}-affinity{}-{}",
-        std::env::consts::OS,
-        std::env::consts::ARCH,
-        logical.max(1),
-        affinity,
-        cpu
-    )
-}
-
-pub fn make_data_dir_fingerprint(path: &Path) -> String {
-    let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
-    let mut parts = vec![canonical.display().to_string()];
-    if let Ok(md) = std::fs::metadata(&canonical) {
-        parts.push(format!("mtime={:?}", md.modified().ok()));
-    }
-    stable_hash_hex(&parts.join("|"))
-}
-
-#[allow(clippy::too_many_arguments)]
-pub fn make_model_fingerprint(
-    data_dir: &Path,
-    num_experts: u32,
-    top_k: usize,
-    d_model: usize,
-    d_ff: usize,
-    expert_size: usize,
-    num_layers: u32,
-    dtype: &str,
-    packed_blob: Option<&Path>,
-    packed_manifest: Option<&Path>,
-) -> String {
-    let raw = format!(
-        "data={}|experts={}|top_k={}|d_model={}|d_ff={}|expert_size={}|layers={}|dtype={}|packed_blob={}|packed_manifest={}",
-        make_data_dir_fingerprint(data_dir),
-        num_experts,
-        top_k,
-        d_model,
-        d_ff,
-        expert_size,
-        num_layers,
-        dtype,
-        packed_blob
-            .map(|p| p.display().to_string())
-            .unwrap_or_else(|| "none".to_string()),
-        packed_manifest
-            .map(|p| p.display().to_string())
-            .unwrap_or_else(|| "none".to_string())
-    );
-    stable_hash_hex(&raw)
-}
-
-pub fn cpu_model() -> Option<String> {
-    #[cfg(target_os = "linux")]
-    {
-        let body = std::fs::read_to_string("/proc/cpuinfo").ok()?;
-        for line in body.lines() {
-            if let Some(rest) = line.strip_prefix("model name") {
-                let model = rest.split_once(':')?.1.trim();
-                if !model.is_empty() {
-                    return Some(model.to_string());
-                }
-            }
-        }
-        None
-    }
-    #[cfg(target_os = "macos")]
-    {
-        let out = Command::new("sysctl")
-            .args(["-n", "machdep.cpu.brand_string"])
-            .output()
-            .ok()?;
-        let model = String::from_utf8_lossy(&out.stdout).trim().to_string();
-        (!model.is_empty()).then_some(model)
-    }
-    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
-    {
-        None
-    }
-}
-
-pub fn stable_hash_hex(input: &str) -> String {
-    // FNV-1a 64-bit: small, deterministic, and good enough for cache-file
-    // names where collisions are inconvenient but not security-sensitive.
-    let mut hash = 0xcbf2_9ce4_8422_2325u64;
-    for byte in input.as_bytes() {
-        hash ^= *byte as u64;
-        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
-    }
-    format!("{hash:016x}")
-}
-
-fn unix_now_secs() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0)
+    let q = q.clamp(0.0, 1.0);
+    let idx = ((sorted_us.len() - 1) as f64 * q).round() as usize;
+    sorted_us[idx] as f64 / 1_000.0
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn ok(candidate: usize, p50: u64, tps: f64) -> CpuAutotuneProbeResult {
-        ok_with_p95(candidate, p50, p50 + 1000, tps)
-    }
-
-    fn ok_with_p95(candidate: usize, p50: u64, p95: u64, tps: f64) -> CpuAutotuneProbeResult {
-        CpuAutotuneProbeResult {
-            candidate_threads: candidate,
-            sustained_tps: Some(tps),
-            compute_p50_us: Some(p50),
-            compute_p95_us: Some(p95),
-            hit_rate_pct: Some(95.0),
-            tokens: 64,
-            cache_slots: 124,
-            dtype: "q4_0".to_string(),
-            backend: Some("cpu".to_string()),
-            quant_path: Some("qmatmul-q4_0".to_string()),
-            success: true,
-            error: None,
-        }
-    }
+    use crate::numa::EffectiveCpuAffinity;
 
     #[test]
-    fn candidates_for_32_vcpus_cover_observed_fast_band() {
-        let candidates = candidate_thread_counts(32);
-        for expected in [24, 26, 27, 28, 29, 30, 31, 32] {
-            assert!(
-                candidates.contains(&expected),
-                "missing candidate {expected}: {candidates:?}"
-            );
-        }
-    }
-
-    #[test]
-    fn selection_prefers_stable_p95_over_slightly_lower_p50() {
-        let results = vec![
-            ok_with_p95(31, 55_711, 99_775, 12.0),
-            ok_with_p95(24, 56_063, 59_007, 11.0),
-        ];
-        let selected = select_best_candidate(&results).unwrap();
-        assert_eq!(selected.candidate_threads, 24);
-    }
-
-    #[test]
-    fn stable_selection_prefers_lowest_p50_then_highest_tps() {
-        let results = vec![
-            ok(28, 55_000, 12.0),
-            ok(29, 54_000, 11.0),
-            ok(30, 54_000, 13.0),
-        ];
-        let selected = select_best_candidate(&results).unwrap();
-        assert_eq!(selected.candidate_threads, 30);
-    }
-
-    #[test]
-    fn selection_ignores_failed_invalid_candidates() {
-        let mut failed = ok_with_p95(24, 40_000, 41_000, 99.0);
-        failed.success = false;
-        let mut invalid = ok(26, 39_000, f64::NAN);
-        invalid.sustained_tps = Some(f64::NAN);
-        let results = vec![failed, invalid, ok(30, 56_000, 12.0)];
-        let selected = select_best_candidate(&results).unwrap();
-        assert_eq!(selected.candidate_threads, 30);
-    }
-
-    #[test]
-    fn selection_falls_back_to_p50_and_tps_when_all_candidates_have_slow_p95() {
-        let results = vec![
-            ok_with_p95(24, 56_063, 90_000, 15.0),
-            ok_with_p95(31, 55_711, 99_775, 9.0),
-            ok_with_p95(30, 55_711, 95_000, 11.0),
-        ];
-        let selected = select_best_candidate(&results).unwrap();
-        assert_eq!(selected.candidate_threads, 30);
-    }
-
-    #[test]
-    fn profile_round_trips_json() {
-        let dir =
-            std::env::temp_dir().join(format!("mer-autotune-profile-test-{}", unix_now_secs()));
-        let key = CpuAutotuneKey {
-            machine_fingerprint: "machine".to_string(),
-            model_fingerprint: "model".to_string(),
-            data_dir_fingerprint: "data".to_string(),
-            dtype: "q4_0".to_string(),
-            cache_slots: 124,
-            backend: "cpu:rayon".to_string(),
+    fn fingerprint_differs_for_different_effective_masks() {
+        let a = EffectiveCpuAffinity {
+            cpus: Some((0..25).collect()),
+            logical_cores: 25,
+            display: "0-24".to_string(),
         };
-        let profile = CpuAutotuneProfile::new(&key, 32, 30, vec![ok(30, 55_000, 13.0)]);
-        let path = dir.join("profile.json");
-        profile.save(&path).unwrap();
-        let loaded = CpuAutotuneProfile::load(&path).unwrap();
-        assert!(loaded.matches_key(&key));
-        assert_eq!(loaded.selected_rayon_threads, 30);
-        assert_eq!(loaded.candidate_results.len(), 1);
-        assert_eq!(loaded.selection_rule, SELECTION_RULE);
-        let _ = std::fs::remove_file(path);
-        let _ = std::fs::remove_dir(dir);
+        let b = EffectiveCpuAffinity {
+            cpus: Some((0..16).collect()),
+            logical_cores: 16,
+            display: "0-15".to_string(),
+        };
+        assert_ne!(
+            machine_fingerprint_from_affinity(&a),
+            machine_fingerprint_from_affinity(&b)
+        );
     }
 
     #[test]
-    fn probe_stdout_parser_uses_last_json_line_after_logs() {
-        let stdout = "2026-07-08T00:00:00Z INFO child starting\n\
-                      {\"candidate_threads\":2,\"sustained_tps\":10.0,\"compute_p50_us\":5,\"compute_p95_us\":7,\"hit_rate_pct\":100.0,\"tokens\":2,\"cache_slots\":2,\"dtype\":\"f32\",\"backend\":\"cpu\",\"quant_path\":\"f32-candle\",\"success\":true,\"error\":null}\n";
-        let parsed = parse_probe_stdout(stdout).unwrap();
-        assert_eq!(parsed.candidate_threads, 2);
-        assert!(parsed.success);
+    fn fingerprint_separates_unknown_affinity_from_known_mask() {
+        let unknown = EffectiveCpuAffinity {
+            cpus: None,
+            logical_cores: 25,
+            display: "unavailable".to_string(),
+        };
+        let masked = EffectiveCpuAffinity {
+            cpus: Some((0..25).collect()),
+            logical_cores: 25,
+            display: "0-24".to_string(),
+        };
+        assert_ne!(
+            machine_fingerprint_from_affinity(&unknown),
+            machine_fingerprint_from_affinity(&masked)
+        );
+    }
+
+    #[test]
+    fn candidate_generation_uses_effective_logical_cores() {
+        let candidates = default_thread_candidates(25);
+        assert!(candidates.contains(&25));
+        assert!(candidates.contains(&crate::parallel::default_compute_threads(25)));
+        assert!(candidates.iter().all(|&c| (1..=25).contains(&c)));
+    }
+
+    #[test]
+    fn p95_aware_selection_prefers_non_slow_candidates_when_possible() {
+        let probes = [
+            RayonAutotuneProbeResult {
+                threads: 8,
+                valid: true,
+                p50_ms: 8.0,
+                p95_ms: 200.0,
+                sustained_tps: 125.0,
+            },
+            RayonAutotuneProbeResult {
+                threads: 12,
+                valid: true,
+                p50_ms: 9.0,
+                p95_ms: 20.0,
+                sustained_tps: 111.0,
+            },
+        ];
+        assert_eq!(select_best_probe(&probes, 100.0).unwrap().threads, 12);
+    }
+
+    #[test]
+    fn progress_timeout_zero_disables_watchdog() {
+        assert!(!normalize_progress_timeout_secs(Some(0), Some(300)).enabled());
+        assert!(!normalize_progress_timeout_secs(None, Some(0)).enabled());
+    }
+
+    #[test]
+    fn positive_progress_timeout_enables_watchdog_config() {
+        let cfg = normalize_progress_timeout_secs(Some(300), None);
+        assert!(cfg.enabled());
+        assert_eq!(cfg.timeout, Some(Duration::from_secs(300)));
     }
 }

--- a/rust-engine/src/rayon_autotune.rs
+++ b/rust-engine/src/rayon_autotune.rs
@@ -332,6 +332,44 @@ pub fn ranked_candidate_summaries(
     ranked
 }
 
+pub fn fine_thread_candidates(
+    effective_logical_cores: usize,
+    top_coarse_candidate_count: usize,
+    previous_high_confidence_profile_threads: Option<usize>,
+    coarse_summaries: &[RayonAutotuneCandidateSummary],
+) -> Vec<usize> {
+    let logical = effective_logical_cores.max(1);
+    let mut selected = Vec::new();
+    push_valid_candidate(
+        &mut selected,
+        crate::parallel::default_compute_threads(logical),
+        logical,
+    );
+    push_valid_candidate(&mut selected, logical, logical);
+    if logical > 1 {
+        push_valid_candidate(&mut selected, logical - 1, logical);
+    }
+    if let Some(threads) = previous_high_confidence_profile_threads {
+        push_valid_candidate(&mut selected, threads, logical);
+    }
+
+    for candidate in ranked_candidate_summaries(coarse_summaries)
+        .into_iter()
+        .filter(|c| c.successful_repeats > 0)
+        .take(top_coarse_candidate_count)
+    {
+        push_valid_candidate(&mut selected, candidate.threads, logical);
+    }
+
+    selected
+}
+
+fn push_valid_candidate(out: &mut Vec<usize>, threads: usize, logical: usize) {
+    if (1..=logical).contains(&threads) && !out.contains(&threads) {
+        out.push(threads);
+    }
+}
+
 pub fn select_best_candidate(
     candidates: &[RayonAutotuneCandidateSummary],
 ) -> Option<RayonAutotuneSelection> {
@@ -855,6 +893,25 @@ mod tests {
         let selected = select_best_candidate(&summaries).unwrap();
         assert_eq!(selected.selected.threads, 12);
         assert_eq!(selected.confidence, RayonAutotuneConfidence::High);
+    }
+
+    #[test]
+    fn fine_candidates_include_anchors_regardless_of_coarse_rank() {
+        let probes = [
+            probe(1, 1, 10.0, 12.0, 14.0, 100.0),
+            probe(2, 1, 11.0, 13.0, 15.0, 90.0),
+            probe(5, 1, 80.0, 82.0, 84.0, 12.0),
+            probe(7, 1, 90.0, 92.0, 94.0, 11.0),
+            probe(8, 1, 95.0, 97.0, 99.0, 10.0),
+        ];
+        let summaries = summarize_candidate_results(&[1, 2, 5, 7, 8], 1, &probes, 100.0, 120.0);
+        let fine = fine_thread_candidates(8, 2, Some(5), &summaries);
+        assert!(fine.contains(&crate::parallel::default_compute_threads(8)));
+        assert!(fine.contains(&8));
+        assert!(fine.contains(&7));
+        assert!(fine.contains(&5));
+        assert!(fine.contains(&1));
+        assert!(fine.contains(&2));
     }
 
     #[test]

--- a/rust-engine/src/rayon_autotune.rs
+++ b/rust-engine/src/rayon_autotune.rs
@@ -79,6 +79,7 @@ fn detected_cpu_features() -> Vec<&'static str> {
     if std::is_x86_feature_detected!("fma") {
         features.push("fma");
     }
+    #[cfg(feature = "nightly-amx")]
     if std::is_x86_feature_detected!("amx-tile") {
         features.push("amx-tile");
     }

--- a/rust-engine/src/rayon_autotune.rs
+++ b/rust-engine/src/rayon_autotune.rs
@@ -7,6 +7,13 @@ use crate::numa::{format_cpulist, EffectiveCpuAffinity};
 
 pub const AUTOTUNE_PROBE_ENV: &str = "MER_RAYON_AUTOTUNE_PROBE";
 pub const DEFAULT_AUTOTUNE_TOKENS: u64 = 2_000;
+pub const DEFAULT_AUTOTUNE_COARSE_TOKENS: u64 = 512;
+pub const DEFAULT_AUTOTUNE_REPEATS: usize = 2;
+pub const DEFAULT_AUTOTUNE_TOP_CANDIDATES: usize = 3;
+pub const DEFAULT_SLOW_P95_THRESHOLD_MS: f64 = 80.0;
+pub const DEFAULT_SLOW_P99_THRESHOLD_MS: f64 = 120.0;
+
+const LOW_VARIANCE_CV: f64 = 0.15;
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct CpuAutotuneKey {
@@ -131,7 +138,142 @@ pub struct RayonAutotuneProbeResult {
     pub valid: bool,
     pub p50_ms: f64,
     pub p95_ms: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub p99_ms: Option<f64>,
     pub sustained_tps: f64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RayonAutotuneProbeStage {
+    Coarse,
+    Fine,
+}
+
+impl RayonAutotuneProbeStage {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Coarse => "coarse",
+            Self::Fine => "fine",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct RayonAutotuneProbeObservation {
+    pub threads: usize,
+    pub stage: RayonAutotuneProbeStage,
+    /// One-based repeat index within this stage.
+    pub repeat: usize,
+    pub tokens: u64,
+    pub valid: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub p50_ms: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub p95_ms: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub p99_ms: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sustained_tps: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+impl RayonAutotuneProbeObservation {
+    pub fn from_probe_result(
+        stage: RayonAutotuneProbeStage,
+        repeat: usize,
+        tokens: u64,
+        result: RayonAutotuneProbeResult,
+    ) -> Self {
+        Self {
+            threads: result.threads,
+            stage,
+            repeat,
+            tokens,
+            valid: result.valid,
+            p50_ms: Some(result.p50_ms),
+            p95_ms: Some(result.p95_ms),
+            p99_ms: result.p99_ms,
+            sustained_tps: Some(result.sustained_tps),
+            reason: (!result.valid).then(|| "probe reported invalid".to_string()),
+        }
+    }
+
+    pub fn invalid(
+        threads: usize,
+        stage: RayonAutotuneProbeStage,
+        repeat: usize,
+        tokens: u64,
+        reason: impl Into<String>,
+    ) -> Self {
+        Self {
+            threads,
+            stage,
+            repeat,
+            tokens,
+            valid: false,
+            p50_ms: None,
+            p95_ms: None,
+            p99_ms: None,
+            sustained_tps: None,
+            reason: Some(reason.into()),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RayonAutotuneConfidence {
+    High,
+    Medium,
+    Low,
+}
+
+impl Default for RayonAutotuneConfidence {
+    fn default() -> Self {
+        Self::Low
+    }
+}
+
+impl RayonAutotuneConfidence {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::High => "high",
+            Self::Medium => "medium",
+            Self::Low => "low",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct RayonAutotuneCandidateSummary {
+    pub threads: usize,
+    pub requested_repeats: usize,
+    pub successful_repeats: usize,
+    pub all_repeats_successful: bool,
+    pub p95_below_slow_threshold: bool,
+    pub p99_below_slow_threshold: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub median_p50_ms: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worst_p95_ms: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worst_p99_ms: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub median_sustained_tps: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub p50_cv: Option<f64>,
+    pub confidence: RayonAutotuneConfidence,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rejection_reason: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct RayonAutotuneSelection {
+    pub selected: RayonAutotuneCandidateSummary,
+    pub confidence: RayonAutotuneConfidence,
+    pub reason: String,
 }
 
 pub fn select_best_probe(
@@ -158,6 +300,313 @@ pub fn select_best_probe(
             .then_with(|| a.threads.cmp(&b.threads))
     });
     valid.into_iter().next()
+}
+
+pub fn summarize_candidate_results(
+    candidates: &[usize],
+    requested_repeats: usize,
+    probes: &[RayonAutotuneProbeObservation],
+    slow_p95_threshold_ms: f64,
+    slow_p99_threshold_ms: f64,
+) -> Vec<RayonAutotuneCandidateSummary> {
+    candidates
+        .iter()
+        .copied()
+        .map(|threads| {
+            summarize_one_candidate(
+                threads,
+                requested_repeats,
+                probes,
+                slow_p95_threshold_ms,
+                slow_p99_threshold_ms,
+            )
+        })
+        .collect()
+}
+
+pub fn ranked_candidate_summaries(
+    candidates: &[RayonAutotuneCandidateSummary],
+) -> Vec<RayonAutotuneCandidateSummary> {
+    let mut ranked = candidates.to_vec();
+    ranked.sort_by(compare_candidate_summaries);
+    ranked
+}
+
+pub fn select_best_candidate(
+    candidates: &[RayonAutotuneCandidateSummary],
+) -> Option<RayonAutotuneSelection> {
+    let ranked = ranked_candidate_summaries(candidates);
+    let selected = ranked
+        .into_iter()
+        .find(|c| c.successful_repeats > 0 && c.median_p50_ms.is_some())?;
+    let confidence = selected.confidence;
+    let reason = selection_reason(&selected);
+    Some(RayonAutotuneSelection {
+        selected,
+        confidence,
+        reason,
+    })
+}
+
+fn summarize_one_candidate(
+    threads: usize,
+    requested_repeats: usize,
+    probes: &[RayonAutotuneProbeObservation],
+    slow_p95_threshold_ms: f64,
+    slow_p99_threshold_ms: f64,
+) -> RayonAutotuneCandidateSummary {
+    let mut p50s = Vec::new();
+    let mut p95s = Vec::new();
+    let mut p99s = Vec::new();
+    let mut tps = Vec::new();
+    for probe in probes.iter().filter(|p| p.threads == threads && p.valid) {
+        if let Some(v) = finite(probe.p50_ms) {
+            p50s.push(v);
+        }
+        if let Some(v) = finite(probe.p95_ms) {
+            p95s.push(v);
+        }
+        if let Some(v) = finite(probe.p99_ms) {
+            p99s.push(v);
+        }
+        if let Some(v) = finite(probe.sustained_tps) {
+            tps.push(v);
+        }
+    }
+
+    let successful_repeats = probes
+        .iter()
+        .filter(|p| p.threads == threads && p.valid)
+        .count();
+    let all_repeats_successful = requested_repeats > 0 && successful_repeats == requested_repeats;
+    let median_p50_ms = median(&mut p50s);
+    let worst_p95_ms = max_finite(&p95s);
+    let worst_p99_ms = max_finite(&p99s);
+    let median_sustained_tps = median(&mut tps);
+    let p50_cv = coefficient_of_variation(&p50s);
+    let p95_below_slow_threshold = worst_p95_ms
+        .map(|v| v <= slow_p95_threshold_ms)
+        .unwrap_or(false);
+    let p99_below_slow_threshold = worst_p99_ms
+        .map(|v| v <= slow_p99_threshold_ms)
+        .unwrap_or(true);
+
+    let rejection_reason = if successful_repeats == 0 {
+        Some("no successful probes".to_string())
+    } else if !all_repeats_successful {
+        Some(format!(
+            "only {successful_repeats}/{requested_repeats} probes succeeded"
+        ))
+    } else if !p95_below_slow_threshold {
+        Some(format!(
+            "worst p95 {:.1}ms exceeds {:.1}ms slow threshold",
+            worst_p95_ms.unwrap_or(f64::INFINITY),
+            slow_p95_threshold_ms
+        ))
+    } else if !p99_below_slow_threshold {
+        Some(format!(
+            "worst p99 {:.1}ms exceeds {:.1}ms slow threshold",
+            worst_p99_ms.unwrap_or(f64::INFINITY),
+            slow_p99_threshold_ms
+        ))
+    } else if requested_repeats < 2 {
+        Some("only one repeat; stability not established".to_string())
+    } else {
+        None
+    };
+
+    let high_variance =
+        requested_repeats >= 2 && p50_cv.map(|cv| cv > LOW_VARIANCE_CV).unwrap_or(false);
+    let confidence = if rejection_reason.is_some() {
+        RayonAutotuneConfidence::Low
+    } else if high_variance {
+        RayonAutotuneConfidence::Medium
+    } else {
+        RayonAutotuneConfidence::High
+    };
+
+    RayonAutotuneCandidateSummary {
+        threads,
+        requested_repeats,
+        successful_repeats,
+        all_repeats_successful,
+        p95_below_slow_threshold,
+        p99_below_slow_threshold,
+        median_p50_ms,
+        worst_p95_ms,
+        worst_p99_ms,
+        median_sustained_tps,
+        p50_cv,
+        confidence,
+        rejection_reason,
+    }
+}
+
+fn compare_candidate_summaries(
+    a: &RayonAutotuneCandidateSummary,
+    b: &RayonAutotuneCandidateSummary,
+) -> std::cmp::Ordering {
+    b.all_repeats_successful
+        .cmp(&a.all_repeats_successful)
+        .then_with(|| b.p95_below_slow_threshold.cmp(&a.p95_below_slow_threshold))
+        .then_with(|| b.p99_below_slow_threshold.cmp(&a.p99_below_slow_threshold))
+        .then_with(|| confidence_rank(b.confidence).cmp(&confidence_rank(a.confidence)))
+        .then_with(|| cmp_optional_f64_asc(a.median_p50_ms, b.median_p50_ms))
+        .then_with(|| cmp_optional_f64_desc(a.median_sustained_tps, b.median_sustained_tps))
+        .then_with(|| cmp_optional_f64_asc(a.p50_cv, b.p50_cv))
+        .then_with(|| a.threads.cmp(&b.threads))
+}
+
+fn confidence_rank(confidence: RayonAutotuneConfidence) -> u8 {
+    match confidence {
+        RayonAutotuneConfidence::High => 2,
+        RayonAutotuneConfidence::Medium => 1,
+        RayonAutotuneConfidence::Low => 0,
+    }
+}
+
+fn cmp_optional_f64_asc(a: Option<f64>, b: Option<f64>) -> std::cmp::Ordering {
+    match (a, b) {
+        (Some(a), Some(b)) => a.total_cmp(&b),
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+        (None, None) => std::cmp::Ordering::Equal,
+    }
+}
+
+fn cmp_optional_f64_desc(a: Option<f64>, b: Option<f64>) -> std::cmp::Ordering {
+    cmp_optional_f64_asc(b, a)
+}
+
+fn selection_reason(selected: &RayonAutotuneCandidateSummary) -> String {
+    let p50 = selected
+        .median_p50_ms
+        .map(format_ms)
+        .unwrap_or_else(|| "n/a".to_string());
+    let p95 = selected
+        .worst_p95_ms
+        .map(format_ms)
+        .unwrap_or_else(|| "n/a".to_string());
+    let p99 = selected
+        .worst_p99_ms
+        .map(format_ms)
+        .unwrap_or_else(|| "n/a".to_string());
+    let tps = selected
+        .median_sustained_tps
+        .map(|v| format!("{v:.1}"))
+        .unwrap_or_else(|| "n/a".to_string());
+    let base = format!(
+        "selected {} threads: {}/{} fine probes succeeded; worst p95={p95}; worst p99={p99}; median p50={p50}; median TPS={tps}; confidence={}",
+        selected.threads,
+        selected.successful_repeats,
+        selected.requested_repeats,
+        selected.confidence.as_str()
+    );
+    match selected.rejection_reason.as_deref() {
+        Some(reason) => format!("{base}; {reason}"),
+        None => base,
+    }
+}
+
+fn finite(v: Option<f64>) -> Option<f64> {
+    v.filter(|v| v.is_finite())
+}
+
+fn median(values: &mut [f64]) -> Option<f64> {
+    if values.is_empty() {
+        return None;
+    }
+    values.sort_by(|a, b| a.total_cmp(b));
+    let mid = values.len() / 2;
+    if values.len() % 2 == 0 {
+        Some((values[mid - 1] + values[mid]) / 2.0)
+    } else {
+        Some(values[mid])
+    }
+}
+
+fn max_finite(values: &[f64]) -> Option<f64> {
+    values
+        .iter()
+        .copied()
+        .filter(|v| v.is_finite())
+        .max_by(|a, b| a.total_cmp(b))
+}
+
+fn coefficient_of_variation(values: &[f64]) -> Option<f64> {
+    if values.is_empty() {
+        return None;
+    }
+    if values.len() == 1 {
+        return Some(0.0);
+    }
+    let mean = values.iter().sum::<f64>() / values.len() as f64;
+    if mean == 0.0 {
+        return Some(0.0);
+    }
+    let variance = values
+        .iter()
+        .map(|v| {
+            let d = *v - mean;
+            d * d
+        })
+        .sum::<f64>()
+        / values.len() as f64;
+    Some(variance.sqrt() / mean.abs())
+}
+
+fn format_ms(v: f64) -> String {
+    format!("{v:.1}ms")
+}
+
+pub fn format_autotune_table(
+    probes: &[RayonAutotuneProbeObservation],
+    candidates: &[RayonAutotuneCandidateSummary],
+) -> String {
+    let mut reasons = BTreeMap::new();
+    for candidate in candidates {
+        if let Some(reason) = candidate.rejection_reason.as_deref() {
+            reasons.insert(candidate.threads, reason);
+        }
+    }
+
+    let mut lines = Vec::with_capacity(probes.len() + 1);
+    lines.push(format!(
+        "{:<7} {:>7} {:>6} {:>9} {:>9} {:>9} {:>9} {:>7} {}",
+        "stage", "threads", "repeat", "p50", "p95", "p99", "TPS", "valid", "reason"
+    ));
+    for probe in probes {
+        let reason = if probe.valid {
+            reasons
+                .get(&probe.threads)
+                .copied()
+                .unwrap_or("")
+                .to_string()
+        } else {
+            probe.reason.as_deref().unwrap_or("invalid").to_string()
+        };
+        lines.push(format!(
+            "{:<7} {:>7} {:>6} {:>9} {:>9} {:>9} {:>9} {:>7} {}",
+            probe.stage.as_str(),
+            probe.threads,
+            probe.repeat,
+            format_optional_ms(probe.p50_ms),
+            format_optional_ms(probe.p95_ms),
+            format_optional_ms(probe.p99_ms),
+            probe
+                .sustained_tps
+                .map(|v| format!("{v:.1}"))
+                .unwrap_or_else(|| "-".to_string()),
+            if probe.valid { "yes" } else { "no" },
+            reason
+        ));
+    }
+    lines.join("\n")
+}
+
+fn format_optional_ms(v: Option<f64>) -> String {
+    v.map(|v| format!("{v:.1}"))
+        .unwrap_or_else(|| "-".to_string())
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -190,9 +639,44 @@ pub fn normalize_progress_timeout_secs(
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RayonAutotuneProfile {
     pub threads: usize,
+    #[serde(default)]
+    pub effective_cpu_mask: Option<Vec<usize>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effective_cpu_mask_display: Option<String>,
+    #[serde(default)]
+    pub logical_cores: usize,
+    #[serde(default)]
+    pub repeats: usize,
+    #[serde(default)]
     pub p50_ms: f64,
+    #[serde(default)]
     pub p95_ms: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub p99_ms: Option<f64>,
+    #[serde(default)]
     pub sustained_tps: f64,
+    #[serde(default)]
+    pub median_p50_ms: f64,
+    #[serde(default)]
+    pub worst_p95_ms: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worst_p99_ms: Option<f64>,
+    #[serde(default)]
+    pub median_sustained_tps: f64,
+    #[serde(default)]
+    pub confidence: RayonAutotuneConfidence,
+    #[serde(default)]
+    pub selection_reason: String,
+    #[serde(default)]
+    pub candidate_results: Vec<RayonAutotuneCandidateSummary>,
+    #[serde(default)]
+    pub probe_results: Vec<RayonAutotuneProbeObservation>,
+}
+
+impl RayonAutotuneProfile {
+    pub fn reusable_by_default(&self) -> bool {
+        self.confidence != RayonAutotuneConfidence::Low
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -291,6 +775,7 @@ mod tests {
                 valid: true,
                 p50_ms: 8.0,
                 p95_ms: 200.0,
+                p99_ms: Some(220.0),
                 sustained_tps: 125.0,
             },
             RayonAutotuneProbeResult {
@@ -298,10 +783,150 @@ mod tests {
                 valid: true,
                 p50_ms: 9.0,
                 p95_ms: 20.0,
+                p99_ms: Some(25.0),
                 sustained_tps: 111.0,
             },
         ];
         assert_eq!(select_best_probe(&probes, 100.0).unwrap().threads, 12);
+    }
+
+    fn probe(
+        threads: usize,
+        repeat: usize,
+        p50_ms: f64,
+        p95_ms: f64,
+        p99_ms: f64,
+        sustained_tps: f64,
+    ) -> RayonAutotuneProbeObservation {
+        RayonAutotuneProbeObservation {
+            threads,
+            stage: RayonAutotuneProbeStage::Fine,
+            repeat,
+            tokens: 2_000,
+            valid: true,
+            p50_ms: Some(p50_ms),
+            p95_ms: Some(p95_ms),
+            p99_ms: Some(p99_ms),
+            sustained_tps: Some(sustained_tps),
+            reason: None,
+        }
+    }
+
+    #[test]
+    fn repeated_candidate_aggregation_tracks_median_and_worst_case() {
+        let probes = [
+            probe(25, 1, 58.0, 61.0, 70.0, 17.0),
+            probe(25, 2, 62.0, 75.0, 82.0, 16.0),
+        ];
+        let summaries = summarize_candidate_results(&[25], 2, &probes, 80.0, 120.0);
+        let s = &summaries[0];
+        assert_eq!(s.successful_repeats, 2);
+        assert!(s.all_repeats_successful);
+        assert_eq!(s.median_p50_ms, Some(60.0));
+        assert_eq!(s.worst_p95_ms, Some(75.0));
+        assert_eq!(s.worst_p99_ms, Some(82.0));
+        assert_eq!(s.median_sustained_tps, Some(16.5));
+        assert_eq!(s.confidence, RayonAutotuneConfidence::High);
+    }
+
+    #[test]
+    fn stable_candidate_beats_lower_p50_with_high_worst_p95() {
+        let probes = [
+            probe(8, 1, 50.0, 120.0, 140.0, 20.0),
+            probe(8, 2, 51.0, 130.0, 150.0, 19.0),
+            probe(12, 1, 58.0, 68.0, 90.0, 17.0),
+            probe(12, 2, 59.0, 70.0, 94.0, 16.0),
+        ];
+        let summaries = summarize_candidate_results(&[8, 12], 2, &probes, 80.0, 120.0);
+        let selected = select_best_candidate(&summaries).unwrap();
+        assert_eq!(selected.selected.threads, 12);
+        assert_eq!(selected.confidence, RayonAutotuneConfidence::High);
+    }
+
+    #[test]
+    fn high_variance_candidate_loses_to_high_confidence_candidate() {
+        let probes = [
+            probe(8, 1, 45.0, 72.0, 88.0, 22.0),
+            probe(8, 2, 80.0, 74.0, 90.0, 21.0),
+            probe(12, 1, 64.0, 70.0, 82.0, 16.0),
+            probe(12, 2, 65.0, 71.0, 83.0, 15.0),
+        ];
+        let summaries = summarize_candidate_results(&[8, 12], 2, &probes, 80.0, 120.0);
+        let selected = select_best_candidate(&summaries).unwrap();
+        assert_eq!(selected.selected.threads, 12);
+        assert_eq!(selected.confidence, RayonAutotuneConfidence::High);
+    }
+
+    #[test]
+    fn profile_confidence_metadata_serializes_and_deserializes() {
+        let probes = vec![probe(25, 1, 58.0, 61.0, 70.0, 17.0)];
+        let candidates = summarize_candidate_results(&[25], 1, &probes, 80.0, 120.0);
+        let profile = RayonAutotuneProfile {
+            threads: 25,
+            effective_cpu_mask: Some((0..25).collect()),
+            effective_cpu_mask_display: Some("0-24".to_string()),
+            logical_cores: 25,
+            repeats: 1,
+            p50_ms: 58.0,
+            p95_ms: 61.0,
+            p99_ms: Some(70.0),
+            sustained_tps: 17.0,
+            median_p50_ms: 58.0,
+            worst_p95_ms: 61.0,
+            worst_p99_ms: Some(70.0),
+            median_sustained_tps: 17.0,
+            confidence: RayonAutotuneConfidence::Low,
+            selection_reason: "only one repeat; stability not established".to_string(),
+            candidate_results: candidates,
+            probe_results: probes,
+        };
+        let json = serde_json::to_string(&profile).unwrap();
+        let back: RayonAutotuneProfile = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.threads, 25);
+        assert_eq!(back.confidence, RayonAutotuneConfidence::Low);
+        assert_eq!(back.effective_cpu_mask_display.as_deref(), Some("0-24"));
+        assert_eq!(back.logical_cores, 25);
+        assert_eq!(back.repeats, 1);
+        assert_eq!(back.worst_p99_ms, Some(70.0));
+        assert!(back.selection_reason.contains("only one repeat"));
+        assert_eq!(back.candidate_results.len(), 1);
+        assert_eq!(back.probe_results.len(), 1);
+    }
+
+    #[test]
+    fn legacy_profile_without_confidence_defaults_to_low() {
+        let legacy = r#"{
+            "threads": 25,
+            "p50_ms": 58.0,
+            "p95_ms": 61.0,
+            "sustained_tps": 17.0
+        }"#;
+        let profile: RayonAutotuneProfile = serde_json::from_str(legacy).unwrap();
+        assert_eq!(profile.confidence, RayonAutotuneConfidence::Low);
+        assert!(!profile.reusable_by_default());
+    }
+
+    #[test]
+    fn selection_reason_is_recorded() {
+        let probes = [
+            probe(25, 1, 58.0, 61.0, 70.0, 17.0),
+            probe(25, 2, 59.0, 62.0, 71.0, 16.0),
+        ];
+        let summaries = summarize_candidate_results(&[25], 2, &probes, 80.0, 120.0);
+        let selected = select_best_candidate(&summaries).unwrap();
+        assert!(selected.reason.contains("selected 25 threads"));
+        assert!(selected.reason.contains("confidence=high"));
+    }
+
+    #[cfg(all(
+        not(feature = "nightly-amx"),
+        any(target_arch = "x86", target_arch = "x86_64")
+    ))]
+    #[test]
+    fn stable_feature_list_does_not_probe_unstable_amx_detection() {
+        assert!(!detected_cpu_features()
+            .iter()
+            .any(|feature| feature.starts_with("amx")));
     }
 
     #[test]

--- a/rust-engine/src/server.rs
+++ b/rust-engine/src/server.rs
@@ -1361,8 +1361,7 @@ async fn stream_tokens(
     requested_max: usize,
     params: SamplingParams,
     session_id: Option<String>,
-) -> Result<Pin<Box<dyn Stream<Item = Result<StreamChunk, GenerateError>> + Send>>, GenerateError>
-{
+) -> Result<Pin<Box<dyn Stream<Item = Result<StreamChunk, GenerateError>> + Send>>, GenerateError> {
     if prompt.is_empty() {
         return Err(GenerateError::InvalidRequest(
             "prompt must be non-empty".into(),
@@ -1512,10 +1511,7 @@ async fn stream_tokens(
                 Ok(tail) => tail,
                 Err(e) => {
                     tracing::error!(error = %e, "real stream: decoder failed on final flush");
-                    return Some((
-                        Err(GenerateError::Tokenizer(e.to_string())),
-                        st,
-                    ));
+                    return Some((Err(GenerateError::Tokenizer(e.to_string())), st));
                 }
             };
             return Some((
@@ -1777,8 +1773,8 @@ fn wrap_completion_events(
                             finish_reason: None,
                         }],
                     };
-                    let ev = Event::default()
-                        .data(serde_json::to_string(&payload).unwrap_or_default());
+                    let ev =
+                        Event::default().data(serde_json::to_string(&payload).unwrap_or_default());
                     Some((Ok(ev), st))
                 }
             }
@@ -1803,7 +1799,9 @@ fn stream_error_payload(e: &GenerateError) -> String {
             kind,
         },
     })
-    .unwrap_or_else(|_| "{\"error\":{\"message\":\"stream failed\",\"type\":\"server_error\"}}".into())
+    .unwrap_or_else(|_| {
+        "{\"error\":{\"message\":\"stream failed\",\"type\":\"server_error\"}}".into()
+    })
 }
 
 async fn build_chat_stream(
@@ -1961,8 +1959,8 @@ fn wrap_chat_events(
                             finish_reason: None,
                         }],
                     };
-                    let ev = Event::default()
-                        .data(serde_json::to_string(&payload).unwrap_or_default());
+                    let ev =
+                        Event::default().data(serde_json::to_string(&payload).unwrap_or_default());
                     Some((Ok(ev), st))
                 }
             }
@@ -2195,6 +2193,7 @@ mod tests {
                 max_concurrent_requests: 0,
                 admission_min_free_blocks: 0,
             },
+            performance: crate::config::PerformanceConfig::default(),
             model: crate::config::ModelConfig {
                 data_dir: PathBuf::from("./data"),
                 num_experts: 8,
@@ -2222,7 +2221,6 @@ mod tests {
             sampling: crate::config::SamplingConfig::default(),
             predictive: crate::config::PredictiveConfig::default(),
             security: crate::config::SecurityConfig::default(),
-            performance: crate::config::PerformanceConfig::default(),
             gpu_cache: crate::config::GpuCacheConfig::default(),
             distributed: crate::config::DistributedConfig::default(),
         }
@@ -3242,8 +3240,7 @@ mod tests {
         // Terminate the scheduler loop before it executes anything.
         shutdown_runtime(rt).await;
 
-        let mut request =
-            RealRequestState::new(&state, &model, model.fresh_kv_caches(), None);
+        let mut request = RealRequestState::new(&state, &model, model.fresh_kv_caches(), None);
         // decode_step registers the KV (registry op is synchronous and
         // survives the loop), then the channel send fails with
         // SchedulerClosed — the fallback must recover the registered
@@ -3255,7 +3252,10 @@ mod tests {
         assert_eq!(scheduler.registrations_total(), 1);
         assert_eq!(scheduler.releases_total(), 1);
         let kv = request.finish().expect("recovered KV must be persistable");
-        assert_eq!(kv[0].seq_len, 1, "the direct decode advanced the recovered KV");
+        assert_eq!(
+            kv[0].seq_len, 1,
+            "the direct decode advanced the recovered KV"
+        );
     }
 
     /// A7 item 1: the scheduler's channels close *after* scheduled
@@ -3271,11 +3271,16 @@ mod tests {
         state.batch_scheduler = Some(scheduler.clone());
 
         let greedy = crate::sampling::SamplingParams::greedy();
-        let mut request =
-            RealRequestState::new(&state, &model, model.fresh_kv_caches(), None);
+        let mut request = RealRequestState::new(&state, &model, model.fresh_kv_caches(), None);
         // Two scheduled decodes mutate the registered KV in place.
-        let n1 = request.decode_step(1, 0, &greedy).await.expect("scheduled step 1");
-        let n2 = request.decode_step(n1, 1, &greedy).await.expect("scheduled step 2");
+        let n1 = request
+            .decode_step(1, 0, &greedy)
+            .await
+            .expect("scheduled step 1");
+        let n2 = request
+            .decode_step(n1, 1, &greedy)
+            .await
+            .expect("scheduled step 2");
         assert_eq!(scheduler.registrations_total(), 1);
 
         shutdown_runtime(rt).await;
@@ -3325,7 +3330,10 @@ mod tests {
         // Wait for the request to register its KV, then steal it.
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
         while scheduler.registrations_total() < 1 {
-            assert!(std::time::Instant::now() < deadline, "request never registered");
+            assert!(
+                std::time::Instant::now() < deadline,
+                "request never registered"
+            );
             tokio::time::sleep(std::time::Duration::from_millis(1)).await;
         }
         let _ = scheduler.release(crate::batch_scheduler::RequestId(0));
@@ -3398,8 +3406,10 @@ mod tests {
         let mut acc = String::new();
         // Pull a couple of content events so the request has
         // registered its KV with the scheduler.
-        read_sse_until(&mut body, &mut acc, |s| s.matches("text_completion").count() >= 2)
-            .await;
+        read_sse_until(&mut body, &mut acc, |s| {
+            s.matches("text_completion").count() >= 2
+        })
+        .await;
         assert!(scheduler.registrations_total() >= 1);
         let _ = scheduler.release(crate::batch_scheduler::RequestId(0));
         // Drain to the end of the stream.
@@ -3468,7 +3478,10 @@ mod tests {
             acc.contains("kv_state_lost"),
             "expected a typed kv_state_lost error event; got:\n{acc}"
         );
-        assert!(!acc.contains("[DONE]"), "no [DONE] after failure; got:\n{acc}");
+        assert!(
+            !acc.contains("[DONE]"),
+            "no [DONE] after failure; got:\n{acc}"
+        );
         assert!(
             !acc.contains(r#""finish_reason":"length""#)
                 && !acc.contains(r#""finish_reason":"stop""#),
@@ -3509,7 +3522,10 @@ mod tests {
         });
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
         while scheduler.registrations_total() < 2 {
-            assert!(std::time::Instant::now() < deadline, "turn 2 never registered");
+            assert!(
+                std::time::Instant::now() < deadline,
+                "turn 2 never registered"
+            );
             tokio::time::sleep(std::time::Duration::from_millis(1)).await;
         }
         let _ = scheduler.release(crate::batch_scheduler::RequestId(1));
@@ -3543,8 +3559,7 @@ mod tests {
         let (state, _tmp) = make_state_with_real_model(cfg).await;
         let model = state.real_model.clone().unwrap();
         let scheduler = state.batch_scheduler.clone().unwrap();
-        let mut request =
-            RealRequestState::new(&state, &model, model.fresh_kv_caches(), None);
+        let mut request = RealRequestState::new(&state, &model, model.fresh_kv_caches(), None);
         request
             .decode_step(1, 0, &crate::sampling::SamplingParams::greedy())
             .await
@@ -3552,7 +3567,11 @@ mod tests {
         assert_eq!(scheduler.registrations_total(), 1);
         assert_eq!(scheduler.active_requests(), 1);
         drop(request);
-        assert_eq!(scheduler.releases_total(), 1, "Drop must release exactly once");
+        assert_eq!(
+            scheduler.releases_total(),
+            1,
+            "Drop must release exactly once"
+        );
         assert_eq!(scheduler.active_requests(), 0);
     }
 
@@ -3564,8 +3583,7 @@ mod tests {
         let (state, _tmp) = make_state_with_real_model(cfg).await;
         let model = state.real_model.clone().unwrap();
         let scheduler = state.batch_scheduler.clone().unwrap();
-        let mut request =
-            RealRequestState::new(&state, &model, model.fresh_kv_caches(), None);
+        let mut request = RealRequestState::new(&state, &model, model.fresh_kv_caches(), None);
         request
             .decode_step(1, 0, &crate::sampling::SamplingParams::greedy())
             .await
@@ -3626,7 +3644,9 @@ mod tests {
         let s = wrap_completion_events(inner, "cmpl-t".into(), "m".into(), metrics.clone());
         let body = sse_events_to_string(s).await;
         let tail_idx = body.find("TAIL€").expect("tail chunk must be emitted");
-        let done_idx = body.find("[DONE]").expect("stream must terminate with [DONE]");
+        let done_idx = body
+            .find("[DONE]")
+            .expect("stream must terminate with [DONE]");
         assert!(
             tail_idx < done_idx,
             "the final decoder tail must be delivered before [DONE]:\n{body}"
@@ -3653,9 +3673,13 @@ mod tests {
             ]));
         let s = wrap_chat_events(inner, "chatcmpl-t".into(), "m".into(), metrics.clone());
         let body = sse_events_to_string(s).await;
-        let role_idx = body.find(r#""role":"assistant""#).expect("role event first");
+        let role_idx = body
+            .find(r#""role":"assistant""#)
+            .expect("role event first");
         let tail_idx = body.find("TAIL€").expect("tail chunk must be emitted");
-        let done_idx = body.find("[DONE]").expect("stream must terminate with [DONE]");
+        let done_idx = body
+            .find("[DONE]")
+            .expect("stream must terminate with [DONE]");
         assert!(role_idx < tail_idx && tail_idx < done_idx);
         assert!(body.contains("chat.completion.chunk"));
         assert_eq!(scrape_tokens_generated(&metrics), 2);
@@ -3678,8 +3702,7 @@ mod tests {
                 let s = wrap_chat_events(inner, "chatcmpl-t".into(), "m".into(), metrics.clone());
                 sse_events_to_string(s).await
             } else {
-                let s =
-                    wrap_completion_events(inner, "cmpl-t".into(), "m".into(), metrics.clone());
+                let s = wrap_completion_events(inner, "cmpl-t".into(), "m".into(), metrics.clone());
                 sse_events_to_string(s).await
             };
             assert!(
@@ -3687,7 +3710,10 @@ mod tests {
                 "chat={chat}: expected an error event; got:\n{body}"
             );
             assert!(body.contains("decoder exploded"), "chat={chat}");
-            assert!(!body.contains("[DONE]"), "chat={chat}: no [DONE] after failure");
+            assert!(
+                !body.contains("[DONE]"),
+                "chat={chat}: no [DONE] after failure"
+            );
             assert!(
                 !body.contains(r#""finish_reason":"length""#)
                     && !body.contains(r#""finish_reason":"stop""#),

--- a/rust-engine/src/server.rs
+++ b/rust-engine/src/server.rs
@@ -2222,6 +2222,7 @@ mod tests {
             sampling: crate::config::SamplingConfig::default(),
             predictive: crate::config::PredictiveConfig::default(),
             security: crate::config::SecurityConfig::default(),
+            performance: crate::config::PerformanceConfig::default(),
             gpu_cache: crate::config::GpuCacheConfig::default(),
             distributed: crate::config::DistributedConfig::default(),
         }


### PR DESCRIPTION
## Summary

This PR refines the Rayon startup autotune path used by MER’s CPU execution mode.

It adds a stability-aware autotune policy that performs a coarse probe pass, promotes top candidates plus anchor candidates into repeated fine probes, records confidence metadata, and avoids using or saving low-confidence selections unless explicitly allowed.

The goal is to make CPU thread selection safer and more observable, especially on VMs where scheduler behavior and effective CPU placement can vary between runs.

## Changes

* Add repeated fine-probe based Rayon autotune selection.
* Always include anchor thread candidates during fine probing:

  * MER default compute thread count
  * all logical cores
  * logical cores minus one
  * previous high-confidence profile candidate when available
  * top coarse-pass candidates
* Add CLI controls:

  * `--autotune-repeats`
  * `--autotune-coarse-tokens`
  * `--autotune-top-candidates`
  * `--autotune-print-table`
  * `--autotune-slow-p95-ms`
  * `--autotune-slow-p99-ms`
  * `--allow-low-confidence-rayon-autotune`
* Add confidence metadata to saved Rayon autotune profiles.
* Skip low-confidence saved profiles unless explicitly allowed.
* Do not use or save low-confidence current-run autotune results unless explicitly allowed.
* Suppress per-token tick logs inside child autotune probes.
* Keep AMX feature detection gated behind the nightly AMX feature.
* Update README guidance for VM and bare-metal usage.

## Validation

Validated locally with:

```bash
cargo test --quiet
cargo test -- --test-threads=1
git diff --check
cargo build --release --features "avx512,blas,tokenizer"
```

Additional VM validation on GCP `g2-standard-32` with Mixtral 8x7B Q4_0 showed that the new policy correctly selects, rejects, saves, or falls back based on confidence.

Representative results:

* High-confidence autotune selected 21 threads and saved the profile.
* Final run used `source="autotune"` and reached ~15.6 TPS with compute p50 around 55–56 ms.
* Low-confidence selections were not used or saved by default.
* Profile reuse worked, but VM variability remained observable across runs.

## Notes

This PR improves thread-count discovery, confidence handling, and benchmark observability. It does not claim to eliminate all VM scheduler variability.

On noisy VMs, per-run autotune is recommended for benchmark runs because effective CPU placement may vary even with the same cpuset. On bare metal or dedicated pinned hosts, high-confidence saved profiles are expected to be more reusable across runs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic Rayon thread tuning for CPU-dense workloads, with reusable performance profiles.
  - Added configurable CPU placement, Rayon thread counts, and progress watchdog timeouts.
  - Added command-line options for CPU masks, autotuning behavior, and benchmark stability controls.
  - Added clear precedence for command-line, configuration, environment, and legacy settings.

- **Documentation**
  - Expanded configuration and CLI documentation with autotuning examples and CPU placement guidance.
  - Updated NUMA and Rayon management descriptions to reflect the new controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->