### PR TITLE
fix: standardize Q4_0 layout across CPU conversion and WGSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2417,6 +2417,15 @@ output directory is created. The converter writes into a sibling
 file and `metadata.json`, then atomically renames staging into place.
 Existing nonempty output directories are refused rather than destroyed.
 
+Q4_0 datasets use the standard GGML/Candle block contract: byte `j` stores
+element `j` in its low nibble and element `j + 16` in its high nibble.
+Converters and `gen-data --dtype q4_0` record
+`"q4_0_layout": "ggml-standard-v1"` in `metadata.json`. Runtime Q4_0
+loading rejects a missing, legacy, or unknown marker; there is no heuristic
+or dual-reader fallback. Reconvert the original GGUF or rerun `gen-data` for
+older MER-generated Q4_0 directories whose nibble layout was not versioned.
+Other dtypes are unaffected.
+
 Use `--experts-only` for the expert-streaming benchmark path. It writes
 expert blobs and metadata, skips dense transformer tensors, and records
 `"conversion_mode": "experts_only"` in `metadata.json`. Validate any

--- a/rust-engine/Cargo.lock
+++ b/rust-engine/Cargo.lock
@@ -2009,6 +2009,7 @@ dependencies = [
  "libc",
  "lru",
  "matrixmultiply",
+ "naga",
  "once_cell",
  "parking_lot",
  "pollster",

--- a/rust-engine/Cargo.toml
+++ b/rust-engine/Cargo.toml
@@ -153,6 +153,9 @@ prost = { version = "0.13", optional = true }
 # the strategies API in our `tests` modules stays compatible without a
 # transitive bump.
 proptest = "1"
+# Parse and validate embedded WGSL in unit tests without requiring a GPU
+# adapter. Keep this aligned with wgpu 0.20's naga dependency.
+naga = { version = "0.20", features = ["wgsl-in"] }
 
 [profile.release]
 lto = "thin"

--- a/rust-engine/src/backend/mod.rs
+++ b/rust-engine/src/backend/mod.rs
@@ -2984,6 +2984,7 @@ mod q4_0_shader_logic_tests {
     //! or offset mistake in the shader's math shows up in CI without
     //! needing a GPU adapter.
 
+    use super::MATMUL_Q4_0_SHADER;
     use crate::inference::{
         dequantize_q4_0_block, quantize_q4_0_block, Q4_0_BLOCK_BYTES, Q4_0_BLOCK_ELEMS,
     };
@@ -3020,7 +3021,7 @@ mod q4_0_shader_logic_tests {
                 let q = read_byte(w, byte_off + 2 + j);
                 let w0 = (q & 0xf) as f32 - 8.0;
                 let w1 = (q >> 4) as f32 - 8.0;
-                partial += w0 * x[x_base + 2 * j] + w1 * x[x_base + 2 * j + 1];
+                partial += w0 * x[x_base + j] + w1 * x[x_base + j + Q4_0_BLOCK_ELEMS / 2];
             }
             sum += d * partial;
             byte_off += Q4_0_BLOCK_BYTES;
@@ -3041,6 +3042,22 @@ mod q4_0_shader_logic_tests {
                 ((state % 2000) as f32 - 1000.0) / 250.0
             })
             .collect()
+    }
+
+    #[test]
+    fn q4_0_wgsl_parses_and_validates_without_gpu_hardware() {
+        let module =
+            naga::front::wgsl::parse_str(MATMUL_Q4_0_SHADER).expect("Q4_0 WGSL must parse");
+        naga::valid::Validator::new(
+            naga::valid::ValidationFlags::all(),
+            naga::valid::Capabilities::all(),
+        )
+        .validate(&module)
+        .expect("Q4_0 WGSL must validate");
+        assert!(module
+            .entry_points
+            .iter()
+            .any(|entry| entry.name == "matmul_q4_0_main"));
     }
 
     /// Quantise an `m × k` row-major matrix into a tight Q4_0 block
@@ -3084,6 +3101,25 @@ mod q4_0_shader_logic_tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn shader_host_mirror_obeys_independent_ggml_nibble_fixture() {
+        let mut block = [0u8; Q4_0_BLOCK_BYTES];
+        block[..2].copy_from_slice(&half::f16::from_f32(0.25).to_bits().to_le_bytes());
+        for (j, byte) in block[2..].iter_mut().enumerate() {
+            *byte = j as u8 | ((15 - j as u8) << 4);
+        }
+        let words = bytes_to_words(&block);
+        let x: Vec<f32> = (0..Q4_0_BLOCK_ELEMS)
+            .map(|i| (i as f32 - 11.0) / 7.0)
+            .collect();
+        let expected: f32 = (0..16)
+            .map(|j| 0.25 * (j as f32 - 8.0) * x[j])
+            .chain((0..16).map(|j| 0.25 * (7.0 - j as f32) * x[j + 16]))
+            .sum();
+        let got = shader_row_dot(&words, 0, 0, Q4_0_BLOCK_ELEMS, &x);
+        assert!((got - expected).abs() < 1e-6, "{got} != {expected}");
     }
 
     #[test]

--- a/rust-engine/src/backend/wgpu_shaders/matmul_q4_0.wgsl
+++ b/rust-engine/src/backend/wgpu_shaders/matmul_q4_0.wgsl
@@ -10,9 +10,9 @@
 //
 // Block layout (must match `inference::dequantize_q4_0_block`):
 //   d  : f16 little-endian (2 bytes)   — block scale
-//   qs : 16 bytes                      — 32× 4-bit weights, low nibble
-//                                        first: elem 2j = qs[j] & 0xF,
-//                                        elem 2j+1 = qs[j] >> 4; both
+//   qs : 16 bytes                      — 32× 4-bit weights. For each j:
+//                                        elem j      = qs[j] & 0xF,
+//                                        elem j + 16 = qs[j] >> 4; both
 //                                        biased by -8.
 //
 // The expert FFN only ever needs N == 1 (a per-token GEMV), so this is a

--- a/rust-engine/src/backend/wgpu_shaders/matmul_q4_0.wgsl
+++ b/rust-engine/src/backend/wgpu_shaders/matmul_q4_0.wgsl
@@ -68,14 +68,15 @@ fn matmul_q4_0_main(@builtin(global_invocation_id) gid: vec3<u32>) {
         let s_hi = read_byte(byte_off + 1u);
         let d = unpack2x16float(s_lo | (s_hi << 8u)).x;
 
-        // 16 nibble bytes → 32 weights. Accumulate the un-scaled dot
-        // product per block and apply the scale once at the end.
+        // GGML Q4_0 stores element j in the low nibble and element j+16
+        // in the high nibble. Accumulate the un-scaled dot product per
+        // block and apply the scale once at the end.
         var partial = 0.0;
         for (var j = 0u; j < 16u; j = j + 1u) {
             let q = read_byte(byte_off + 2u + j);
             let w0 = f32(q & 0xfu) - 8.0;
             let w1 = f32(q >> 4u) - 8.0;
-            partial = partial + w0 * X[x_base + 2u * j] + w1 * X[x_base + 2u * j + 1u];
+            partial = partial + w0 * X[x_base + j] + w1 * X[x_base + j + 16u];
         }
         sum = sum + d * partial;
 

--- a/rust-engine/src/gguf_loader.rs
+++ b/rust-engine/src/gguf_loader.rs
@@ -1816,6 +1816,17 @@ pub fn validate_data_dir(data_dir: &Path) -> io::Result<DataValidationReport> {
         }
     }
 
