### PR TITLE
bench: add Phase 4D-C sparse admission screening

### DIFF
--- a/README.md
+++ b/README.md
@@ -1514,6 +1514,26 @@ shows how close the best rejection came to admission; a minimum admitted ratio
 at or above `1` identifies the weakest admitted candidate, and remains `null`
 when no candidate was admitted.
 
+Phase 4D-C uses the Phase 4D-B score evidence to screen lower thresholds for
+sparse, measurable admissions without changing the formula, precision
+behavior, predictor, fanout, cache, or production defaults. Its exact order is
+`demand-only`, `second-only-f1`, then governed
+`second-only-f1-governed-bt001-cw000`,
+`second-only-f1-governed-bt0005-cw000`, and
+`second-only-f1-governed-bt00025-cw000`. The governed base thresholds are
+respectively `0.001`, `0.0005`, and `0.00025`; all use precision floor `0.05`
+and contention weight `0.0`.
+
+```bash
+scripts/collect_qwen3_coder_prompt2_phase4d_c_sparse_admission.sh /path/to/artifacts
+```
+
+The resulting `phase4d-c-sparse-admission-summary.json` reports every
+measurement and treats admission-count and admission-rate monotonicity only as
+observations. This two-run, short-prompt screen is explicitly non-qualifying:
+it identifies a threshold candidate for a later fully qualified benchmark and
+does not select or hard-code a winner.
+
 After selecting a candidate, the existing diagnostic collector supports the
 required eight-token trace smoke and the full diagnostic trace:
 

--- a/scripts/collect_qwen3_coder_prompt2_baseline.sh
+++ b/scripts/collect_qwen3_coder_prompt2_baseline.sh
@@ -1072,6 +1072,21 @@ run_case() {
         observed_critical_path_coverage:
           $collection_qualification.observed_critical_path_coverage
       }
+    elif $collection_qualification.qualification_kind ==
+         "phase4d-c-sparse-admission-screening" then
+      {
+        qualification_kind: $collection_qualification.qualification_kind,
+        sparse_admission_collection_valid:
+          $collection_qualification.sparse_admission_collection_valid,
+        performance_qualification_applicable:
+          $collection_qualification.performance_qualification_applicable,
+        performance_qualification_reason:
+          $collection_qualification.performance_qualification_reason,
+        production_critical_path_coverage_gates_passed:
+          $collection_qualification.production_critical_path_coverage_gates_passed,
+        observed_critical_path_coverage:
+          $collection_qualification.observed_critical_path_coverage
+      }
     else
       {}
     end)' "$json" > "$ARTIFACT_DIR/$stem.case-summary.json"

--- a/scripts/collect_qwen3_coder_prompt2_baseline.sh
+++ b/scripts/collect_qwen3_coder_prompt2_baseline.sh
@@ -17,7 +17,7 @@ TOKENIZER=${MER_QWEN_TOKENIZER:-$MER_QWEN_CONVERTED_DIR/tokenizer.json}
 ARTIFACT_DIR=${1:-}
 MODE_ARG=${2:-four-case}
 if [[ -z "$ARTIFACT_DIR" ]]; then
-  echo "usage: $0 ARTIFACT_DIR [four-case|phase4c-untraced|phase4d-screening|phase4d-b-score-calibration|phase4b-diagnostic|--resident-only]" >&2
+  echo "usage: $0 ARTIFACT_DIR [four-case|phase4c-untraced|phase4d-screening|phase4d-b-score-calibration|phase4d-c-sparse-admission|phase4b-diagnostic|--resident-only]" >&2
   exit 2
 fi
 case "$MODE_ARG" in
@@ -64,13 +64,25 @@ case "$MODE_ARG" in
         ;;
     esac
     ;;
+  phase4d-c-sparse-admission)
+    COLLECTOR_MODE=phase4d-c-sparse-admission
+    QUALIFICATION_KIND=phase4d-c-sparse-admission-screening
+    EXPERIMENT_NAME=prompt2-phase4d-c-sparse-admission
+    case "$PREFETCH_VARIANT" in
+      demand-only|second-only-f1|second-only-f1-governed-bt001-cw000|second-only-f1-governed-bt0005-cw000|second-only-f1-governed-bt00025-cw000) ;;
+      *)
+        echo "phase4d-c-sparse-admission requires a named Phase 4D-C screening variant; found: $PREFETCH_VARIANT" >&2
+        exit 2
+        ;;
+    esac
+    ;;
   resident-only|--resident-only)
     COLLECTOR_MODE=resident-only
     QUALIFICATION_KIND=performance-baseline
     EXPERIMENT_NAME=prompt2-phase4a-prefetch-ablation
     ;;
   *)
-    echo "unknown collector mode: $MODE_ARG (expected four-case, phase4c-untraced, phase4d-screening, phase4d-b-score-calibration, phase4b-diagnostic, or --resident-only)" >&2
+    echo "unknown collector mode: $MODE_ARG (expected four-case, phase4c-untraced, phase4d-screening, phase4d-b-score-calibration, phase4d-c-sparse-admission, phase4b-diagnostic, or --resident-only)" >&2
     exit 2
     ;;
 esac
@@ -85,7 +97,8 @@ if [[ "$COLLECTOR_MODE" == phase4b-diagnostic ]]; then
   fi
 fi
 if [[ "$COLLECTOR_MODE" == phase4d-screening ||
-      "$COLLECTOR_MODE" == phase4d-b-score-calibration ]]; then
+      "$COLLECTOR_MODE" == phase4d-b-score-calibration ||
+      "$COLLECTOR_MODE" == phase4d-c-sparse-admission ]]; then
   MEASURED_RUNS=2
 fi
 
@@ -161,12 +174,15 @@ WORKTREE_STATUS=$(git -C "$ROOT" status --short)
 if [[ -n "$WORKTREE_STATUS" &&
       ("$COLLECTOR_MODE" == phase4d-screening ||
        "$COLLECTOR_MODE" == phase4d-b-score-calibration ||
+       "$COLLECTOR_MODE" == phase4d-c-sparse-admission ||
        "${MER_ALLOW_DIRTY:-0}" != 1) ]]; then
   echo "refusing a baseline from a dirty worktree; commit/stash changes or set MER_ALLOW_DIRTY=1 for a non-qualifying diagnostic" >&2
   if [[ "$COLLECTOR_MODE" == phase4d-screening ]]; then
     echo "Phase 4D-A screening always requires a clean worktree" >&2
   elif [[ "$COLLECTOR_MODE" == phase4d-b-score-calibration ]]; then
     echo "Phase 4D-B score calibration always requires a clean worktree" >&2
+  elif [[ "$COLLECTOR_MODE" == phase4d-c-sparse-admission ]]; then
+    echo "Phase 4D-C sparse admission screening always requires a clean worktree" >&2
   fi
   printf '%s\n' "$WORKTREE_STATUS" >&2
   exit 1
@@ -255,7 +271,8 @@ prompt2_render_config "$TEMPLATE" "$ARTIFACT_DIR/configs/qwen3-coder-q8-1536.tom
 if [[ "$COLLECTOR_MODE" != phase4b-diagnostic &&
       "$COLLECTOR_MODE" != phase4c-untraced &&
       "$COLLECTOR_MODE" != phase4d-screening &&
-      "$COLLECTOR_MODE" != phase4d-b-score-calibration ]]; then
+      "$COLLECTOR_MODE" != phase4d-b-score-calibration &&
+      "$COLLECTOR_MODE" != phase4d-c-sparse-admission ]]; then
   prompt2_render_config "$TEMPLATE" "$ARTIFACT_DIR/configs/qwen3-coder-q8-6144.toml" \
     "$MODEL_REAL" "$TOKENIZER_REAL" 6144 "$PREDICT_FANOUT" "$PIPELINE_DEPTH" \
     "$FIRST_ORDER_ENABLED" "$SECOND_ORDER_ENABLED" \
