### PR TITLE
bench: add Phase 4D-B governor score diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1491,6 +1491,29 @@ two measured-window counter deltas, not exact lifecycle-cohort precision. Raw
 completed and used counts remain available, and the governor's adaptive signal
 is reported separately as `governor_precision_ewma_final`.
 
+Phase 4D-B is a separate diagnostic follow-up to Phase 4D-A's observation that
+every governed screen admitted zero candidates, including the `0.005` base
+threshold with zero contention weight. It measures the candidate-probability,
+effective-precision, score, effective-threshold, and score-to-threshold-ratio
+distributions without changing the governor formula, predictor, or runtime
+defaults. It runs only `demand-only`, ungoverned `second-only-f1`, and the
+governed `0.02/1.0` and `0.005/0.0` cases:
+
+```bash
+scripts/collect_qwen3_coder_prompt2_phase4d_b_score_calibration.sh /path/to/artifacts
+```
+
+The final `phase4d-b-governor-score-calibration-summary.json` is diagnostic and
+non-qualifying by design. Counts, means, extrema, decision boundaries, and
+foreground splits cover every decision in each reset window. Percentiles are
+nearest-rank values over a deterministic ring of the most recent 512 finite
+decisions; no per-candidate event stream is retained. Empty populations use
+`null` statistics and disabled controls report zero decisions rather than
+fabricated scores. A maximum rejected score-to-threshold ratio just below `1`
+shows how close the best rejection came to admission; a minimum admitted ratio
+at or above `1` identifies the weakest admitted candidate, and remains `null`
+when no candidate was admitted.
+
 After selecting a candidate, the existing diagnostic collector supports the
 required eight-token trace smoke and the full diagnostic trace:
 