+    // Mixed metadata is only a summary; the UTH2 projection ranges are
+    // authoritative. Reconcile the marker against the observed headers so
+    // an omitted or incomplete histogram cannot conceal Q4_0 payloads.
+    if dtype == WeightDtype::Mixed {
+        validate_q4_0_layout_marker(
+            metadata_uses_q4_0(dtype, Some(&observed_hist)),
+            meta.q4_0_layout.as_deref(),
+            &meta_path,
+        )?;
+    }
+
     if let Some(expected_hist) = meta.projection_dtype_histogram {
         if dtype == WeightDtype::Mixed && expected_hist != observed_hist {
             return Err(io::Error::new(
@@ -1845,11 +1856,85 @@ fn metadata_uses_q4_0(
         || (dtype == WeightDtype::Mixed
             && projection_dtype_histogram.is_some_and(|histogram| {
                 histogram.keys().any(|layout| {
-                    layout
-                        .split('/')
-                        .any(|projection| projection.eq_ignore_ascii_case("q4_0"))
+                    layout.split('/').any(|projection| {
+                        WeightDtype::from_str_opt(projection) == Some(WeightDtype::Q4_0)
+                    })
                 })
             }))
+}
+
+fn projection_dtype_histogram_is_complete(
+    histogram: &BTreeMap<String, usize>,
+    num_experts: usize,
+) -> bool {
+    !histogram.is_empty()
+        && histogram.iter().all(|(layout, count)| {
+            *count > 0
+                && layout.split('/').count() == 3
+                && layout.split('/').all(|projection| {
+                    WeightDtype::from_str_opt(projection)
+                        .is_some_and(|dtype| dtype != WeightDtype::Mixed)
+                })
+        })
+        && histogram
+            .values()
+            .try_fold(0usize, |total, count| total.checked_add(*count))
+            == Some(num_experts)
+}
+
+fn mixed_expert_headers_use_q4_0(data_dir: &Path, num_experts: usize) -> io::Result<bool> {
+    use std::io::Read;
+
+    for id in 0..num_experts {
+        let path = data_dir.join(format!("expert_{id}.bin"));
+        let mut head = [0u8; crate::tensor_header::UTH2_BYTES];
+        let mut file = fs::File::open(&path).map_err(|err| {
+            io::Error::new(
+                err.kind(),
+                format!(
+                    "mixed metadata cannot prove Q4_0 is absent: failed to open UTH2 header {}: {err}",
+                    path.display()
+                ),
+            )
+        })?;
+        file.read_exact(&mut head).map_err(|err| {
+            io::Error::new(
+                err.kind(),
+                format!(
+                    "mixed metadata cannot prove Q4_0 is absent: failed to read UTH2 header {}: {err}",
+                    path.display()
+                ),
+            )
+        })?;
+        let header = MixedExpertHeader::probe(&head).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "mixed metadata cannot prove Q4_0 is absent: expert file {} has no valid UTH2 header; regenerate or reconvert the dataset",
+                    path.display()
+                ),
+            )
+        })?;
+        if [header.gate, header.up, header.down]
+            .into_iter()
+            .any(|projection| projection.dtype.to_weight() == WeightDtype::Q4_0)
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn mixed_metadata_or_headers_use_q4_0(
+    data_dir: &Path,
+    meta: &ValidationMetadata,
+) -> io::Result<bool> {
+    if let Some(histogram) = meta.projection_dtype_histogram.as_ref() {
+        if projection_dtype_histogram_is_complete(histogram, meta.num_experts) {
+            return Ok(metadata_uses_q4_0(WeightDtype::Mixed, Some(histogram)));
+        }
+    }
+    mixed_expert_headers_use_q4_0(data_dir, meta.num_experts)
 }
 
 fn validate_q4_0_layout_marker(
@@ -1930,7 +2015,9 @@ pub fn validate_q4_0_dataset_layout(
         }
     };
     let requires_q4_0 = configured_dtype == WeightDtype::Q4_0
-        || metadata_uses_q4_0(declared_dtype, meta.projection_dtype_histogram.as_ref());
+        || metadata_uses_q4_0(declared_dtype, meta.projection_dtype_histogram.as_ref())
+        || (declared_dtype == WeightDtype::Mixed
+            && mixed_metadata_or_headers_use_q4_0(data_dir, &meta)?);
     validate_q4_0_layout_marker(requires_q4_0, meta.q4_0_layout.as_deref(), &meta_path)
 }
 
@@ -4405,6 +4492,18 @@ mod tests {
     }
 
     #[test]
+    fn mixed_histogram_q4_0_detection_uses_supported_dtype_aliases() {
+        for layout in ["q4_0/q8_0/q8_0", "Q4_0/q8_0/q8_0", "q4/q8_0/q8_0"] {
+            let histogram = BTreeMap::from([(layout.to_string(), 1usize)]);
+            assert!(metadata_uses_q4_0(
+                WeightDtype::Mixed,
+                Some(&histogram)
+            ));
+            assert!(projection_dtype_histogram_is_complete(&histogram, 1));
+        }
+    }
+
+    #[test]
     fn uniform_tail_block_layout_uses_uth2_plan() {
         let weights = Q5K_BLOCK_ELEMS + 1;
         let payload_bytes =
@@ -4998,6 +5097,59 @@ mod tests {
             meta["projection_dtype_histogram"]["q4_0/q4_0/q8_0"],
             num_experts
         );
+        validate_data_dir(&out).expect("mixed Q4_0 metadata validates");
+        validate_q4_0_dataset_layout(&out, WeightDtype::Mixed)
+            .expect("runtime accepts mixed Q4_0 metadata");
+
+        let meta_path = out.join("metadata.json");
+        let mut missing_histogram = meta.clone();
+        missing_histogram
+            .as_object_mut()
+            .unwrap()
+            .remove("projection_dtype_histogram");
+        missing_histogram
+            .as_object_mut()
+            .unwrap()
+            .remove("q4_0_layout");
+        fs::write(
+            &meta_path,
+            serde_json::to_vec_pretty(&missing_histogram).unwrap(),
+        )
+        .unwrap();
+        for err in [
+            validate_data_dir(&out).expect_err("UTH2 Q4_0 requires a layout marker"),
+            validate_q4_0_dataset_layout(&out, WeightDtype::Mixed)
+                .expect_err("runtime must inspect UTH2 when the histogram is missing"),
+        ] {
+            assert!(err.to_string().contains("<missing>"), "{err}");
+        }
+
+        missing_histogram["q4_0_layout"] = serde_json::json!(Q4_0_LAYOUT_STANDARD_V1);
+        fs::write(
+            &meta_path,
+            serde_json::to_vec_pretty(&missing_histogram).unwrap(),
+        )
+        .unwrap();
+        validate_data_dir(&out).expect("UTH2 inspection proves standard Q4_0 layout");
+        validate_q4_0_dataset_layout(&out, WeightDtype::Mixed)
+            .expect("standard marker makes runtime mixed metadata safe");
+
+        let mut incomplete_histogram = meta.clone();
+        incomplete_histogram["projection_dtype_histogram"] =
+            serde_json::json!({"q8_0/q8_0/q8_0": num_experts - 1});
+        incomplete_histogram
+            .as_object_mut()
+            .unwrap()
+            .remove("q4_0_layout");
+        fs::write(
+            &meta_path,
+            serde_json::to_vec_pretty(&incomplete_histogram).unwrap(),
+        )
+        .unwrap();
+        let err = validate_q4_0_dataset_layout(&out, WeightDtype::Mixed)
+            .expect_err("runtime must inspect UTH2 when the histogram is incomplete");
+        assert!(err.to_string().contains("<missing>"), "{err}");
+        fs::write(&meta_path, serde_json::to_vec_pretty(&meta).unwrap()).unwrap();
 
         let q4_payload = (d_ff * d_model / Q4_0_BLOCK_ELEMS) * Q4_0_BLOCK_BYTES;
         let q8_payload = (d_ff * d_model / Q8_0_BLOCK_ELEMS) * Q8_0_BLOCK_BYTES;

--- a/rust-engine/src/gguf_loader.rs
+++ b/rust-engine/src/gguf_loader.rs
@@ -18,11 +18,10 @@
 //! already consumes: `gate_proj || up_proj || down_proj` row-major, with
 //! gate / up shape `[d_ff, d_model]` and down shape `[d_model, d_ff]`.
 //! For F32, F16 and BF16 source dtypes the bytes are repacked into that
-//! layout directly (BF16 and F16 are decoded to F32); for Q4_0 / Q4_K we
-//! currently dequantise to F32 because the
-//! GGUF stores each (gate, up, down) tensor as a single block stream
-//! that doesn't slice cleanly along the expert axis at the byte level.
-//! This preserves the **engine's** on-disk format invariants
+//! layout directly (BF16 and F16 are decoded to F32). Supported native
+//! quantised tensors whose expert slices are block-aligned are copied
+//! byte-for-byte; other layouts use the F32 conversion path. This
+//! preserves the **engine's** on-disk format invariants
 //! (`expert_size` is the same for every expert, the file is page-padded,
 //! and `metadata.json::dtype` correctly describes the contents).
 
@@ -32,9 +31,9 @@ use crate::dense_tensor::{
 use crate::gguf::{ggml_dtype, GgufFile, GgufSource, GgufTensorInfo, GgufValue};
 use crate::inference::{
     dequantize_bf16_to_f32, dequantize_f16_to_f32, expert_weight_bytes_for,
-    projection_weight_bytes_for, WeightDtype,
-    Q4K_BLOCK_BYTES, Q4K_BLOCK_ELEMS, Q4_0_BLOCK_BYTES, Q4_0_BLOCK_ELEMS, Q5K_BLOCK_BYTES,
-    Q5K_BLOCK_ELEMS, Q6K_BLOCK_BYTES, Q6K_BLOCK_ELEMS, Q8_0_BLOCK_BYTES, Q8_0_BLOCK_ELEMS,
+    projection_weight_bytes_for, WeightDtype, Q4K_BLOCK_BYTES, Q4K_BLOCK_ELEMS, Q4_0_BLOCK_BYTES,
+    Q4_0_BLOCK_ELEMS, Q4_0_LAYOUT_STANDARD_V1, Q5K_BLOCK_BYTES, Q5K_BLOCK_ELEMS, Q6K_BLOCK_BYTES,
+    Q6K_BLOCK_ELEMS, Q8_0_BLOCK_BYTES, Q8_0_BLOCK_ELEMS,
 };
 use crate::tensor_header::{MixedExpertHeader, ProjectionRange, TensorHeader, UthDtypeId};
 use serde::{Deserialize, Serialize};
@@ -101,6 +100,8 @@ struct ExtractedMetadata<'a> {
     expert_layout_version: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     projection_dtype_histogram: Option<BTreeMap<String, usize>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    q4_0_layout: Option<&'a str>,
     experts_written: usize,
     dense_tensors_written: usize,
 }
@@ -1236,6 +1237,10 @@ fn extract_experts_from_source_inner(
         projection_dtype_histogram: native_plan
             .as_ref()
             .and_then(NativeQuantPlan::metadata_histogram),
+        q4_0_layout: native_plan
+            .as_ref()
+            .filter(|plan| plan.contains_q4_0())
+            .map(|_| Q4_0_LAYOUT_STANDARD_V1),
         experts_written: report.experts_written,
         dense_tensors_written: report.dense_written,
     };
@@ -1598,6 +1603,8 @@ struct ValidationMetadata {
     #[serde(default)]
     projection_dtype_histogram: Option<BTreeMap<String, usize>>,
     #[serde(default)]
+    q4_0_layout: Option<String>,
+    #[serde(default)]
     experts_written: Option<usize>,
 }
 
@@ -1654,6 +1661,11 @@ pub fn validate_data_dir(data_dir: &Path) -> io::Result<DataValidationReport> {
             format!("metadata dtype {:?} is not supported", meta.dtype),
         )
     })?;