@@ -269,7 +286,8 @@ POOL_SLOTS=(1536 6144)
 if [[ "$COLLECTOR_MODE" == phase4b-diagnostic ||
       "$COLLECTOR_MODE" == phase4c-untraced ||
       "$COLLECTOR_MODE" == phase4d-screening ||
-      "$COLLECTOR_MODE" == phase4d-b-score-calibration ]]; then
+      "$COLLECTOR_MODE" == phase4d-b-score-calibration ||
+      "$COLLECTOR_MODE" == phase4d-c-sparse-admission ]]; then
   POOL_SLOTS=(1536)
 fi
 for slots in "${POOL_SLOTS[@]}"; do
@@ -1296,6 +1314,86 @@ elif [[ "$COLLECTOR_MODE" == phase4d-b-score-calibration ]]; then
     }
   ' > "$ARTIFACT_DIR/qualification.json"
 # END PHASE4D_B_SCORE_CALIBRATION_COLLECTION
+# BEGIN PHASE4D_C_SPARSE_ADMISSION_COLLECTION
+elif [[ "$COLLECTOR_MODE" == phase4d-c-sparse-admission ]]; then
+  run_case 1536 short 14 "$SHORT_PROMPT_SHA"
+
+  jq -n \
+    --arg variant "$PREFETCH_VARIANT" \
+    --slurpfile case_summary "$ARTIFACT_DIR/baseline-1536-short.case-summary.json" \
+    --slurpfile provenance "$ARTIFACT_DIR/ablation-provenance.json" \
+    --slurpfile raw "$ARTIFACT_DIR/baseline-1536-short.json" '
+    $case_summary[0] as $case |
+    $provenance[0] as $provenance |
+    $raw[0] as $raw |
+    {
+      schema: {name:"mer-prompt2-phase4d-c-sparse-admission-variant", version:1},
+      qualification_kind: "phase4d-c-sparse-admission-screening",
+      variant: $variant,
+      cache_slots: 1536,
+      prompt_fixture: "short",
+      output_tokens: 128,
+      warmup_runs: 1,
+      measured_runs: 2,
+      cache_reset: "keep",
+      greedy: true,
+      traced: false,
+      metadata: $case.phase4c_predictor,
+      governor_configuration: $case.phase4c_governor.configuration,
+      governor_counters_by_run: $case.phase4c_governor.counters_by_run,
+      governor_totals: $case.phase4c_governor.totals,
+      governor_score_diagnostics_by_run: $case.phase4c_governor.score_diagnostics_by_run,
+      governor_score_diagnostics: $case.phase4c_governor.score_diagnostics_aggregate,
+      governor_score_diagnostics_reconcile: $case.phase4c_governor.score_diagnostics_aggregate_reconcile,
+      foreground_accounting: {
+        final_by_run: [$case.phase4c_governor.counters_by_run[] | .governor_foreground_inflight_final],
+        final_aggregate: $case.phase4c_governor.totals.governor_foreground_inflight_final
+      },
+      prefetch_counters: $case.phase4a_prefetch.counters,
+      provenance: {
+        git_commit_full: $provenance.git_commit_full,
+        binary_sha256: $provenance.binary_sha256,
+        model_hashes: $provenance.model_hashes,
+        tokenizer_identity: $provenance.tokenizer_identity,
+        target_host: $provenance.host,
+        model_mount_identity: $provenance.model_mount_identity,
+        cargo_features: $provenance.cargo_features,
+        prompt_hashes: $provenance.prompt_hashes
+      },
+      decode_tps_mean: $case.decode_tps_mean,
+      ssd_bytes: $case.ssd_bytes_total,
+      demand_read_service_mean_seconds: $case.phase3a_decode.physical_read_issue_to_completion_mean_seconds,
+      output_token_ids: $raw.runs[0].output_token_ids,
+      output_parity_within_variant: $raw.aggregate.output_token_parity,
+      screening_collection_valid: $case.sparse_admission_collection_valid,
+      performance_qualification_applicable: false,
+      performance_qualification_reason: $case.performance_qualification_reason,
+      qualification_passed: false
+    }
+  ' > "$ARTIFACT_DIR/phase4d-c-sparse-admission-variant-summary.json"
+
+  jq -n \
+    --arg commit "$EXPECTED_COMMIT" \
+    --arg captured_at_utc "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg variant "$PREFETCH_VARIANT" \
+    --slurpfile variant_summary "$ARTIFACT_DIR/phase4d-c-sparse-admission-variant-summary.json" '
+    {
+      schema: {name:"mer-prompt2-qualification", version:1},
+      git_commit_full: $commit,
+      captured_at_utc: $captured_at_utc,
+      qualification_kind: "phase4d-c-sparse-admission-screening",
+      phase4d_c_variant: $variant,
+      one_required_1536_short_case_present: true,
+      no_6144_cases_collected: true,
+      trace_disabled: true,
+      screening_collection_valid: $variant_summary[0].screening_collection_valid,
+      governor_score_diagnostics_reconcile: $variant_summary[0].governor_score_diagnostics_reconcile,
+      performance_qualification_applicable: false,
+      performance_qualification_reason: "Phase 4D-C screens sparse admissions to identify a candidate for a later qualified benchmark",
+      qualification_passed: false
+    }
+  ' > "$ARTIFACT_DIR/qualification.json"
+# END PHASE4D_C_SPARSE_ADMISSION_COLLECTION
 elif [[ "$COLLECTOR_MODE" == phase4c-untraced ]]; then
   run_case 1536 short 14 "$SHORT_PROMPT_SHA"
   run_case 1536 medium 65 "$MEDIUM_PROMPT_SHA"

--- a/scripts/collect_qwen3_coder_prompt2_phase4d_c_sparse_admission.sh
+++ b/scripts/collect_qwen3_coder_prompt2_phase4d_c_sparse_admission.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+COLLECTOR="$ROOT/scripts/collect_qwen3_coder_prompt2_baseline.sh"
+FILTER="$ROOT/scripts/qwen3_coder_prompt2_phase4d_c_sparse_admission.jq"
+SCREENING_DIR=${1:-}
+
+if [[ -z "$SCREENING_DIR" ]]; then
+  echo "usage: $0 SCREENING_DIR" >&2
+  exit 2
+fi
+if [[ -n "${MER_PROMPT2_PHASE4B_TRACE_PATH:-}" ]]; then
+  echo "Phase 4D-C sparse admission screening must be untraced; unset MER_PROMPT2_PHASE4B_TRACE_PATH" >&2
+  exit 2
+fi
+if [[ -n "$(git -C "$ROOT" status --short)" ]]; then
+  echo "Phase 4D-C sparse admission screening requires a clean worktree" >&2
+  git -C "$ROOT" status --short >&2
+  exit 1
+fi
+RUNNER_GIT_COMMIT_FULL=$(git -C "$ROOT" rev-parse HEAD)
+
+mkdir -p "$SCREENING_DIR"
+SCREENING_DIR=$(cd "$SCREENING_DIR" && pwd)
+variant_specs=(
+  "demand-only|0.05|0.02|1.0"
+  "second-only-f1|0.05|0.02|1.0"
+  "second-only-f1-governed-bt001-cw000|0.05|0.001|0.0"
+  "second-only-f1-governed-bt0005-cw000|0.05|0.0005|0.0"
+  "second-only-f1-governed-bt00025-cw000|0.05|0.00025|0.0"
+)
+
+first=true
+for spec in "${variant_specs[@]}"; do
+  IFS='|' read -r variant precision_floor base_threshold contention_weight <<<"$spec"
+  skip_build=1
+  if [[ "$first" == true ]]; then
+    skip_build=0
+    first=false
+  fi
+  MER_ALLOW_DIRTY=0 \
+  MER_SKIP_BUILD="$skip_build" \
+  MER_PROMPT2_PREFETCH_VARIANT="$variant" \
+  MER_PROMPT2_PREFETCH_GOVERNOR_PRECISION_FLOOR="$precision_floor" \
+  MER_PROMPT2_PREFETCH_GOVERNOR_BASE_THRESHOLD="$base_threshold" \
+  MER_PROMPT2_PREFETCH_GOVERNOR_CONTENTION_WEIGHT="$contention_weight" \
+    bash "$COLLECTOR" "$SCREENING_DIR/$variant" phase4d-c-sparse-admission
+done
+
+jq -n \
+  --arg runner_git_commit_full "$RUNNER_GIT_COMMIT_FULL" \
+  --slurpfile demand "$SCREENING_DIR/demand-only/phase4d-c-sparse-admission-variant-summary.json" \
+  --slurpfile second "$SCREENING_DIR/second-only-f1/phase4d-c-sparse-admission-variant-summary.json" \
+  --slurpfile high "$SCREENING_DIR/second-only-f1-governed-bt001-cw000/phase4d-c-sparse-admission-variant-summary.json" \
+  --slurpfile mid "$SCREENING_DIR/second-only-f1-governed-bt0005-cw000/phase4d-c-sparse-admission-variant-summary.json" \
+  --slurpfile low "$SCREENING_DIR/second-only-f1-governed-bt00025-cw000/phase4d-c-sparse-admission-variant-summary.json" \
+  -f "$FILTER" > "$SCREENING_DIR/phase4d-c-sparse-admission-summary.json"
+
+jq -e '
+  .qualification_kind == "phase4d-c-sparse-admission-screening" and
+  .performance_qualification_applicable == false and
+  .qualification_passed == false and
+  .screening_gates_passed == true
+' "$SCREENING_DIR/phase4d-c-sparse-admission-summary.json" >/dev/null
+
+echo "Phase 4D-C sparse admission screening complete: $SCREENING_DIR"