--- a/rust-engine/src/engine.rs
+++ b/rust-engine/src/engine.rs
@@ -5217,6 +5217,8 @@ impl Engine {
     }
 
     pub fn report(&self) -> EngineReport {
+        let (governor_decisions, governor_score_diagnostics) =
+            self.core.governor.decisions_and_diagnostics();
         let cycle = self.metrics.cycle_hist.lock();
         let io = self.metrics.io_hist.lock();
         let compute = self.metrics.compute_hist.lock();
@@ -5381,9 +5383,10 @@ impl Engine {
                 .load(Ordering::Relaxed),
             governor_enabled: self.core.governor.is_enabled(),
             governor_precision: self.core.governor.precision(),
-            governor_admitted: self.core.governor.decisions().0,
-            governor_throttled: self.core.governor.decisions().1,
+            governor_admitted: governor_decisions.0,
+            governor_throttled: governor_decisions.1,
             governor_foreground_inflight: self.core.governor.foreground_inflight(),
+            governor_score_diagnostics,
             pregate_enabled: self.speculation.pregate.is_some(),
             pregate_accuracy: self
                 .speculation
@@ -5422,6 +5425,14 @@ impl Engine {
             q8_down_kernel_seconds: crate::inference::q8_down_kernel_seconds(),
             demand_fetch: self.metrics.demand_fetch.snapshot(),
         }
+    }
+
+    /// Reset only the bounded governor score diagnostic window. Admission
+    /// state, precision EWMA, direct counters, and foreground accounting are
+    /// preserved. Bench-real calls this before each warmup/measured run so its
+    /// per-run distributions reconcile with direct counter deltas.
+    pub fn reset_governor_score_diagnostics(&self) -> (u64, u64) {
+        self.core.governor.reset_decision_diagnostics()
     }
 
     pub fn print_summary(&self) {
@@ -5756,6 +5767,9 @@ pub struct EngineReport {
     /// **Tier 4.** Foreground reads still in flight when this report was
     /// sampled. A completed benchmark run should normally report zero.
     pub governor_foreground_inflight: i64,
+    /// Bounded score/threshold distribution diagnostics since the most recent
+    /// diagnostic reset.
+    pub governor_score_diagnostics: crate::prefetch_governor::GovernorDecisionDiagnosticsSnapshot,
     /// **Tier 3.** Whether the per-layer pre-gate predictor is enabled.
     pub pregate_enabled: bool,
     /// **Tier 3.** Fraction of scored pre-gate predictions that

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -2435,6 +2435,8 @@ struct BenchRealRunCacheIo {
     governor_rejected_candidates: u64,
     governor_total_decisions: u64,
     governor_admission_rate: f64,
+    governor_score_diagnostics: crate::prefetch_governor::GovernorDecisionDiagnosticsSnapshot,
+    governor_score_diagnostics_reconcile: bool,
     /// Final controller state sampled after this measured run.
     governor_precision_ewma_final: f64,
     governor_foreground_inflight_final: i64,
@@ -2546,6 +2548,8 @@ struct BenchRealAggregate {
     hit_rate: f64,
     ssd_bytes_total: u64,
     output_token_parity: bool,
+    governor_score_diagnostics: crate::prefetch_governor::GovernorDecisionDiagnosticsSnapshot,
+    governor_score_diagnostics_reconcile: bool,
 }
 
 fn phase4b_trace_from_env(
@@ -4538,6 +4542,7 @@ async fn run_bench_real_once(
     if !runtime.engine.reset_demand_fetch_telemetry() {
         return Err("cannot reset Phase 3A telemetry while a foreground read is active".into());
     }
+    let governor_decisions_before = runtime.engine.reset_governor_score_diagnostics();
     let pre = runtime.engine.report();
     let truncated_payload_uses_before = crate::inference::truncated_expert_payload_uses();
     let nonfinite_attention_before = crate::transformer::nonfinite_softmax_fallbacks();
@@ -4684,11 +4689,28 @@ async fn run_bench_real_once(
         governor_total_decisions,
         governor_admission_rate,
     ) = bench_real_governor_decision_delta(
-        pre.governor_admitted,
+        governor_decisions_before.0,
         post.governor_admitted,
-        pre.governor_throttled,
+        governor_decisions_before.1,
         post.governor_throttled,
     );
+    let governor_score_diagnostics = post.governor_score_diagnostics.clone();
+    let governor_score_diagnostics_reconcile = bench_real_governor_score_reconciles(
+        governor_admitted_candidates,
+        governor_rejected_candidates,
+        &governor_score_diagnostics,
+    );
+    if !governor_score_diagnostics_reconcile {
+        return Err(format!(
+            "bench-real governor score diagnostics do not reconcile: direct admitted={} rejected={}, diagnostic admitted={} rejected={} total={}",
+            governor_admitted_candidates,
+            governor_rejected_candidates,
+            governor_score_diagnostics.admitted,
+            governor_score_diagnostics.rejected,
+            governor_score_diagnostics.total_decisions,
+        )
+        .into());
+    }
     let useful_prefetch_bytes = prefetch_used
         .saturating_mul(runtime.cfg.model.expert_size as u64)
         .min(prefetch_bytes);
@@ -4799,6 +4821,8 @@ async fn run_bench_real_once(
             governor_rejected_candidates,
             governor_total_decisions,
             governor_admission_rate,
+            governor_score_diagnostics,
+            governor_score_diagnostics_reconcile,
             governor_precision_ewma_final: post.governor_precision,
             governor_foreground_inflight_final: post.governor_foreground_inflight,
             // All three drop counters fire before a storage read is issued.
@@ -4992,6 +5016,30 @@ fn aggregate_bench_real(runs: &[BenchRealRunReport]) -> BenchRealAggregate {
     let output_token_parity = runs
         .windows(2)
         .all(|pair| pair[0].output_token_ids == pair[1].output_token_ids);
+    let governor_score_run_snapshots: Vec<_> = runs
+        .iter()
+        .map(|run| run.cache_io.governor_score_diagnostics.clone())
+        .collect();
+    let governor_score_diagnostics =
+        crate::prefetch_governor::GovernorDecisionDiagnosticsSnapshot::merge(
+            &governor_score_run_snapshots,
+        );
+    let governor_admitted_candidates: u64 = runs
+        .iter()
+        .map(|run| run.cache_io.governor_admitted_candidates)
+        .sum();
+    let governor_rejected_candidates: u64 = runs
+        .iter()
+        .map(|run| run.cache_io.governor_rejected_candidates)
+        .sum();
+    let governor_score_diagnostics_reconcile = runs
+        .iter()
+        .all(|run| run.cache_io.governor_score_diagnostics_reconcile)
+        && bench_real_governor_score_reconciles(
+            governor_admitted_candidates,
+            governor_rejected_candidates,
+            &governor_score_diagnostics,
+        );
     BenchRealAggregate {
         prompt_seconds_mean: runs.iter().map(|r| r.prompt_seconds).sum::<f64>() / n,
         prompt_tps_mean: runs.iter().map(|r| r.prompt_tps).sum::<f64>() / n,
@@ -5004,7 +5052,19 @@ fn aggregate_bench_real(runs: &[BenchRealRunReport]) -> BenchRealAggregate {
         hit_rate,
         ssd_bytes_total: runs.iter().map(|r| r.ssd_bytes).sum(),
         output_token_parity,
+        governor_score_diagnostics,
+        governor_score_diagnostics_reconcile,
     }
+}
+
+fn bench_real_governor_score_reconciles(
+    admitted: u64,
+    rejected: u64,
+    diagnostics: &crate::prefetch_governor::GovernorDecisionDiagnosticsSnapshot,
+) -> bool {
+    diagnostics.total_decisions == admitted.saturating_add(rejected)
+        && diagnostics.admitted == admitted
+        && diagnostics.rejected == rejected
 }
 
 fn bench_real_governor_decision_delta(
@@ -8580,6 +8640,28 @@ mod tests {
         let (admitted, rejected, total, rate) = bench_real_governor_decision_delta(10, 10, 20, 20);
         assert_eq!((admitted, rejected, total), (0, 0, 0));
         assert_eq!(rate, 0.0);
+    }
+
+    #[test]
+    fn bench_real_governor_score_diagnostics_reconcile_with_direct_counters() {
+        let governor = crate::prefetch_governor::PrefetchGovernor::new(
+            true,
+            crate::prefetch_governor::GovernorConfig::default(),
+        );
+        assert!(governor.admit(1.0));
+        assert!(!governor.admit(0.0));
+        let (admitted, rejected) = governor.decisions();
+        let diagnostics = governor.decision_diagnostics();
+        assert!(bench_real_governor_score_reconciles(
+            admitted,
+            rejected,
+            &diagnostics
+        ));
+        assert!(!bench_real_governor_score_reconciles(
+            admitted + 1,
+            rejected,
+            &diagnostics
+        ));
     }
 
     #[test]

--- a/rust-engine/src/prefetch_governor.rs
+++ b/rust-engine/src/prefetch_governor.rs
@@ -31,7 +31,17 @@
 //! default `false`) so existing deployments and benchmarks are
 //! bit-for-bit unchanged until they enable it.
 
-use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+use serde::Serialize;
+use std::sync::{
+    atomic::{AtomicI64, AtomicU64, Ordering},
+    Mutex,
+};
+
+/// Maximum number of exact decision samples retained for percentile
+/// calculation. Counts, means, extrema, and decision-boundary values are
+/// accumulated over every decision in the window; only percentile samples
+/// are bounded to the most recent entries.
+pub const GOVERNOR_SCORE_SAMPLE_CAPACITY: usize = 512;
 
 /// Pack/unpack an `f64` into the bits of an `AtomicU64` so the EWMA can
 /// be read on the hot admission path with a single relaxed load.
@@ -42,6 +52,617 @@ fn load_f64(a: &AtomicU64) -> f64 {
 #[inline]
 fn store_f64(a: &AtomicU64, v: f64) {
     a.store(v.to_bits(), Ordering::Relaxed);
+}
+
+#[derive(Clone, Copy, Debug)]
+struct GovernorDecision {
+    candidate_probability: f64,
+    effective_precision: f64,
+    candidate_score: f64,
+    base_threshold: f64,
+    foreground_inflight: u64,
+    contention_weight: f64,
+    effective_threshold: f64,
+    admitted: bool,
+    score_minus_threshold_margin: f64,
+    score_to_threshold_ratio: Option<f64>,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct GovernorDecisionSample {
+    candidate_probability: f64,
+    effective_precision: f64,
+    candidate_score: f64,
+    effective_threshold: f64,
+    score_to_threshold_ratio: Option<f64>,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct RunningStats {
+    count: u64,
+    minimum: Option<f64>,
+    maximum: Option<f64>,
+    mean: f64,
+}
+
+impl RunningStats {
+    fn record(&mut self, value: f64) {
+        debug_assert!(value.is_finite());
+        self.count = self.count.saturating_add(1);
+        self.minimum = Some(self.minimum.map_or(value, |current| current.min(value)));
+        self.maximum = Some(self.maximum.map_or(value, |current| current.max(value)));
+        self.mean += (value - self.mean) / self.count as f64;
+    }
+}
+
+/// Finite distribution summary. Every value is `null` when `count == 0`.
+/// Percentiles use nearest-rank selection over the bounded decision sample.
+#[derive(Clone, Debug, Serialize)]
+pub struct GovernorDistributionSummary {
+    pub count: u64,
+    pub minimum: Option<f64>,
+    pub maximum: Option<f64>,
+    pub mean: Option<f64>,
+    pub p50: Option<f64>,
+    pub p90: Option<f64>,
+    pub p95: Option<f64>,
+    pub p99: Option<f64>,
+}
+
+impl GovernorDistributionSummary {
+    fn empty() -> Self {
+        Self {
+            count: 0,
+            minimum: None,
+            maximum: None,
+            mean: None,
+            p50: None,
+            p90: None,
+            p95: None,
+            p99: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct GovernorDecisionBoundary {
+    pub maximum_rejected_candidate_score: Option<f64>,
+    pub maximum_rejected_score_to_threshold_ratio: Option<f64>,
+    pub minimum_admitted_candidate_score: Option<f64>,
+    pub minimum_admitted_score_to_threshold_ratio: Option<f64>,
+    pub closest_rejected_score_minus_threshold_margin: Option<f64>,
+    pub closest_admitted_score_minus_threshold_margin: Option<f64>,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct GovernorForegroundDecisionCounts {
+    pub foreground_inflight_zero: u64,
+    pub foreground_inflight_zero_admitted: u64,
+    pub foreground_inflight_zero_rejected: u64,
+    pub foreground_inflight_positive: u64,
+    pub foreground_inflight_positive_admitted: u64,
+    pub foreground_inflight_positive_rejected: u64,
+}
+
+/// Bounded Phase 4D-B governor score diagnostics for one reset window.
+///
+/// Exact counters and running statistics cover every decision. Percentiles are
+/// nearest-rank values over a deterministic ring containing the most recent
+/// [`GOVERNOR_SCORE_SAMPLE_CAPACITY`] finite decisions. The private sample is
+/// retained only so measured-run snapshots can be merged without serializing
+/// per-decision events.
+#[derive(Clone, Debug, Serialize)]
+pub struct GovernorDecisionDiagnosticsSnapshot {
+    pub semantics: &'static str,
+    pub enabled: bool,
+    pub sample_capacity: usize,
+    pub sampled_decisions: usize,
+    pub total_decisions: u64,
+    pub admitted: u64,
+    pub rejected: u64,
+    pub invalid_numeric_decisions: u64,
+    pub ratio_undefined_decisions: u64,
+    pub base_threshold: f64,
+    pub contention_weight: f64,
+    pub candidate_probability: GovernorDistributionSummary,
+    pub effective_precision: GovernorDistributionSummary,
+    pub candidate_score: GovernorDistributionSummary,
+    pub effective_threshold: GovernorDistributionSummary,
+    pub score_to_threshold_ratio: GovernorDistributionSummary,
+    pub decision_boundary: GovernorDecisionBoundary,
+    pub foreground_inflight_decisions: GovernorForegroundDecisionCounts,
+    #[serde(skip)]
+    samples: Vec<GovernorDecisionSample>,
+}
+
+#[derive(Debug, Default)]
+struct GovernorDecisionDiagnostics {
+    total_decisions: u64,
+    admitted: u64,
+    rejected: u64,
+    invalid_numeric_decisions: u64,
+    ratio_undefined_decisions: u64,
+    candidate_probability: RunningStats,
+    effective_precision: RunningStats,
+    candidate_score: RunningStats,
+    effective_threshold: RunningStats,
+    score_to_threshold_ratio: RunningStats,
+    decision_boundary: GovernorDecisionBoundary,
+    foreground_inflight_decisions: GovernorForegroundDecisionCounts,
+    samples: Vec<GovernorDecisionSample>,
+    next_sample: usize,
+}
+
+impl GovernorDecisionDiagnostics {
+    fn record(&mut self, decision: GovernorDecision) {
+        self.total_decisions = self.total_decisions.saturating_add(1);
+        if decision.admitted {
+            self.admitted = self.admitted.saturating_add(1);
+        } else {
+            self.rejected = self.rejected.saturating_add(1);
+        }
+
+        let foreground = &mut self.foreground_inflight_decisions;
+        if decision.foreground_inflight == 0 {
+            foreground.foreground_inflight_zero =
+                foreground.foreground_inflight_zero.saturating_add(1);
+            if decision.admitted {
+                foreground.foreground_inflight_zero_admitted = foreground
+                    .foreground_inflight_zero_admitted
+                    .saturating_add(1);
+            } else {
+                foreground.foreground_inflight_zero_rejected = foreground
+                    .foreground_inflight_zero_rejected
+                    .saturating_add(1);
+            }
+        } else {
+            foreground.foreground_inflight_positive =
+                foreground.foreground_inflight_positive.saturating_add(1);
+            if decision.admitted {
+                foreground.foreground_inflight_positive_admitted = foreground
+                    .foreground_inflight_positive_admitted
+                    .saturating_add(1);
+            } else {
+                foreground.foreground_inflight_positive_rejected = foreground
+                    .foreground_inflight_positive_rejected
+                    .saturating_add(1);
+            }
+        }
+
+        let required_values = [
+            decision.candidate_probability,
+            decision.effective_precision,
+            decision.candidate_score,
+            decision.base_threshold,
+            decision.contention_weight,
+            decision.effective_threshold,
+            decision.score_minus_threshold_margin,
+        ];
+        if required_values.iter().any(|value| !value.is_finite()) {
+            self.invalid_numeric_decisions = self.invalid_numeric_decisions.saturating_add(1);
+            return;
+        }
+
+        self.candidate_probability
+            .record(decision.candidate_probability);
+        self.effective_precision
+            .record(decision.effective_precision);
+        self.candidate_score.record(decision.candidate_score);
+        self.effective_threshold
+            .record(decision.effective_threshold);
+        if let Some(ratio) = decision.score_to_threshold_ratio {
+            if ratio.is_finite() {
+                self.score_to_threshold_ratio.record(ratio);
+            } else {
+                self.ratio_undefined_decisions = self.ratio_undefined_decisions.saturating_add(1);
+            }
+        } else {
+            self.ratio_undefined_decisions = self.ratio_undefined_decisions.saturating_add(1);
+        }
+
+        let boundary = &mut self.decision_boundary;
+        if decision.admitted {
+            boundary.minimum_admitted_candidate_score = Some(
+                boundary
+                    .minimum_admitted_candidate_score
+                    .map_or(decision.candidate_score, |current| {
+                        current.min(decision.candidate_score)
+                    }),
+            );
+            boundary.closest_admitted_score_minus_threshold_margin = Some(
+                boundary
+                    .closest_admitted_score_minus_threshold_margin
+                    .map_or(decision.score_minus_threshold_margin, |current| {
+                        current.min(decision.score_minus_threshold_margin)
+                    }),
+            );
+            if let Some(ratio) = decision.score_to_threshold_ratio.filter(|v| v.is_finite()) {
+                boundary.minimum_admitted_score_to_threshold_ratio = Some(
+                    boundary
+                        .minimum_admitted_score_to_threshold_ratio
+                        .map_or(ratio, |current| current.min(ratio)),
+                );
+            }
+        } else {
+            boundary.maximum_rejected_candidate_score = Some(
+                boundary
+                    .maximum_rejected_candidate_score
+                    .map_or(decision.candidate_score, |current| {
+                        current.max(decision.candidate_score)
+                    }),
+            );
+            boundary.closest_rejected_score_minus_threshold_margin = Some(
+                boundary
+                    .closest_rejected_score_minus_threshold_margin
+                    .map_or(decision.score_minus_threshold_margin, |current| {
+                        current.max(decision.score_minus_threshold_margin)
+                    }),
+            );
+            if let Some(ratio) = decision.score_to_threshold_ratio.filter(|v| v.is_finite()) {
+                boundary.maximum_rejected_score_to_threshold_ratio = Some(
+                    boundary
+                        .maximum_rejected_score_to_threshold_ratio
+                        .map_or(ratio, |current| current.max(ratio)),
+                );
+            }
+        }
+
+        let sample = GovernorDecisionSample {
+            candidate_probability: decision.candidate_probability,
+            effective_precision: decision.effective_precision,
+            candidate_score: decision.candidate_score,
+            effective_threshold: decision.effective_threshold,
+            score_to_threshold_ratio: decision
+                .score_to_threshold_ratio
+                .filter(|value| value.is_finite()),
+        };
+        if self.samples.len() < GOVERNOR_SCORE_SAMPLE_CAPACITY {
+            self.samples.push(sample);
+        } else {
+            self.samples[self.next_sample] = sample;
+            self.next_sample = (self.next_sample + 1) % GOVERNOR_SCORE_SAMPLE_CAPACITY;
+        }
+    }
+
+    fn chronological_samples(&self) -> Vec<GovernorDecisionSample> {
+        if self.samples.len() < GOVERNOR_SCORE_SAMPLE_CAPACITY || self.next_sample == 0 {
+            return self.samples.clone();
+        }
+        let mut samples = Vec::with_capacity(GOVERNOR_SCORE_SAMPLE_CAPACITY);
+        samples.extend_from_slice(&self.samples[self.next_sample..]);
+        samples.extend_from_slice(&self.samples[..self.next_sample]);
+        samples
+    }
+}
+
+fn nearest_rank(values: &mut [f64], quantile: f64) -> Option<f64> {
+    if values.is_empty() {
+        return None;
+    }
+    values.sort_by(f64::total_cmp);
+    let rank = (quantile * values.len() as f64).ceil().max(1.0) as usize;
+    values.get(rank.saturating_sub(1)).copied()
+}
+
+fn distribution_summary(
+    stats: RunningStats,
+    samples: &[GovernorDecisionSample],
+    select: fn(&GovernorDecisionSample) -> Option<f64>,
+) -> GovernorDistributionSummary {
+    if stats.count == 0 {
+        return GovernorDistributionSummary::empty();
+    }
+    let sampled: Vec<f64> = samples.iter().filter_map(select).collect();
+    let percentile = |quantile| {
+        let mut values = sampled.clone();
+        nearest_rank(&mut values, quantile)
+    };
+    GovernorDistributionSummary {
+        count: stats.count,
+        minimum: stats.minimum,
+        maximum: stats.maximum,
+        mean: Some(stats.mean),
+        p50: percentile(0.50),
+        p90: percentile(0.90),
+        p95: percentile(0.95),
+        p99: percentile(0.99),
+    }
+}
+
+fn merge_distribution(
+    summaries: impl Iterator<Item = GovernorDistributionSummary>,
+    samples: &[GovernorDecisionSample],
+    select: fn(&GovernorDecisionSample) -> Option<f64>,
+) -> GovernorDistributionSummary {
+    let mut merged = RunningStats::default();
+    for summary in summaries {
+        if summary.count == 0 {
+            continue;
+        }
+        let prior_count = merged.count;
+        let next_count = prior_count.saturating_add(summary.count);
+        let summary_mean = summary
+            .mean
+            .expect("non-empty governor distribution has a mean");
+        merged.mean = if prior_count == 0 {
+            summary_mean
+        } else {
+            merged.mean + (summary_mean - merged.mean) * (summary.count as f64 / next_count as f64)
+        };
+        merged.count = next_count;
+        if let Some(minimum) = summary.minimum {
+            merged.minimum = Some(
+                merged
+                    .minimum
+                    .map_or(minimum, |current| current.min(minimum)),
+            );
+        }
+        if let Some(maximum) = summary.maximum {
+            merged.maximum = Some(
+                merged
+                    .maximum
+                    .map_or(maximum, |current| current.max(maximum)),
+            );
+        }
+    }
+    distribution_summary(merged, samples, select)
+}
+
+fn push_bounded_sample(
+    samples: &mut Vec<GovernorDecisionSample>,
+    next_sample: &mut usize,
+    sample: GovernorDecisionSample,
+) {
+    if samples.len() < GOVERNOR_SCORE_SAMPLE_CAPACITY {
+        samples.push(sample);
+    } else {
+        samples[*next_sample] = sample;
+        *next_sample = (*next_sample + 1) % GOVERNOR_SCORE_SAMPLE_CAPACITY;
+    }
+}
+
+fn optional_max(values: impl Iterator<Item = Option<f64>>) -> Option<f64> {
+    values.flatten().reduce(|current, value| current.max(value))
+}
+
+fn optional_min(values: impl Iterator<Item = Option<f64>>) -> Option<f64> {
+    values.flatten().reduce(|current, value| current.min(value))
+}
+
+impl GovernorDecisionDiagnosticsSnapshot {
+    fn from_state(
+        enabled: bool,
+        base_threshold: f64,
+        contention_weight: f64,
+        state: &GovernorDecisionDiagnostics,
+    ) -> Self {
+        let samples = state.chronological_samples();
+        Self {
+            semantics: "exact all-decision counts, running means, extrema, boundaries, and foreground splits; nearest-rank percentiles over a deterministic ring of the most recent 512 finite decisions since reset; ratio is undefined and excluded when the effective threshold is zero or division is nonfinite",
+            enabled,
+            sample_capacity: GOVERNOR_SCORE_SAMPLE_CAPACITY,
+            sampled_decisions: samples.len(),
+            total_decisions: state.total_decisions,
+            admitted: state.admitted,
+            rejected: state.rejected,
+            invalid_numeric_decisions: state.invalid_numeric_decisions,
+            ratio_undefined_decisions: state.ratio_undefined_decisions,
+            base_threshold,
+            contention_weight,
+            candidate_probability: distribution_summary(
+                state.candidate_probability,
+                &samples,
+                |sample| Some(sample.candidate_probability),
+            ),
+            effective_precision: distribution_summary(
+                state.effective_precision,
+                &samples,
+                |sample| Some(sample.effective_precision),
+            ),
+            candidate_score: distribution_summary(
+                state.candidate_score,
+                &samples,
+                |sample| Some(sample.candidate_score),
+            ),
+            effective_threshold: distribution_summary(
+                state.effective_threshold,
+                &samples,
+                |sample| Some(sample.effective_threshold),
+            ),
+            score_to_threshold_ratio: distribution_summary(
+                state.score_to_threshold_ratio,
+                &samples,
+                |sample| sample.score_to_threshold_ratio,
+            ),
+            decision_boundary: state.decision_boundary.clone(),
+            foreground_inflight_decisions: state.foreground_inflight_decisions.clone(),
+            samples,
+        }
+    }
+
+    /// Merge measured-run diagnostics. Exact summaries are merged by count;
+    /// percentiles use the same bounded ring semantics over the retained run
+    /// samples, in run order.
+    pub fn merge(snapshots: &[Self]) -> Self {
+        let default = GovernorConfig::default();
+        let enabled = snapshots.iter().any(|snapshot| snapshot.enabled);
+        let base_threshold = snapshots
+            .first()
+            .map(|snapshot| snapshot.base_threshold)
+            .unwrap_or(default.base_threshold);
+        let contention_weight = snapshots
+            .first()
+            .map(|snapshot| snapshot.contention_weight)
+            .unwrap_or(default.contention_weight);
+        let mut samples = Vec::with_capacity(GOVERNOR_SCORE_SAMPLE_CAPACITY);
+        let mut next_sample = 0;
+        for snapshot in snapshots {
+            for &sample in &snapshot.samples {
+                push_bounded_sample(&mut samples, &mut next_sample, sample);
+            }
+        }
+        if samples.len() == GOVERNOR_SCORE_SAMPLE_CAPACITY && next_sample > 0 {
+            samples.rotate_left(next_sample);
+        }
+        let total_decisions = snapshots
+            .iter()
+            .map(|snapshot| snapshot.total_decisions)
+            .sum();
+        let admitted = snapshots.iter().map(|snapshot| snapshot.admitted).sum();
+        let rejected = snapshots.iter().map(|snapshot| snapshot.rejected).sum();
+        let invalid_numeric_decisions = snapshots
+            .iter()
+            .map(|snapshot| snapshot.invalid_numeric_decisions)
+            .sum();
+        let ratio_undefined_decisions = snapshots
+            .iter()
+            .map(|snapshot| snapshot.ratio_undefined_decisions)
+            .sum();
+        let foreground_inflight_decisions = GovernorForegroundDecisionCounts {
+            foreground_inflight_zero: snapshots
+                .iter()
+                .map(|snapshot| {
+                    snapshot
+                        .foreground_inflight_decisions
+                        .foreground_inflight_zero
+                })
+                .sum(),
+            foreground_inflight_zero_admitted: snapshots
+                .iter()
+                .map(|snapshot| {
+                    snapshot
+                        .foreground_inflight_decisions
+                        .foreground_inflight_zero_admitted
+                })
+                .sum(),
+            foreground_inflight_zero_rejected: snapshots
+                .iter()
+                .map(|snapshot| {
+                    snapshot
+                        .foreground_inflight_decisions
+                        .foreground_inflight_zero_rejected
+                })
+                .sum(),
+            foreground_inflight_positive: snapshots
+                .iter()
+                .map(|snapshot| {
+                    snapshot
+                        .foreground_inflight_decisions
+                        .foreground_inflight_positive
+                })
+                .sum(),
+            foreground_inflight_positive_admitted: snapshots
+                .iter()
+                .map(|snapshot| {
+                    snapshot
+                        .foreground_inflight_decisions
+                        .foreground_inflight_positive_admitted
+                })
+                .sum(),
+            foreground_inflight_positive_rejected: snapshots
+                .iter()
+                .map(|snapshot| {
+                    snapshot
+                        .foreground_inflight_decisions
+                        .foreground_inflight_positive_rejected
+                })
+                .sum(),
+        };
+        Self {
+            semantics: "exact merged measured-run counts, weighted running means, extrema, boundaries, and foreground splits; nearest-rank percentiles over a deterministic ring of the most recent 512 retained finite decision samples in run order; ratio excludes zero-threshold or nonfinite divisions",
+            enabled,
+            sample_capacity: GOVERNOR_SCORE_SAMPLE_CAPACITY,
+            sampled_decisions: samples.len(),
+            total_decisions,
+            admitted,
+            rejected,
+            invalid_numeric_decisions,
+            ratio_undefined_decisions,
+            base_threshold,
+            contention_weight,
+            candidate_probability: merge_distribution(
+                snapshots
+                    .iter()
+                    .map(|snapshot| snapshot.candidate_probability.clone()),
+                &samples,
+                |sample| Some(sample.candidate_probability),
+            ),
+            effective_precision: merge_distribution(
+                snapshots
+                    .iter()
+                    .map(|snapshot| snapshot.effective_precision.clone()),
+                &samples,
+                |sample| Some(sample.effective_precision),
+            ),
+            candidate_score: merge_distribution(
+                snapshots
+                    .iter()
+                    .map(|snapshot| snapshot.candidate_score.clone()),
+                &samples,
+                |sample| Some(sample.candidate_score),
+            ),
+            effective_threshold: merge_distribution(
+                snapshots
+                    .iter()
+                    .map(|snapshot| snapshot.effective_threshold.clone()),
+                &samples,
+                |sample| Some(sample.effective_threshold),
+            ),
+            score_to_threshold_ratio: merge_distribution(
+                snapshots
+                    .iter()
+                    .map(|snapshot| snapshot.score_to_threshold_ratio.clone()),
+                &samples,
+                |sample| sample.score_to_threshold_ratio,
+            ),
+            decision_boundary: GovernorDecisionBoundary {
+                maximum_rejected_candidate_score: optional_max(
+                    snapshots.iter().map(|snapshot| {
+                        snapshot
+                            .decision_boundary
+                            .maximum_rejected_candidate_score
+                    }),
+                ),
+                maximum_rejected_score_to_threshold_ratio: optional_max(
+                    snapshots.iter().map(|snapshot| {
+                        snapshot
+                            .decision_boundary
+                            .maximum_rejected_score_to_threshold_ratio
+                    }),
+                ),
+                minimum_admitted_candidate_score: optional_min(
+                    snapshots.iter().map(|snapshot| {
+                        snapshot
+                            .decision_boundary
+                            .minimum_admitted_candidate_score
+                    }),
+                ),
+                minimum_admitted_score_to_threshold_ratio: optional_min(
+                    snapshots.iter().map(|snapshot| {
+                        snapshot
+                            .decision_boundary
+                            .minimum_admitted_score_to_threshold_ratio
+                    }),
+                ),
+                closest_rejected_score_minus_threshold_margin: optional_max(
+                    snapshots.iter().map(|snapshot| {
+                        snapshot
+                            .decision_boundary
+                            .closest_rejected_score_minus_threshold_margin
+                    }),
+                ),
+                closest_admitted_score_minus_threshold_margin: optional_min(
+                    snapshots.iter().map(|snapshot| {
+                        snapshot
+                            .decision_boundary
+                            .closest_admitted_score_minus_threshold_margin
+                    }),
+                ),
+            },
+            foreground_inflight_decisions,
+            samples,
+        }
+    }
 }
 
 /// Tunables for [`PrefetchGovernor`]. All values have safe, conservative
@@ -78,9 +699,9 @@ impl Default for GovernorConfig {
     }
 }
 
-/// Lock-free adaptive prefetch admission controller. Cheap to share
-/// behind an `Arc`: every field is a single atomic and the hot
-/// [`Self::admit`] path performs only relaxed loads.
+/// Adaptive prefetch admission controller. The decision inputs and direct
+/// counters remain atomic; enabled Phase 4D-B diagnostics add one bounded
+/// telemetry lock after the decision has been computed.
 #[derive(Debug)]
 pub struct PrefetchGovernor {
     enabled: bool,
@@ -109,6 +730,11 @@ pub struct PrefetchGovernor {
     throttled: AtomicU64,
     /// Telemetry: prefetches the governor admitted.
     admitted: AtomicU64,
+
+    /// Bounded score/threshold diagnostics. This lock never participates in
+    /// the admission calculation; poisoning is recovered so telemetry cannot
+    /// change a decision or fail the request path.
+    decision_diagnostics: Mutex<GovernorDecisionDiagnostics>,
 }
 
 /// RAII token for foreground-read accounting. Dropping the guard always
@@ -149,6 +775,7 @@ impl PrefetchGovernor {
             window_used: AtomicU64::new(0),
             throttled: AtomicU64::new(0),
             admitted: AtomicU64::new(0),
+            decision_diagnostics: Mutex::new(GovernorDecisionDiagnostics::default()),
         };
         // Seed the EWMA optimistically at `max(floor, 0.5)` so a freshly
         // started engine gives speculation a fair chance to prove itself
@@ -187,17 +814,48 @@ impl PrefetchGovernor {
         if !self.enabled {
             return true;
         }
-        let precision = load_f64(&self.precision_ewma).max(self.precision_floor);
-        let inflight = self.foreground_inflight.load(Ordering::Relaxed).max(0) as f64;
-        let value = prob.max(0.0) * precision;
-        let bar = self.base_threshold * (1.0 + self.contention_weight * inflight);
-        let ok = value >= bar;
-        if ok {
+        let decision = self.evaluate(prob);
+        let mut diagnostics = self
+            .decision_diagnostics
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if decision.admitted {
             self.admitted.fetch_add(1, Ordering::Relaxed);
         } else {
             self.throttled.fetch_add(1, Ordering::Relaxed);
         }
-        ok
+        diagnostics.record(decision);
+        decision.admitted
+    }
+
+    #[inline]
+    fn evaluate(&self, prob: f64) -> GovernorDecision {
+        let precision = load_f64(&self.precision_ewma).max(self.precision_floor);
+        let foreground_inflight = self.foreground_inflight.load(Ordering::Relaxed).max(0) as u64;
+        let candidate_probability = prob.max(0.0);
+        let candidate_score = candidate_probability * precision;
+        let effective_threshold =
+            self.base_threshold * (1.0 + self.contention_weight * foreground_inflight as f64);
+        let admitted = candidate_score >= effective_threshold;
+        let score_minus_threshold_margin = candidate_score - effective_threshold;
+        let score_to_threshold_ratio = if effective_threshold > 0.0 {
+            let ratio = candidate_score / effective_threshold;
+            ratio.is_finite().then_some(ratio)
+        } else {
+            None
+        };
+        GovernorDecision {
+            candidate_probability,
+            effective_precision: precision,
+            candidate_score,
+            base_threshold: self.base_threshold,
+            foreground_inflight,
+            contention_weight: self.contention_weight,
+            effective_threshold,
+            admitted,
+            score_minus_threshold_margin,
+            score_to_threshold_ratio,
+        }
     }
 
     /// RAII-free gauge bump: a foreground (blocking) read has started.
@@ -282,6 +940,58 @@ impl PrefetchGovernor {
             self.throttled.load(Ordering::Relaxed),
         )
     }
+
+    /// Snapshot bounded governor score diagnostics since the most recent
+    /// reset. Disabled governors return zero decisions and null distributions.
+    pub fn decision_diagnostics(&self) -> GovernorDecisionDiagnosticsSnapshot {
+        let diagnostics = self
+            .decision_diagnostics
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        GovernorDecisionDiagnosticsSnapshot::from_state(
+            self.enabled,
+            self.base_threshold,
+            self.contention_weight,
+            &diagnostics,
+        )
+    }
+
+    /// Atomically observe direct counters and their matching bounded
+    /// diagnostic window. Admission updates both while holding the same lock,
+    /// so the two views cannot straddle a decision.
+    pub fn decisions_and_diagnostics(&self) -> ((u64, u64), GovernorDecisionDiagnosticsSnapshot) {
+        let diagnostics = self
+            .decision_diagnostics
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let decisions = (
+            self.admitted.load(Ordering::Relaxed),
+            self.throttled.load(Ordering::Relaxed),
+        );
+        let snapshot = GovernorDecisionDiagnosticsSnapshot::from_state(
+            self.enabled,
+            self.base_threshold,
+            self.contention_weight,
+            &diagnostics,
+        );
+        (decisions, snapshot)
+    }
+
+    /// Start a fresh bounded diagnostic window without changing governor
+    /// precision, direct counters, foreground accounting, or admission policy.
+    /// The returned direct-counter boundary is sampled under the same lock as
+    /// the reset so subsequent deltas reconcile exactly with the new window.
+    pub fn reset_decision_diagnostics(&self) -> (u64, u64) {
+        let mut diagnostics = self
+            .decision_diagnostics
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *diagnostics = GovernorDecisionDiagnostics::default();
+        (
+            self.admitted.load(Ordering::Relaxed),
+            self.throttled.load(Ordering::Relaxed),
+        )
+    }
 }
 
 impl Default for PrefetchGovernor {
@@ -293,6 +1003,13 @@ impl Default for PrefetchGovernor {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn assert_close(actual: f64, expected: f64) {
+        assert!(
+            (actual - expected).abs() <= 1e-12,
+            "expected {expected}, got {actual}"
+        );
+    }
 
     #[test]
     fn disabled_governor_admits_everything() {
@@ -416,5 +1133,263 @@ mod tests {
         assert_eq!(admitted, 2);
         assert_eq!(rejected, 1);
         assert_eq!(total, 3);
+    }
+
+    #[test]
+    fn governor_score_diagnostics_use_exact_admission_values() {
+        let cfg = GovernorConfig {
+            precision_floor: 0.4,
+            contention_weight: 0.5,
+            base_threshold: 0.2,
+            ..GovernorConfig::default()
+        };
+        let g = PrefetchGovernor::new(true, cfg);
+        store_f64(&g.precision_ewma, 0.4);
+        g.begin_foreground();
+        g.begin_foreground();
+
+        let decision = g.evaluate(0.75);
+        assert_close(decision.candidate_probability, 0.75);
+        assert_close(decision.effective_precision, 0.4);
+        assert_close(decision.candidate_score, 0.3);
+        assert_close(decision.base_threshold, 0.2);
+        assert_eq!(decision.foreground_inflight, 2);
+        assert_close(decision.contention_weight, 0.5);
+        assert_close(decision.effective_threshold, 0.4);
+        assert!(!decision.admitted);
+        assert_close(decision.score_minus_threshold_margin, -0.1);
+        assert_close(decision.score_to_threshold_ratio.unwrap(), 0.75);
+
+        assert!(!g.admit(0.75));
+        let diagnostics = g.decision_diagnostics();
+        assert_eq!(diagnostics.total_decisions, 1);
+        assert_eq!(diagnostics.rejected, 1);
+        assert_close(diagnostics.candidate_score.mean.unwrap(), 0.3);
+        assert_close(diagnostics.effective_threshold.mean.unwrap(), 0.4);
+        assert_close(diagnostics.score_to_threshold_ratio.mean.unwrap(), 0.75);
+        assert_close(
+            diagnostics
+                .decision_boundary
+                .closest_rejected_score_minus_threshold_margin
+                .unwrap(),
+            -0.1,
+        );
+        assert_eq!(
+            diagnostics
+                .foreground_inflight_decisions
+                .foreground_inflight_positive_rejected,
+            1
+        );
+    }
+
+    #[test]
+    fn governor_score_diagnostics_cover_admission_and_foreground_groups() {
+        let cfg = GovernorConfig {
+            precision_floor: 1.0,
+            base_threshold: 0.2,
+            contention_weight: 1.0,
+            ..GovernorConfig::default()
+        };
+        let g = PrefetchGovernor::new(true, cfg);
+        store_f64(&g.precision_ewma, 1.0);
+        assert!(g.admit(0.3));
+        g.begin_foreground();
+        assert!(!g.admit(0.3));
+        let diagnostics = g.decision_diagnostics();
+        assert_eq!(diagnostics.total_decisions, 2);
+        assert_eq!(diagnostics.admitted, 1);
+        assert_eq!(diagnostics.rejected, 1);
+        assert_eq!(diagnostics.candidate_probability.count, 2);
+        assert_close(diagnostics.effective_threshold.minimum.unwrap(), 0.2);
+        assert_close(diagnostics.effective_threshold.maximum.unwrap(), 0.4);
+        assert_eq!(
+            diagnostics
+                .foreground_inflight_decisions
+                .foreground_inflight_zero_admitted,
+            1
+        );
+        assert_eq!(
+            diagnostics
+                .foreground_inflight_decisions
+                .foreground_inflight_positive_rejected,
+            1
+        );
+        assert_close(
+            diagnostics
+                .decision_boundary
+                .minimum_admitted_candidate_score
+                .unwrap(),
+            0.3,
+        );
+        assert_close(
+            diagnostics
+                .decision_boundary
+                .maximum_rejected_score_to_threshold_ratio
+                .unwrap(),
+            0.75,
+        );
+    }
+
+    #[test]
+    fn governor_score_empty_and_zero_threshold_semantics_are_explicit() {
+        let disabled = PrefetchGovernor::disabled().decision_diagnostics();
+        assert!(!disabled.enabled);
+        assert_eq!(disabled.total_decisions, 0);
+        assert!(disabled.candidate_score.mean.is_none());
+        assert!(disabled.score_to_threshold_ratio.p99.is_none());
+        assert!(disabled
+            .decision_boundary
+            .minimum_admitted_candidate_score
+            .is_none());
+
+        let g = PrefetchGovernor::new(
+            true,
+            GovernorConfig {
+                base_threshold: 0.0,
+                ..GovernorConfig::default()
+            },
+        );
+        assert!(g.admit(0.0));
+        let diagnostics = g.decision_diagnostics();
+        assert_eq!(diagnostics.total_decisions, 1);
+        assert_eq!(diagnostics.ratio_undefined_decisions, 1);
+        assert_eq!(diagnostics.score_to_threshold_ratio.count, 0);
+        assert!(diagnostics.score_to_threshold_ratio.mean.is_none());
+    }
+
+    #[test]
+    fn governor_score_percentiles_are_nearest_rank_and_memory_is_bounded() {
+        let g = PrefetchGovernor::new(
+            true,
+            GovernorConfig {
+                precision_floor: 1.0,
+                base_threshold: 0.1,
+                ..GovernorConfig::default()
+            },
+        );
+        store_f64(&g.precision_ewma, 1.0);
+        for value in 1..=10 {
+            g.admit(value as f64 / 10.0);
+        }
+        let percentiles = g.decision_diagnostics();
+        assert_close(percentiles.candidate_probability.p50.unwrap(), 0.5);
+        assert_close(percentiles.candidate_probability.p90.unwrap(), 0.9);
+        assert_close(percentiles.candidate_probability.p95.unwrap(), 1.0);
+        assert_close(percentiles.candidate_probability.p99.unwrap(), 1.0);
+
+        g.reset_decision_diagnostics();
+        for index in 0..(GOVERNOR_SCORE_SAMPLE_CAPACITY + 73) {
+            g.admit((index % 101) as f64 / 100.0);
+        }
+        let bounded = g.decision_diagnostics();
+        assert_eq!(
+            bounded.total_decisions,
+            (GOVERNOR_SCORE_SAMPLE_CAPACITY + 73) as u64
+        );
+        assert_eq!(bounded.sample_capacity, GOVERNOR_SCORE_SAMPLE_CAPACITY);
+        assert_eq!(bounded.sampled_decisions, GOVERNOR_SCORE_SAMPLE_CAPACITY);
+        assert_eq!(bounded.samples.len(), GOVERNOR_SCORE_SAMPLE_CAPACITY);
+    }
+
+    #[test]
+    fn governor_score_outputs_are_finite_and_counters_reconcile() {
+        let g = PrefetchGovernor::new(true, GovernorConfig::default());
+        for probability in [0.0, 0.01, 0.1, 0.5, 1.0] {
+            g.admit(probability);
+        }
+        let diagnostics = g.decision_diagnostics();
+        let (admitted, rejected) = g.decisions();
+        assert_eq!(diagnostics.total_decisions, admitted + rejected);
+        assert_eq!(diagnostics.admitted, admitted);
+        assert_eq!(diagnostics.rejected, rejected);
+        assert_eq!(diagnostics.invalid_numeric_decisions, 0);
+        for distribution in [
+            &diagnostics.candidate_probability,
+            &diagnostics.effective_precision,
+            &diagnostics.candidate_score,
+            &diagnostics.effective_threshold,
+            &diagnostics.score_to_threshold_ratio,
+        ] {
+            for value in [
+                distribution.minimum,
+                distribution.maximum,
+                distribution.mean,
+                distribution.p50,
+                distribution.p90,
+                distribution.p95,
+                distribution.p99,
+            ]
+            .into_iter()
+            .flatten()
+            {
+                assert!(value.is_finite());
+            }
+        }
+    }
+
+    #[test]
+    fn governor_score_reset_returns_exact_direct_counter_boundary() {
+        let g = PrefetchGovernor::new(true, GovernorConfig::default());
+        assert!(g.admit(1.0));
+        let boundary = g.reset_decision_diagnostics();
+        assert_eq!(boundary, (1, 0));
+
+        assert!(!g.admit(0.0));
+        let (direct, diagnostics) = g.decisions_and_diagnostics();
+        assert_eq!(direct, (1, 1));
+        assert_eq!(
+            diagnostics.total_decisions,
+            direct.0.saturating_sub(boundary.0) + direct.1.saturating_sub(boundary.1)
+        );
+        assert_eq!(diagnostics.admitted, 0);
+        assert_eq!(diagnostics.rejected, 1);
+    }
+
+    #[test]
+    fn governor_score_measured_run_snapshots_merge_with_exact_counts() {
+        let g = PrefetchGovernor::new(true, GovernorConfig::default());
+        assert!(g.admit(1.0));
+        assert!(!g.admit(0.0));
+        let first = g.decision_diagnostics();
+        g.reset_decision_diagnostics();
+        assert!(g.admit(0.5));
+        let second = g.decision_diagnostics();
+        let merged = GovernorDecisionDiagnosticsSnapshot::merge(&[first, second]);
+        assert_eq!(merged.total_decisions, 3);
+        assert_eq!(merged.admitted, 2);
+        assert_eq!(merged.rejected, 1);
+        assert_eq!(merged.sampled_decisions, 3);
+        assert_eq!(merged.candidate_score.count, 3);
+        assert_eq!(
+            merged
+                .foreground_inflight_decisions
+                .foreground_inflight_zero,
+            3
+        );
+        assert!(merged.candidate_score.mean.unwrap().is_finite());
+    }
+
+    #[test]
+    fn governor_score_decision_matches_pre_diagnostic_formula() {
+        let cfg = GovernorConfig {
+            precision_floor: 0.25,
+            base_threshold: 0.05,
+            contention_weight: 0.75,
+            ..GovernorConfig::default()
+        };
+        let g = PrefetchGovernor::new(true, cfg);
+        store_f64(&g.precision_ewma, 0.3);
+        for inflight in 0..=3 {
+            while g.foreground_inflight() < inflight {
+                g.begin_foreground();
+            }
+            for probability in [-0.5_f64, 0.0, 0.1, 0.5, 1.0] {
+                let precision = load_f64(&g.precision_ewma).max(g.precision_floor);
+                let foreground = g.foreground_inflight().max(0) as f64;
+                let legacy = probability.max(0.0) * precision
+                    >= g.base_threshold * (1.0 + g.contention_weight * foreground);
+                assert_eq!(g.evaluate(probability).admitted, legacy);
+            }
+        }
     }
 }

--- a/scripts/collect_qwen3_coder_prompt2_baseline.sh
+++ b/scripts/collect_qwen3_coder_prompt2_baseline.sh
@@ -17,7 +17,7 @@ TOKENIZER=${MER_QWEN_TOKENIZER:-$MER_QWEN_CONVERTED_DIR/tokenizer.json}
 ARTIFACT_DIR=${1:-}
 MODE_ARG=${2:-four-case}
 if [[ -z "$ARTIFACT_DIR" ]]; then
-  echo "usage: $0 ARTIFACT_DIR [four-case|phase4c-untraced|phase4d-screening|phase4b-diagnostic|--resident-only]" >&2
+  echo "usage: $0 ARTIFACT_DIR [four-case|phase4c-untraced|phase4d-screening|phase4d-b-score-calibration|phase4b-diagnostic|--resident-only]" >&2
   exit 2
 fi
 case "$MODE_ARG" in
@@ -52,13 +52,25 @@ case "$MODE_ARG" in
         ;;
     esac
     ;;
+  phase4d-b-score-calibration)
+    COLLECTOR_MODE=phase4d-b-score-calibration
+    QUALIFICATION_KIND=phase4d-b-score-calibration-diagnostic
+    EXPERIMENT_NAME=prompt2-phase4d-b-governor-score-calibration
+    case "$PREFETCH_VARIANT" in
+      demand-only|second-only-f1|second-only-f1-governed-current|second-only-f1-governed-bt005-cw000) ;;
+      *)
+        echo "phase4d-b-score-calibration requires a named Phase 4D-B diagnostic variant; found: $PREFETCH_VARIANT" >&2
+        exit 2
+        ;;
+    esac
+    ;;
   resident-only|--resident-only)
     COLLECTOR_MODE=resident-only
     QUALIFICATION_KIND=performance-baseline
     EXPERIMENT_NAME=prompt2-phase4a-prefetch-ablation
     ;;
   *)
-    echo "unknown collector mode: $MODE_ARG (expected four-case, phase4c-untraced, phase4d-screening, phase4b-diagnostic, or --resident-only)" >&2
+    echo "unknown collector mode: $MODE_ARG (expected four-case, phase4c-untraced, phase4d-screening, phase4d-b-score-calibration, phase4b-diagnostic, or --resident-only)" >&2
     exit 2
     ;;
 esac
@@ -72,7 +84,8 @@ if [[ "$COLLECTOR_MODE" == phase4b-diagnostic ]]; then
     exit 2
   fi
 fi
-if [[ "$COLLECTOR_MODE" == phase4d-screening ]]; then
+if [[ "$COLLECTOR_MODE" == phase4d-screening ||
+      "$COLLECTOR_MODE" == phase4d-b-score-calibration ]]; then
   MEASURED_RUNS=2
 fi
 
@@ -146,10 +159,14 @@ test -x /usr/bin/time
 
 WORKTREE_STATUS=$(git -C "$ROOT" status --short)
 if [[ -n "$WORKTREE_STATUS" &&
-      ("$COLLECTOR_MODE" == phase4d-screening || "${MER_ALLOW_DIRTY:-0}" != 1) ]]; then
+      ("$COLLECTOR_MODE" == phase4d-screening ||
+       "$COLLECTOR_MODE" == phase4d-b-score-calibration ||
+       "${MER_ALLOW_DIRTY:-0}" != 1) ]]; then
   echo "refusing a baseline from a dirty worktree; commit/stash changes or set MER_ALLOW_DIRTY=1 for a non-qualifying diagnostic" >&2
   if [[ "$COLLECTOR_MODE" == phase4d-screening ]]; then
     echo "Phase 4D-A screening always requires a clean worktree" >&2
+  elif [[ "$COLLECTOR_MODE" == phase4d-b-score-calibration ]]; then
+    echo "Phase 4D-B score calibration always requires a clean worktree" >&2
   fi
   printf '%s\n' "$WORKTREE_STATUS" >&2
   exit 1
@@ -235,7 +252,10 @@ prompt2_render_config "$TEMPLATE" "$ARTIFACT_DIR/configs/qwen3-coder-q8-1536.tom
   "$FIRST_ORDER_ENABLED" "$SECOND_ORDER_ENABLED" \
   "$FALLBACK_PRIOR_FILL_ENABLED" "$FANOUT_IS_UPPER_BOUND" \
   "$PREFETCH_GOVERNOR_ENABLED"
-if [[ "$COLLECTOR_MODE" != phase4b-diagnostic && "$COLLECTOR_MODE" != phase4c-untraced && "$COLLECTOR_MODE" != phase4d-screening ]]; then
+if [[ "$COLLECTOR_MODE" != phase4b-diagnostic &&
+      "$COLLECTOR_MODE" != phase4c-untraced &&
+      "$COLLECTOR_MODE" != phase4d-screening &&
+      "$COLLECTOR_MODE" != phase4d-b-score-calibration ]]; then
   prompt2_render_config "$TEMPLATE" "$ARTIFACT_DIR/configs/qwen3-coder-q8-6144.toml" \
     "$MODEL_REAL" "$TOKENIZER_REAL" 6144 "$PREDICT_FANOUT" "$PIPELINE_DEPTH" \
     "$FIRST_ORDER_ENABLED" "$SECOND_ORDER_ENABLED" \
@@ -246,7 +266,10 @@ fi
 # Physical pool sizing from build_bench_real_runtime:
 # primary=(cache_slots+1), shadow=predict_fanout*pipeline_depth.
 POOL_SLOTS=(1536 6144)
-if [[ "$COLLECTOR_MODE" == phase4b-diagnostic || "$COLLECTOR_MODE" == phase4c-untraced || "$COLLECTOR_MODE" == phase4d-screening ]]; then
+if [[ "$COLLECTOR_MODE" == phase4b-diagnostic ||
+      "$COLLECTOR_MODE" == phase4c-untraced ||
+      "$COLLECTOR_MODE" == phase4d-screening ||
+      "$COLLECTOR_MODE" == phase4d-b-score-calibration ]]; then
   POOL_SLOTS=(1536)
 fi
 for slots in "${POOL_SLOTS[@]}"; do
@@ -577,6 +600,20 @@ run_case() {
         (if .governor_total_decisions == 0 then 0
          else (.governor_admitted_candidates / .governor_total_decisions)
          end) and
+      .governor_score_diagnostics_reconcile == true and
+      .governor_score_diagnostics.total_decisions ==
+        .governor_total_decisions and
+      .governor_score_diagnostics.admitted ==
+        .governor_admitted_candidates and
+      .governor_score_diagnostics.rejected ==
+        .governor_rejected_candidates and
+      .governor_score_diagnostics.total_decisions ==
+        (.governor_score_diagnostics.admitted +
+         .governor_score_diagnostics.rejected) and
+      .governor_score_diagnostics.invalid_numeric_decisions == 0 and
+      .governor_score_diagnostics.sample_capacity == 512 and
+      .governor_score_diagnostics.sampled_decisions >= 0 and
+      .governor_score_diagnostics.sampled_decisions <= 512 and
       .governor_precision_ewma_final >= 0 and
       .governor_precision_ewma_final <= 1 and
       .governor_foreground_inflight_final == 0 and
@@ -729,6 +766,10 @@ run_case() {
       governor_rejected_candidates: .cache_io.governor_rejected_candidates,
       governor_total_decisions: .cache_io.governor_total_decisions,
       governor_admission_rate: .cache_io.governor_admission_rate,
+      governor_score_diagnostics:
+        .cache_io.governor_score_diagnostics,
+      governor_score_diagnostics_reconcile:
+        .cache_io.governor_score_diagnostics_reconcile,
       governor_precision_ewma_final: .cache_io.governor_precision_ewma_final,
       governor_foreground_inflight_final:
         .cache_io.governor_foreground_inflight_final,
@@ -879,7 +920,17 @@ run_case() {
             ($governor_runs |
              map(.demand_read_activity_while_speculation_active.total) |
              add)
-        }
+        },
+        score_diagnostics_by_run:
+          [$governor_runs[] | {
+            run_index,
+            reconcile: .governor_score_diagnostics_reconcile,
+            diagnostics: .governor_score_diagnostics
+          }],
+        score_diagnostics_aggregate:
+          .aggregate.governor_score_diagnostics,
+        score_diagnostics_aggregate_reconcile:
+          .aggregate.governor_score_diagnostics_reconcile
       },
       phase3a_decode: {
         routed_layers_observed: ([.runs[].demand_miss_fanout.decode.routed_layers_observed] | add),
@@ -981,6 +1032,20 @@ run_case() {
         qualification_kind: $collection_qualification.qualification_kind,
         screening_collection_valid:
           $collection_qualification.screening_collection_valid,
+        performance_qualification_applicable: false,
+        performance_qualification_reason:
+          $collection_qualification.performance_qualification_reason,
+        production_critical_path_coverage_gates_passed:
+          $collection_qualification.production_critical_path_coverage_gates_passed,
+        observed_critical_path_coverage:
+          $collection_qualification.observed_critical_path_coverage
+      }
+    elif $collection_qualification.qualification_kind ==
+         "phase4d-b-score-calibration-diagnostic" then
+      {
+        qualification_kind: $collection_qualification.qualification_kind,
+        score_calibration_collection_valid:
+          $collection_qualification.score_calibration_collection_valid,
         performance_qualification_applicable: false,
         performance_qualification_reason:
           $collection_qualification.performance_qualification_reason,
@@ -1135,6 +1200,102 @@ elif [[ "$COLLECTOR_MODE" == phase4d-screening ]]; then
     }
   ' > "$ARTIFACT_DIR/qualification.json"
 # END PHASE4D_SCREENING_COLLECTION
+# BEGIN PHASE4D_B_SCORE_CALIBRATION_COLLECTION
+elif [[ "$COLLECTOR_MODE" == phase4d-b-score-calibration ]]; then
+  run_case 1536 short 14 "$SHORT_PROMPT_SHA"
+
+  jq -n \
+    --arg variant "$PREFETCH_VARIANT" \
+    --slurpfile case_summary \
+      "$ARTIFACT_DIR/baseline-1536-short.case-summary.json" \
+    --slurpfile provenance "$ARTIFACT_DIR/ablation-provenance.json" \
+    --slurpfile raw "$ARTIFACT_DIR/baseline-1536-short.json" '
+    $case_summary[0] as $case |
+    $provenance[0] as $provenance |
+    $raw[0] as $raw |
+    {
+      schema: {
+        name:"mer-prompt2-phase4d-b-governor-score-calibration-variant",
+        version:1
+      },
+      qualification_kind: "phase4d-b-score-calibration-diagnostic",
+      variant: $variant,
+      cache_slots: 1536,
+      prompt_fixture: "short",
+      output_tokens: 128,
+      warmup_runs: 1,
+      measured_runs: 2,
+      cache_reset: "keep",
+      greedy: true,
+      traced: false,
+      metadata: $case.phase4c_predictor,
+      governor_configuration: $case.phase4c_governor.configuration,
+      governor_counters_by_run: $case.phase4c_governor.counters_by_run,
+      governor_totals: $case.phase4c_governor.totals,
+      governor_score_diagnostics_by_run:
+        $case.phase4c_governor.score_diagnostics_by_run,
+      governor_score_diagnostics:
+        $case.phase4c_governor.score_diagnostics_aggregate,
+      governor_score_diagnostics_reconcile:
+        $case.phase4c_governor.score_diagnostics_aggregate_reconcile,
+      foreground_accounting: {
+        final_by_run:
+          [$case.phase4c_governor.counters_by_run[] |
+           .governor_foreground_inflight_final],
+        final_aggregate:
+          $case.phase4c_governor.totals.governor_foreground_inflight_final
+      },
+      prefetch_counters: $case.phase4a_prefetch.counters,
+      provenance: {
+        git_commit_full: $provenance.git_commit_full,
+        binary_sha256: $provenance.binary_sha256,
+        model_hashes: $provenance.model_hashes,
+        tokenizer_identity: $provenance.tokenizer_identity,
+        target_host: $provenance.host,
+        model_mount_identity: $provenance.model_mount_identity,
+        cargo_features: $provenance.cargo_features,
+        prompt_hashes: $provenance.prompt_hashes
+      },
+      decode_tps_mean: $case.decode_tps_mean,
+      ssd_bytes: $case.ssd_bytes_total,
+      demand_read_service_mean_seconds:
+        $case.phase3a_decode.physical_read_issue_to_completion_mean_seconds,
+      output_token_ids: $raw.runs[0].output_token_ids,
+      output_parity_within_variant: $raw.aggregate.output_token_parity,
+      diagnostic_collection_valid:
+        $case.score_calibration_collection_valid,
+      performance_qualification_applicable: false,
+      performance_qualification_reason: $case.performance_qualification_reason,
+      qualification_passed: false
+    }
+  ' > "$ARTIFACT_DIR/phase4d-b-score-calibration-variant-summary.json"
+
+  jq -n \
+    --arg commit "$EXPECTED_COMMIT" \
+    --arg captured_at_utc "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg variant "$PREFETCH_VARIANT" \
+    --slurpfile variant_summary \
+      "$ARTIFACT_DIR/phase4d-b-score-calibration-variant-summary.json" '
+    {
+      schema: {name:"mer-prompt2-qualification", version:1},
+      git_commit_full: $commit,
+      captured_at_utc: $captured_at_utc,
+      qualification_kind: "phase4d-b-score-calibration-diagnostic",
+      phase4d_b_variant: $variant,
+      one_required_1536_short_case_present: true,
+      no_6144_cases_collected: true,
+      trace_disabled: true,
+      diagnostic_collection_valid:
+        $variant_summary[0].diagnostic_collection_valid,
+      governor_score_diagnostics_reconcile:
+        $variant_summary[0].governor_score_diagnostics_reconcile,
+      performance_qualification_applicable: false,
+      performance_qualification_reason:
+        "Phase 4D-B records bounded governor score distributions for diagnosis and is not a qualified production performance baseline",
+      qualification_passed: false
+    }
+  ' > "$ARTIFACT_DIR/qualification.json"
+# END PHASE4D_B_SCORE_CALIBRATION_COLLECTION
 elif [[ "$COLLECTOR_MODE" == phase4c-untraced ]]; then
   run_case 1536 short 14 "$SHORT_PROMPT_SHA"
   run_case 1536 medium 65 "$MEDIUM_PROMPT_SHA"

--- a/scripts/collect_qwen3_coder_prompt2_phase4d_b_score_calibration.sh
+++ b/scripts/collect_qwen3_coder_prompt2_phase4d_b_score_calibration.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+COLLECTOR="$ROOT/scripts/collect_qwen3_coder_prompt2_baseline.sh"
+FILTER="$ROOT/scripts/qwen3_coder_prompt2_phase4d_b_score_calibration.jq"
+DIAGNOSTIC_DIR=${1:-}
+
+if [[ -z "$DIAGNOSTIC_DIR" ]]; then
+  echo "usage: $0 DIAGNOSTIC_DIR" >&2
+  exit 2
+fi
+if [[ -n "${MER_PROMPT2_PHASE4B_TRACE_PATH:-}" ]]; then
+  echo "Phase 4D-B score calibration must be untraced; unset MER_PROMPT2_PHASE4B_TRACE_PATH" >&2
+  exit 2
+fi
+if [[ -n "$(git -C "$ROOT" status --short)" ]]; then
+  echo "Phase 4D-B score calibration requires a clean worktree" >&2
+  git -C "$ROOT" status --short >&2
+  exit 1
+fi
+RUNNER_GIT_COMMIT_FULL=$(git -C "$ROOT" rev-parse HEAD)
+
+mkdir -p "$DIAGNOSTIC_DIR"
+DIAGNOSTIC_DIR=$(cd "$DIAGNOSTIC_DIR" && pwd)
+variant_specs=(
+  "demand-only|0.05|0.02|1.0"
+  "second-only-f1|0.05|0.02|1.0"
+  "second-only-f1-governed-current|0.05|0.02|1.0"
+  "second-only-f1-governed-bt005-cw000|0.05|0.005|0.0"
+)
+
+first=true
+for spec in "${variant_specs[@]}"; do
+  IFS='|' read -r variant precision_floor base_threshold contention_weight <<<"$spec"
+  skip_build=1
+  if [[ "$first" == true ]]; then
+    skip_build=0
+    first=false
+  fi
+  MER_ALLOW_DIRTY=0 \
+  MER_SKIP_BUILD="$skip_build" \
+  MER_PROMPT2_PREFETCH_VARIANT="$variant" \
+  MER_PROMPT2_PREFETCH_GOVERNOR_PRECISION_FLOOR="$precision_floor" \
+  MER_PROMPT2_PREFETCH_GOVERNOR_BASE_THRESHOLD="$base_threshold" \
+  MER_PROMPT2_PREFETCH_GOVERNOR_CONTENTION_WEIGHT="$contention_weight" \
+    bash "$COLLECTOR" "$DIAGNOSTIC_DIR/$variant" \
+      phase4d-b-score-calibration
+done
+
+jq -n \
+  --arg runner_git_commit_full "$RUNNER_GIT_COMMIT_FULL" \
+  --slurpfile demand "$DIAGNOSTIC_DIR/demand-only/phase4d-b-score-calibration-variant-summary.json" \
+  --slurpfile second "$DIAGNOSTIC_DIR/second-only-f1/phase4d-b-score-calibration-variant-summary.json" \
+  --slurpfile current "$DIAGNOSTIC_DIR/second-only-f1-governed-current/phase4d-b-score-calibration-variant-summary.json" \
+  --slurpfile low "$DIAGNOSTIC_DIR/second-only-f1-governed-bt005-cw000/phase4d-b-score-calibration-variant-summary.json" \
+  -f "$FILTER" \
+  > "$DIAGNOSTIC_DIR/phase4d-b-governor-score-calibration-summary.json"
+
+jq -e '
+  .qualification_kind == "phase4d-b-score-calibration-diagnostic" and
+  .performance_qualification_applicable == false and
+  .qualification_passed == false and
+  .diagnostic_gates_passed == true
+' "$DIAGNOSTIC_DIR/phase4d-b-governor-score-calibration-summary.json" >/dev/null
+
+echo "Phase 4D-B governor score calibration complete: $DIAGNOSTIC_DIR"

--- a/scripts/qwen3_coder_prompt2_collection_qualification.jq
+++ b/scripts/qwen3_coder_prompt2_collection_qualification.jq
@@ -74,6 +74,8 @@ elif $qualification_kind == "phase4b-diagnostic" then
   diagnostic_collection_valid
 elif $qualification_kind == "phase4d-governor-screening" then
   screening_collection_valid
+elif $qualification_kind == "phase4d-b-score-calibration-diagnostic" then
+  screening_collection_valid
 else
   false
 end) as $collection_valid |
@@ -100,6 +102,12 @@ end) as $collection_valid |
     else null
     end
   ),
+  score_calibration_collection_valid: (
+    if $qualification_kind == "phase4d-b-score-calibration-diagnostic"
+    then $collection_valid
+    else null
+    end
+  ),
   performance_qualification_applicable: ($qualification_kind == "performance-baseline"),
   performance_qualification_passed: (
     if $qualification_kind == "performance-baseline"
@@ -112,6 +120,8 @@ end) as $collection_valid |
       "synchronous Phase 4B JSONL tracing adds diagnostic wall time outside production critical-path categories; traced TPS and coverage are not comparable with untraced Phase 4A performance baselines"
     elif $qualification_kind == "phase4d-governor-screening" then
       "Phase 4D-A uses one warmup and two measured short-prompt runs for calibration screening; it is diagnostic evidence and not a qualified production performance baseline"
+    elif $qualification_kind == "phase4d-b-score-calibration-diagnostic" then
+      "Phase 4D-B records bounded governor score and threshold distributions from one warmup and two measured short-prompt runs; it is diagnostic evidence and not a qualified production performance baseline"
     else
       null
     end

--- a/scripts/qwen3_coder_prompt2_phase4d_b_score_calibration.jq
+++ b/scripts/qwen3_coder_prompt2_phase4d_b_score_calibration.jq
@@ -126,11 +126,16 @@ def direct_counters_reconcile:
      .governor_totals.governor_rejected_candidates);
 
 def diagnostic_counters_reconcile:
+  .governor_configuration.enabled as $governor_enabled |
+  .governor_totals as $governor_totals |
   ([.governor_counters_by_run[] |
+    . as $run |
     .governor_score_diagnostics_reconcile == true and
-    (.governor_score_diagnostics |
-     diagnostics_valid(.enabled;
-       .total_decisions; .admitted; .rejected)) and
+    ($run.governor_score_diagnostics |
+     diagnostics_valid($governor_enabled;
+       $run.governor_total_decisions;
+       $run.governor_admitted_candidates;
+       $run.governor_rejected_candidates)) and
     .governor_score_diagnostics.total_decisions ==
       .governor_total_decisions and
     .governor_score_diagnostics.admitted ==
@@ -139,8 +144,10 @@ def diagnostic_counters_reconcile:
       .governor_rejected_candidates] | all) and
   .governor_score_diagnostics_reconcile == true and
   (.governor_score_diagnostics |
-   diagnostics_valid(.enabled;
-     .total_decisions; .admitted; .rejected)) and
+   diagnostics_valid($governor_enabled;
+     $governor_totals.governor_total_decisions;
+     $governor_totals.governor_admitted_candidates;
+     $governor_totals.governor_rejected_candidates)) and
   .governor_score_diagnostics.total_decisions ==
     .governor_totals.governor_total_decisions and
   .governor_score_diagnostics.admitted ==

--- a/scripts/qwen3_coder_prompt2_phase4d_b_score_calibration.jq
+++ b/scripts/qwen3_coder_prompt2_phase4d_b_score_calibration.jq
@@ -1,0 +1,328 @@
+def item($value): $value[0];
+
+def finite_number:
+  type == "number" and (isnan or isinfinite) == false;
+
+def nullable_finite:
+  . == null or finite_number;
+
+def distribution_valid($expected_count):
+  .count == $expected_count and
+  (if $expected_count == 0 then
+     [.minimum, .maximum, .mean, .p50, .p90, .p95, .p99] |
+     all(. == null)
+   else
+     [.minimum, .maximum, .mean, .p50, .p90, .p95, .p99] |
+     all(finite_number)
+   end);
+
+def boundary_valid($admitted; $rejected):
+  (if $rejected == 0 then
+     .maximum_rejected_candidate_score == null and
+     .maximum_rejected_score_to_threshold_ratio == null and
+     .closest_rejected_score_minus_threshold_margin == null
+   else
+     (.maximum_rejected_candidate_score | finite_number) and
+     (.maximum_rejected_score_to_threshold_ratio | finite_number) and
+     .maximum_rejected_score_to_threshold_ratio < 1 and
+     (.closest_rejected_score_minus_threshold_margin | finite_number) and
+     .closest_rejected_score_minus_threshold_margin < 0
+   end) and
+  (if $admitted == 0 then
+     .minimum_admitted_candidate_score == null and
+     .minimum_admitted_score_to_threshold_ratio == null and
+     .closest_admitted_score_minus_threshold_margin == null
+   else
+     (.minimum_admitted_candidate_score | finite_number) and
+     (.minimum_admitted_score_to_threshold_ratio | finite_number) and
+     .minimum_admitted_score_to_threshold_ratio >= 1 and
+     (.closest_admitted_score_minus_threshold_margin | finite_number) and
+     .closest_admitted_score_minus_threshold_margin >= 0
+   end);
+
+def foreground_counts_valid($total; $admitted; $rejected):
+  .foreground_inflight_zero >= 0 and
+  .foreground_inflight_zero_admitted >= 0 and
+  .foreground_inflight_zero_rejected >= 0 and
+  .foreground_inflight_positive >= 0 and
+  .foreground_inflight_positive_admitted >= 0 and
+  .foreground_inflight_positive_rejected >= 0 and
+  .foreground_inflight_zero ==
+    (.foreground_inflight_zero_admitted +
+     .foreground_inflight_zero_rejected) and
+  .foreground_inflight_positive ==
+    (.foreground_inflight_positive_admitted +
+     .foreground_inflight_positive_rejected) and
+  (.foreground_inflight_zero + .foreground_inflight_positive) == $total and
+  (.foreground_inflight_zero_admitted +
+   .foreground_inflight_positive_admitted) == $admitted and
+  (.foreground_inflight_zero_rejected +
+   .foreground_inflight_positive_rejected) == $rejected;
+
+def diagnostics_valid($enabled; $total; $admitted; $rejected):
+  .enabled == $enabled and
+  (.semantics | type == "string" and length > 0) and
+  .sample_capacity == 512 and
+  .sampled_decisions == ([$total, 512] | min) and
+  .total_decisions == $total and
+  .admitted == $admitted and
+  .rejected == $rejected and
+  .total_decisions == (.admitted + .rejected) and
+  .invalid_numeric_decisions == 0 and
+  .ratio_undefined_decisions == 0 and
+  (.base_threshold | finite_number) and
+  (.contention_weight | finite_number) and
+  (.candidate_probability | distribution_valid($total)) and
+  (.effective_precision | distribution_valid($total)) and
+  (.candidate_score | distribution_valid($total)) and
+  (.effective_threshold | distribution_valid($total)) and
+  (.score_to_threshold_ratio | distribution_valid($total)) and
+  (.decision_boundary | boundary_valid($admitted; $rejected)) and
+  (.foreground_inflight_decisions |
+   foreground_counts_valid($total; $admitted; $rejected));
+
+def expected_governor_config($enabled; $base_threshold; $contention_weight):
+  {
+    enabled: $enabled,
+    precision_floor: 0.05,
+    contention_weight: $contention_weight,
+    base_threshold: $base_threshold,
+    runtime_default_precision_alpha: 0.2,
+    runtime_default_base_threshold: 0.02
+  };
+
+def second_only_metadata_valid($variant; $enabled):
+  .metadata == {
+    variant: $variant,
+    predictor_mode: "second-order-only",
+    predict_fanout: 1,
+    pipeline_depth: 3,
+    first_order_enabled: false,
+    second_order_enabled: true,
+    fallback_prior_fill_enabled: false,
+    fanout_is_upper_bound: true,
+    governor_enabled: $enabled,
+    neural_speculator_enabled: false
+  };
+
+def direct_run_reconciles:
+  .governor_total_decisions ==
+    (.governor_admitted_candidates + .governor_rejected_candidates) and
+  .direct_governor_decisions.total_decisions ==
+    .governor_total_decisions and
+  .direct_governor_decisions.admitted_candidates ==
+    .governor_admitted_candidates and
+  .direct_governor_decisions.rejected_candidates ==
+    .governor_rejected_candidates;
+
+def direct_counters_reconcile:
+  ([.governor_counters_by_run[] | direct_run_reconciles] | all) and
+  .governor_totals.governor_admitted_candidates ==
+    ([.governor_counters_by_run[].governor_admitted_candidates] | add) and
+  .governor_totals.governor_rejected_candidates ==
+    ([.governor_counters_by_run[].governor_rejected_candidates] | add) and
+  .governor_totals.governor_total_decisions ==
+    (.governor_totals.governor_admitted_candidates +
+     .governor_totals.governor_rejected_candidates);
+
+def diagnostic_counters_reconcile:
+  ([.governor_counters_by_run[] |
+    .governor_score_diagnostics_reconcile == true and
+    (.governor_score_diagnostics |
+     diagnostics_valid(.enabled;
+       .total_decisions; .admitted; .rejected)) and
+    .governor_score_diagnostics.total_decisions ==
+      .governor_total_decisions and
+    .governor_score_diagnostics.admitted ==
+      .governor_admitted_candidates and
+    .governor_score_diagnostics.rejected ==
+      .governor_rejected_candidates] | all) and
+  .governor_score_diagnostics_reconcile == true and
+  (.governor_score_diagnostics |
+   diagnostics_valid(.enabled;
+     .total_decisions; .admitted; .rejected)) and
+  .governor_score_diagnostics.total_decisions ==
+    .governor_totals.governor_total_decisions and
+  .governor_score_diagnostics.admitted ==
+    .governor_totals.governor_admitted_candidates and
+  .governor_score_diagnostics.rejected ==
+    .governor_totals.governor_rejected_candidates;
+
+def nonempty_string:
+  type == "string" and length > 0;
+
+def git_sha:
+  type == "string" and test("^[0-9a-f]{40}$");
+
+def sha256:
+  type == "string" and test("^[0-9a-f]{64}$");
+
+def provenance_complete($runner_git_commit_full):
+  .provenance.git_commit_full == $runner_git_commit_full and
+  (.provenance.git_commit_full | git_sha) and
+  (.provenance.binary_sha256 | sha256) and
+  (.provenance.model_hashes.config_json_sha256 | sha256) and
+  (.provenance.model_hashes.dense_manifest_sha256 | sha256) and
+  (.provenance.tokenizer_identity.path | nonempty_string) and
+  (.provenance.tokenizer_identity.sha256 | sha256) and
+  (.provenance.target_host.hostname | nonempty_string) and
+  .provenance.target_host.logical_cpu_count == 32 and
+  .provenance.target_host.requested_cpu_mask == "0-31" and
+  .provenance.target_host.effective_cpu_mask == "0-31" and
+  (.provenance.model_mount_identity.target | nonempty_string) and
+  (.provenance.model_mount_identity.fstype | nonempty_string) and
+  (.provenance.model_mount_identity.options | nonempty_string) and
+  (.provenance.cargo_features | type) == "array" and
+  (.provenance.cargo_features | length) > 0 and
+  (.provenance.prompt_hashes.short_sha256 | sha256);
+
+def reported_variant($variant):
+  {
+    variant: $variant.variant,
+    governor_configuration: $variant.governor_configuration,
+    provenance: $variant.provenance,
+    decode_tps_mean: $variant.decode_tps_mean,
+    ssd_bytes: $variant.ssd_bytes,
+    demand_read_service_mean_seconds:
+      $variant.demand_read_service_mean_seconds,
+    governor_counters_by_run: $variant.governor_counters_by_run,
+    governor_totals: $variant.governor_totals,
+    governor_direct_counters: {
+      admitted: $variant.governor_totals.governor_admitted_candidates,
+      rejected: $variant.governor_totals.governor_rejected_candidates,
+      total: $variant.governor_totals.governor_total_decisions
+    },
+    governor_score_diagnostics: $variant.governor_score_diagnostics,
+    governor_score_diagnostics_by_run:
+      $variant.governor_score_diagnostics_by_run,
+    governor_score_diagnostics_reconcile:
+      $variant.governor_score_diagnostics_reconcile,
+    foreground_accounting: $variant.foreground_accounting,
+    prefetch_counters: $variant.prefetch_counters,
+    output_token_ids: $variant.output_token_ids,
+    diagnostic_collection_valid: $variant.diagnostic_collection_valid,
+    qualification_passed: false
+  };
+
+[
+  item($demand),
+  item($second),
+  item($current),
+  item($low)
+] as $variants |
+[
+  "demand-only",
+  "second-only-f1",
+  "second-only-f1-governed-current",
+  "second-only-f1-governed-bt005-cw000"
+] as $expected_order |
+($variants[0].provenance) as $reference_provenance |
+{
+  exact_variant_order:
+    ([$variants[].variant] == $expected_order),
+  deterministic_output_parity:
+    (($variants | all(.output_parity_within_variant == true)) and
+     ([$variants[].output_token_ids] | unique | length) == 1),
+  expected_predictor_configuration:
+    ($variants[0].metadata == {
+       variant: "demand-only",
+       predictor_mode: "demand-only",
+       predict_fanout: 0,
+       pipeline_depth: 3,
+       first_order_enabled: true,
+       second_order_enabled: true,
+       fallback_prior_fill_enabled: true,
+       fanout_is_upper_bound: false,
+       governor_enabled: false,
+       neural_speculator_enabled: false
+     } and
+     ($variants[1] |
+      second_only_metadata_valid("second-only-f1"; false)) and
+     ($variants[2] |
+      second_only_metadata_valid("second-only-f1-governed-current"; true)) and
+     ($variants[3] |
+      second_only_metadata_valid(
+        "second-only-f1-governed-bt005-cw000"; true))),
+  expected_governor_configuration:
+    ($variants[0].governor_configuration ==
+       expected_governor_config(false; 0.02; 1.0) and
+     $variants[1].governor_configuration ==
+       expected_governor_config(false; 0.02; 1.0) and
+     $variants[2].governor_configuration ==
+       expected_governor_config(true; 0.02; 1.0) and
+     $variants[3].governor_configuration ==
+       expected_governor_config(true; 0.005; 0.0)),
+  direct_counters_reconcile:
+    ($variants | all(direct_counters_reconcile)),
+  diagnostic_decision_counters_reconcile:
+    ($variants | all(diagnostic_counters_reconcile)),
+  foreground_read_accounting_balanced:
+    ($variants | all(
+      ([.foreground_accounting.final_by_run[]] | all(. == 0)) and
+      .foreground_accounting.final_aggregate == 0)),
+  cross_variant_provenance_identical:
+    (($runner_git_commit_full | git_sha) and
+     ($variants | all(
+       .provenance == $reference_provenance and
+       provenance_complete($runner_git_commit_full)
+     ))),
+  demand_only_has_no_governor_decisions:
+    ($variants[0].governor_totals.governor_total_decisions == 0 and
+     $variants[0].governor_score_diagnostics.total_decisions == 0),
+  ungoverned_control_performs_speculative_work:
+    ($variants[1].prefetch_counters.prefetch_submitted > 0 and
+     $variants[1].prefetch_counters.prefetch_completed > 0 and
+     $variants[1].governor_totals.governor_total_decisions == 0 and
+     $variants[1].governor_score_diagnostics.total_decisions == 0),
+  governed_variants_make_governor_decisions:
+    ($variants[2:4] | all(
+      .governor_totals.governor_total_decisions > 0 and
+      .governor_score_diagnostics.total_decisions > 0)),
+  all_statistics_finite_or_explicitly_null:
+    ($variants | all(diagnostic_counters_reconcile)),
+  diagnostic_mode_is_non_qualifying:
+    ($variants | all(
+      .qualification_kind == "phase4d-b-score-calibration-diagnostic" and
+      .diagnostic_collection_valid == true and
+      .performance_qualification_applicable == false and
+      .qualification_passed == false and
+      .traced == false and
+      .cache_slots == 1536 and
+      .prompt_fixture == "short" and
+      .output_tokens == 128 and
+      .warmup_runs == 1 and
+      .measured_runs == 2 and
+      .cache_reset == "keep" and
+      .greedy == true and
+      .metadata.neural_speculator_enabled == false
+    ))
+} as $gates |
+{
+  schema: {
+    name:"mer-prompt2-phase4d-b-governor-score-calibration-summary",
+    version:1
+  },
+  qualification_kind: "phase4d-b-score-calibration-diagnostic",
+  performance_qualification_applicable: false,
+  performance_qualification_reason:
+    "Phase 4D-B measures bounded governor score and threshold distributions and cannot qualify as a production performance baseline",
+  qualification_passed: false,
+  traced: false,
+  cache_slots: 1536,
+  prompt_fixture: "short",
+  output_tokens: 128,
+  warmup_runs: 1,
+  measured_runs: 2,
+  cache_reset: "keep",
+  greedy: true,
+  neural_speculator_enabled: false,
+  percentile_semantics:
+    "nearest-rank percentiles over a deterministic ring of the most recent 512 finite decisions; counts, means, extrema, boundary values, and foreground splits cover every decision in each reset window",
+  empty_population_semantics:
+    "distribution statistics and decision-boundary values are null when their population is empty; disabled-governor controls report zero decisions and do not fabricate scores",
+  runner_git_commit_full: $runner_git_commit_full,
+  expected_variant_order: $expected_order,
+  variants: [$variants[] | reported_variant(.)],
+  gates: $gates,
+  diagnostic_gates_passed: ([$gates[]] | all(. == true))
+}

--- a/scripts/tests/test_qwen3_coder_prompt2_phase4d_b_score_calibration.sh
+++ b/scripts/tests/test_qwen3_coder_prompt2_phase4d_b_score_calibration.sh
@@ -356,6 +356,28 @@ jq -e '
   .qualification_passed == false
 ' "$TEST_ROOT/counter-mismatch-summary.json" >/dev/null
 
+jq '.governor_counters_by_run[0].governor_score_diagnostics.enabled = false' \
+  "$TEST_ROOT/current.json" > "$TEST_ROOT/run-enabled-mismatch.json"
+render_summary "$TEST_ROOT/demand.json" "$TEST_ROOT/second.json" \
+  "$TEST_ROOT/run-enabled-mismatch.json" "$TEST_ROOT/low.json" \
+  "$TEST_ROOT/run-enabled-mismatch-summary.json"
+jq -e '
+  .gates.diagnostic_decision_counters_reconcile == false and
+  .diagnostic_gates_passed == false and
+  .qualification_passed == false
+' "$TEST_ROOT/run-enabled-mismatch-summary.json" >/dev/null
+
+jq '.governor_score_diagnostics.enabled = false' \
+  "$TEST_ROOT/current.json" > "$TEST_ROOT/aggregate-enabled-mismatch.json"
+render_summary "$TEST_ROOT/demand.json" "$TEST_ROOT/second.json" \
+  "$TEST_ROOT/aggregate-enabled-mismatch.json" "$TEST_ROOT/low.json" \
+  "$TEST_ROOT/aggregate-enabled-mismatch-summary.json"
+jq -e '
+  .gates.diagnostic_decision_counters_reconcile == false and
+  .diagnostic_gates_passed == false and
+  .qualification_passed == false
+' "$TEST_ROOT/aggregate-enabled-mismatch-summary.json" >/dev/null
+
 jq '.governor_score_diagnostics.candidate_score.mean = "NaN"' \
   "$TEST_ROOT/current.json" > "$TEST_ROOT/nonfinite.json"
 render_summary "$TEST_ROOT/demand.json" "$TEST_ROOT/second.json" \

--- a/scripts/tests/test_qwen3_coder_prompt2_phase4d_b_score_calibration.sh
+++ b/scripts/tests/test_qwen3_coder_prompt2_phase4d_b_score_calibration.sh
@@ -1,0 +1,436 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+FILTER="$ROOT/scripts/qwen3_coder_prompt2_phase4d_b_score_calibration.jq"
+RUNNER="$ROOT/scripts/collect_qwen3_coder_prompt2_phase4d_b_score_calibration.sh"
+COLLECTOR="$ROOT/scripts/collect_qwen3_coder_prompt2_baseline.sh"
+TEST_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/mer-prompt2-phase4d-b-score.XXXXXX")
+trap 'rm -rf -- "$TEST_ROOT"' EXIT
+
+TEST_GIT_COMMIT_FULL=0123456789012345678901234567890123456789
+TEST_SHA256=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+make_variant() {
+  local variant=$1
+  local governor_enabled=$2
+  local base_threshold=$3
+  local contention_weight=$4
+  local admitted_per_run=$5
+  local rejected_per_run=$6
+  local prefetch_submitted=$7
+  local prefetch_completed=$8
+  local output=$9
+
+  jq -n \
+    --arg variant "$variant" \
+    --argjson governor_enabled "$governor_enabled" \
+    --argjson base_threshold "$base_threshold" \
+    --argjson contention_weight "$contention_weight" \
+    --argjson admitted "$admitted_per_run" \
+    --argjson rejected "$rejected_per_run" \
+    --argjson prefetch_submitted "$prefetch_submitted" \
+    --argjson prefetch_completed "$prefetch_completed" \
+    --arg git_commit_full "$TEST_GIT_COMMIT_FULL" \
+    --arg sha "$TEST_SHA256" '
+    def distribution($count; $minimum; $maximum; $mean):
+      if $count == 0 then
+        {
+          count: 0,
+          minimum: null,
+          maximum: null,
+          mean: null,
+          p50: null,
+          p90: null,
+          p95: null,
+          p99: null
+        }
+      else
+        {
+          count: $count,
+          minimum: $minimum,
+          maximum: $maximum,
+          mean: $mean,
+          p50: $mean,
+          p90: $maximum,
+          p95: $maximum,
+          p99: $maximum
+        }
+      end;
+
+    def diagnostics($enabled; $base; $weight; $admitted; $rejected):
+      ($admitted + $rejected) as $total |
+      ($base * 0.2) as $rejected_score |
+      ($base * 1.2) as $admitted_score |
+      {
+        semantics:
+          "exact counts and bounded nearest-rank percentiles over the most recent 512 finite decisions",
+        enabled: $enabled,
+        sample_capacity: 512,
+        sampled_decisions: $total,
+        total_decisions: $total,
+        admitted: $admitted,
+        rejected: $rejected,
+        invalid_numeric_decisions: 0,
+        ratio_undefined_decisions: 0,
+        base_threshold: $base,
+        contention_weight: $weight,
+        candidate_probability:
+          distribution($total; 0.1; 0.5; 0.3),
+        effective_precision:
+          distribution($total; 0.05; 0.5; 0.2),
+        candidate_score:
+          distribution(
+            $total;
+            (if $rejected > 0 then $rejected_score else $admitted_score end);
+            (if $admitted > 0 then $admitted_score else $rejected_score end);
+            (if $admitted > 0 and $rejected > 0 then
+               (($rejected_score + $admitted_score) / 2)
+             elif $admitted > 0 then $admitted_score
+             else $rejected_score
+             end)),
+        effective_threshold:
+          distribution($total; $base; $base; $base),
+        score_to_threshold_ratio:
+          distribution(
+            $total;
+            (if $rejected > 0 then 0.2 else 1.2 end);
+            (if $admitted > 0 then 1.2 else 0.2 end);
+            (if $admitted > 0 and $rejected > 0 then 0.7
+             elif $admitted > 0 then 1.2
+             else 0.2
+             end)),
+        decision_boundary: {
+          maximum_rejected_candidate_score:
+            (if $rejected > 0 then $rejected_score else null end),
+          maximum_rejected_score_to_threshold_ratio:
+            (if $rejected > 0 then 0.2 else null end),
+          minimum_admitted_candidate_score:
+            (if $admitted > 0 then $admitted_score else null end),
+          minimum_admitted_score_to_threshold_ratio:
+            (if $admitted > 0 then 1.2 else null end),
+          closest_rejected_score_minus_threshold_margin:
+            (if $rejected > 0 then ($rejected_score - $base) else null end),
+          closest_admitted_score_minus_threshold_margin:
+            (if $admitted > 0 then ($admitted_score - $base) else null end)
+        },
+        foreground_inflight_decisions: {
+          foreground_inflight_zero: $total,
+          foreground_inflight_zero_admitted: $admitted,
+          foreground_inflight_zero_rejected: $rejected,
+          foreground_inflight_positive: 0,
+          foreground_inflight_positive_admitted: 0,
+          foreground_inflight_positive_rejected: 0
+        }
+      };
+
+    def run($index):
+      diagnostics(
+        $governor_enabled;
+        $base_threshold;
+        $contention_weight;
+        $admitted;
+        $rejected
+      ) as $diagnostics |
+      {
+        run_index: $index,
+        governor_enabled: $governor_enabled,
+        governor_admitted_candidates: $admitted,
+        governor_rejected_candidates: $rejected,
+        governor_total_decisions: ($admitted + $rejected),
+        governor_admission_rate:
+          (if ($admitted + $rejected) == 0 then 0
+           else ($admitted / ($admitted + $rejected)) end),
+        governor_precision_ewma_final: 0.05,
+        governor_foreground_inflight_final: 0,
+        governor_score_diagnostics: $diagnostics,
+        governor_score_diagnostics_reconcile: true,
+        direct_governor_decisions: {
+          admitted_candidates: $admitted,
+          rejected_candidates: $rejected,
+          total_decisions: ($admitted + $rejected),
+          admission_rate:
+            (if ($admitted + $rejected) == 0 then 0
+             else ($admitted / ($admitted + $rejected)) end)
+        }
+      };
+
+    [run(0), run(1)] as $runs |
+    ($admitted * 2) as $admitted_total |
+    ($rejected * 2) as $rejected_total |
+    diagnostics(
+      $governor_enabled;
+      $base_threshold;
+      $contention_weight;
+      $admitted_total;
+      $rejected_total
+    ) as $aggregate_diagnostics |
+    {
+      schema: {
+        name: "mer-prompt2-phase4d-b-governor-score-calibration-variant",
+        version: 1
+      },
+      qualification_kind: "phase4d-b-score-calibration-diagnostic",
+      variant: $variant,
+      cache_slots: 1536,
+      prompt_fixture: "short",
+      output_tokens: 128,
+      warmup_runs: 1,
+      measured_runs: 2,
+      cache_reset: "keep",
+      greedy: true,
+      traced: false,
+      metadata:
+        (if $variant == "demand-only" then
+          {
+            variant: $variant,
+            predictor_mode: "demand-only",
+            predict_fanout: 0,
+            pipeline_depth: 3,
+            first_order_enabled: true,
+            second_order_enabled: true,
+            fallback_prior_fill_enabled: true,
+            fanout_is_upper_bound: false,
+            governor_enabled: false,
+            neural_speculator_enabled: false
+          }
+        else
+          {
+            variant: $variant,
+            predictor_mode: "second-order-only",
+            predict_fanout: 1,
+            pipeline_depth: 3,
+            first_order_enabled: false,
+            second_order_enabled: true,
+            fallback_prior_fill_enabled: false,
+            fanout_is_upper_bound: true,
+            governor_enabled: $governor_enabled,
+            neural_speculator_enabled: false
+          }
+        end),
+      governor_configuration: {
+        enabled: $governor_enabled,
+        precision_floor: 0.05,
+        contention_weight: $contention_weight,
+        base_threshold: $base_threshold,
+        runtime_default_precision_alpha: 0.2,
+        runtime_default_base_threshold: 0.02
+      },
+      governor_counters_by_run: $runs,
+      governor_totals: {
+        governor_admitted_candidates: $admitted_total,
+        governor_rejected_candidates: $rejected_total,
+        governor_total_decisions: ($admitted_total + $rejected_total),
+        governor_foreground_inflight_final: 0
+      },
+      governor_score_diagnostics_by_run:
+        [$runs[] | {
+          run_index,
+          reconcile: .governor_score_diagnostics_reconcile,
+          diagnostics: .governor_score_diagnostics
+        }],
+      governor_score_diagnostics: $aggregate_diagnostics,
+      governor_score_diagnostics_reconcile: true,
+      foreground_accounting: {
+        final_by_run: [0, 0],
+        final_aggregate: 0
+      },
+      prefetch_counters: {
+        prefetch_submitted: $prefetch_submitted,
+        prefetch_completed: $prefetch_completed,
+        prefetch_used: 0,
+        prefetch_bytes: 0,
+        useful_prefetch_bytes: 0,
+        unused_prefetch_bytes_at_sample: 0,
+        prefetch_dropped_concurrency: 0,
+        prefetch_dropped_pool_starved: 0,
+        prefetch_dropped_governor: $rejected_total,
+        prefetch_dropped_bytes: 0
+      },
+      provenance: {
+        git_commit_full: $git_commit_full,
+        binary_sha256: $sha,
+        model_hashes: {
+          config_json_sha256: $sha,
+          dense_manifest_sha256: $sha
+        },
+        tokenizer_identity: {
+          path: "/mnt/localssd/qwen/tokenizer.json",
+          sha256: $sha
+        },
+        target_host: {
+          hostname: "qwen-host",
+          logical_cpu_count: 32,
+          requested_cpu_mask: "0-31",
+          effective_cpu_mask: "0-31"
+        },
+        model_mount_identity: {
+          target: "/mnt/localssd",
+          fstype: "ext4",
+          options: "rw,noatime"
+        },
+        cargo_features: ["avx512", "blas", "io_uring", "tokenizer"],
+        prompt_hashes: {short_sha256: $sha}
+      },
+      decode_tps_mean: 4.2,
+      ssd_bytes: 4096,
+      demand_read_service_mean_seconds: 0.01,
+      output_token_ids: [10, 20, 30],
+      output_parity_within_variant: true,
+      diagnostic_collection_valid: true,
+      performance_qualification_applicable: false,
+      qualification_passed: false
+    }
+  ' > "$output"
+}
+
+render_summary() {
+  local demand=$1
+  local second=$2
+  local current=$3
+  local low=$4
+  local output=$5
+  jq -n \
+    --arg runner_git_commit_full "$TEST_GIT_COMMIT_FULL" \
+    --slurpfile demand "$demand" \
+    --slurpfile second "$second" \
+    --slurpfile current "$current" \
+    --slurpfile low "$low" \
+    -f "$FILTER" > "$output"
+}
+
+make_variant demand-only false 0.02 1.0 0 0 0 0 "$TEST_ROOT/demand.json"
+make_variant second-only-f1 false 0.02 1.0 0 0 4 4 "$TEST_ROOT/second.json"
+make_variant second-only-f1-governed-current true 0.02 1.0 0 2 0 0 \
+  "$TEST_ROOT/current.json"
+make_variant second-only-f1-governed-bt005-cw000 true 0.005 0.0 1 1 2 2 \
+  "$TEST_ROOT/low.json"
+
+render_summary \
+  "$TEST_ROOT/demand.json" \
+  "$TEST_ROOT/second.json" \
+  "$TEST_ROOT/current.json" \
+  "$TEST_ROOT/low.json" \
+  "$TEST_ROOT/valid-summary.json"
+
+jq -e '
+  .diagnostic_gates_passed == true and
+  .qualification_passed == false and
+  .expected_variant_order == [
+    "demand-only",
+    "second-only-f1",
+    "second-only-f1-governed-current",
+    "second-only-f1-governed-bt005-cw000"
+  ] and
+  .variants[0].governor_score_diagnostics.total_decisions == 0 and
+  .variants[0].governor_score_diagnostics.candidate_score.mean == null and
+  .variants[2].governor_score_diagnostics.admitted == 0 and
+  .variants[2].governor_totals.governor_rejected_candidates == 4 and
+  .variants[2].governor_score_diagnostics_reconcile == true and
+  .variants[2].governor_score_diagnostics.decision_boundary.maximum_rejected_candidate_score != null and
+  .variants[2].governor_score_diagnostics.decision_boundary.maximum_rejected_score_to_threshold_ratio < 1 and
+  .variants[3].governor_score_diagnostics.decision_boundary.minimum_admitted_candidate_score != null and
+  .variants[3].governor_score_diagnostics.decision_boundary.minimum_admitted_score_to_threshold_ratio >= 1
+' "$TEST_ROOT/valid-summary.json" >/dev/null
+
+render_summary \
+  "$TEST_ROOT/second.json" \
+  "$TEST_ROOT/demand.json" \
+  "$TEST_ROOT/current.json" \
+  "$TEST_ROOT/low.json" \
+  "$TEST_ROOT/order-mismatch-summary.json"
+jq -e '
+  .gates.exact_variant_order == false and
+  .diagnostic_gates_passed == false and
+  .qualification_passed == false
+' "$TEST_ROOT/order-mismatch-summary.json" >/dev/null
+
+jq '.governor_score_diagnostics.total_decisions += 1' \
+  "$TEST_ROOT/current.json" > "$TEST_ROOT/counter-mismatch.json"
+render_summary "$TEST_ROOT/demand.json" "$TEST_ROOT/second.json" \
+  "$TEST_ROOT/counter-mismatch.json" "$TEST_ROOT/low.json" \
+  "$TEST_ROOT/counter-mismatch-summary.json"
+jq -e '
+  .gates.diagnostic_decision_counters_reconcile == false and
+  .diagnostic_gates_passed == false and
+  .qualification_passed == false
+' "$TEST_ROOT/counter-mismatch-summary.json" >/dev/null
+
+jq '.governor_score_diagnostics.candidate_score.mean = "NaN"' \
+  "$TEST_ROOT/current.json" > "$TEST_ROOT/nonfinite.json"
+render_summary "$TEST_ROOT/demand.json" "$TEST_ROOT/second.json" \
+  "$TEST_ROOT/nonfinite.json" "$TEST_ROOT/low.json" \
+  "$TEST_ROOT/nonfinite-summary.json"
+jq -e '
+  .gates.all_statistics_finite_or_explicitly_null == false and
+  .diagnostic_gates_passed == false
+' "$TEST_ROOT/nonfinite-summary.json" >/dev/null
+
+jq '.foreground_accounting.final_by_run[0] = 1' \
+  "$TEST_ROOT/current.json" > "$TEST_ROOT/foreground.json"
+render_summary "$TEST_ROOT/demand.json" "$TEST_ROOT/second.json" \
+  "$TEST_ROOT/foreground.json" "$TEST_ROOT/low.json" \
+  "$TEST_ROOT/foreground-summary.json"
+jq -e '
+  .gates.foreground_read_accounting_balanced == false and
+  .diagnostic_gates_passed == false
+' "$TEST_ROOT/foreground-summary.json" >/dev/null
+
+jq '.provenance.binary_sha256 =
+      "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"' \
+  "$TEST_ROOT/current.json" > "$TEST_ROOT/provenance.json"
+render_summary "$TEST_ROOT/demand.json" "$TEST_ROOT/second.json" \
+  "$TEST_ROOT/provenance.json" "$TEST_ROOT/low.json" \
+  "$TEST_ROOT/provenance-summary.json"
+jq -e '
+  .gates.cross_variant_provenance_identical == false and
+  .diagnostic_gates_passed == false
+' "$TEST_ROOT/provenance-summary.json" >/dev/null
+
+jq '.output_token_ids[0] = 99' \
+  "$TEST_ROOT/current.json" > "$TEST_ROOT/output.json"
+render_summary "$TEST_ROOT/demand.json" "$TEST_ROOT/second.json" \
+  "$TEST_ROOT/output.json" "$TEST_ROOT/low.json" \
+  "$TEST_ROOT/output-summary.json"
+jq -e '
+  .gates.deterministic_output_parity == false and
+  .diagnostic_gates_passed == false
+' "$TEST_ROOT/output-summary.json" >/dev/null
+
+jq '.governor_configuration.base_threshold = 0.01' \
+  "$TEST_ROOT/current.json" > "$TEST_ROOT/config.json"
+render_summary "$TEST_ROOT/demand.json" "$TEST_ROOT/second.json" \
+  "$TEST_ROOT/config.json" "$TEST_ROOT/low.json" \
+  "$TEST_ROOT/config-summary.json"
+jq -e '
+  .gates.expected_governor_configuration == false and
+  .diagnostic_gates_passed == false
+' "$TEST_ROOT/config-summary.json" >/dev/null
+
+expected_specs='  "demand-only|0.05|0.02|1.0"
+  "second-only-f1|0.05|0.02|1.0"
+  "second-only-f1-governed-current|0.05|0.02|1.0"
+  "second-only-f1-governed-bt005-cw000|0.05|0.005|0.0"'
+actual_specs=$(sed -n '/^variant_specs=($/,/^)/p' "$RUNNER" | sed '1d;$d')
+test "$actual_specs" = "$expected_specs"
+
+phase4d_b_plan=$(sed -n \
+  '/^# BEGIN PHASE4D_B_SCORE_CALIBRATION_COLLECTION$/,/^# END PHASE4D_B_SCORE_CALIBRATION_COLLECTION$/p' \
+  "$COLLECTOR")
+test "$(grep -Fxc '# BEGIN PHASE4D_B_SCORE_CALIBRATION_COLLECTION' \
+  <<<"$phase4d_b_plan")" -eq 1
+test "$(grep -Fxc '# END PHASE4D_B_SCORE_CALIBRATION_COLLECTION' \
+  <<<"$phase4d_b_plan")" -eq 1
+test "$(grep -c '^elif \[\[ "$COLLECTOR_MODE" ==' \
+  <<<"$phase4d_b_plan")" -eq 1
+grep -Fx 'elif [[ "$COLLECTOR_MODE" == phase4d-b-score-calibration ]]; then' \
+  <<<"$phase4d_b_plan" >/dev/null
+grep -F 'run_case 1536 short 14 "$SHORT_PROMPT_SHA"' \
+  <<<"$phase4d_b_plan" >/dev/null
+if grep -F 'run_case 1536 medium' <<<"$phase4d_b_plan" >/dev/null ||
+   grep -F 'run_case 6144' <<<"$phase4d_b_plan" >/dev/null; then
+  echo "Phase 4D-B collector must run only the 1,536-slot short prompt" >&2
+  exit 1
+fi
+
+echo "Phase 4D-B governor score calibration fixtures: PASS"


### PR DESCRIPTION
## Summary

- Compute one structured governor decision and use its exact values for admission and bounded diagnostics.
- Report exact counts, running means, extrema, decision boundaries, foreground splits, and nearest-rank percentiles over the most recent 512 finite decisions.
- Expose per-run and aggregate score diagnostics through bench-real with race-safe direct-counter reconciliation.
- Add a separate four-case Phase 4D-B diagnostic collector, JSON report, fixtures, and README guidance.

## Why

Phase 4D-A rejected every governed candidate, including base_threshold=0.005 with contention_weight=0. Existing counters did not expose the score and effective-threshold distributions needed to explain that result.

## Impact

This is diagnostic and non-qualifying. It does not change governor defaults, the admission formula, predictor behavior, Phase 4C files, or Phase 4D-A screening semantics. Disabled governors report zero decisions with explicit null statistics.

The bounded telemetry lock adds diagnostic overhead when the governor is enabled; no performance claim is made in this PR.

## Validation

- git diff --check
- Shell syntax checks for the shared collector and both Phase 4D runners
- Focused prefetch_governor, governor_score, and bench_real_direct_governor Rust tests
- The same focused Rust tests with --no-default-features
- Prompt 2 collector qualification fixtures
- Phase 4C matrix fixtures
- Phase 4D-A screening fixtures
- Phase 4D-B score-calibration fixtures
- Dedicated Phase 4C files verified unchanged from 681fe3ff2e99b659c8b114ea5f50e9a5100f0c8b

The target-host benchmark was intentionally not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added governor score diagnostics for decision counts, score distributions, thresholds, contention groups, and recent percentiles.
  * Included diagnostic snapshots and counter reconciliation in benchmark reports.
  * Added a score-calibration workflow with four benchmark variants and combined summary output.
* **Bug Fixes**
  * Added validation for mismatched counters, invalid statistics, inconsistent configurations, and incomplete diagnostic data.
* **Tests**
  * Expanded coverage for diagnostics, reset and merge behavior, calibration validation, and output ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->