+    validate_q4_0_layout_marker(
+        metadata_uses_q4_0(dtype, meta.projection_dtype_histogram.as_ref()),
+        meta.q4_0_layout.as_deref(),
+        &meta_path,
+    )?;
     if meta.block_align == 0 || !meta.block_align.is_power_of_two() {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -1823,6 +1835,103 @@ pub fn validate_data_dir(data_dir: &Path) -> io::Result<DataValidationReport> {
         dtype,
         mixed_experts: observed_mixed,
     })
+}
+
+fn metadata_uses_q4_0(
+    dtype: WeightDtype,
+    projection_dtype_histogram: Option<&BTreeMap<String, usize>>,
+) -> bool {
+    dtype == WeightDtype::Q4_0
+        || (dtype == WeightDtype::Mixed
+            && projection_dtype_histogram.is_some_and(|histogram| {
+                histogram.keys().any(|layout| {
+                    layout
+                        .split('/')
+                        .any(|projection| projection.eq_ignore_ascii_case("q4_0"))
+                })
+            }))
+}
+
+fn validate_q4_0_layout_marker(
+    requires_q4_0: bool,
+    marker: Option<&str>,
+    meta_path: &Path,
+) -> io::Result<()> {
+    if !requires_q4_0 {
+        return Ok(());
+    }
+    if marker == Some(Q4_0_LAYOUT_STANDARD_V1) {
+        return Ok(());
+    }
+    let found = marker.unwrap_or("<missing>");
+    Err(io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!(
+            "metadata {} has missing, legacy, or unsupported Q4_0 layout marker {found:?}; expected q4_0_layout={Q4_0_LAYOUT_STANDARD_V1:?}. Reconvert the original GGUF or regenerate this dataset before loading it",
+            meta_path.display()
+        ),
+    ))
+}
+
+/// Fail closed before opening a runtime dataset that is known to use Q4_0.
+///
+/// Q4_0 datasets created before the standard GGML nibble contract were
+/// versioned may contain the legacy adjacent-nibble layout. They must be
+/// reconverted or regenerated; production does not guess or dual-decode.
+pub fn validate_q4_0_dataset_layout(
+    data_dir: &Path,
+    configured_dtype: WeightDtype,
+) -> io::Result<()> {
+    let configured_may_use_q4_0 =
+        configured_dtype == WeightDtype::Q4_0 || configured_dtype == WeightDtype::Mixed;
+    let meta_path = data_dir.join("metadata.json");
+    let body = match fs::read_to_string(&meta_path) {
+        Ok(body) => body,
+        Err(err)
+            if configured_dtype == WeightDtype::Mixed && err.kind() == io::ErrorKind::NotFound =>
+        {
+            // Preserve pre-existing non-Q4 mixed-dataset behavior when no
+            // metadata exists. A metadata-declared mixed Q4_0 dataset is
+            // still checked below.
+            return Ok(());
+        }
+        Err(_) if !configured_may_use_q4_0 => return Ok(()),
+        Err(err) => {
+            return Err(io::Error::new(
+                err.kind(),
+                format!(
+                    "Q4_0 dataset metadata {} is required to prove q4_0_layout={Q4_0_LAYOUT_STANDARD_V1:?}; reconvert the original GGUF or regenerate this dataset: {err}",
+                    meta_path.display()
+                ),
+            ));
+        }
+    };
+    let meta: ValidationMetadata = match serde_json::from_str(&body) {
+        Ok(meta) => meta,
+        Err(_) if !configured_may_use_q4_0 => return Ok(()),
+        Err(err) => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "Q4_0 dataset metadata {} is invalid; reconvert the original GGUF or regenerate this dataset: {err}",
+                    meta_path.display()
+                ),
+            ));
+        }
+    };
+    let declared_dtype = match WeightDtype::from_str_opt(&meta.dtype) {
+        Some(dtype) => dtype,
+        None if !configured_may_use_q4_0 => return Ok(()),
+        None => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("metadata dtype {:?} is not supported", meta.dtype),
+            ));
+        }
+    };
+    let requires_q4_0 = configured_dtype == WeightDtype::Q4_0
+        || metadata_uses_q4_0(declared_dtype, meta.projection_dtype_histogram.as_ref());
+    validate_q4_0_layout_marker(requires_q4_0, meta.q4_0_layout.as_deref(), &meta_path)
 }
 
 fn f32_vec_to_le_bytes(v: &[f32]) -> Vec<u8> {
@@ -2439,6 +2548,17 @@ impl NativeQuantPlan {
         match self {
             NativeQuantPlan::Homogeneous { .. } => None,
             NativeQuantPlan::Mixed { histogram, .. } => Some(histogram.clone()),
+        }
+    }
+
+    fn contains_q4_0(&self) -> bool {
+        match self {
+            NativeQuantPlan::Homogeneous { dtype } => *dtype == WeightDtype::Q4_0,
+            NativeQuantPlan::Mixed { layouts, .. } => layouts.iter().any(|layout| {
+                [layout.gate, layout.up, layout.down]
+                    .into_iter()
+                    .any(|projection| projection.dtype == WeightDtype::Q4_0)
+            }),
         }
     }
 }