--- a/scripts/qwen3_coder_prompt2_collection_qualification.jq
+++ b/scripts/qwen3_coder_prompt2_collection_qualification.jq
@@ -76,6 +76,8 @@ elif $qualification_kind == "phase4d-governor-screening" then
   screening_collection_valid
 elif $qualification_kind == "phase4d-b-score-calibration-diagnostic" then
   screening_collection_valid
+elif $qualification_kind == "phase4d-c-sparse-admission-screening" then
+  screening_collection_valid
 else
   false
 end) as $collection_valid |
@@ -108,6 +110,12 @@ end) as $collection_valid |
     else null
     end
   ),
+  sparse_admission_collection_valid: (
+    if $qualification_kind == "phase4d-c-sparse-admission-screening"
+    then $collection_valid
+    else null
+    end
+  ),
   performance_qualification_applicable: ($qualification_kind == "performance-baseline"),
   performance_qualification_passed: (
     if $qualification_kind == "performance-baseline"
@@ -122,6 +130,8 @@ end) as $collection_valid |
       "Phase 4D-A uses one warmup and two measured short-prompt runs for calibration screening; it is diagnostic evidence and not a qualified production performance baseline"
     elif $qualification_kind == "phase4d-b-score-calibration-diagnostic" then
       "Phase 4D-B records bounded governor score and threshold distributions from one warmup and two measured short-prompt runs; it is diagnostic evidence and not a qualified production performance baseline"
+    elif $qualification_kind == "phase4d-c-sparse-admission-screening" then
+      "Phase 4D-C screens sparse governor admissions with one warmup and two measured short-prompt runs; it identifies a candidate for later qualification and is not a qualified production performance baseline"
     else
       null
     end

--- a/scripts/qwen3_coder_prompt2_collector_config.sh
+++ b/scripts/qwen3_coder_prompt2_collector_config.sh
@@ -158,6 +158,42 @@ prompt2_resolve_ablation_config() {
       governor_base_threshold_default=0.005
       governor_contention_weight_default=0.0
       ;;
+    second-only-f1-governed-bt001-cw000)
+      PREDICTOR_MODE=second-order-only
+      predict_fanout_raw=1
+      pipeline_depth_raw=3
+      FIRST_ORDER_ENABLED=false
+      SECOND_ORDER_ENABLED=true
+      FALLBACK_PRIOR_FILL_ENABLED=false
+      FANOUT_IS_UPPER_BOUND=true
+      PREFETCH_GOVERNOR_ENABLED=true
+      governor_base_threshold_default=0.001
+      governor_contention_weight_default=0.0
+      ;;
+    second-only-f1-governed-bt0005-cw000)
+      PREDICTOR_MODE=second-order-only
+      predict_fanout_raw=1
+      pipeline_depth_raw=3
+      FIRST_ORDER_ENABLED=false
+      SECOND_ORDER_ENABLED=true
+      FALLBACK_PRIOR_FILL_ENABLED=false
+      FANOUT_IS_UPPER_BOUND=true
+      PREFETCH_GOVERNOR_ENABLED=true
+      governor_base_threshold_default=0.0005
+      governor_contention_weight_default=0.0
+      ;;
+    second-only-f1-governed-bt00025-cw000)
+      PREDICTOR_MODE=second-order-only
+      predict_fanout_raw=1
+      pipeline_depth_raw=3
+      FIRST_ORDER_ENABLED=false
+      SECOND_ORDER_ENABLED=true
+      FALLBACK_PRIOR_FILL_ENABLED=false
+      FANOUT_IS_UPPER_BOUND=true
+      PREFETCH_GOVERNOR_ENABLED=true
+      governor_base_threshold_default=0.00025
+      governor_contention_weight_default=0.0
+      ;;
     *)
       echo "MER_PROMPT2_PREFETCH_VARIANT is not a supported Prompt 2 variant; found: $PREFETCH_VARIANT" >&2
       return 2

--- a/scripts/qwen3_coder_prompt2_phase4d_c_sparse_admission.jq
+++ b/scripts/qwen3_coder_prompt2_phase4d_c_sparse_admission.jq
@@ -1,0 +1,399 @@
+def item($value): $value[0];
+
+def finite_number:
+  type == "number" and (isnan or isinfinite) == false;
+
+def nullable_finite:
+  . == null or finite_number;
+
+def distribution_valid($expected_count):
+  .count == $expected_count and
+  (if $expected_count == 0 then
+     [.minimum, .maximum, .mean, .p50, .p90, .p95, .p99] |
+     all(. == null)
+   else
+     [.minimum, .maximum, .mean, .p50, .p90, .p95, .p99] |
+     all(finite_number)
+   end);
+
+def boundary_valid($admitted; $rejected):
+  (if $rejected == 0 then
+     .maximum_rejected_candidate_score == null and
+     .maximum_rejected_score_to_threshold_ratio == null and
+     .closest_rejected_score_minus_threshold_margin == null
+   else
+     (.maximum_rejected_candidate_score | finite_number) and
+     (.maximum_rejected_score_to_threshold_ratio | finite_number) and
+     .maximum_rejected_score_to_threshold_ratio < 1 and
+     (.closest_rejected_score_minus_threshold_margin | finite_number) and
+     .closest_rejected_score_minus_threshold_margin < 0
+   end) and
+  (if $admitted == 0 then
+     .minimum_admitted_candidate_score == null and
+     .minimum_admitted_score_to_threshold_ratio == null and
+     .closest_admitted_score_minus_threshold_margin == null
+   else
+     (.minimum_admitted_candidate_score | finite_number) and
+     (.minimum_admitted_score_to_threshold_ratio | finite_number) and
+     .minimum_admitted_score_to_threshold_ratio >= 1 and
+     (.closest_admitted_score_minus_threshold_margin | finite_number) and
+     .closest_admitted_score_minus_threshold_margin >= 0
+   end);
+
+def foreground_counts_valid($total; $admitted; $rejected):
+  .foreground_inflight_zero >= 0 and
+  .foreground_inflight_zero_admitted >= 0 and
+  .foreground_inflight_zero_rejected >= 0 and
+  .foreground_inflight_positive >= 0 and
+  .foreground_inflight_positive_admitted >= 0 and
+  .foreground_inflight_positive_rejected >= 0 and
+  .foreground_inflight_zero ==
+    (.foreground_inflight_zero_admitted +
+     .foreground_inflight_zero_rejected) and
+  .foreground_inflight_positive ==
+    (.foreground_inflight_positive_admitted +
+     .foreground_inflight_positive_rejected) and
+  (.foreground_inflight_zero + .foreground_inflight_positive) == $total and
+  (.foreground_inflight_zero_admitted +
+   .foreground_inflight_positive_admitted) == $admitted and
+  (.foreground_inflight_zero_rejected +
+   .foreground_inflight_positive_rejected) == $rejected;
+
+def diagnostics_valid($enabled; $total; $admitted; $rejected):
+  .enabled == $enabled and
+  (.semantics | type == "string" and length > 0) and
+  .sample_capacity == 512 and
+  .sampled_decisions == ([$total, 512] | min) and
+  .total_decisions == $total and
+  .admitted == $admitted and
+  .rejected == $rejected and
+  .total_decisions == (.admitted + .rejected) and
+  .invalid_numeric_decisions == 0 and
+  .ratio_undefined_decisions == 0 and
+  (.base_threshold | finite_number) and
+  (.contention_weight | finite_number) and
+  (.candidate_probability | distribution_valid($total)) and
+  (.effective_precision | distribution_valid($total)) and
+  (.candidate_score | distribution_valid($total)) and
+  (.effective_threshold | distribution_valid($total)) and
+  (.score_to_threshold_ratio | distribution_valid($total)) and
+  (.decision_boundary | boundary_valid($admitted; $rejected)) and
+  (.foreground_inflight_decisions |
+   foreground_counts_valid($total; $admitted; $rejected));
+
+def expected_governor_config($enabled; $base_threshold; $contention_weight):
+  {
+    enabled: $enabled,
+    precision_floor: 0.05,
+    contention_weight: $contention_weight,
+    base_threshold: $base_threshold,
+    runtime_default_precision_alpha: 0.2,
+    runtime_default_base_threshold: 0.02
+  };
+
+def second_only_metadata_valid($variant; $enabled):
+  .metadata == {
+    variant: $variant,
+    predictor_mode: "second-order-only",
+    predict_fanout: 1,
+    pipeline_depth: 3,
+    first_order_enabled: false,
+    second_order_enabled: true,
+    fallback_prior_fill_enabled: false,
+    fanout_is_upper_bound: true,
+    governor_enabled: $enabled,
+    neural_speculator_enabled: false
+  };
+
+def direct_run_reconciles:
+  .governor_total_decisions ==
+    (.governor_admitted_candidates + .governor_rejected_candidates) and
+  .direct_governor_decisions.total_decisions ==
+    .governor_total_decisions and
+  .direct_governor_decisions.admitted_candidates ==
+    .governor_admitted_candidates and
+  .direct_governor_decisions.rejected_candidates ==
+    .governor_rejected_candidates and
+  .governor_admission_rate ==
+    (if .governor_total_decisions == 0 then 0
+     else (.governor_admitted_candidates / .governor_total_decisions)
+     end) and
+  .direct_governor_decisions.admission_rate == .governor_admission_rate;
+
+def direct_counters_reconcile:
+  ([.governor_counters_by_run[] | direct_run_reconciles] | all) and
+  .governor_totals.governor_admitted_candidates ==
+    ([.governor_counters_by_run[].governor_admitted_candidates] | add) and
+  .governor_totals.governor_rejected_candidates ==
+    ([.governor_counters_by_run[].governor_rejected_candidates] | add) and
+  .governor_totals.governor_total_decisions ==
+    (.governor_totals.governor_admitted_candidates +
+     .governor_totals.governor_rejected_candidates) and
+  .prefetch_counters.prefetch_dropped_governor ==
+    .governor_totals.governor_rejected_candidates;
+
+def diagnostic_counters_reconcile:
+  .governor_configuration.enabled as $governor_enabled |
+  .governor_totals as $governor_totals |
+  ([.governor_counters_by_run[] |
+    . as $run |
+    .governor_score_diagnostics_reconcile == true and
+    ($run.governor_score_diagnostics |
+     diagnostics_valid($governor_enabled;
+       $run.governor_total_decisions;
+       $run.governor_admitted_candidates;
+       $run.governor_rejected_candidates)) and
+    .governor_score_diagnostics.total_decisions ==
+      .governor_total_decisions and
+    .governor_score_diagnostics.admitted ==
+      .governor_admitted_candidates and
+    .governor_score_diagnostics.rejected ==
+      .governor_rejected_candidates] | all) and
+  .governor_score_diagnostics_reconcile == true and
+  (.governor_score_diagnostics |
+   diagnostics_valid($governor_enabled;
+     $governor_totals.governor_total_decisions;
+     $governor_totals.governor_admitted_candidates;
+     $governor_totals.governor_rejected_candidates)) and
+  .governor_score_diagnostics.total_decisions ==
+    .governor_totals.governor_total_decisions and
+  .governor_score_diagnostics.admitted ==
+    .governor_totals.governor_admitted_candidates and
+  .governor_score_diagnostics.rejected ==
+    .governor_totals.governor_rejected_candidates;
+
+def nonempty_string:
+  type == "string" and length > 0;
+
+def git_sha:
+  type == "string" and test("^[0-9a-f]{40}$");
+
+def sha256:
+  type == "string" and test("^[0-9a-f]{64}$");
+
+def provenance_complete($runner_git_commit_full):
+  .provenance.git_commit_full == $runner_git_commit_full and
+  (.provenance.git_commit_full | git_sha) and
+  (.provenance.binary_sha256 | sha256) and
+  (.provenance.model_hashes.config_json_sha256 | sha256) and
+  (.provenance.model_hashes.dense_manifest_sha256 | sha256) and
+  (.provenance.tokenizer_identity.path | nonempty_string) and
+  (.provenance.tokenizer_identity.sha256 | sha256) and
+  (.provenance.target_host.hostname | nonempty_string) and
+  .provenance.target_host.logical_cpu_count == 32 and
+  .provenance.target_host.requested_cpu_mask == "0-31" and
+  .provenance.target_host.effective_cpu_mask == "0-31" and
+  (.provenance.model_mount_identity.target | nonempty_string) and
+  (.provenance.model_mount_identity.fstype | nonempty_string) and
+  (.provenance.model_mount_identity.options | nonempty_string) and
+  (.provenance.cargo_features | type) == "array" and
+  (.provenance.cargo_features | length) > 0 and
+  (.provenance.prompt_hashes.short_sha256 | sha256);
+
+def reported_variant($variant):
+  {
+    variant: $variant.variant,
+    predictor_configuration: $variant.metadata,
+    governor_configuration: $variant.governor_configuration,
+    provenance: $variant.provenance,
+    decode_tps_mean: $variant.decode_tps_mean,
+    ssd_bytes: $variant.ssd_bytes,
+    demand_read_service_mean_seconds:
+      $variant.demand_read_service_mean_seconds,
+    governor_counters_by_run: $variant.governor_counters_by_run,
+    governor_totals: $variant.governor_totals,
+    governor_direct_counters: {
+      admitted: $variant.governor_totals.governor_admitted_candidates,
+      rejected: $variant.governor_totals.governor_rejected_candidates,
+      total: $variant.governor_totals.governor_total_decisions
+    },
+    admission_rate:
+      (if $variant.governor_totals.governor_total_decisions == 0 then 0
+       else ($variant.governor_totals.governor_admitted_candidates /
+             $variant.governor_totals.governor_total_decisions)
+       end),
+    governor_score_diagnostics: $variant.governor_score_diagnostics,
+    governor_score_diagnostics_by_run:
+      $variant.governor_score_diagnostics_by_run,
+    governor_score_diagnostics_reconcile:
+      $variant.governor_score_diagnostics_reconcile,
+    foreground_accounting: $variant.foreground_accounting,
+    prefetch_counters: $variant.prefetch_counters,
+    output_token_ids: $variant.output_token_ids,
+    screening_collection_valid: $variant.screening_collection_valid,
+    qualification_passed: false
+  };
+
+[
+  item($demand),
+  item($second),
+  item($high),
+  item($mid),
+  item($low)
+] as $variants |
+[
+  "demand-only",
+  "second-only-f1",
+  "second-only-f1-governed-bt001-cw000",
+  "second-only-f1-governed-bt0005-cw000",
+  "second-only-f1-governed-bt00025-cw000"
+] as $expected_order |
+($variants[0].provenance) as $reference_provenance |
+{
+  exact_variant_order:
+    ([$variants[].variant] == $expected_order),
+  deterministic_output_parity:
+    (($variants | all(.output_parity_within_variant == true)) and
+     ([$variants[].output_token_ids] | unique | length) == 1),
+  expected_predictor_configuration:
+    ($variants[0].metadata == {
+       variant: "demand-only",
+       predictor_mode: "demand-only",
+       predict_fanout: 0,
+       pipeline_depth: 3,
+       first_order_enabled: true,
+       second_order_enabled: true,
+       fallback_prior_fill_enabled: true,
+       fanout_is_upper_bound: false,
+       governor_enabled: false,
+       neural_speculator_enabled: false
+     } and
+     ($variants[1] |
+      second_only_metadata_valid("second-only-f1"; false)) and
+     ($variants[2] |
+      second_only_metadata_valid("second-only-f1-governed-bt001-cw000"; true)) and
+     ($variants[3] |
+      second_only_metadata_valid(
+        "second-only-f1-governed-bt0005-cw000"; true)) and
+     ($variants[4] |
+      second_only_metadata_valid(
+        "second-only-f1-governed-bt00025-cw000"; true))),
+  expected_governor_configuration:
+    ($variants[0].governor_configuration ==
+       expected_governor_config(false; 0.02; 1.0) and
+     $variants[1].governor_configuration ==
+       expected_governor_config(false; 0.02; 1.0) and
+     $variants[2].governor_configuration ==
+       expected_governor_config(true; 0.001; 0.0) and
+     $variants[3].governor_configuration ==
+       expected_governor_config(true; 0.0005; 0.0) and
+     $variants[4].governor_configuration ==
+       expected_governor_config(true; 0.00025; 0.0)),
+  direct_counters_reconcile:
+    ($variants | all(direct_counters_reconcile)),
+  diagnostic_decision_counters_reconcile:
+    ($variants | all(diagnostic_counters_reconcile)),
+  foreground_read_accounting_balanced:
+    ($variants | all(
+      ([.foreground_accounting.final_by_run[]] | all(. == 0)) and
+      .foreground_accounting.final_aggregate == 0)),
+  cross_variant_provenance_identical:
+    (($runner_git_commit_full | git_sha) and
+     ($variants | all(
+       .provenance == $reference_provenance and
+       provenance_complete($runner_git_commit_full)
+     ))),
+  demand_only_has_no_governor_decisions:
+    ($variants[0].governor_totals.governor_total_decisions == 0 and
+     $variants[0].governor_score_diagnostics.total_decisions == 0 and
+     ([$variants[0].prefetch_counters[]] | all(. == 0))),
+  ungoverned_control_performs_speculative_work:
+    ($variants[1].prefetch_counters.prefetch_submitted > 0 and
+     $variants[1].prefetch_counters.prefetch_completed > 0 and
+     $variants[1].governor_totals.governor_total_decisions == 0 and
+     $variants[1].governor_score_diagnostics.total_decisions == 0),
+  governed_variants_make_governor_decisions:
+    ($variants[2:5] | all(
+      .governor_totals.governor_total_decisions > 0 and
+      .governor_score_diagnostics.total_decisions > 0)),
+  governed_variants_admit_candidates:
+    ($variants[2:5] | all(
+      .governor_totals.governor_admitted_candidates > 0)),
+  governed_variants_reject_candidates:
+    ($variants[2:5] | all(
+      .governor_totals.governor_rejected_candidates > 0)),
+  all_statistics_finite_or_explicitly_null:
+    ($variants | all(
+      diagnostic_counters_reconcile and
+      (.decode_tps_mean | nullable_finite) and
+      (.ssd_bytes | nullable_finite) and
+      (.demand_read_service_mean_seconds | nullable_finite))),
+  screening_mode_is_non_qualifying:
+    ($variants | all(
+      .qualification_kind == "phase4d-c-sparse-admission-screening" and
+      .screening_collection_valid == true and
+      .performance_qualification_applicable == false and
+      .qualification_passed == false and
+      .traced == false and
+      .cache_slots == 1536 and
+      .prompt_fixture == "short" and
+      .output_tokens == 128 and
+      .warmup_runs == 1 and
+      .measured_runs == 2 and
+      .cache_reset == "keep" and
+      .greedy == true and
+      .metadata.neural_speculator_enabled == false
+    ))
+} as $gates |
+{
+  schema: {
+    name:"mer-prompt2-phase4d-c-sparse-admission-summary",
+    version:1
+  },
+  qualification_kind: "phase4d-c-sparse-admission-screening",
+  performance_qualification_applicable: false,
+  performance_qualification_reason:
+    "Phase 4D-C screens sparse admissions to identify a threshold candidate for a later fully qualified benchmark; it is not itself a performance baseline",
+  qualification_passed: false,
+  traced: false,
+  cache_slots: 1536,
+  prompt_fixture: "short",
+  output_tokens: 128,
+  warmup_runs: 1,
+  measured_runs: 2,
+  cache_reset: "keep",
+  greedy: true,
+  neural_speculator_enabled: false,
+  percentile_semantics:
+    "nearest-rank percentiles over a deterministic ring of the most recent 512 finite decisions; counts, means, extrema, boundary values, and foreground splits cover every decision in each reset window",
+  empty_population_semantics:
+    "distribution statistics and decision-boundary values are null when their population is empty; disabled-governor controls report zero decisions and do not fabricate scores",
+  runner_git_commit_full: $runner_git_commit_full,
+  expected_variant_order: $expected_order,
+  variants: [$variants[] |
+    (reported_variant(.) + {
+      performance_deltas_relative_to_demand_only: {
+        decode_tps_mean: (.decode_tps_mean - $variants[0].decode_tps_mean),
+        ssd_bytes: (.ssd_bytes - $variants[0].ssd_bytes),
+        demand_read_service_mean_seconds:
+          (.demand_read_service_mean_seconds -
+           $variants[0].demand_read_service_mean_seconds)
+      },
+      performance_deltas_relative_to_ungoverned_second_only_f1:
+        (if .variant == "demand-only" then null else {
+          decode_tps_mean: (.decode_tps_mean - $variants[1].decode_tps_mean),
+          ssd_bytes: (.ssd_bytes - $variants[1].ssd_bytes),
+          demand_read_service_mean_seconds:
+            (.demand_read_service_mean_seconds -
+             $variants[1].demand_read_service_mean_seconds)
+        } end)
+    })],
+  monotonicity_observations: {
+    threshold_order_descending:
+      ([$variants[2:5][].governor_configuration.base_threshold] ==
+       [0.001, 0.0005, 0.00025]),
+    admission_counts_nondecreasing_as_threshold_decreases:
+      ([range(2; 4) as $i |
+        $variants[$i].governor_totals.governor_admitted_candidates <=
+        $variants[$i + 1].governor_totals.governor_admitted_candidates] | all),
+    admission_rates_nondecreasing_as_threshold_decreases:
+      ([range(2; 4) as $i |
+        ($variants[$i].governor_totals.governor_admitted_candidates /
+         $variants[$i].governor_totals.governor_total_decisions) <=
+        ($variants[$i + 1].governor_totals.governor_admitted_candidates /
+         $variants[$i + 1].governor_totals.governor_total_decisions)] | all),
+    structural_gate: false
+  },
+  gates: $gates,
+  screening_gates_passed: ([$gates[]] | all(. == true))
+}