@@ -4172,6 +4292,119 @@ mod tests {
     }
 
     #[test]
+    fn native_q4_0_interleaved_extraction_preserves_exact_bytes() {
+        struct FakeSource {
+            tensors: std::collections::HashMap<String, GgufTensorInfo>,
+            data: std::collections::HashMap<String, Vec<u8>>,
+            metadata: std::collections::HashMap<String, GgufValue>,
+        }
+        impl GgufSource for FakeSource {
+            fn metadata(&self) -> &std::collections::HashMap<String, GgufValue> {
+                &self.metadata
+            }
+            fn tensor_info(&self, name: &str) -> Option<&GgufTensorInfo> {
+                self.tensors.get(name)
+            }
+            fn read_tensor_owned(&self, name: &str) -> io::Result<Option<Vec<u8>>> {
+                Ok(self.data.get(name).cloned())
+            }
+        }
+
+        let d_model = 4usize;
+        let d_ff = 16usize;
+        let num_experts = 3usize;
+        let blocks = d_model * d_ff / Q4_0_BLOCK_ELEMS;
+        let mut tensors = std::collections::HashMap::new();
+        let mut data = std::collections::HashMap::new();
+        for (projection, name) in [
+            "blk.0.ffn_gate_exps.weight",
+            "blk.0.ffn_up_exps.weight",
+            "blk.0.ffn_down_exps.weight",
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let blob: Vec<u8> = (0..num_experts)
+                .flat_map(|expert| q4_0_fixture_blob(blocks, expert, projection))
+                .collect();
+            tensors.insert(
+                name.to_string(),
+                GgufTensorInfo {
+                    name: name.to_string(),
+                    shape: vec![d_model as u64, d_ff as u64, num_experts as u64],
+                    ggml_dtype: ggml_dtype::Q4_0,
+                    offset: 0,
+                    byte_len: blob.len() as u64,
+                },
+            );
+            data.insert(name.to_string(), blob);
+        }
+        let source = FakeSource {
+            tensors,
+            data,
+            metadata: std::collections::HashMap::new(),
+        };
+        let extracted = load_layer_expert_native_quant(
+            &source,
+            0,
+            num_experts,
+            d_model,
+            d_ff,
+            WeightDtype::Q4_0,
+        )
+        .expect("interleaved extraction");
+        for (expert, (gate, up, down)) in extracted.iter().enumerate() {
+            assert_eq!(gate, &q4_0_fixture_blob(blocks, expert, 0));
+            assert_eq!(up, &q4_0_fixture_blob(blocks, expert, 1));
+            assert_eq!(down, &q4_0_fixture_blob(blocks, expert, 2));
+        }
+    }
+
+    #[test]
+    fn runtime_q4_0_layout_check_is_explicit_and_fail_closed() {
+        let tmp = tempfile_dir();
+        assert!(validate_q4_0_dataset_layout(&tmp, WeightDtype::F32).is_ok());
+
+        let missing = validate_q4_0_dataset_layout(&tmp, WeightDtype::Q4_0)
+            .expect_err("Q4_0 metadata is mandatory");
+        assert!(missing.to_string().contains("regenerate"));
+
+        fs::write(tmp.join("metadata.json"), b"{not-json").unwrap();
+        assert!(validate_q4_0_dataset_layout(&tmp, WeightDtype::F32).is_ok());
+        let corrupt = validate_q4_0_dataset_layout(&tmp, WeightDtype::Q4_0)
+            .expect_err("corrupt metadata must fail");
+        assert!(corrupt.to_string().contains("invalid"));
+
+        let mut metadata = serde_json::json!({
+            "num_experts": 1,
+            "d_model": 32,
+            "d_ff": 32,
+            "expert_size": DEFAULT_BLOCK_ALIGN,
+            "block_align": DEFAULT_BLOCK_ALIGN,
+            "dtype": "q4_0",
+            "experts_written": 1,
+        });
+        fs::write(
+            tmp.join("metadata.json"),
+            serde_json::to_vec_pretty(&metadata).unwrap(),
+        )
+        .unwrap();
+        let unversioned = validate_q4_0_dataset_layout(&tmp, WeightDtype::Q4_0)
+            .expect_err("unversioned Q4_0 must fail");
+        assert!(unversioned.to_string().contains("<missing>"));
+        assert!(validate_q4_0_dataset_layout(&tmp, WeightDtype::F32).is_err());
+
+        metadata["q4_0_layout"] = serde_json::json!(Q4_0_LAYOUT_STANDARD_V1);
+        fs::write(
+            tmp.join("metadata.json"),
+            serde_json::to_vec_pretty(&metadata).unwrap(),
+        )
+        .unwrap();
+        validate_q4_0_dataset_layout(&tmp, WeightDtype::Q4_0).expect("standard marker accepted");
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
     fn uniform_tail_block_layout_uses_uth2_plan() {
         let weights = Q5K_BLOCK_ELEMS + 1;
         let payload_bytes =
@@ -4230,6 +4463,20 @@ mod tests {
         out
     }
 
+    fn q4_0_fixture_blob(blocks: usize, expert: usize, projection: usize) -> Vec<u8> {
+        let mut out = Vec::with_capacity(blocks * Q4_0_BLOCK_BYTES);
+        for block in 0..blocks {
+            let scale = 0.0625 * (1 + expert * 3 + projection * 5 + block) as f32;
+            out.extend_from_slice(&half::f16::from_f32(scale).to_bits().to_le_bytes());
+            for j in 0..16 {
+                let low = (j + expert + projection * 3 + block * 5) as u8 & 0x0f;
+                let high = (15usize + expert * 7 + projection * 5 + block * 3 - j) as u8 & 0x0f;
+                out.push(low | (high << 4));
+            }
+        }
+        out
+    }
+
     /// Leak an owned `String` into a `'static str`. Test-only helper for
     /// building metadata key tables whose names are computed at runtime
     /// (e.g. `<arch>.block_count`); the small leak is bounded by the
@@ -4251,14 +4498,6 @@ mod tests {
         use crate::gguf::GGUF_MAGIC;
         assert_eq!((d_ff * d_model) % Q4_0_BLOCK_ELEMS, 0);
         let blocks = (d_ff * d_model) / Q4_0_BLOCK_ELEMS;
-        // One Q4_0 block: f16 scale 0.1 (0x2e66) + 16 nibble-pair bytes.
-        let q4_0_block: Vec<u8> = {
-            let mut b = vec![0x66u8, 0x2e];
-            b.extend_from_slice(&[0x77u8; 16]);
-            b
-        };
-        let expert_blob: Vec<u8> = q4_0_block.repeat(blocks);
-
         let mut out = Vec::new();
         out.extend_from_slice(GGUF_MAGIC);
         out.extend_from_slice(&3u32.to_le_bytes());
@@ -4402,21 +4641,21 @@ mod tests {
                 &format!("blk.0.ffn_gate.{e}.weight"),
                 &[d_model as u64, d_ff as u64],
                 ggml_dtype::Q4_0,
-                expert_blob.clone(),
+                q4_0_fixture_blob(blocks, e, 0),
             );
             push_raw(
                 &mut out,
                 &format!("blk.0.ffn_up.{e}.weight"),
                 &[d_model as u64, d_ff as u64],
                 ggml_dtype::Q4_0,
-                expert_blob.clone(),
+                q4_0_fixture_blob(blocks, e, 1),
             );
             push_raw(
                 &mut out,
                 &format!("blk.0.ffn_down.{e}.weight"),
                 &[d_ff as u64, d_model as u64],
                 ggml_dtype::Q4_0,
-                expert_blob.clone(),
+                q4_0_fixture_blob(blocks, e, 2),
             );
         }
         while out.len() % 32 != 0 {
@@ -4438,17 +4677,11 @@ mod tests {
         assert_eq!((d_ff * d_model) % Q8_0_BLOCK_ELEMS, 0);
         let q4_blocks = (d_ff * d_model) / Q4_0_BLOCK_ELEMS;
         let q8_blocks = (d_ff * d_model) / Q8_0_BLOCK_ELEMS;
-        let q4_block: Vec<u8> = {
-            let mut b = half::f16::from_f32(0.1).to_bits().to_le_bytes().to_vec();
-            b.extend_from_slice(&[0x88u8; 16]);
-            b
-        };
         let q8_block: Vec<u8> = {
             let mut b = half::f16::from_f32(0.1).to_bits().to_le_bytes().to_vec();
             b.extend_from_slice(&[1u8; 32]);
             b
         };
-        let q4_blob = q4_block.repeat(q4_blocks);
         let q8_blob = q8_block.repeat(q8_blocks);
 
         let mut out = Vec::new();
@@ -4593,14 +4826,14 @@ mod tests {
                 &format!("blk.0.ffn_gate.{e}.weight"),
                 &[d_model as u64, d_ff as u64],
                 ggml_dtype::Q4_0,
-                q4_blob.clone(),
+                q4_0_fixture_blob(q4_blocks, e, 0),
             );
             push_raw(
                 &mut out,
                 &format!("blk.0.ffn_up.{e}.weight"),
                 &[d_model as u64, d_ff as u64],
                 ggml_dtype::Q4_0,
-                q4_blob.clone(),
+                q4_0_fixture_blob(q4_blocks, e, 1),
             );
             push_raw(
                 &mut out,
@@ -4665,6 +4898,34 @@ mod tests {
         let meta: serde_json::Value =
             serde_json::from_slice(&fs::read(out.join("metadata.json")).unwrap()).unwrap();
         assert_eq!(meta["dtype"], "q4_0");
+        assert_eq!(meta["q4_0_layout"], Q4_0_LAYOUT_STANDARD_V1);
+        validate_data_dir(&out).expect("converted GGUF Q4_0 validates");
+
+        let meta_path = out.join("metadata.json");
+        for (marker, expected_fragment) in [
+            (None, "<missing>"),
+            (Some("mer-adjacent-v0"), "mer-adjacent-v0"),
+            (Some("ggml-standard-v999"), "ggml-standard-v999"),
+        ] {
+            let mut incompatible = meta.clone();
+            match marker {
+                Some(value) => incompatible["q4_0_layout"] = serde_json::json!(value),
+                None => {
+                    incompatible.as_object_mut().unwrap().remove("q4_0_layout");
+                }
+            }
+            fs::write(
+                &meta_path,
+                serde_json::to_vec_pretty(&incompatible).unwrap(),
+            )
+            .unwrap();
+            let err = validate_data_dir(&out).expect_err("incompatible Q4_0 marker must fail");
+            let message = err.to_string();
+            assert!(message.contains(expected_fragment), "{message}");
+            assert!(message.contains("Reconvert") && message.contains("regenerate"));
+        }
+        fs::write(&meta_path, serde_json::to_vec_pretty(&meta).unwrap()).unwrap();
+        validate_data_dir(&out).expect("restored standard marker validates");
 
         // Raw quantised payload size, much smaller than the F32 dequant
         // (which would be 3 * d_ff * d_model * 4 bytes).
@@ -4677,6 +4938,19 @@ mod tests {
                 payload.len() >= q4_payload && payload.len() < f32_payload,
                 "expert {e} payload {} should be raw Q4_0 ({q4_payload}), not F32 ({f32_payload})",
                 payload.len()
+            );
+            let one_projection = q4_payload / 3;
+            assert_eq!(
+                &payload[..one_projection],
+                q4_0_fixture_blob((d_model * d_ff) / Q4_0_BLOCK_ELEMS, e, 0).as_slice()
+            );
+            assert_eq!(
+                &payload[one_projection..2 * one_projection],
+                q4_0_fixture_blob((d_model * d_ff) / Q4_0_BLOCK_ELEMS, e, 1).as_slice()
+            );
+            assert_eq!(
+                &payload[2 * one_projection..3 * one_projection],
+                q4_0_fixture_blob((d_model * d_ff) / Q4_0_BLOCK_ELEMS, e, 2).as_slice()
             );
         }
         let _ = fs::remove_dir_all(&tmp);
@@ -4719,6 +4993,7 @@ mod tests {
             serde_json::from_slice(&fs::read(out.join("metadata.json")).unwrap()).unwrap();
         assert_eq!(meta["dtype"], "mixed");
         assert_eq!(meta["expert_layout_version"], 2);
+        assert_eq!(meta["q4_0_layout"], Q4_0_LAYOUT_STANDARD_V1);
         assert_eq!(
             meta["projection_dtype_histogram"]["q4_0/q4_0/q8_0"],
             num_experts
@@ -4767,9 +5042,10 @@ mod tests {
         );
         assert_eq!(actual.len(), expected.len());
         for (idx, (a, b)) in actual.iter().zip(expected.iter()).enumerate() {
+            let tolerance = 3e-3 * b.abs().max(1.0) + 3e-5;
             assert!(
-                (a - b).abs() <= 1e-5,
-                "mixed direct output mismatch at {idx}: actual={a}, expected={b}"
+                (a - b).abs() <= tolerance,
+                "mixed direct output mismatch at {idx}: actual={a}, expected={b}, tolerance={tolerance}"
             );
         }
         let _ = fs::remove_dir_all(&tmp);

--- a/rust-engine/src/inference.rs
+++ b/rust-engine/src/inference.rs
@@ -746,15 +746,18 @@ pub const MXFP4_SCALE_BLOCK: usize = 32;
 /// layout (one f16 scale, no min, no sub-blocks).
 pub const Q4_0_BLOCK_BYTES: usize = 2 + Q4_0_BLOCK_ELEMS / 2;
 
+/// On-disk Q4_0 nibble ordering used by GGML, GGUF, and Candle.
+pub const Q4_0_LAYOUT_STANDARD_V1: &str = "ggml-standard-v1";
+
 /// Dequantise one Q4_0 block into `dst` (must hold exactly
 /// [`Q4_0_BLOCK_ELEMS`] floats).
 ///
 /// Inverse of the GGUF Q4_0 quantiser:
 /// ```text
 ///   d  = f16 super-scale (first 2 bytes, little-endian)
-///   for i in 0..32:
-///       q4 = qs[i >> 1] >> ((i & 1) * 4) & 0xF      (low/high nibble)
-///       dst[i] = d * (q4 as i32 - 8) as f32
+///   for j in 0..16:
+///       dst[j]      = d * ((qs[j] & 0xF) - 8)
+///       dst[j + 16] = d * ((qs[j] >> 4) - 8)
 /// ```
 pub fn dequantize_q4_0_block(src: &[u8], dst: &mut [f32]) {
     assert_eq!(
@@ -771,11 +774,12 @@ pub fn dequantize_q4_0_block(src: &[u8], dst: &mut [f32]) {
     );
     let d = half::f16::from_bits(u16::from_le_bytes([src[0], src[1]])).to_f32();
     let qs = &src[2..2 + Q4_0_BLOCK_ELEMS / 2];
-    for i in 0..Q4_0_BLOCK_ELEMS {
-        let byte = qs[i >> 1];
-        let q4 = if i & 1 == 0 { byte & 0x0F } else { byte >> 4 };
-        // Symmetric range: q4 ∈ 0..15 dequantises to q4-8 ∈ -8..+7.
-        dst[i] = d * (q4 as i32 - 8) as f32;
+    for j in 0..Q4_0_BLOCK_ELEMS / 2 {
+        let byte = qs[j];
+        // GGML stores element j in the low nibble and element j+16 in
+        // the high nibble. Symmetric q4 values decode from 0..15 to -8..+7.
+        dst[j] = d * ((byte & 0x0F) as i32 - 8) as f32;
+        dst[j + Q4_0_BLOCK_ELEMS / 2] = d * ((byte >> 4) as i32 - 8) as f32;
     }
 }
 
@@ -822,18 +826,17 @@ pub fn quantize_q4_0_block(src: &[f32], dst: &mut [u8]) {
         return;
     }
     let inv_d = 1.0 / d;
-    let qs = &mut dst[2..2 + Q4_0_BLOCK_ELEMS / 2];
-    for i in 0..Q4_0_BLOCK_ELEMS {
+    let quantize = |i: usize| {
         let v = if i < src.len() { src[i] } else { 0.0 };
         // Round to nearest, shift +8 to map [-8,+7] → [0,15], clamp.
         let q = (v * inv_d).round() as i32 + 8;
-        let q4 = q.clamp(0, 15) as u8;
-        let byte = &mut qs[i >> 1];
-        if i & 1 == 0 {
-            *byte = (*byte & 0xF0) | (q4 & 0x0F);
-        } else {
-            *byte = (*byte & 0x0F) | ((q4 & 0x0F) << 4);
-        }
+        q.clamp(0, 15) as u8
+    };
+    let qs = &mut dst[2..2 + Q4_0_BLOCK_ELEMS / 2];
+    for j in 0..Q4_0_BLOCK_ELEMS / 2 {
+        let low = quantize(j);
+        let high = quantize(j + Q4_0_BLOCK_ELEMS / 2);
+        qs[j] = low | (high << 4);
     }
 }
 
@@ -4183,6 +4186,11 @@ fn forward_q4_0_qmm_from_exact_bytes(
     d_ff: usize,
     one_bytes: usize,
 ) -> Result<HiddenState, ExpertWeightsError> {
+    if !d_model.is_multiple_of(Q4_0_BLOCK_ELEMS) || !d_ff.is_multiple_of(Q4_0_BLOCK_ELEMS) {
+        return Err(ExpertWeightsError::InvalidLayout(format!(
+            "Q4_0 QMatMul requires d_model and d_ff to be multiples of {Q4_0_BLOCK_ELEMS}, got d_model={d_model}, d_ff={d_ff}"
+        )));
+    }
     let gate_b = &bytes[0..one_bytes];
     let up_b = &bytes[one_bytes..2 * one_bytes];
     let down_b = &bytes[2 * one_bytes..3 * one_bytes];
@@ -5576,6 +5584,58 @@ mod tests {
         // refactor can't silently change the on-disk layout.
         assert_eq!(Q4_0_BLOCK_ELEMS, 32);
         assert_eq!(Q4_0_BLOCK_BYTES, 2 + 16); // f16 + 16 nibble bytes
+        assert_eq!(Q4_0_LAYOUT_STANDARD_V1, "ggml-standard-v1");
+    }
+
+    #[test]
+    fn q4_0_non_symmetric_block_matches_ggml_and_candle() {
+        let mut block = [0u8; Q4_0_BLOCK_BYTES];
+        block[..2].copy_from_slice(&half::f16::from_f32(0.5).to_bits().to_le_bytes());
+        for (j, byte) in block[2..].iter_mut().enumerate() {
+            *byte = j as u8 | ((15 - j as u8) << 4);
+        }
+
+        let mut mer = [0.0f32; Q4_0_BLOCK_ELEMS];
+        dequantize_q4_0_block(&block, &mut mer);
+        let expected: Vec<f32> = (0..16)
+            .map(|j| 0.5 * (j as f32 - 8.0))
+            .chain((0..16).map(|j| 0.5 * (7.0 - j as f32)))
+            .collect();
+        assert_eq!(mer.as_slice(), expected.as_slice());
+
+        let candle = cpu_qtensor_from_blocks(&block, 1, Q4_0_BLOCK_ELEMS, GgmlDType::Q4_0)
+            .expect("Candle Q4_0 tensor")
+            .dequantize(&Device::Cpu)
+            .expect("Candle dequantize")
+            .flatten_all()
+            .expect("flatten Candle tensor")
+            .to_vec1::<f32>()
+            .expect("Candle values");
+        assert_eq!(candle, expected);
+    }
+
+    #[test]
+    fn q4_0_writer_emits_exact_ggml_nibble_bytes() {
+        let low_q: [u8; 16] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 8];
+        let high_q: [u8; 16] = [9, 10, 11, 12, 13, 14, 15, 8, 1, 2, 3, 4, 5, 6, 7, 8];
+        let src: Vec<f32> = low_q
+            .iter()
+            .chain(high_q.iter())
+            .map(|q| *q as f32 - 8.0)
+            .collect();
+        let mut block = [0u8; Q4_0_BLOCK_BYTES];
+        quantize_q4_0_block(&src, &mut block);
+
+        assert_eq!(
+            &block[..2],
+            &half::f16::from_f32(1.0).to_bits().to_le_bytes()
+        );
+        let expected: Vec<u8> = low_q
+            .iter()
+            .zip(high_q.iter())
+            .map(|(&low, &high)| low | (high << 4))
+            .collect();
+        assert_eq!(&block[2..], expected.as_slice());
     }
 
     #[test]
@@ -5606,6 +5666,46 @@ mod tests {
         for (a, b) in src.iter().zip(decoded.iter()) {
             let err = (a - b).abs();
             assert!(err <= d * 1.01, "err {err} exceeds bound {d}");
+        }
+    }
+
+    #[test]
+    fn q4_0_round_trip_covers_diverse_block_shapes() {
+        let mut pseudo_random = [0.0f32; Q4_0_BLOCK_ELEMS];
+        let mut state = 0xD1CE_BA5E_1234_5678u64;
+        for value in &mut pseudo_random {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            *value = ((state % 20_001) as f32 - 10_000.0) / 37.0;
+        }
+        let cases: Vec<[f32; Q4_0_BLOCK_ELEMS]> = vec![
+            [0.0; Q4_0_BLOCK_ELEMS],
+            std::array::from_fn(|i| (i as f32 - 15.5) / 3.0),
+            std::array::from_fn(|i| if i & 1 == 0 { -7.0 } else { 7.0 }),
+            std::array::from_fn(|i| {
+                if i < 16 {
+                    i as f32 / 5.0
+                } else {
+                    -50.0 + i as f32
+                }
+            }),
+            std::array::from_fn(|i| if i == 0 { -1.0e4 } else { i as f32 * 1.0e-3 }),
+            pseudo_random,
+        ];
+
+        for (case_idx, src) in cases.iter().enumerate() {
+            let mut block = [0u8; Q4_0_BLOCK_BYTES];
+            quantize_q4_0_block(src, &mut block);
+            let mut decoded = [0.0f32; Q4_0_BLOCK_ELEMS];
+            dequantize_q4_0_block(&block, &mut decoded);
+            let d = src.iter().fold(0.0f32, |max, value| max.max(value.abs())) / 7.0;
+            for (element, (&actual, &wanted)) in decoded.iter().zip(src.iter()).enumerate() {
+                assert!(
+                    (actual - wanted).abs() <= d * 1.01 + f32::EPSILON,
+                    "case {case_idx} element {element}: {actual} vs {wanted}, d={d}"
+                );
+            }
         }
     }
 
@@ -6426,22 +6526,21 @@ mod tests {
         let d_model = Q4_0_BLOCK_ELEMS; // 32 — block-aligned cols.
         let d_ff = 64usize;
         let blocks_per_matrix = (d_model * d_ff).div_ceil(Q4_0_BLOCK_ELEMS);
-        // Build one synthetic Q4_0 block with structured nibble
-        // contents: scale = 0.05, every nibble = 9 (signed-4 →
-        // (9 - 8) = 1 → weight = 0.05). Replicating it across all
-        // tensors gives a constant-weight expert whose output is
-        // analytically tractable and finite.
-        let mut blk = [0u8; Q4_0_BLOCK_BYTES];
-        let scale: f32 = 0.05;
-        let scale16 = half::f16::from_f32(scale).to_bits().to_le_bytes();
-        blk[0..2].copy_from_slice(&scale16);
-        let q = 9u8; // signed offset 9-8=+1
-        for i in 2..Q4_0_BLOCK_BYTES {
-            blk[i] = q | (q << 4);
-        }
         let mut bytes = Vec::new();
-        for _ in 0..(3 * blocks_per_matrix) {
-            bytes.extend_from_slice(&blk);
+        for projection in 0..3 {
+            for block_idx in 0..blocks_per_matrix {
+                let weights: [f32; Q4_0_BLOCK_ELEMS] = std::array::from_fn(|i| {
+                    let sign = if (i + block_idx + projection) & 1 == 0 {
+                        1.0
+                    } else {
+                        -1.0
+                    };
+                    sign * ((i * 11 + block_idx * 7 + projection * 5) % 17) as f32 / 20.0
+                });
+                let mut block = [0u8; Q4_0_BLOCK_BYTES];
+                quantize_q4_0_block(&weights, &mut block);
+                bytes.extend_from_slice(&block);
+            }
         }
 
         // Hidden state: deterministic synth.
@@ -6459,14 +6558,29 @@ mod tests {
                 a.is_finite() && b.is_finite(),
                 "non-finite at idx {i}: baseline={a} qmm={b}"
             );
-            // Baseline & qmm differ only in matmul accumulation
-            // order + f16 dequant rounding; bound generously.
-            let tol = 1e-3 * a.abs().max(1.0) + 1e-5;
+            // Candle's quantized QMatMul converts each activation operand
+            // to Q8_0 before the Q4_0 dot product. The baseline keeps F32
+            // activations, so full-expert SwiGLU compounds two bounded
+            // activation-quantization errors even though the weight bytes
+            // (covered independently above) are identical.
+            let tol = 5e-2 * a.abs().max(1.0) + 1e-5;
             assert!(
                 (a - b).abs() <= tol,
                 "QMatMul Q4_0 path diverged at {i}: baseline={a} qmm={b} (tol={tol})"
             );
         }
+    }
+
+    #[test]
+    fn q4_0_qmm_rejects_unaligned_dimensions() {
+        let d_model = Q4_0_BLOCK_ELEMS - 1;
+        let d_ff = Q4_0_BLOCK_ELEMS;
+        let bytes = synth_q4_0_blob(d_model, d_ff);
+        let x = vec![0.0; d_model];
+        assert!(matches!(
+            forward_q4_0_qmm_from_bytes(&bytes, &x, d_model, d_ff, 0),
+            Err(ExpertWeightsError::InvalidLayout(_))
+        ));
     }
 
     /// Build a synthetic Q4_0 `gate||up||down` blob for the given dims

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -3343,6 +3343,7 @@ async fn build_bench_real_runtime(
         )
         .into());
     }
+    crate::gguf_loader::validate_q4_0_dataset_layout(&cfg.model.data_dir, cfg.model.dtype)?;
 
     let storage = NvmeStorage::new(StorageConfig {
         base_path: cfg.model.data_dir.clone(),
@@ -4622,6 +4623,7 @@ async fn cmd_serve(config_path: PathBuf) -> Result<(), Box<dyn std::error::Error
         )
         .into());
     }
+    crate::gguf_loader::validate_q4_0_dataset_layout(&cfg.model.data_dir, cfg.model.dtype)?;
 
     // Wire the multi-layer extractor naming when num_layers > 1, so
     // either `expert_<id>.bin` or `expert_<layer>_<local>.bin` works.
@@ -5444,6 +5446,25 @@ fn cmd_gen_data(
         d_ff,
         dtype,
     )?;
+    if dtype == WeightDtype::Q4_0 {
+        let metadata = serde_json::json!({
+            "format_version": 2,
+            "conversion_mode": "synthetic",
+            "num_experts": num_experts,
+            "d_model": d_model,
+            "d_ff": d_ff,
+            "expert_size": expert_size,
+            "maximum_payload_bytes": weight_bytes,
+            "block_align": block_align,
+            "dtype": dtype.as_str(),
+            "weight_layout": "gate_proj || up_proj || down_proj (row-major)",
+            "q4_0_layout": crate::inference::Q4_0_LAYOUT_STANDARD_V1,
+            "experts_written": num_experts,
+        });
+        let mut body = serde_json::to_vec_pretty(&metadata)?;
+        body.push(b'\n');
+        std::fs::write(data_dir.join("metadata.json"), body)?;
+    }
     let total_bytes = num_experts as u64 * expert_size as u64;
     info!(
         elapsed_s = started.elapsed().as_secs_f64(),
@@ -5806,6 +5827,7 @@ async fn cmd_run(
     // `metadata.json` / `alias-map` lookups downstream. The other
     // directories only need to contain `expert_<id>.bin`.
     args.data_dir = primary_dir.clone();
+    crate::gguf_loader::validate_q4_0_dataset_layout(&args.data_dir, args.dtype)?;
 
     if args.io_uring {
         // CPU placement is a startup-level decision now. If the operator
@@ -7071,6 +7093,25 @@ fn json_get_u32_array(line: &str, key: &str) -> Vec<u32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn gen_data_q4_0_records_standard_layout_metadata() {
+        let dir = tempdir_unique("q4-standard-metadata");
+        cmd_gen_data(&dir, 2, 4096, 32, 32, 4096, "q4_0").expect("generate Q4_0");
+        let metadata: serde_json::Value = serde_json::from_slice(
+            &std::fs::read(dir.join("metadata.json")).expect("metadata.json"),
+        )
+        .expect("metadata JSON");
+        assert_eq!(metadata["dtype"], "q4_0");
+        assert_eq!(
+            metadata["q4_0_layout"],
+            crate::inference::Q4_0_LAYOUT_STANDARD_V1
+        );
+        crate::gguf_loader::validate_data_dir(&dir).expect("generated dataset validates");
+        crate::gguf_loader::validate_q4_0_dataset_layout(&dir, crate::inference::WeightDtype::Q4_0)
+            .expect("runtime accepts generated dataset");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     #[test]
     fn cli_parses_rayon_threads_after_run_subcommand() {


### PR DESCRIPTION
## Summary

Standardizes MER's Q4_0 representation on the canonical GGML/Candle block layout across conversion, runtime decoding, CPU execution, and WGSL shader semantics.

This removes MER's previous private adjacent-nibble interpretation and establishes one explicit serialized Q4_0 contract:

- one fp16 scale per 32-element block
- byte `j` low nibble -> element `j`
- byte `j` high nibble -> element `j + 16`
- quantized value = nibble - 8

Converted/generated Q4_0 datasets now declare:

```json
"q4_0_layout": "ggml-standard-v1"
```

Runtime loading fails closed for missing, legacy, unknown, or malformed Q4_0 layout metadata rather than guessing the layout.

Changes
Standardized Q4_0 decode/extraction semantics.
Standardized Q4_0 writer output.
Corrected WGSL Q4_0 nibble extraction.
Added independent asymmetric GGML/Candle fixtures so symmetric data cannot conceal nibble-layout errors.
Added explicit Q4_0 serialized-layout metadata.
Added runtime validation for Q4_0 metadata.
Added validation to run, serve, and real-benchmark entry paths.
Preserved conversion from original standard GGUF sources.
Documented the Q4_0 storage contract and compatibility requirements.
Compatibility / migration

Previously generated MER Q4_0 expert directories using the private adjacent-pair layout are intentionally not auto-detected or silently accepted.

They must be regenerated or reconverted.

There is no heuristic dual-layout production reader.

Non-Q4 datasets retain their previous behavior unless metadata explicitly declares a Q4_0 layout.

Validation

Validated on macOS during implementation and independently on Linux/GCP at:

f0f0c7428293a3dd53de06a8a7e70b4664d2e52c

Linux target:

Ubuntu 22.04 / GCP
32 vCPU Intel Xeon
AVX2 / AVX-512 / AVX-512 VNNI
NVIDIA L4 24 GB

Linux test results:

Q4_0 focused tests: 24 passed, 0 failed
quantization tests: 33 passed, 0 failed
GGUF/conversion tests: 48 passed, 0 failed
backend tests: 32 passed, 0 failed
inference tests: 69 passed, 0 failed
full test suite: 738 passed, 0 failed, 2 ignored
concurrency stress: 4 passed, 0 failed
git diff HEAD^ --check: passed

Release builds:

cargo build --release --features "avx512,blas,tokenizer,io_uring"
PASS

cargo build --release --features "cuda,avx512,blas,tokenizer,io_uring"
PASS

A fresh synthetic Q4_0 dataset generated by this branch was also validated at runtime:

dtype = q4_0
q4_0_layout = ggml-standard-v1
CPU Q4_0 execution completed successfully

macOS implementation validation also passed the focused Q4_0, quantization, GGUF/conversion, backend, inference, full-unit and concurrency tests available on that host. Linux-only io_uring validation was performed separately on the GCP host above.

GPU hardware validation note

The corrected WGSL Q4_0 shader has parser/validation and host-mirror semantic coverage, but live WGSL execution on the available GCP L4 host could not be completed because that host did not expose a usable NVIDIA Vulkan device.

Diagnostics established:

NVIDIA L4 was visible through nvidia-smi
NVIDIA driver/userspace were aligned at 580.173.02
Vulkan loader was installed
NVIDIA Vulkan ICD was installed
forcing /usr/share/vulkan/icd.d/nvidia_icd.json failed with ERROR_INCOMPATIBLE_DRIVER
wgpu therefore exposed only Mesa llvmpipe
MER's explicit run --gpu correctly failed closed rather than treating the software renderer as a GPU or silently running on CPU

This is recorded as a target-host Vulkan provisioning limitation, NOT as successful live GPU shader qualification.

The CUDA-capable release build result above verifies build compatibility only. It is NOT claimed as Q4 GPU runtime qualification.

Scope

This PR intentionally does not add or change:

strict hybrid benchmarking
resolved component execution planning
GPU expert fail-closed runtime policy beyond existing behavior
physical VRAM residency accounting
batched top-k GPU execution
CUDA backend redesign
GPU attention / KV / dense migration
SSD/RAM/VRAM scheduler redesign
Prompt2 / Phase 4D prediction behavior
throughput claims

No generated-token TPS or GPU-performance claim is made by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Q4_0 quantized model calculations to match the standard GGML/GGUF/Candle layout.
  * Added validation to reject unsupported, missing, or legacy Q4_0 layout metadata.
  * Q4_0 operations now reject dimensions that are not aligned to required 32-element blocks.

* **Documentation**
  * Documented the required `q4_0_layout: ggml-standard-v1` metadata marker.
  * Generated Q4_0 datasets now include metadata describing their layout and parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->