--- a/scripts/tests/test_qwen3_coder_prompt2_phase4d_c_sparse_admission.sh
+++ b/scripts/tests/test_qwen3_coder_prompt2_phase4d_c_sparse_admission.sh
@@ -1,0 +1,350 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+FILTER="$ROOT/scripts/qwen3_coder_prompt2_phase4d_c_sparse_admission.jq"
+RUNNER="$ROOT/scripts/collect_qwen3_coder_prompt2_phase4d_c_sparse_admission.sh"
+COLLECTOR="$ROOT/scripts/collect_qwen3_coder_prompt2_baseline.sh"
+TEST_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/mer-prompt2-phase4d-c-sparse.XXXXXX")
+trap 'rm -rf -- "$TEST_ROOT"' EXIT
+
+TEST_GIT_COMMIT_FULL=0123456789012345678901234567890123456789
+TEST_SHA256=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+make_variant() {
+  local variant=$1
+  local governor_enabled=$2
+  local base_threshold=$3
+  local contention_weight=$4
+  local admitted_per_run=$5
+  local rejected_per_run=$6
+  local prefetch_submitted=$7
+  local prefetch_completed=$8
+  local output=$9
+
+  jq -n \
+    --arg variant "$variant" \
+    --argjson governor_enabled "$governor_enabled" \
+    --argjson base_threshold "$base_threshold" \
+    --argjson contention_weight "$contention_weight" \
+    --argjson admitted "$admitted_per_run" \
+    --argjson rejected "$rejected_per_run" \
+    --argjson prefetch_submitted "$prefetch_submitted" \
+    --argjson prefetch_completed "$prefetch_completed" \
+    --arg git_commit_full "$TEST_GIT_COMMIT_FULL" \
+    --arg sha "$TEST_SHA256" '
+    def distribution($count; $minimum; $maximum; $mean):
+      if $count == 0 then
+        {
+          count: 0,
+          minimum: null,
+          maximum: null,
+          mean: null,
+          p50: null,
+          p90: null,
+          p95: null,
+          p99: null
+        }
+      else
+        {
+          count: $count,
+          minimum: $minimum,
+          maximum: $maximum,
+          mean: $mean,
+          p50: $mean,
+          p90: $maximum,
+          p95: $maximum,
+          p99: $maximum
+        }
+      end;
+
+    def diagnostics($enabled; $base; $weight; $admitted; $rejected):
+      ($admitted + $rejected) as $total |
+      ($base * 0.2) as $rejected_score |
+      ($base * 1.2) as $admitted_score |
+      {
+        semantics:
+          "exact counts and bounded nearest-rank percentiles over the most recent 512 finite decisions",
+        enabled: $enabled,
+        sample_capacity: 512,
+        sampled_decisions: $total,
+        total_decisions: $total,
+        admitted: $admitted,
+        rejected: $rejected,
+        invalid_numeric_decisions: 0,
+        ratio_undefined_decisions: 0,
+        base_threshold: $base,
+        contention_weight: $weight,
+        candidate_probability:
+          distribution($total; 0.1; 0.5; 0.3),
+        effective_precision:
+          distribution($total; 0.05; 0.5; 0.2),
+        candidate_score:
+          distribution(
+            $total;
+            (if $rejected > 0 then $rejected_score else $admitted_score end);
+            (if $admitted > 0 then $admitted_score else $rejected_score end);
+            (if $admitted > 0 and $rejected > 0 then
+               (($rejected_score + $admitted_score) / 2)
+             elif $admitted > 0 then $admitted_score
+             else $rejected_score
+             end)),
+        effective_threshold:
+          distribution($total; $base; $base; $base),
+        score_to_threshold_ratio:
+          distribution(
+            $total;
+            (if $rejected > 0 then 0.2 else 1.2 end);
+            (if $admitted > 0 then 1.2 else 0.2 end);
+            (if $admitted > 0 and $rejected > 0 then 0.7
+             elif $admitted > 0 then 1.2
+             else 0.2
+             end)),
+        decision_boundary: {
+          maximum_rejected_candidate_score:
+            (if $rejected > 0 then $rejected_score else null end),
+          maximum_rejected_score_to_threshold_ratio:
+            (if $rejected > 0 then 0.2 else null end),
+          minimum_admitted_candidate_score:
+            (if $admitted > 0 then $admitted_score else null end),
+          minimum_admitted_score_to_threshold_ratio:
+            (if $admitted > 0 then 1.2 else null end),
+          closest_rejected_score_minus_threshold_margin:
+            (if $rejected > 0 then ($rejected_score - $base) else null end),
+          closest_admitted_score_minus_threshold_margin:
+            (if $admitted > 0 then ($admitted_score - $base) else null end)
+        },
+        foreground_inflight_decisions: {
+          foreground_inflight_zero: $total,
+          foreground_inflight_zero_admitted: $admitted,
+          foreground_inflight_zero_rejected: $rejected,
+          foreground_inflight_positive: 0,
+          foreground_inflight_positive_admitted: 0,
+          foreground_inflight_positive_rejected: 0
+        }
+      };
+
+    def run($index):
+      diagnostics(
+        $governor_enabled;
+        $base_threshold;
+        $contention_weight;
+        $admitted;
+        $rejected
+      ) as $diagnostics |
+      {
+        run_index: $index,
+        governor_enabled: $governor_enabled,
+        governor_admitted_candidates: $admitted,
+        governor_rejected_candidates: $rejected,
+        governor_total_decisions: ($admitted + $rejected),
+        governor_admission_rate:
+          (if ($admitted + $rejected) == 0 then 0
+           else ($admitted / ($admitted + $rejected)) end),
+        governor_precision_ewma_final: 0.05,
+        governor_foreground_inflight_final: 0,
+        governor_score_diagnostics: $diagnostics,
+        governor_score_diagnostics_reconcile: true,
+        direct_governor_decisions: {
+          admitted_candidates: $admitted,
+          rejected_candidates: $rejected,
+          total_decisions: ($admitted + $rejected),
+          admission_rate:
+            (if ($admitted + $rejected) == 0 then 0
+             else ($admitted / ($admitted + $rejected)) end)
+        }
+      };
+
+    [run(0), run(1)] as $runs |
+    ($admitted * 2) as $admitted_total |
+    ($rejected * 2) as $rejected_total |
+    diagnostics(
+      $governor_enabled;
+      $base_threshold;
+      $contention_weight;
+      $admitted_total;
+      $rejected_total
+    ) as $aggregate_diagnostics |
+    {
+      schema: {
+        name: "mer-prompt2-phase4d-c-sparse-admission-variant",
+        version: 1
+      },
+      qualification_kind: "phase4d-c-sparse-admission-screening",
+      variant: $variant,
+      cache_slots: 1536,
+      prompt_fixture: "short",
+      output_tokens: 128,
+      warmup_runs: 1,
+      measured_runs: 2,
+      cache_reset: "keep",
+      greedy: true,
+      traced: false,
+      metadata:
+        (if $variant == "demand-only" then
+          {
+            variant: $variant,
+            predictor_mode: "demand-only",
+            predict_fanout: 0,
+            pipeline_depth: 3,
+            first_order_enabled: true,
+            second_order_enabled: true,
+            fallback_prior_fill_enabled: true,
+            fanout_is_upper_bound: false,
+            governor_enabled: false,
+            neural_speculator_enabled: false
+          }
+        else
+          {
+            variant: $variant,
+            predictor_mode: "second-order-only",
+            predict_fanout: 1,
+            pipeline_depth: 3,
+            first_order_enabled: false,
+            second_order_enabled: true,
+            fallback_prior_fill_enabled: false,
+            fanout_is_upper_bound: true,
+            governor_enabled: $governor_enabled,
+            neural_speculator_enabled: false
+          }
+        end),
+      governor_configuration: {
+        enabled: $governor_enabled,
+        precision_floor: 0.05,
+        contention_weight: $contention_weight,
+        base_threshold: $base_threshold,
+        runtime_default_precision_alpha: 0.2,
+        runtime_default_base_threshold: 0.02
+      },
+      governor_counters_by_run: $runs,
+      governor_totals: {
+        governor_admitted_candidates: $admitted_total,
+        governor_rejected_candidates: $rejected_total,
+        governor_total_decisions: ($admitted_total + $rejected_total),
+        governor_foreground_inflight_final: 0
+      },
+      governor_score_diagnostics_by_run:
+        [$runs[] | {
+          run_index,
+          reconcile: .governor_score_diagnostics_reconcile,
+          diagnostics: .governor_score_diagnostics
+        }],
+      governor_score_diagnostics: $aggregate_diagnostics,
+      governor_score_diagnostics_reconcile: true,
+      foreground_accounting: {
+        final_by_run: [0, 0],
+        final_aggregate: 0
+      },
+      prefetch_counters: {
+        prefetch_submitted: $prefetch_submitted,
+        prefetch_completed: $prefetch_completed,
+        prefetch_used: 0,
+        prefetch_bytes: 0,
+        useful_prefetch_bytes: 0,
+        unused_prefetch_bytes_at_sample: 0,
+        prefetch_dropped_concurrency: 0,
+        prefetch_dropped_pool_starved: 0,
+        prefetch_dropped_governor: $rejected_total,
+        prefetch_dropped_bytes: 0
+      },
+      provenance: {
+        git_commit_full: $git_commit_full,
+        binary_sha256: $sha,
+        model_hashes: {
+          config_json_sha256: $sha,
+          dense_manifest_sha256: $sha
+        },
+        tokenizer_identity: {
+          path: "/mnt/localssd/qwen/tokenizer.json",
+          sha256: $sha
+        },
+        target_host: {
+          hostname: "qwen-host",
+          logical_cpu_count: 32,
+          requested_cpu_mask: "0-31",
+          effective_cpu_mask: "0-31"
+        },
+        model_mount_identity: {
+          target: "/mnt/localssd",
+          fstype: "ext4",
+          options: "rw,noatime"
+        },
+        cargo_features: ["avx512", "blas", "io_uring", "tokenizer"],
+        prompt_hashes: {short_sha256: $sha}
+      },
+      decode_tps_mean: 4.2,
+      ssd_bytes: 4096,
+      demand_read_service_mean_seconds: 0.01,
+      output_token_ids: [10, 20, 30],
+      output_parity_within_variant: true,
+      screening_collection_valid: true,
+      performance_qualification_applicable: false,
+      qualification_passed: false
+    }
+  ' > "$output"
+}
+
+render_summary() {
+  jq -n --arg runner_git_commit_full "$TEST_GIT_COMMIT_FULL" \
+    --slurpfile demand "$1" --slurpfile second "$2" \
+    --slurpfile high "$3" --slurpfile mid "$4" --slurpfile low "$5" \
+    -f "$FILTER" > "$6"
+}
+
+make_variant demand-only false 0.02 1.0 0 0 0 0 "$TEST_ROOT/demand.json"
+make_variant second-only-f1 false 0.02 1.0 0 0 4 4 "$TEST_ROOT/second.json"
+make_variant second-only-f1-governed-bt001-cw000 true 0.001 0.0 1 3 2 2 "$TEST_ROOT/high.json"
+make_variant second-only-f1-governed-bt0005-cw000 true 0.0005 0.0 2 2 4 4 "$TEST_ROOT/mid.json"
+make_variant second-only-f1-governed-bt00025-cw000 true 0.00025 0.0 3 1 6 6 "$TEST_ROOT/low.json"
+
+render() {
+  render_summary "$TEST_ROOT/demand.json" "$TEST_ROOT/second.json" \
+    "${1:-$TEST_ROOT/high.json}" "${2:-$TEST_ROOT/mid.json}" \
+    "${3:-$TEST_ROOT/low.json}" "$4"
+}
+
+render "" "" "" "$TEST_ROOT/valid.json"
+jq -e '.screening_gates_passed and (.qualification_passed == false) and
+  (.variants | length == 5) and .gates.governed_variants_admit_candidates and
+  .gates.governed_variants_reject_candidates and
+  (.monotonicity_observations.structural_gate == false)' "$TEST_ROOT/valid.json" >/dev/null
+
+# Wrong order.
+render_summary "$TEST_ROOT/second.json" "$TEST_ROOT/demand.json" \
+  "$TEST_ROOT/high.json" "$TEST_ROOT/mid.json" "$TEST_ROOT/low.json" "$TEST_ROOT/order.json"
+jq -e '.gates.exact_variant_order == false and .screening_gates_passed == false' "$TEST_ROOT/order.json" >/dev/null
+
+assert_gate_fails() {
+  local mutation=$1 gate=$2 label=$3 source=${4:-$TEST_ROOT/high.json}
+  jq "$mutation" "$source" > "$TEST_ROOT/$label.json"
+  render "$TEST_ROOT/$label.json" "" "" "$TEST_ROOT/$label-summary.json"
+  jq -e --arg gate "$gate" '.gates[$gate] == false and .screening_gates_passed == false and .qualification_passed == false' \
+    "$TEST_ROOT/$label-summary.json" >/dev/null
+}
+
+assert_gate_fails '.governor_configuration.base_threshold = 0.01' expected_governor_configuration wrong-threshold
+assert_gate_fails '.metadata.governor_enabled = false' expected_predictor_configuration wrong-assignment
+assert_gate_fails '.governor_totals.governor_total_decisions += 1' direct_counters_reconcile counter-mismatch
+assert_gate_fails '.governor_score_diagnostics.total_decisions += 1' diagnostic_decision_counters_reconcile diagnostic-mismatch
+assert_gate_fails '.governor_totals.governor_admitted_candidates = 0' governed_variants_admit_candidates zero-admissions
+assert_gate_fails '.governor_totals.governor_rejected_candidates = 0' governed_variants_reject_candidates zero-rejections
+assert_gate_fails '.provenance.binary_sha256 = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"' cross_variant_provenance_identical provenance
+assert_gate_fails '.output_token_ids[0] = 99' deterministic_output_parity output-token
+assert_gate_fails '.governor_score_diagnostics.candidate_score.mean = "NaN"' all_statistics_finite_or_explicitly_null invalid-statistic
+assert_gate_fails '.performance_qualification_applicable = true | .qualification_passed = true' screening_mode_is_non_qualifying accidental-qualification
+
+expected_specs='  "demand-only|0.05|0.02|1.0"
+  "second-only-f1|0.05|0.02|1.0"
+  "second-only-f1-governed-bt001-cw000|0.05|0.001|0.0"
+  "second-only-f1-governed-bt0005-cw000|0.05|0.0005|0.0"
+  "second-only-f1-governed-bt00025-cw000|0.05|0.00025|0.0"'
+actual_specs=$(sed -n '/^variant_specs=($/,/^)/p' "$RUNNER" | sed '1d;$d')
+test "$actual_specs" = "$expected_specs"
+
+phase4d_c_plan=$(sed -n '/^# BEGIN PHASE4D_C_SPARSE_ADMISSION_COLLECTION$/,/^# END PHASE4D_C_SPARSE_ADMISSION_COLLECTION$/p' "$COLLECTOR")
+grep -Fx 'elif [[ "$COLLECTOR_MODE" == phase4d-c-sparse-admission ]]; then' <<<"$phase4d_c_plan" >/dev/null
+grep -F 'run_case 1536 short 14 "$SHORT_PROMPT_SHA"' <<<"$phase4d_c_plan" >/dev/null
+! grep -E 'run_case (1536 medium|6144)' <<<"$phase4d_c_plan" >/dev/null
+grep -F 'phase4d-c-sparse-admission-variant-summary.json' <<<"$phase4d_c_plan" >/dev/null
+
+echo "Phase 4D-C sparse admission fixtures: PASS"

--- a/scripts/tests/test_qwen3_coder_prompt2_prefetch_collector.sh
+++ b/scripts/tests/test_qwen3_coder_prompt2_prefetch_collector.sh
@@ -677,6 +677,22 @@ grep -F 'EXPERIMENT_NAME=prompt2-phase4d-c-sparse-admission' "$COLLECTOR" >/dev/
 grep -F 'phase4d-c-sparse-admission-variant-summary.json' "$COLLECTOR" >/dev/null
 grep -F 'Phase 4D-C sparse admission screening always requires a clean worktree' "$COLLECTOR" >/dev/null
 
+phase4d_c_case_augmentation=$(sed -n \
+  '/"phase4d-c-sparse-admission-screening" then/,/^    else$/p' "$COLLECTOR")
+phase4d_c_case_augmentation=$(tr '\n' ' ' <<<"$phase4d_c_case_augmentation" | tr -s '[:space:]' ' ')
+for field in \
+  qualification_kind \
+  sparse_admission_collection_valid \
+  performance_qualification_applicable \
+  performance_qualification_reason \
+  production_critical_path_coverage_gates_passed \
+  observed_critical_path_coverage; do
+  grep -F "$field: \$collection_qualification.$field" \
+    <<<"$phase4d_c_case_augmentation" >/dev/null
+done
+grep -F 'screening_collection_valid: $case.sparse_admission_collection_valid' \
+  "$COLLECTOR" >/dev/null
+
 set +e
 MER_PROMPT2_PREFETCH_VARIANT=second-only-f1-governed-bt001-cw000 \
 MER_QWEN_CONVERTED_DIR=/does/not/exist MER_EXPECTED_NVME_MOUNT=/does/not/exist \

--- a/scripts/tests/test_qwen3_coder_prompt2_prefetch_collector.sh
+++ b/scripts/tests/test_qwen3_coder_prompt2_prefetch_collector.sh
@@ -650,4 +650,65 @@ if grep -F 'run_case 6144' "$TEST_ROOT/diagnostic-case-plan.txt" >/dev/null; the
   exit 1
 fi
 
+for spec in \
+  second-only-f1-governed-bt001-cw000:0.001 \
+  second-only-f1-governed-bt0005-cw000:0.0005 \
+  second-only-f1-governed-bt00025-cw000:0.00025; do
+  IFS=: read -r variant threshold <<<"$spec"
+  MER_PROMPT2_PREFETCH_VARIANT=$variant prompt2_resolve_ablation_config
+  test "$PREDICTOR_MODE" = second-order-only
+  test "$PREDICT_FANOUT" -eq 1
+  test "$PREFETCH_GOVERNOR_ENABLED" = true
+  test "$PREFETCH_GOVERNOR_PRECISION_FLOOR" = 0.05
+  test "$PREFETCH_GOVERNOR_CONTENTION_WEIGHT" = 0.0
+  test "$PREFETCH_GOVERNOR_BASE_THRESHOLD" = "$threshold"
+  prompt2_render_config "$TEMPLATE" "$TEST_ROOT/$variant.toml" \
+    /mnt/localssd/model /mnt/localssd/model/tokenizer.json 1536 \
+    "$PREDICT_FANOUT" "$PIPELINE_DEPTH" "$FIRST_ORDER_ENABLED" \
+    "$SECOND_ORDER_ENABLED" "$FALLBACK_PRIOR_FILL_ENABLED" \
+    "$FANOUT_IS_UPPER_BOUND" "$PREFETCH_GOVERNOR_ENABLED"
+  grep -Fx "prefetch_governor_base_threshold = $threshold" "$TEST_ROOT/$variant.toml" >/dev/null
+  grep -Fx 'prefetch_precision_floor = 0.05' "$TEST_ROOT/$variant.toml" >/dev/null
+  grep -Fx 'prefetch_contention_weight = 0.0' "$TEST_ROOT/$variant.toml" >/dev/null
+done
+
+grep -F 'QUALIFICATION_KIND=phase4d-c-sparse-admission-screening' "$COLLECTOR" >/dev/null
+grep -F 'EXPERIMENT_NAME=prompt2-phase4d-c-sparse-admission' "$COLLECTOR" >/dev/null
+grep -F 'phase4d-c-sparse-admission-variant-summary.json' "$COLLECTOR" >/dev/null
+grep -F 'Phase 4D-C sparse admission screening always requires a clean worktree' "$COLLECTOR" >/dev/null
+
+set +e
+MER_PROMPT2_PREFETCH_VARIANT=second-only-f1-governed-bt001-cw000 \
+MER_QWEN_CONVERTED_DIR=/does/not/exist MER_EXPECTED_NVME_MOUNT=/does/not/exist \
+  bash "$COLLECTOR" "$TEST_ROOT/phase4d-c-accepted" \
+    phase4d-c-sparse-admission >/dev/null 2>&1
+accepted_status=$?
+MER_PROMPT2_PREFETCH_VARIANT=current-f2 \
+MER_QWEN_CONVERTED_DIR=/does/not/exist MER_EXPECTED_NVME_MOUNT=/does/not/exist \
+  bash "$COLLECTOR" "$TEST_ROOT/phase4d-c-rejected" \
+    phase4d-c-sparse-admission >/dev/null 2>&1
+rejected_status=$?
+MER_PROMPT2_PREFETCH_VARIANT=second-only-f1-governed-bt001-cw000 \
+MER_QWEN_CONVERTED_DIR=/does/not/exist MER_EXPECTED_NVME_MOUNT=/does/not/exist \
+MER_PROMPT2_PHASE4B_TRACE_PATH='/tmp/{case}.jsonl' \
+  bash "$COLLECTOR" "$TEST_ROOT/phase4d-c-traced" \
+    phase4d-c-sparse-admission >/dev/null 2>&1
+traced_status=$?
+set -e
+test "$accepted_status" -ne 2
+test "$rejected_status" -eq 2
+test "$traced_status" -eq 2
+test ! -e "$TEST_ROOT/phase4d-c-accepted"
+test ! -e "$TEST_ROOT/phase4d-c-rejected"
+test ! -e "$TEST_ROOT/phase4d-c-traced"
+
+jq --arg qualification_kind phase4d-c-sparse-admission-screening \
+  -f "$COLLECTION_QUALIFIER" "$TEST_ROOT/phase4d-screening-collection.json" \
+  > "$TEST_ROOT/phase4d-c-qualification.json"
+jq -e '.qualification_kind == "phase4d-c-sparse-admission-screening" and
+  .collection_qualification_valid == true and
+  .sparse_admission_collection_valid == true and
+  .performance_qualification_applicable == false and
+  .qualification_passed == false' "$TEST_ROOT/phase4d-c-qualification.json" >/dev/null
+
 echo "Prompt 2 collector qualification fixtures: PASS"


### PR DESCRIPTION
## Summary

- Add a Phase 4D-C sparse-admission screening mode.
- Screen governor base thresholds 0.001, 0.0005, and 0.00025.
- Preserve second-order-only prediction, fanout 1, precision floor 0.05, and contention weight 0.
- Report governor decisions, score diagnostics, performance deltas, provenance, and non-gating monotonicity observations.

## Scope

This is a two-run, short-prompt, non-qualifying screening experiment. It does not modify the Rust engine, governor formula, predictor behavior, or production defaults.

## Validation

- Phase 4D-C fixture tests
- Existing Phase 4D-A fixture tests
- Existing Phase 4D-B fixture tests
- Shared Prompt 2 collector tests
- Shell syntax checks
- git diff --check
- No rust-engine changes
- Phase 4D-B dedicated files unchanged

The target-host Phase 4D-C benchmark has not yet been run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a sparse-admission screening workflow with multiple prefetch threshold variants.
  - Added structured summaries showing screening results, performance comparisons, configuration details, and validation status.
  - Added safeguards for execution order, environment readiness, clean workspaces, and consistent collected data.

- **Documentation**
  - Documented the Phase 4D-C screening procedure, run order, collection settings, and interpretation of results.

- **Tests**
  - Added coverage for valid and invalid screening data, configuration rendering, collection behavior, and workflow integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->