### PR TITLE
refactor: add authoritative resolved execution plan

### DIFF
--- a/rust-engine/src/backend/mod.rs
+++ b/rust-engine/src/backend/mod.rs
@@ -1,10 +1,11 @@
 //! Math-backend module connecting GPU execution via wgpu and providing a CPU fallback.
 
-use std::fmt;
-use std::sync::Arc;
-use std::sync::OnceLock;
 use anyhow::{anyhow, Result};
 use parking_lot::Mutex as ParkingMutex;
+use std::fmt;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::sync::OnceLock;
 
 /// Maximum FFN intermediate dimension supported. Sized for Mixtral-8x7B (d_ff=14336).
 /// Increase if using models with larger d_ff.
@@ -1204,8 +1205,8 @@ impl GpuBackend {
     /// gate, up and down block streams concatenated back-to-back, each
     /// `(d_ff·d_model / 32) × 18` bytes. Both `d_model` and `d_ff` must be
     /// multiples of the 32-element Q4_0 block (the caller guarantees this
-    /// via `Engine::gpu_eligible_dtype`), so every matrix row starts on a
-    /// block boundary. Buffers short by at most one page are zero-padded,
+    /// via `routed_expert_gpu_compatibility`), so every matrix row starts on
+    /// a block boundary. Buffers short by at most one page are zero-padded,
     /// mirroring the CPU loader's `q4_expert_bytes_with_tolerance`.
     fn build_expert_entry_q4_0(
         &self,
@@ -2145,58 +2146,17 @@ impl Backend for CandleBackend {
 pub enum BackendBox {
     Gpu(GpuBackend),
     Cpu(CandleBackend),
+    #[cfg(test)]
+    TestGpu(CandleBackend),
 }
 
 impl BackendBox {
-    pub async fn init(
-        num_layers: usize,
-        max_seq_len: usize,
-        num_heads: usize,
-        num_kv_heads: usize,
-        head_dim: usize,
-        v_head_dim: usize,
-        gpu_expert_cache: Arc<crate::expert_cache::GpuExpertCache>,
-        q4_truncation_tolerance: usize,
-    ) -> Self {
-        match GpuBackend::try_new(num_layers, max_seq_len, num_heads, num_kv_heads, head_dim, v_head_dim, gpu_expert_cache, q4_truncation_tolerance).await {
-            Ok(gpu) => BackendBox::Gpu(gpu),
-            Err(e) => {
-                tracing::warn!(
-                    reason = %e,
-                    compute_plane = "cpu-fallback",
-                    "GPU init failed — activating CPU fallback"
-                );
-                BackendBox::Cpu(CandleBackend::new())
-            }
-        }
-    }
-
-    pub fn init_blocking(
-        num_layers: usize,
-        max_seq_len: usize,
-        num_heads: usize,
-        num_kv_heads: usize,
-        head_dim: usize,
-        v_head_dim: usize,
-        gpu_expert_cache: Arc<crate::expert_cache::GpuExpertCache>,
-        q4_truncation_tolerance: usize,
-    ) -> Self {
-        pollster::block_on(Self::init(
-            num_layers,
-            max_seq_len,
-            num_heads,
-            num_kv_heads,
-            head_dim,
-            v_head_dim,
-            gpu_expert_cache,
-            q4_truncation_tolerance,
-        ))
-    }
-
     pub fn compute_plane(&self) -> &str {
         match self {
             BackendBox::Gpu(gpu) => gpu.compute_plane(),
             BackendBox::Cpu(_) => "cpu-fallback",
+            #[cfg(test)]
+            BackendBox::TestGpu(_) => "test-gpu",
         }
     }
 }
@@ -2206,6 +2166,8 @@ impl Backend for BackendBox {
         match self {
             BackendBox::Gpu(gpu) => gpu.device_name(),
             BackendBox::Cpu(cpu) => cpu.device_name(),
+            #[cfg(test)]
+            BackendBox::TestGpu(_) => "test-gpu",
         }
     }
 
@@ -2213,6 +2175,8 @@ impl Backend for BackendBox {
         match self {
             BackendBox::Gpu(gpu) => gpu.is_gpu(),
             BackendBox::Cpu(cpu) => cpu.is_gpu(),
+            #[cfg(test)]
+            BackendBox::TestGpu(_) => true,
         }
     }
 
@@ -2220,6 +2184,8 @@ impl Backend for BackendBox {
         match self {
             BackendBox::Gpu(gpu) => gpu.matmul_into(a, b, out),
             BackendBox::Cpu(cpu) => cpu.matmul_into(a, b, out),
+            #[cfg(test)]
+            BackendBox::TestGpu(cpu) => cpu.matmul_into(a, b, out),
         }
     }
 
@@ -2227,6 +2193,8 @@ impl Backend for BackendBox {
         match self {
             BackendBox::Gpu(gpu) => gpu.swiglu_into(gate, up, out),
             BackendBox::Cpu(cpu) => cpu.swiglu_into(gate, up, out),
+            #[cfg(test)]
+            BackendBox::TestGpu(cpu) => cpu.swiglu_into(gate, up, out),
         }
     }
 
@@ -2234,6 +2202,8 @@ impl Backend for BackendBox {
         match self {
             BackendBox::Gpu(gpu) => gpu.softmax(x),
             BackendBox::Cpu(cpu) => cpu.softmax(x),
+            #[cfg(test)]
+            BackendBox::TestGpu(cpu) => cpu.softmax(x),
         }
     }
 
@@ -2247,6 +2217,8 @@ impl Backend for BackendBox {
         match self {
             BackendBox::Gpu(gpu) => gpu.kv_cache_insert(layer, position, k, v),
             BackendBox::Cpu(cpu) => cpu.kv_cache_insert(layer, position, k, v),
+            #[cfg(test)]
+            BackendBox::TestGpu(cpu) => cpu.kv_cache_insert(layer, position, k, v),
         }
     }
 
@@ -2260,6 +2232,8 @@ impl Backend for BackendBox {
         match self {
             BackendBox::Gpu(gpu) => gpu.kv_attend(layer, q, seq_len, out),
             BackendBox::Cpu(cpu) => cpu.kv_attend(layer, q, seq_len, out),
+            #[cfg(test)]
+            BackendBox::TestGpu(cpu) => cpu.kv_attend(layer, q, seq_len, out),
         }
     }
 
@@ -2275,36 +2249,10 @@ impl Backend for BackendBox {
         match self {
             Self::Gpu(g) => g.expert_matmul(layer_idx, expert_id, x, d_model, d_ff, out),
             Self::Cpu(c) => c.expert_matmul(layer_idx, expert_id, x, d_model, d_ff, out),
+            #[cfg(test)]
+            Self::TestGpu(c) => c.expert_matmul(layer_idx, expert_id, x, d_model, d_ff, out),
         }
     }
-}
-
-// =====================================================================
-// Global active backend Registry
-// =====================================================================
-
-static BACKEND: OnceLock<Arc<BackendBox>> = OnceLock::new();
-
-/// Install `b` as the process-wide active backend. Returns `Err` if a
-/// backend has already been installed.
-pub fn set_backend(b: Arc<BackendBox>) -> Result<(), &'static str> {
-    BACKEND
-        .set(b)
-        .map_err(|_| "backend already installed; call before any token is generated")
-}
-
-/// Install the default backend (`CandleBackend`) if none has been set yet.
-pub fn install_default() {
-    let _ = BACKEND.set(Arc::new(BackendBox::Cpu(CandleBackend::new())));
-}
-
-/// Active backend. Falls back to a CPU reference backend when nothing has
-/// been installed.
-pub fn current() -> Arc<BackendBox> {
-    BACKEND
-        .get()
-        .cloned()
-        .unwrap_or_else(|| Arc::new(BackendBox::Cpu(CandleBackend::new())))
 }
 
 // =====================================================================
@@ -2324,7 +2272,7 @@ pub enum ComputeOffload {
     Auto,
     /// **Explicitly named hybrid mode**: attention runs on the *checked
     /// CPU* path (strict numerics validated per softmax row) while
-    /// expert/dense FFN compute is offloaded to the GPU. This is the only
+    /// routed-expert FFN compute is offloaded to the GPU. This is the only
     /// mode in which a GPU backend is installed under strict attention
     /// numerics — the split is logged at startup and exposed through
     /// per-component backend metrics, never silently reported as full
@@ -2365,32 +2313,408 @@ pub struct BackendResolution {
     pub reason: Option<String>,
 }
 
-impl BackendResolution {
-    /// Compute plane the attention path executes on.
-    pub fn attention_plane(&self) -> &'static str {
-        match self.resolved {
-            ResolvedBackend::Cpu | ResolvedBackend::HybridCpuAttentionGpuExperts => "cpu",
-            ResolvedBackend::Gpu => "gpu",
+/// Concrete execution plane selected for one transformer component.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExecutionPlane {
+    Cpu,
+    Gpu,
+}
+
+impl ExecutionPlane {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Cpu => "cpu",
+            Self::Gpu => "gpu",
+        }
+    }
+}
+
+/// Runtime inputs that determine whether the current routed-expert GPU
+/// kernels can execute a resident expert without a deterministic CPU bypass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RoutedExpertGpuSpec {
+    pub dtype: crate::inference::WeightDtype,
+    pub d_model: usize,
+    pub d_ff: usize,
+}
+
+/// Pure compatibility failure returned by [`routed_expert_gpu_compatibility`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RoutedExpertGpuIncompatibility {
+    UnsupportedDtype {
+        dtype: crate::inference::WeightDtype,
+    },
+    MisalignedQ4_0 {
+        d_model: usize,
+        d_ff: usize,
+        block_elems: usize,
+    },
+}
+
+impl fmt::Display for RoutedExpertGpuIncompatibility {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedDtype { dtype } => write!(
+                f,
+                "routed-expert dtype {} is unsupported by the GPU expert path; supported dtypes \
+                 are f32 and block-aligned q4_0",
+                dtype.as_str()
+            ),
+            Self::MisalignedQ4_0 {
+                d_model,
+                d_ff,
+                block_elems,
+            } => write!(
+                f,
+                "routed-expert q4_0 geometry requires d_model and d_ff to be multiples of \
+                 {block_elems}; got d_model={d_model}, d_ff={d_ff}"
+            ),
+        }
+    }
+}
+
+/// Authoritative routed-expert GPU compatibility rule shared by resolution
+/// and execution. This must stay aligned with the formats implemented by
+/// `GpuBackend::expert_matmul`.
+pub fn routed_expert_gpu_compatibility(
+    spec: RoutedExpertGpuSpec,
+) -> std::result::Result<(), RoutedExpertGpuIncompatibility> {
+    use crate::inference::{WeightDtype, Q4_0_BLOCK_ELEMS};
+
+    match spec.dtype {
+        WeightDtype::F32 => Ok(()),
+        WeightDtype::Q4_0
+            if spec.d_model.is_multiple_of(Q4_0_BLOCK_ELEMS)
+                && spec.d_ff.is_multiple_of(Q4_0_BLOCK_ELEMS) =>
+        {
+            Ok(())
+        }
+        WeightDtype::Q4_0 => Err(RoutedExpertGpuIncompatibility::MisalignedQ4_0 {
+            d_model: spec.d_model,
+            d_ff: spec.d_ff,
+            block_elems: Q4_0_BLOCK_ELEMS,
+        }),
+        dtype => Err(RoutedExpertGpuIncompatibility::UnsupportedDtype { dtype }),
+    }
+}
+
+/// Stable, process-local identity for one resolved execution context.
+///
+/// This is deliberately not a pointer address: it is safe to include in
+/// startup diagnostics and lets tests prove that the plan and runtime consume
+/// the same context.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ExecutionContextId(u64);
+
+impl fmt::Display for ExecutionContextId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+static NEXT_EXECUTION_CONTEXT_ID: AtomicU64 = AtomicU64::new(1);
+
+fn next_execution_context_id() -> ExecutionContextId {
+    let id = NEXT_EXECUTION_CONTEXT_ID.fetch_add(1, Ordering::Relaxed);
+    assert_ne!(id, 0, "execution context id space exhausted");
+    ExecutionContextId(id)
+}
+
+/// Immutable source of truth for requested mode and resolved component planes.
+///
+/// Requested mode is operator intent; it is not an execution report. Runtime
+/// consumers and reporting must use these resolved planes from the authoritative
+/// [`ExecutionContext`] instead of re-deriving them from configuration flags.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedExecutionPlan {
+    requested: ComputeOffload,
+    resolved: ResolvedBackend,
+    context_id: ExecutionContextId,
+    embeddings: ExecutionPlane,
+    lm_head: ExecutionPlane,
+    dense_projections: ExecutionPlane,
+    attention: ExecutionPlane,
+    kv: ExecutionPlane,
+    router: ExecutionPlane,
+    routed_experts: ExecutionPlane,
+    routed_expert_gpu_spec: RoutedExpertGpuSpec,
+    fallback_occurred: bool,
+    reason: Option<String>,
+}
+
+impl ResolvedExecutionPlan {
+    fn from_resolution(
+        resolution: BackendResolution,
+        context_id: ExecutionContextId,
+        gpu_expert_cache_available: bool,
+        routed_expert_gpu_spec: RoutedExpertGpuSpec,
+    ) -> Self {
+        let cpu = ExecutionPlane::Cpu;
+        let routed_expert_gpu_compatible =
+            routed_expert_gpu_compatibility(routed_expert_gpu_spec).is_ok();
+        let (attention, kv, routed_experts) = match resolution.resolved {
+            ResolvedBackend::Cpu => (cpu, cpu, cpu),
+            ResolvedBackend::Gpu => (
+                ExecutionPlane::Gpu,
+                ExecutionPlane::Gpu,
+                if gpu_expert_cache_available && routed_expert_gpu_compatible {
+                    ExecutionPlane::Gpu
+                } else {
+                    cpu
+                },
+            ),
+            ResolvedBackend::HybridCpuAttentionGpuExperts => (
+                cpu,
+                cpu,
+                if gpu_expert_cache_available && routed_expert_gpu_compatible {
+                    ExecutionPlane::Gpu
+                } else {
+                    cpu
+                },
+            ),
+        };
+        Self {
+            requested: resolution.requested,
+            resolved: resolution.resolved,
+            context_id,
+            embeddings: cpu,
+            lm_head: cpu,
+            dense_projections: cpu,
+            attention,
+            kv,
+            router: cpu,
+            routed_experts,
+            routed_expert_gpu_spec,
+            fallback_occurred: resolution.fallback_occurred,
+            reason: resolution.reason,
         }
     }
 
-    /// Compute plane the expert/dense FFN path executes on.
-    pub fn expert_plane(&self) -> &'static str {
-        match self.resolved {
-            ResolvedBackend::Cpu => "cpu",
-            ResolvedBackend::Gpu | ResolvedBackend::HybridCpuAttentionGpuExperts => "gpu",
+    pub const fn requested(&self) -> ComputeOffload {
+        self.requested
+    }
+
+    pub const fn resolved(&self) -> ResolvedBackend {
+        self.resolved
+    }
+
+    pub const fn context_id(&self) -> ExecutionContextId {
+        self.context_id
+    }
+
+    pub const fn embeddings(&self) -> ExecutionPlane {
+        self.embeddings
+    }
+
+    pub const fn lm_head(&self) -> ExecutionPlane {
+        self.lm_head
+    }
+
+    pub const fn dense_projections(&self) -> ExecutionPlane {
+        self.dense_projections
+    }
+
+    pub const fn attention(&self) -> ExecutionPlane {
+        self.attention
+    }
+
+    pub const fn kv(&self) -> ExecutionPlane {
+        self.kv
+    }
+
+    pub const fn router(&self) -> ExecutionPlane {
+        self.router
+    }
+
+    pub const fn routed_experts(&self) -> ExecutionPlane {
+        self.routed_experts
+    }
+
+    pub const fn routed_expert_gpu_spec(&self) -> RoutedExpertGpuSpec {
+        self.routed_expert_gpu_spec
+    }
+
+    pub const fn fallback_occurred(&self) -> bool {
+        self.fallback_occurred
+    }
+
+    pub fn reason(&self) -> Option<&str> {
+        self.reason.as_deref()
+    }
+
+    /// Stable metric labels for every explicitly modelled component.
+    pub const fn component_planes(&self) -> [(&'static str, ExecutionPlane); 7] {
+        [
+            ("embeddings", self.embeddings),
+            ("lm_head", self.lm_head),
+            ("dense_projections", self.dense_projections),
+            ("attention", self.attention),
+            ("kv", self.kv),
+            ("router", self.router),
+            // Keep the existing public metric label for compatibility; the
+            // typed plan calls the component `routed_experts` explicitly.
+            ("experts", self.routed_experts),
+        ]
+    }
+}
+
+/// The one authoritative backend context for a resolved runtime.
+///
+/// A hybrid context owns one CPU backend and exactly one GPU backend. Component
+/// accessors select between those immutable members using the resolved plan, so
+/// neither the model nor the engine can independently construct or choose a
+/// different backend. The expert cache is owned here for the same reason: the
+/// engine attaches the exact cache used to construct the GPU backend.
+pub struct ExecutionContext {
+    plan: ResolvedExecutionPlan,
+    cpu_backend: Arc<BackendBox>,
+    gpu_backend: Option<Arc<BackendBox>>,
+    gpu_expert_cache: Arc<crate::expert_cache::GpuExpertCache>,
+}
+
+impl ExecutionContext {
+    fn new(
+        plan: ResolvedExecutionPlan,
+        gpu_backend: Option<Arc<BackendBox>>,
+        gpu_expert_cache: Arc<crate::expert_cache::GpuExpertCache>,
+    ) -> Self {
+        debug_assert_eq!(
+            plan.component_planes()
+                .iter()
+                .any(|(_, plane)| *plane == ExecutionPlane::Gpu),
+            gpu_backend.is_some()
+        );
+        debug_assert!(
+            plan.routed_experts() != ExecutionPlane::Gpu || gpu_expert_cache.capacity_bytes() > 0
+        );
+        Self {
+            plan,
+            cpu_backend: Arc::new(BackendBox::Cpu(CandleBackend::new())),
+            gpu_backend,
+            gpu_expert_cache,
         }
     }
 
-    /// Whether a GPU backend should be installed for this resolution.
-    pub fn install_gpu_backend(&self) -> bool {
-        !matches!(self.resolved, ResolvedBackend::Cpu)
+    pub fn plan(&self) -> &ResolvedExecutionPlan {
+        &self.plan
+    }
+
+    pub const fn id(&self) -> ExecutionContextId {
+        self.plan.context_id()
+    }
+
+    fn backend_for(&self, plane: ExecutionPlane) -> &Arc<BackendBox> {
+        match plane {
+            ExecutionPlane::Cpu => &self.cpu_backend,
+            ExecutionPlane::Gpu => self
+                .gpu_backend
+                .as_ref()
+                .expect("resolved GPU plane must own a GPU backend"),
+        }
+    }
+
+    pub fn attention_backend(&self) -> &Arc<BackendBox> {
+        self.backend_for(self.plan.attention())
+    }
+
+    pub fn routed_expert_backend(&self) -> &Arc<BackendBox> {
+        self.backend_for(self.plan.routed_experts())
+    }
+
+    pub fn gpu_expert_cache(&self) -> &Arc<crate::expert_cache::GpuExpertCache> {
+        &self.gpu_expert_cache
+    }
+
+    pub fn primary_backend(&self) -> &Arc<BackendBox> {
+        self.gpu_backend.as_ref().unwrap_or(&self.cpu_backend)
+    }
+}
+
+impl fmt::Debug for ExecutionContext {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ExecutionContext")
+            .field("plan", &self.plan)
+            .field("device", &self.primary_backend().device_name())
+            .finish()
+    }
+}
+
+/// Geometry and policy inputs that must be valid before GPU initialization.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GpuBackendGeometry {
+    pub num_layers: usize,
+    pub max_seq_len: usize,
+    pub num_heads: usize,
+    pub num_kv_heads: usize,
+    pub head_dim: usize,
+    pub v_head_dim: usize,
+    pub q4_truncation_tolerance: usize,
+}
+
+impl GpuBackendGeometry {
+    fn validate(&self) -> std::result::Result<(), BackendResolutionError> {
+        if self.num_layers == 0
+            || self.max_seq_len == 0
+            || self.num_heads == 0
+            || self.head_dim == 0
+        {
+            return Err(BackendResolutionError::InvalidGeometry {
+                detail: format!(
+                    "GPU geometry requires non-zero num_layers, max_seq_len, num_heads, and \
+                     head_dim (got {}, {}, {}, {})",
+                    self.num_layers, self.max_seq_len, self.num_heads, self.head_dim
+                ),
+            });
+        }
+        let kv_heads = if self.num_kv_heads == 0 {
+            self.num_heads
+        } else {
+            self.num_kv_heads
+        };
+        if self.num_heads % kv_heads != 0 {
+            return Err(BackendResolutionError::InvalidGeometry {
+                detail: format!(
+                    "GPU geometry requires num_kv_heads ({kv_heads}) to divide num_heads ({})",
+                    self.num_heads
+                ),
+            });
+        }
+        let v_head_dim = if self.v_head_dim == 0 {
+            self.head_dim
+        } else {
+            self.v_head_dim
+        };
+        let k_dim = kv_heads.checked_mul(self.head_dim);
+        let v_dim = kv_heads.checked_mul(v_head_dim);
+        let kv_elems = k_dim
+            .zip(v_dim)
+            .and_then(|(k, v)| k.checked_add(v))
+            .and_then(|per_token| per_token.checked_mul(self.max_seq_len))
+            .and_then(|per_layer| per_layer.checked_mul(self.num_layers));
+        if kv_elems.is_none() {
+            return Err(BackendResolutionError::InvalidGeometry {
+                detail: "GPU KV geometry overflows addressable memory".to_string(),
+            });
+        }
+        Ok(())
     }
 }
 
 /// Error returned when a requested compute backend cannot be honored.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BackendResolutionError {
+    /// Invalid GPU sizing or attention geometry detected before adapter or
+    /// device initialization.
+    InvalidGeometry { detail: String },
+    /// Hybrid selects GPU routed experts, but no non-zero VRAM expert cache
+    /// was configured to make that plane executable.
+    RoutedExpertGpuCacheRequired,
+    /// Explicit Hybrid requested GPU routed experts, but the current expert
+    /// dtype or geometry cannot execute through the GPU expert kernels.
+    RoutedExpertGpuIncompatible {
+        requested: ComputeOffload,
+        incompatibility: RoutedExpertGpuIncompatibility,
+    },
     /// An explicit `gpu`/`hybrid` request but GPU initialization failed.
     GpuUnavailable {
         requested: ComputeOffload,
@@ -2398,7 +2722,7 @@ pub enum BackendResolutionError {
     },
     /// `compute_offload = "gpu"` combined with strict attention numerics:
     /// GPU attention performs its softmax on-device where non-finite rows
-    /// cannot be detected, so strict full-GPU inference is unsupported
+    /// cannot be detected, so strict GPU-attention inference is unsupported
     /// until GPU numerical detection exists.
     StrictGpuUnsupported,
     /// `compute_offload = "hybrid"` combined with
@@ -2411,6 +2735,22 @@ pub enum BackendResolutionError {
 impl std::fmt::Display for BackendResolutionError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            BackendResolutionError::InvalidGeometry { detail } => {
+                write!(f, "invalid GPU backend geometry: {detail}")
+            }
+            BackendResolutionError::RoutedExpertGpuCacheRequired => write!(
+                f,
+                "compute_offload = \"hybrid\" requires gpu_cache.enabled = true and \
+                 gpu_cache.vram_capacity_mb > 0 so routed experts can execute on GPU"
+            ),
+            BackendResolutionError::RoutedExpertGpuIncompatible {
+                requested,
+                incompatibility,
+            } => write!(
+                f,
+                "compute_offload = {requested:?} requires GPU routed experts, but the current \
+                 expert path is incompatible: {incompatibility}"
+            ),
             BackendResolutionError::GpuUnavailable { requested, detail } => write!(
                 f,
                 "compute_offload = {requested:?} was requested but GPU initialization failed: \
@@ -2429,7 +2769,7 @@ impl std::fmt::Display for BackendResolutionError {
                 f,
                 "compute_offload = \"hybrid\" pins attention to the checked CPU path and is \
                  incompatible with real_transformer.allow_nonfinite_attention_fallback = true; \
-                 use compute_offload = \"gpu\" for full-GPU legacy-fallback execution"
+                 use compute_offload = \"gpu\" for GPU-attention legacy-fallback execution"
             ),
         }
     }
@@ -2562,7 +2902,7 @@ where
                 resolved: ResolvedBackend::HybridCpuAttentionGpuExperts,
                 fallback_occurred: false,
                 reason: Some(
-                    "hybrid: attention pinned to the checked CPU path; expert/dense FFN \
+                    "hybrid: attention pinned to the checked CPU path; routed-expert FFN \
                      compute offloaded to the GPU"
                         .to_string(),
                 ),
@@ -2570,6 +2910,164 @@ where
             Err(detail) => Err(BackendResolutionError::GpuUnavailable { requested, detail }),
         },
     }
+}
+
+fn gpu_initialization_may_run(requested: ComputeOffload, strict_attention: bool) -> bool {
+    matches!(
+        (requested, strict_attention),
+        (ComputeOffload::Gpu, false)
+            | (ComputeOffload::Auto, false)
+            | (ComputeOffload::Hybrid, true)
+    )
+}
+
+/// Resolve the execution plan and construct its sole production GPU backend,
+/// if one is selected.
+pub fn resolve_execution_context(
+    requested: ComputeOffload,
+    strict_attention: bool,
+    geometry: GpuBackendGeometry,
+    routed_expert_gpu_spec: RoutedExpertGpuSpec,
+    gpu_expert_cache: Arc<crate::expert_cache::GpuExpertCache>,
+) -> std::result::Result<Arc<ExecutionContext>, BackendResolutionError> {
+    let context_gpu_expert_cache = gpu_expert_cache.clone();
+    resolve_execution_context_with(
+        requested,
+        strict_attention,
+        geometry,
+        routed_expert_gpu_spec,
+        context_gpu_expert_cache,
+        move |geometry| {
+            pollster::block_on(GpuBackend::try_new(
+                geometry.num_layers,
+                geometry.max_seq_len,
+                geometry.num_heads,
+                geometry.num_kv_heads,
+                geometry.head_dim,
+                geometry.v_head_dim,
+                gpu_expert_cache,
+                geometry.q4_truncation_tolerance,
+            ))
+            .map(|gpu| Arc::new(BackendBox::Gpu(gpu)))
+            .map_err(|e| e.to_string())
+        },
+    )
+}
+
+/// Injectable resolution boundary used by hardware-independent tests.
+/// Production callers use [`resolve_execution_context`]. The factory is
+/// consulted at most once and never for a CPU-only resolution.
+pub(crate) fn resolve_execution_context_with<F>(
+    requested: ComputeOffload,
+    strict_attention: bool,
+    geometry: GpuBackendGeometry,
+    routed_expert_gpu_spec: RoutedExpertGpuSpec,
+    gpu_expert_cache: Arc<crate::expert_cache::GpuExpertCache>,
+    gpu_init: F,
+) -> std::result::Result<Arc<ExecutionContext>, BackendResolutionError>
+where
+    F: FnOnce(&GpuBackendGeometry) -> std::result::Result<Arc<BackendBox>, String>,
+{
+    let gpu_expert_cache_available = gpu_expert_cache.capacity_bytes() > 0;
+    let expert_compatibility = routed_expert_gpu_compatibility(routed_expert_gpu_spec);
+    if requested == ComputeOffload::Hybrid {
+        expert_compatibility.map_err(|incompatibility| {
+            BackendResolutionError::RoutedExpertGpuIncompatible {
+                requested,
+                incompatibility,
+            }
+        })?;
+    }
+    if requested == ComputeOffload::Hybrid && !gpu_expert_cache_available {
+        return Err(BackendResolutionError::RoutedExpertGpuCacheRequired);
+    }
+    if gpu_initialization_may_run(requested, strict_attention) {
+        geometry.validate()?;
+    }
+
+    let mut gpu_backend = None;
+    let resolution = resolve_backend_selection_with_numerics(requested, strict_attention, || {
+        match gpu_init(&geometry) {
+            Ok(backend) if backend.is_gpu() => {
+                gpu_backend = Some(backend);
+                Ok(())
+            }
+            Ok(_) => Err("GPU backend factory returned a CPU backend".to_string()),
+            Err(detail) => Err(detail),
+        }
+    })?;
+
+    let context_id = next_execution_context_id();
+    let plan = ResolvedExecutionPlan::from_resolution(
+        resolution,
+        context_id,
+        gpu_expert_cache_available,
+        routed_expert_gpu_spec,
+    );
+    Ok(Arc::new(ExecutionContext::new(
+        plan,
+        gpu_backend,
+        gpu_expert_cache,
+    )))
+}
+
+/// Construct an isolated CPU context. Existing CPU-only engine constructors
+/// use this to preserve their behaviour without consulting process-global
+/// mutable state.
+pub fn cpu_execution_context() -> Arc<ExecutionContext> {
+    let context_id = next_execution_context_id();
+    let plan = ResolvedExecutionPlan::from_resolution(
+        BackendResolution {
+            requested: ComputeOffload::Cpu,
+            resolved: ResolvedBackend::Cpu,
+            fallback_occurred: false,
+            reason: None,
+        },
+        context_id,
+        false,
+        RoutedExpertGpuSpec {
+            dtype: crate::inference::WeightDtype::F32,
+            d_model: 0,
+            d_ff: 0,
+        },
+    );
+    Arc::new(ExecutionContext::new(
+        plan,
+        None,
+        Arc::new(crate::expert_cache::GpuExpertCache::new(0, 0.5, 16)),
+    ))
+}
+
+// =====================================================================
+// Global authoritative execution-context registry
+// =====================================================================
+
+static EXECUTION_CONTEXT: OnceLock<Arc<ExecutionContext>> = OnceLock::new();
+
+/// Install the process-wide authoritative context. Runtime owners should clone
+/// and inject this exact `Arc`; they must not reconstruct a backend from config.
+pub fn set_execution_context(context: Arc<ExecutionContext>) -> Result<(), &'static str> {
+    EXECUTION_CONTEXT
+        .set(context)
+        .map_err(|_| "execution context already installed; resolve before any token is generated")
+}
+
+/// Install a default CPU context if no context has been resolved yet.
+pub fn install_default() {
+    let _ = EXECUTION_CONTEXT.set(cpu_execution_context());
+}
+
+/// Active execution context. The first unresolved read permanently installs
+/// the CPU default, so a caller cannot retain context A while startup later
+/// replaces the registry with context B.
+pub fn current_execution_context() -> Arc<ExecutionContext> {
+    EXECUTION_CONTEXT.get_or_init(cpu_execution_context).clone()
+}
+
+/// Compatibility accessor for CPU-only utilities that only need a backend.
+/// Model and engine runtime paths consume [`ExecutionContext`] directly.
+pub fn current() -> Arc<BackendBox> {
+    current_execution_context().primary_backend().clone()
 }
 
 // =====================================================================
@@ -2659,6 +3157,338 @@ mod tests {
         }
     }
 
+    fn test_gpu_geometry() -> GpuBackendGeometry {
+        GpuBackendGeometry {
+            num_layers: 2,
+            max_seq_len: 128,
+            num_heads: 4,
+            num_kv_heads: 2,
+            head_dim: 8,
+            v_head_dim: 8,
+            q4_truncation_tolerance: 0,
+        }
+    }
+
+    fn test_routed_expert_gpu_spec(dtype: crate::inference::WeightDtype) -> RoutedExpertGpuSpec {
+        RoutedExpertGpuSpec {
+            dtype,
+            d_model: 32,
+            d_ff: 64,
+        }
+    }
+
+    fn test_gpu_backend() -> Arc<BackendBox> {
+        Arc::new(BackendBox::TestGpu(CandleBackend::new()))
+    }
+
+    fn test_gpu_expert_cache(capacity_bytes: usize) -> Arc<crate::expert_cache::GpuExpertCache> {
+        Arc::new(crate::expert_cache::GpuExpertCache::new(
+            capacity_bytes,
+            0.5,
+            16,
+        ))
+    }
+
+    #[test]
+    fn routed_expert_gpu_compatibility_accepts_f32() {
+        assert_eq!(
+            routed_expert_gpu_compatibility(test_routed_expert_gpu_spec(
+                crate::inference::WeightDtype::F32,
+            )),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn routed_expert_gpu_compatibility_accepts_aligned_q4_0() {
+        assert_eq!(
+            routed_expert_gpu_compatibility(test_routed_expert_gpu_spec(
+                crate::inference::WeightDtype::Q4_0,
+            )),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn hybrid_rejects_unsupported_expert_dtypes_before_gpu_factory() {
+        for dtype in [
+            crate::inference::WeightDtype::Q8_0,
+            crate::inference::WeightDtype::Mixed,
+            crate::inference::WeightDtype::F16,
+        ] {
+            let mut attempts = 0;
+            let err = resolve_execution_context_with(
+                ComputeOffload::Hybrid,
+                true,
+                test_gpu_geometry(),
+                test_routed_expert_gpu_spec(dtype),
+                test_gpu_expert_cache(1024),
+                |_| {
+                    attempts += 1;
+                    Ok(test_gpu_backend())
+                },
+            )
+            .unwrap_err();
+            assert_eq!(attempts, 0, "GPU factory ran for incompatible {dtype:?}");
+            assert!(matches!(
+                err,
+                BackendResolutionError::RoutedExpertGpuIncompatible {
+                    requested: ComputeOffload::Hybrid,
+                    incompatibility: RoutedExpertGpuIncompatibility::UnsupportedDtype {
+                        dtype: rejected,
+                    },
+                } if rejected == dtype
+            ));
+        }
+    }
+
+    #[test]
+    fn hybrid_rejects_misaligned_q4_0_before_gpu_factory() {
+        let mut attempts = 0;
+        let err = resolve_execution_context_with(
+            ComputeOffload::Hybrid,
+            true,
+            test_gpu_geometry(),
+            RoutedExpertGpuSpec {
+                dtype: crate::inference::WeightDtype::Q4_0,
+                d_model: 31,
+                d_ff: 64,
+            },
+            test_gpu_expert_cache(1024),
+            |_| {
+                attempts += 1;
+                Ok(test_gpu_backend())
+            },
+        )
+        .unwrap_err();
+        assert_eq!(attempts, 0);
+        assert!(matches!(
+            err,
+            BackendResolutionError::RoutedExpertGpuIncompatible {
+                requested: ComputeOffload::Hybrid,
+                incompatibility: RoutedExpertGpuIncompatibility::MisalignedQ4_0 {
+                    d_model: 31,
+                    d_ff: 64,
+                    block_elems: 32,
+                },
+            }
+        ));
+        assert!(err.to_string().contains("d_model=31"));
+    }
+
+    #[test]
+    fn legacy_gpu_and_auto_plans_keep_incompatible_experts_on_cpu() {
+        for requested in [ComputeOffload::Gpu, ComputeOffload::Auto] {
+            let mut attempts = 0;
+            let context = resolve_execution_context_with(
+                requested,
+                false,
+                test_gpu_geometry(),
+                test_routed_expert_gpu_spec(crate::inference::WeightDtype::Q8_0),
+                test_gpu_expert_cache(1024),
+                |_| {
+                    attempts += 1;
+                    Ok(test_gpu_backend())
+                },
+            )
+            .unwrap();
+            assert_eq!(attempts, 1);
+            assert_eq!(context.plan().resolved(), ResolvedBackend::Gpu);
+            assert_eq!(context.plan().attention(), ExecutionPlane::Gpu);
+            assert_eq!(context.plan().routed_experts(), ExecutionPlane::Cpu);
+            assert!(!context.routed_expert_backend().is_gpu());
+        }
+    }
+
+    #[test]
+    fn cpu_execution_plan_is_all_cpu_and_skips_gpu_factory() {
+        let mut attempts = 0;
+        let context = resolve_execution_context_with(
+            ComputeOffload::Cpu,
+            true,
+            test_gpu_geometry(),
+            test_routed_expert_gpu_spec(crate::inference::WeightDtype::F32),
+            test_gpu_expert_cache(0),
+            |_| {
+                attempts += 1;
+                Ok(test_gpu_backend())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(attempts, 0);
+        assert_eq!(context.plan().requested(), ComputeOffload::Cpu);
+        assert_eq!(context.plan().resolved(), ResolvedBackend::Cpu);
+        assert!(context
+            .plan()
+            .component_planes()
+            .iter()
+            .all(|(_, plane)| *plane == ExecutionPlane::Cpu));
+        assert!(!context.primary_backend().is_gpu());
+        assert_eq!(context.id(), context.plan().context_id());
+    }
+
+    #[test]
+    fn hybrid_plan_constructs_exactly_one_gpu_context_and_keeps_only_experts_on_gpu() {
+        let mut attempts = 0;
+        let expected_backend = test_gpu_backend();
+        let factory_backend = expected_backend.clone();
+        let expected_cache = test_gpu_expert_cache(1024);
+        let context = resolve_execution_context_with(
+            ComputeOffload::Hybrid,
+            true,
+            test_gpu_geometry(),
+            test_routed_expert_gpu_spec(crate::inference::WeightDtype::F32),
+            expected_cache.clone(),
+            |_| {
+                attempts += 1;
+                Ok(factory_backend)
+            },
+        )
+        .unwrap();
+
+        let plan = context.plan();
+        assert_eq!(attempts, 1);
+        assert_eq!(plan.requested(), ComputeOffload::Hybrid);
+        assert_eq!(
+            plan.resolved(),
+            ResolvedBackend::HybridCpuAttentionGpuExperts
+        );
+        assert_eq!(plan.embeddings(), ExecutionPlane::Cpu);
+        assert_eq!(plan.lm_head(), ExecutionPlane::Cpu);
+        assert_eq!(plan.dense_projections(), ExecutionPlane::Cpu);
+        assert_eq!(plan.attention(), ExecutionPlane::Cpu);
+        assert_eq!(plan.kv(), ExecutionPlane::Cpu);
+        assert_eq!(plan.router(), ExecutionPlane::Cpu);
+        assert_eq!(plan.routed_experts(), ExecutionPlane::Gpu);
+        assert!(Arc::ptr_eq(
+            context.routed_expert_backend(),
+            &expected_backend
+        ));
+        assert!(Arc::ptr_eq(context.gpu_expert_cache(), &expected_cache));
+        assert!(!context.attention_backend().is_gpu());
+    }
+
+    #[test]
+    fn explicit_gpu_context_resolution_fails_closed_on_initialization_failure() {
+        let err = resolve_execution_context_with(
+            ComputeOffload::Gpu,
+            false,
+            test_gpu_geometry(),
+            test_routed_expert_gpu_spec(crate::inference::WeightDtype::F32),
+            test_gpu_expert_cache(1024),
+            |_| Err("adapter incompatible with required PUSH_CONSTANTS".to_string()),
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            BackendResolutionError::GpuUnavailable {
+                requested: ComputeOffload::Gpu,
+                ..
+            }
+        ));
+        assert!(err.to_string().contains("PUSH_CONSTANTS"));
+    }
+
+    #[test]
+    fn auto_context_fallback_is_explicitly_cpu_and_preserves_request() {
+        let context = resolve_execution_context_with(
+            ComputeOffload::Auto,
+            false,
+            test_gpu_geometry(),
+            test_routed_expert_gpu_spec(crate::inference::WeightDtype::F32),
+            test_gpu_expert_cache(1024),
+            |_| Err("no compatible adapter".to_string()),
+        )
+        .unwrap();
+        let plan = context.plan();
+        assert_eq!(plan.requested(), ComputeOffload::Auto);
+        assert_eq!(plan.resolved(), ResolvedBackend::Cpu);
+        assert!(plan.fallback_occurred());
+        assert!(plan.reason().unwrap().contains("no compatible adapter"));
+        assert!(plan
+            .component_planes()
+            .iter()
+            .all(|(_, plane)| *plane == ExecutionPlane::Cpu));
+        assert!(!context.primary_backend().is_gpu());
+    }
+
+    #[test]
+    fn invalid_gpu_geometry_fails_before_factory_or_runtime() {
+        let mut attempts = 0;
+        let mut geometry = test_gpu_geometry();
+        geometry.num_heads = 0;
+        let err = resolve_execution_context_with(
+            ComputeOffload::Hybrid,
+            true,
+            geometry,
+            test_routed_expert_gpu_spec(crate::inference::WeightDtype::F32),
+            test_gpu_expert_cache(1024),
+            |_| {
+                attempts += 1;
+                Ok(test_gpu_backend())
+            },
+        )
+        .unwrap_err();
+        assert_eq!(attempts, 0);
+        assert!(matches!(
+            err,
+            BackendResolutionError::InvalidGeometry { .. }
+        ));
+    }
+
+    #[test]
+    fn backend_factory_cannot_claim_gpu_with_a_cpu_backend() {
+        let err = resolve_execution_context_with(
+            ComputeOffload::Hybrid,
+            true,
+            test_gpu_geometry(),
+            test_routed_expert_gpu_spec(crate::inference::WeightDtype::F32),
+            test_gpu_expert_cache(1024),
+            |_| Ok(Arc::new(BackendBox::Cpu(CandleBackend::new()))),
+        )
+        .unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("GPU backend factory returned a CPU backend"));
+    }
+
+    #[test]
+    fn hybrid_requires_an_executable_gpu_expert_cache_before_initialization() {
+        let mut attempts = 0;
+        let err = resolve_execution_context_with(
+            ComputeOffload::Hybrid,
+            true,
+            test_gpu_geometry(),
+            test_routed_expert_gpu_spec(crate::inference::WeightDtype::F32),
+            test_gpu_expert_cache(0),
+            |_| {
+                attempts += 1;
+                Ok(test_gpu_backend())
+            },
+        )
+        .unwrap_err();
+        assert_eq!(attempts, 0);
+        assert_eq!(err, BackendResolutionError::RoutedExpertGpuCacheRequired);
+    }
+
+    #[test]
+    fn full_gpu_without_expert_cache_reports_experts_on_cpu() {
+        let context = resolve_execution_context_with(
+            ComputeOffload::Gpu,
+            false,
+            test_gpu_geometry(),
+            test_routed_expert_gpu_spec(crate::inference::WeightDtype::F32),
+            test_gpu_expert_cache(0),
+            |_| Ok(test_gpu_backend()),
+        )
+        .unwrap();
+        assert_eq!(context.plan().attention(), ExecutionPlane::Gpu);
+        assert_eq!(context.plan().kv(), ExecutionPlane::Gpu);
+        assert_eq!(context.plan().routed_experts(), ExecutionPlane::Cpu);
+        assert!(!context.routed_expert_backend().is_gpu());
+    }
+
     // ---- Finding 5: explicit GPU requests fail closed ----
 
     #[test]
@@ -2737,9 +3567,7 @@ mod tests {
         assert!(!out.fallback_occurred, "strict auto->cpu is a resolution, not a fallback");
         assert!(out.reason.is_some(), "the auto->cpu reason must be recorded");
         assert!(!attempted, "strict auto must not attempt GPU initialization");
-        assert!(!out.install_gpu_backend());
-        assert_eq!(out.attention_plane(), "cpu");
-        assert_eq!(out.expert_plane(), "cpu");
+        assert_eq!(out.resolved, ResolvedBackend::Cpu);
     }
 
     #[test]
@@ -2747,9 +3575,6 @@ mod tests {
         let out = resolve_backend_selection_with_numerics(ComputeOffload::Hybrid, true, || Ok(()))
             .unwrap();
         assert_eq!(out.resolved, ResolvedBackend::HybridCpuAttentionGpuExperts);
-        assert_eq!(out.attention_plane(), "cpu");
-        assert_eq!(out.expert_plane(), "gpu");
-        assert!(out.install_gpu_backend());
         assert!(out.reason.is_some(), "the hybrid split must be recorded");
     }
 
@@ -2782,9 +3607,6 @@ mod tests {
         let out = resolve_backend_selection_with_numerics(ComputeOffload::Gpu, false, || Ok(()))
             .unwrap();
         assert_eq!(out.resolved, ResolvedBackend::Gpu);
-        assert_eq!(out.attention_plane(), "gpu");
-        assert_eq!(out.expert_plane(), "gpu");
-        assert!(out.install_gpu_backend());
     }
 
     #[test]

--- a/rust-engine/src/backend/mod.rs
+++ b/rust-engine/src/backend/mod.rs
@@ -7,8 +7,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::sync::OnceLock;
 
-/// Maximum FFN intermediate dimension supported. Sized for Mixtral-8x7B (d_ff=14336).
-/// Increase if using models with larger d_ff.
+/// Maximum routed-expert workspace dimension supported for both `d_model` and
+/// `d_ff`. Sized for Mixtral-8x7B (`d_ff = 14336`).
 const MAX_EXPERT_D_FF: usize = 16_384;
 
 // Embed WGSL shaders using include_str
@@ -570,6 +570,14 @@ pub struct GpuBackend {
 }
 
 impl GpuBackend {
+    fn min_storage_buffer_offset_alignment(&self) -> u64 {
+        (self
+            .device
+            .limits()
+            .min_storage_buffer_offset_alignment as u64)
+            .max(1)
+    }
+
     pub async fn try_new(
         num_layers: usize,
         max_seq_len: usize,
@@ -1124,33 +1132,29 @@ impl GpuBackend {
         d_model:      usize,
         d_ff:         usize,
     ) -> anyhow::Result<VramExpertEntry> {
-
-        let proj_bytes = d_ff * d_model * 4;  // bytes per projection matrix
         anyhow::ensure!(
-            proj_bytes > 0,
+            d_model > 0 && d_ff > 0,
             "invalid expert shape: d_ff={} d_model={} produces zero-byte projections",
             d_ff,
             d_model
         );
+        let spec = RoutedExpertGpuSpec {
+            dtype: crate::inference::WeightDtype::F32,
+            d_model,
+            d_ff,
+        };
+        // Re-run startup compatibility at upload as a defensive check. Both
+        // paths share the checked projection-layout formula below.
+        routed_expert_gpu_compatibility(spec).map_err(|e| anyhow!(e))?;
+        let layout = f32_expert_projection_layout(
+            spec,
+            self.min_storage_buffer_offset_alignment(),
+        )
+        .map_err(|e| anyhow!(e))?;
         anyhow::ensure!(
-            weight_bytes.len() >= 3 * proj_bytes,
+            weight_bytes.len() >= layout.required_bytes,
             "expert weight buffer too small: got {} bytes, need {} (3 × d_ff={} × d_model={} × 4)",
-            weight_bytes.len(), 3 * proj_bytes, d_ff, d_model
-        );
-        anyhow::ensure!(
-            d_ff <= MAX_EXPERT_D_FF,
-            "d_ff={} exceeds MAX_EXPERT_D_FF={}; increase the constant",
-            d_ff, MAX_EXPERT_D_FF
-        );
-        // `d_model` flows through the same `MAX_EXPERT_D_FF`-sized workspace
-        // buffers (`x_buf`, and `mid_1` reused for the [d_model] down output)
-        // and host scratch, so bound it here too — otherwise an oversized
-        // `d_model` only trips a late `assert!` mid-dispatch instead of
-        // failing cleanly at load time.
-        anyhow::ensure!(
-            d_model <= MAX_EXPERT_D_FF,
-            "d_model={} exceeds MAX_EXPERT_D_FF={}; increase the constant",
-            d_model, MAX_EXPERT_D_FF
+            weight_bytes.len(), layout.required_bytes, d_ff, d_model
         );
 
         // ── Upload weights to VRAM ────────────────────────────────────────────
@@ -1162,33 +1166,12 @@ impl GpuBackend {
         });
         self.queue.write_buffer(&weight_buf, 0, weight_bytes);
 
-        // ── Sub-range offsets ─────────────────────────────────────────────────
-        // The per-dispatch bind groups (built in `expert_matmul_from_vram`
-        // against the checked-out workspace) bind gate/up/down as offset
-        // sub-ranges of this buffer, so the offsets must honour the
-        // device's storage-offset alignment.
-        let up_offset    = proj_bytes as u64;
-        let down_offset  = 2 * proj_bytes as u64;
-        let min_align = (self.device.limits().min_storage_buffer_offset_alignment as u64).max(1);
-        anyhow::ensure!(
-            up_offset % min_align == 0,
-            "expert projection slice offset {} is not aligned to min_storage_buffer_offset_alignment={}",
-            up_offset,
-            min_align
-        );
-        anyhow::ensure!(
-            down_offset % min_align == 0,
-            "expert projection slice offset {} is not aligned to min_storage_buffer_offset_alignment={}",
-            down_offset,
-            min_align
-        );
-
         Ok(VramExpertEntry {
             weight_buf,
             d_model,
             d_ff,
             layout: VramWeightLayout::F32,
-            proj_bytes: proj_bytes as u64,
+            proj_bytes: layout.projection_offset,
             up_block_off: 0,
             down_block_off: 0,
         })
@@ -1221,23 +1204,14 @@ impl GpuBackend {
             "invalid expert shape: d_ff={} d_model={}",
             d_ff, d_model
         );
-        anyhow::ensure!(
-            d_model % Q4_0_BLOCK_ELEMS == 0 && d_ff % Q4_0_BLOCK_ELEMS == 0,
-            "Q4_0 GPU path requires block-aligned dims: d_model={} d_ff={} (block={})",
-            d_model, d_ff, Q4_0_BLOCK_ELEMS
-        );
-        anyhow::ensure!(
-            d_ff <= MAX_EXPERT_D_FF,
-            "d_ff={} exceeds MAX_EXPERT_D_FF={}; increase the constant",
-            d_ff, MAX_EXPERT_D_FF
-        );
-        // Same `MAX_EXPERT_D_FF` workspace bound applies to `d_model`
-        // (the down projection writes [d_model] into a workspace buffer).
-        anyhow::ensure!(
-            d_model <= MAX_EXPERT_D_FF,
-            "d_model={} exceeds MAX_EXPERT_D_FF={}; increase the constant",
-            d_model, MAX_EXPERT_D_FF
-        );
+        // Re-run the shared block-alignment and workspace checks at upload so
+        // startup validation never replaces this defensive boundary.
+        routed_expert_gpu_compatibility(RoutedExpertGpuSpec {
+            dtype: crate::inference::WeightDtype::Q4_0,
+            d_model,
+            d_ff,
+        })
+        .map_err(|e| anyhow!(e))?;
 
         // `checked_mul` guards against `usize` overflow on user-configurable
         // dims; the division is exact (block alignment is enforced above and
@@ -2344,10 +2318,23 @@ pub enum RoutedExpertGpuIncompatibility {
     UnsupportedDtype {
         dtype: crate::inference::WeightDtype,
     },
+    ShapeExceedsWorkspace {
+        d_model: usize,
+        d_ff: usize,
+        max: usize,
+    },
     MisalignedQ4_0 {
         d_model: usize,
         d_ff: usize,
         block_elems: usize,
+    },
+    F32ProjectionSizeOverflow {
+        d_model: usize,
+        d_ff: usize,
+    },
+    F32StorageOffsetMisaligned {
+        projection_bytes: usize,
+        required_alignment: u64,
     },
 }
 
@@ -2360,6 +2347,11 @@ impl fmt::Display for RoutedExpertGpuIncompatibility {
                  are f32 and block-aligned q4_0",
                 dtype.as_str()
             ),
+            Self::ShapeExceedsWorkspace { d_model, d_ff, max } => write!(
+                f,
+                "routed-expert GPU workspace supports d_model and d_ff up to {max}; got \
+                 d_model={d_model}, d_ff={d_ff}"
+            ),
             Self::MisalignedQ4_0 {
                 d_model,
                 d_ff,
@@ -2369,17 +2361,41 @@ impl fmt::Display for RoutedExpertGpuIncompatibility {
                 "routed-expert q4_0 geometry requires d_model and d_ff to be multiples of \
                  {block_elems}; got d_model={d_model}, d_ff={d_ff}"
             ),
+            Self::F32ProjectionSizeOverflow { d_model, d_ff } => write!(
+                f,
+                "routed-expert f32 projection size overflows addressable storage for \
+                 d_model={d_model}, d_ff={d_ff}"
+            ),
+            Self::F32StorageOffsetMisaligned {
+                projection_bytes,
+                required_alignment,
+            } => write!(
+                f,
+                "routed-expert f32 projection size {projection_bytes} bytes does not satisfy \
+                 the selected GPU's min_storage_buffer_offset_alignment={required_alignment}"
+            ),
         }
     }
 }
 
-/// Authoritative routed-expert GPU compatibility rule shared by resolution
-/// and execution. This must stay aligned with the formats implemented by
-/// `GpuBackend::expert_matmul`.
+impl std::error::Error for RoutedExpertGpuIncompatibility {}
+
+/// Authoritative device-independent routed-expert GPU compatibility rule
+/// shared by resolution and execution. Device-specific limits are validated
+/// separately during backend construction. Both checks must stay aligned with
+/// the formats implemented by `GpuBackend::expert_matmul`.
 pub fn routed_expert_gpu_compatibility(
     spec: RoutedExpertGpuSpec,
 ) -> std::result::Result<(), RoutedExpertGpuIncompatibility> {
     use crate::inference::{WeightDtype, Q4_0_BLOCK_ELEMS};
+
+    if spec.d_model > MAX_EXPERT_D_FF || spec.d_ff > MAX_EXPERT_D_FF {
+        return Err(RoutedExpertGpuIncompatibility::ShapeExceedsWorkspace {
+            d_model: spec.d_model,
+            d_ff: spec.d_ff,
+            max: MAX_EXPERT_D_FF,
+        });
+    }
 
     match spec.dtype {
         WeightDtype::F32 => Ok(()),
@@ -2396,6 +2412,60 @@ pub fn routed_expert_gpu_compatibility(
         }),
         dtype => Err(RoutedExpertGpuIncompatibility::UnsupportedDtype { dtype }),
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct F32ExpertProjectionLayout {
+    projection_bytes: usize,
+    projection_offset: u64,
+    required_bytes: usize,
+}
+
+/// Checked F32 projection layout shared by startup compatibility validation
+/// and the defensive upload path.
+fn f32_expert_projection_layout(
+    spec: RoutedExpertGpuSpec,
+    required_alignment: u64,
+) -> std::result::Result<F32ExpertProjectionLayout, RoutedExpertGpuIncompatibility> {
+    let overflow = || RoutedExpertGpuIncompatibility::F32ProjectionSizeOverflow {
+        d_model: spec.d_model,
+        d_ff: spec.d_ff,
+    };
+    let projection_bytes = spec
+        .d_ff
+        .checked_mul(spec.d_model)
+        .and_then(|elements| elements.checked_mul(std::mem::size_of::<f32>()))
+        .ok_or_else(overflow)?;
+    let down_offset_bytes = projection_bytes.checked_mul(2).ok_or_else(overflow)?;
+    let required_bytes = projection_bytes.checked_mul(3).ok_or_else(overflow)?;
+    let projection_offset = u64::try_from(projection_bytes).map_err(|_| overflow())?;
+    let down_offset = u64::try_from(down_offset_bytes).map_err(|_| overflow())?;
+    let required_alignment = required_alignment.max(1);
+    if !projection_offset.is_multiple_of(required_alignment)
+        || !down_offset.is_multiple_of(required_alignment)
+    {
+        return Err(
+            RoutedExpertGpuIncompatibility::F32StorageOffsetMisaligned {
+                projection_bytes,
+                required_alignment,
+            },
+        );
+    }
+    Ok(F32ExpertProjectionLayout {
+        projection_bytes,
+        projection_offset,
+        required_bytes,
+    })
+}
+
+fn routed_expert_gpu_device_compatibility(
+    spec: RoutedExpertGpuSpec,
+    min_storage_buffer_offset_alignment: u64,
+) -> std::result::Result<(), RoutedExpertGpuIncompatibility> {
+    if spec.dtype == crate::inference::WeightDtype::F32 {
+        f32_expert_projection_layout(spec, min_storage_buffer_offset_alignment)?;
+    }
+    Ok(())
 }
 
 /// Stable, process-local identity for one resolved execution context.
@@ -2448,10 +2518,9 @@ impl ResolvedExecutionPlan {
         context_id: ExecutionContextId,
         gpu_expert_cache_available: bool,
         routed_expert_gpu_spec: RoutedExpertGpuSpec,
+        routed_expert_gpu_compatible: bool,
     ) -> Self {
         let cpu = ExecutionPlane::Cpu;
-        let routed_expert_gpu_compatible =
-            routed_expert_gpu_compatibility(routed_expert_gpu_spec).is_ok();
         let (attention, kv, routed_experts) = match resolution.resolved {
             ResolvedBackend::Cpu => (cpu, cpu, cpu),
             ResolvedBackend::Gpu => (
@@ -2578,14 +2647,16 @@ impl ExecutionContext {
         gpu_backend: Option<Arc<BackendBox>>,
         gpu_expert_cache: Arc<crate::expert_cache::GpuExpertCache>,
     ) -> Self {
-        debug_assert_eq!(
+        assert_eq!(
             plan.component_planes()
                 .iter()
                 .any(|(_, plane)| *plane == ExecutionPlane::Gpu),
-            gpu_backend.is_some()
+            gpu_backend.is_some(),
+            "resolved component planes and GPU backend ownership disagree: {plan:?}"
         );
-        debug_assert!(
-            plan.routed_experts() != ExecutionPlane::Gpu || gpu_expert_cache.capacity_bytes() > 0
+        assert!(
+            plan.routed_experts() != ExecutionPlane::Gpu || gpu_expert_cache.capacity_bytes() > 0,
+            "GPU routed-expert plane requires a non-zero VRAM expert cache"
         );
         Self {
             plan,
@@ -2931,7 +3002,7 @@ pub fn resolve_execution_context(
     gpu_expert_cache: Arc<crate::expert_cache::GpuExpertCache>,
 ) -> std::result::Result<Arc<ExecutionContext>, BackendResolutionError> {
     let context_gpu_expert_cache = gpu_expert_cache.clone();
-    resolve_execution_context_with(
+    resolve_execution_context_with_device_limits(
         requested,
         strict_attention,
         geometry,
@@ -2948,7 +3019,14 @@ pub fn resolve_execution_context(
                 gpu_expert_cache,
                 geometry.q4_truncation_tolerance,
             ))
-            .map(|gpu| Arc::new(BackendBox::Gpu(gpu)))
+            .map(|gpu| {
+                let min_storage_buffer_offset_alignment =
+                    gpu.min_storage_buffer_offset_alignment();
+                (
+                    Arc::new(BackendBox::Gpu(gpu)),
+                    min_storage_buffer_offset_alignment,
+                )
+            })
             .map_err(|e| e.to_string())
         },
     )
@@ -2957,6 +3035,7 @@ pub fn resolve_execution_context(
 /// Injectable resolution boundary used by hardware-independent tests.
 /// Production callers use [`resolve_execution_context`]. The factory is
 /// consulted at most once and never for a CPU-only resolution.
+#[cfg(test)]
 pub(crate) fn resolve_execution_context_with<F>(
     requested: ComputeOffload,
     strict_attention: bool,
@@ -2967,6 +3046,29 @@ pub(crate) fn resolve_execution_context_with<F>(
 ) -> std::result::Result<Arc<ExecutionContext>, BackendResolutionError>
 where
     F: FnOnce(&GpuBackendGeometry) -> std::result::Result<Arc<BackendBox>, String>,
+{
+    resolve_execution_context_with_device_limits(
+        requested,
+        strict_attention,
+        geometry,
+        routed_expert_gpu_spec,
+        gpu_expert_cache,
+        move |geometry| gpu_init(geometry).map(|backend| (backend, 1)),
+    )
+}
+
+fn resolve_execution_context_with_device_limits<F>(
+    requested: ComputeOffload,
+    strict_attention: bool,
+    geometry: GpuBackendGeometry,
+    routed_expert_gpu_spec: RoutedExpertGpuSpec,
+    gpu_expert_cache: Arc<crate::expert_cache::GpuExpertCache>,
+    gpu_init: F,
+) -> std::result::Result<Arc<ExecutionContext>, BackendResolutionError>
+where
+    F: FnOnce(
+        &GpuBackendGeometry,
+    ) -> std::result::Result<(Arc<BackendBox>, u64), String>,
 {
     let gpu_expert_cache_available = gpu_expert_cache.capacity_bytes() > 0;
     let expert_compatibility = routed_expert_gpu_compatibility(routed_expert_gpu_spec);
@@ -2986,16 +3088,37 @@ where
     }
 
     let mut gpu_backend = None;
+    let mut min_storage_buffer_offset_alignment = None;
     let resolution = resolve_backend_selection_with_numerics(requested, strict_attention, || {
         match gpu_init(&geometry) {
-            Ok(backend) if backend.is_gpu() => {
+            Ok((backend, required_alignment)) if backend.is_gpu() => {
                 gpu_backend = Some(backend);
+                min_storage_buffer_offset_alignment = Some(required_alignment);
                 Ok(())
             }
-            Ok(_) => Err("GPU backend factory returned a CPU backend".to_string()),
+            Ok((_, _)) => Err("GPU backend factory returned a CPU backend".to_string()),
             Err(detail) => Err(detail),
         }
     })?;
+
+    let device_compatibility = min_storage_buffer_offset_alignment
+        .map(|required_alignment| {
+            routed_expert_gpu_device_compatibility(
+                routed_expert_gpu_spec,
+                required_alignment,
+            )
+        })
+        .unwrap_or(Ok(()));
+    if requested == ComputeOffload::Hybrid {
+        device_compatibility.map_err(|incompatibility| {
+            BackendResolutionError::RoutedExpertGpuIncompatible {
+                requested,
+                incompatibility,
+            }
+        })?;
+    }
+    let routed_expert_gpu_compatible =
+        expert_compatibility.is_ok() && device_compatibility.is_ok();
 
     let context_id = next_execution_context_id();
     let plan = ResolvedExecutionPlan::from_resolution(
@@ -3003,6 +3126,7 @@ where
         context_id,
         gpu_expert_cache_available,
         routed_expert_gpu_spec,
+        routed_expert_gpu_compatible,
     );
     Ok(Arc::new(ExecutionContext::new(
         plan,
@@ -3030,6 +3154,7 @@ pub fn cpu_execution_context() -> Arc<ExecutionContext> {
             d_model: 0,
             d_ff: 0,
         },
+        true,
     );
     Arc::new(ExecutionContext::new(
         plan,
@@ -3170,10 +3295,18 @@ mod tests {
     }
 
     fn test_routed_expert_gpu_spec(dtype: crate::inference::WeightDtype) -> RoutedExpertGpuSpec {
+        test_routed_expert_gpu_spec_with_shape(dtype, 32, 64)
+    }
+
+    fn test_routed_expert_gpu_spec_with_shape(
+        dtype: crate::inference::WeightDtype,
+        d_model: usize,
+        d_ff: usize,
+    ) -> RoutedExpertGpuSpec {
         RoutedExpertGpuSpec {
             dtype,
-            d_model: 32,
-            d_ff: 64,
+            d_model,
+            d_ff,
         }
     }
 
@@ -3206,6 +3339,147 @@ mod tests {
                 crate::inference::WeightDtype::Q4_0,
             )),
             Ok(())
+        );
+    }
+
+    #[test]
+    fn routed_expert_gpu_compatibility_accepts_workspace_limit() {
+        for dtype in [
+            crate::inference::WeightDtype::F32,
+            crate::inference::WeightDtype::Q4_0,
+        ] {
+            assert_eq!(
+                routed_expert_gpu_compatibility(test_routed_expert_gpu_spec_with_shape(
+                    dtype,
+                    MAX_EXPERT_D_FF,
+                    MAX_EXPERT_D_FF,
+                )),
+                Ok(())
+            );
+        }
+    }
+
+    #[test]
+    fn routed_expert_gpu_compatibility_rejects_d_model_above_workspace() {
+        let err = routed_expert_gpu_compatibility(test_routed_expert_gpu_spec_with_shape(
+            crate::inference::WeightDtype::F32,
+            MAX_EXPERT_D_FF + 1,
+            64,
+        ));
+        assert_eq!(
+            err,
+            Err(RoutedExpertGpuIncompatibility::ShapeExceedsWorkspace {
+                d_model: MAX_EXPERT_D_FF + 1,
+                d_ff: 64,
+                max: MAX_EXPERT_D_FF,
+            })
+        );
+    }
+
+    #[test]
+    fn routed_expert_gpu_compatibility_rejects_d_ff_above_workspace() {
+        let err = routed_expert_gpu_compatibility(test_routed_expert_gpu_spec_with_shape(
+            crate::inference::WeightDtype::Q4_0,
+            64,
+            MAX_EXPERT_D_FF + 32,
+        ));
+        assert_eq!(
+            err,
+            Err(RoutedExpertGpuIncompatibility::ShapeExceedsWorkspace {
+                d_model: 64,
+                d_ff: MAX_EXPERT_D_FF + 32,
+                max: MAX_EXPERT_D_FF,
+            })
+        );
+    }
+
+    #[test]
+    fn hybrid_workspace_rejection_skips_gpu_factory() {
+        for spec in [
+            test_routed_expert_gpu_spec_with_shape(
+                crate::inference::WeightDtype::F32,
+                MAX_EXPERT_D_FF + 1,
+                64,
+            ),
+            test_routed_expert_gpu_spec_with_shape(
+                crate::inference::WeightDtype::Q4_0,
+                64,
+                MAX_EXPERT_D_FF + 32,
+            ),
+        ] {
+            let mut attempts = 0;
+            let err = resolve_execution_context_with(
+                ComputeOffload::Hybrid,
+                true,
+                test_gpu_geometry(),
+                spec,
+                test_gpu_expert_cache(1024),
+                |_| {
+                    attempts += 1;
+                    Ok(test_gpu_backend())
+                },
+            )
+            .unwrap_err();
+            assert_eq!(attempts, 0);
+            assert!(matches!(
+                err,
+                BackendResolutionError::RoutedExpertGpuIncompatible {
+                    requested: ComputeOffload::Hybrid,
+                    incompatibility: RoutedExpertGpuIncompatibility::ShapeExceedsWorkspace { .. },
+                }
+            ));
+        }
+    }
+
+    #[test]
+    fn f32_projection_layout_accepts_device_alignment() {
+        let layout = f32_expert_projection_layout(
+            test_routed_expert_gpu_spec(crate::inference::WeightDtype::F32),
+            256,
+        )
+        .unwrap();
+        assert_eq!(layout.projection_bytes, 32 * 64 * 4);
+        assert_eq!(layout.projection_offset, (32 * 64 * 4) as u64);
+        assert_eq!(layout.required_bytes, 3 * 32 * 64 * 4);
+    }
+
+    #[test]
+    fn f32_projection_layout_rejects_device_misalignment() {
+        let err = f32_expert_projection_layout(
+            test_routed_expert_gpu_spec_with_shape(
+                crate::inference::WeightDtype::F32,
+                32,
+                65,
+            ),
+            256,
+        )
+        .unwrap_err();
+        assert_eq!(
+            err,
+            RoutedExpertGpuIncompatibility::F32StorageOffsetMisaligned {
+                projection_bytes: 32 * 65 * 4,
+                required_alignment: 256,
+            }
+        );
+    }
+
+    #[test]
+    fn f32_projection_layout_rejects_checked_overflow() {
+        let err = f32_expert_projection_layout(
+            test_routed_expert_gpu_spec_with_shape(
+                crate::inference::WeightDtype::F32,
+                usize::MAX,
+                2,
+            ),
+            256,
+        )
+        .unwrap_err();
+        assert_eq!(
+            err,
+            RoutedExpertGpuIncompatibility::F32ProjectionSizeOverflow {
+                d_model: usize::MAX,
+                d_ff: 2,
+            }
         );
     }
 
@@ -3301,6 +3575,62 @@ mod tests {
     }
 
     #[test]
+    fn hybrid_device_misalignment_is_typed_after_one_gpu_initialization() {
+        let mut attempts = 0;
+        let err = resolve_execution_context_with_device_limits(
+            ComputeOffload::Hybrid,
+            true,
+            test_gpu_geometry(),
+            test_routed_expert_gpu_spec_with_shape(
+                crate::inference::WeightDtype::F32,
+                32,
+                65,
+            ),
+            test_gpu_expert_cache(1024),
+            |_| {
+                attempts += 1;
+                Ok((test_gpu_backend(), 256))
+            },
+        )
+        .unwrap_err();
+        assert_eq!(attempts, 1);
+        assert_eq!(
+            err,
+            BackendResolutionError::RoutedExpertGpuIncompatible {
+                requested: ComputeOffload::Hybrid,
+                incompatibility:
+                    RoutedExpertGpuIncompatibility::F32StorageOffsetMisaligned {
+                        projection_bytes: 32 * 65 * 4,
+                        required_alignment: 256,
+                    },
+            }
+        );
+    }
+
+    #[test]
+    fn legacy_gpu_and_auto_device_misalignment_keeps_experts_on_cpu() {
+        for requested in [ComputeOffload::Gpu, ComputeOffload::Auto] {
+            let context = resolve_execution_context_with_device_limits(
+                requested,
+                false,
+                test_gpu_geometry(),
+                test_routed_expert_gpu_spec_with_shape(
+                    crate::inference::WeightDtype::F32,
+                    32,
+                    65,
+                ),
+                test_gpu_expert_cache(1024),
+                |_| Ok((test_gpu_backend(), 256)),
+            )
+            .unwrap();
+            assert_eq!(context.plan().resolved(), ResolvedBackend::Gpu);
+            assert_eq!(context.plan().attention(), ExecutionPlane::Gpu);
+            assert_eq!(context.plan().routed_experts(), ExecutionPlane::Cpu);
+            assert!(!context.routed_expert_backend().is_gpu());
+        }
+    }
+
+    #[test]
     fn cpu_execution_plan_is_all_cpu_and_skips_gpu_factory() {
         let mut attempts = 0;
         let context = resolve_execution_context_with(
@@ -3334,7 +3664,7 @@ mod tests {
         let expected_backend = test_gpu_backend();
         let factory_backend = expected_backend.clone();
         let expected_cache = test_gpu_expert_cache(1024);
-        let context = resolve_execution_context_with(
+        let context = resolve_execution_context_with_device_limits(
             ComputeOffload::Hybrid,
             true,
             test_gpu_geometry(),
@@ -3342,7 +3672,7 @@ mod tests {
             expected_cache.clone(),
             |_| {
                 attempts += 1;
-                Ok(factory_backend)
+                Ok((factory_backend, 256))
             },
         )
         .unwrap();
@@ -3367,6 +3697,42 @@ mod tests {
         ));
         assert!(Arc::ptr_eq(context.gpu_expert_cache(), &expected_cache));
         assert!(!context.attention_backend().is_gpu());
+    }
+
+    #[test]
+    #[should_panic(expected = "resolved component planes and GPU backend ownership disagree")]
+    fn execution_context_rejects_gpu_plane_without_gpu_backend() {
+        let plan = ResolvedExecutionPlan::from_resolution(
+            BackendResolution {
+                requested: ComputeOffload::Gpu,
+                resolved: ResolvedBackend::Gpu,
+                fallback_occurred: false,
+                reason: None,
+            },
+            next_execution_context_id(),
+            true,
+            test_routed_expert_gpu_spec(crate::inference::WeightDtype::F32),
+            true,
+        );
+        let _ = ExecutionContext::new(plan, None, test_gpu_expert_cache(1024));
+    }
+
+    #[test]
+    #[should_panic(expected = "GPU routed-expert plane requires a non-zero VRAM expert cache")]
+    fn execution_context_rejects_gpu_experts_without_cache() {
+        let plan = ResolvedExecutionPlan::from_resolution(
+            BackendResolution {
+                requested: ComputeOffload::Hybrid,
+                resolved: ResolvedBackend::HybridCpuAttentionGpuExperts,
+                fallback_occurred: false,
+                reason: None,
+            },
+            next_execution_context_id(),
+            true,
+            test_routed_expert_gpu_spec(crate::inference::WeightDtype::F32),
+            true,
+        );
+        let _ = ExecutionContext::new(plan, Some(test_gpu_backend()), test_gpu_expert_cache(0));
     }
 
     #[test]
@@ -3567,7 +3933,6 @@ mod tests {
         assert!(!out.fallback_occurred, "strict auto->cpu is a resolution, not a fallback");
         assert!(out.reason.is_some(), "the auto->cpu reason must be recorded");
         assert!(!attempted, "strict auto must not attempt GPU initialization");
-        assert_eq!(out.resolved, ResolvedBackend::Cpu);
     }
 
     #[test]
@@ -3603,7 +3968,7 @@ mod tests {
     }
 
     #[test]
-    fn non_strict_gpu_resolution_reports_gpu_planes() {
+    fn non_strict_gpu_resolution_resolves_to_gpu() {
         let out = resolve_backend_selection_with_numerics(ComputeOffload::Gpu, false, || Ok(()))
             .unwrap();
         assert_eq!(out.resolved, ResolvedBackend::Gpu);

--- a/rust-engine/src/batch_scheduler.rs
+++ b/rust-engine/src/batch_scheduler.rs
@@ -920,7 +920,7 @@ impl BatchScheduler {
         //     real token does not pay the one-shot kernel-init
         //     cost.
         {
-            let backend = crate::backend::current();
+            let backend = engine.execution_context().routed_expert_backend();
             let gate_f16 = vec![half::f16::from_f32(0.1); 16];
             let up_f16 = vec![half::f16::from_f32(0.2); 16];
             let mut out_f16 = vec![half::f16::ZERO; 16];

--- a/rust-engine/src/config.rs
+++ b/rust-engine/src/config.rs
@@ -470,18 +470,13 @@ pub struct RealTransformerConfig {
     #[serde(default = "default_pressure_critical_threshold")]
     pub pressure_critical_threshold: f32,
 
-    /// **Hybrid compute offload** (gist Part 2, fix #5). Picks which
-    /// [`crate::backend::Backend`] implementation handles the dense
-    /// transformer body's matmul / attention / LM-head. `"cpu"`
-    /// (default) routes through [`crate::backend::CandleBackend`] /
-    /// the auto-escalating SIMD dispatcher in [`crate::kernels`].
-    /// `"gpu"` selects the [`crate::backend::GpuBackend`] integration
-    /// seam. At present this is a compatibility/configuration switch
-    /// for the GPU backend path rather than a guaranteed operational
-    /// GPU offload mode, so execution still falls back to the CPU
-    /// dense path when GPU acceleration is not active. The
-    /// SSD-streamed expert pipeline stays CPU-side either way,
-    /// matching the gist's "budget GPU augments CPU" posture.
+    /// Requested compute mode. Startup resolves this once into an immutable
+    /// [`crate::backend::ResolvedExecutionPlan`]; runtime and reporting consume
+    /// that plan rather than interpreting this request independently. `"cpu"`
+    /// is the compatibility default, `"gpu"` is explicit and fail-closed,
+    /// `"auto"` retains its documented CPU fallback, and `"hybrid"` keeps
+    /// embeddings, LM head, dense projections, attention, KV, and routing on
+    /// CPU while selecting the GPU plane only for routed experts.
     #[serde(default)]
     pub compute_offload: crate::backend::ComputeOffload,
 

--- a/rust-engine/src/config.rs
+++ b/rust-engine/src/config.rs
@@ -476,7 +476,12 @@ pub struct RealTransformerConfig {
     /// is the compatibility default, `"gpu"` is explicit and fail-closed,
     /// `"auto"` retains its documented CPU fallback, and `"hybrid"` keeps
     /// embeddings, LM head, dense projections, attention, KV, and routing on
-    /// CPU while selecting the GPU plane only for routed experts.
+    /// CPU while selecting the GPU plane only for routed experts. `"hybrid"`
+    /// requires strict attention semantics
+    /// (`allow_nonfinite_attention_fallback = false`), an enabled GPU expert
+    /// cache with a non-zero VRAM budget, and a routed-expert dtype/geometry
+    /// supported by the current GPU expert implementation. Invalid Hybrid
+    /// combinations are hard startup errors.
     #[serde(default)]
     pub compute_offload: crate::backend::ComputeOffload,
 

--- a/rust-engine/src/engine.rs
+++ b/rust-engine/src/engine.rs
@@ -1786,14 +1786,12 @@ impl Engine {
         self.core.execution_context.routed_expert_backend()
     }
 
-    /// Whether the configured expert dtype is eligible for the GPU
-    /// `Backend::expert_matmul` fast path. F32 always qualifies. Q4_0
-    /// qualifies only when both `d_model` and `d_ff` are
-    /// Q4_0-block-aligned: the raw block stream then has every matrix
-    /// row starting on a 32-element block boundary, which is what the
-    /// inline-dequant GEMV shader (`matmul_q4_0.wgsl`) assumes when it
-    /// walks `k / 32` blocks per row. All other dtypes stay on the
-    /// CPU path.
+    /// Whether the configured expert dtype and shape are eligible for the GPU
+    /// `Backend::expert_matmul` fast path. F32 and Q4_0 must fit the fixed GPU
+    /// expert workspace. Q4_0 additionally requires both `d_model` and `d_ff`
+    /// to be block-aligned so every matrix row starts on a 32-element block
+    /// boundary, as assumed by `matmul_q4_0.wgsl`. All other dtypes stay on
+    /// the CPU path.
     fn gpu_eligible_dtype(&self) -> bool {
         crate::backend::routed_expert_gpu_compatibility(
             crate::backend::RoutedExpertGpuSpec {
@@ -2548,11 +2546,6 @@ impl Engine {
                         is_gpu = self.routed_expert_backend().is_gpu(),
                         gpu_eligible_dtype = self.gpu_eligible_dtype(),
                         "generate GPU fast-path guard"
-                    );
-                    info!(
-                        is_gpu = self.routed_expert_backend().is_gpu(),
-                        gpu_eligible = self.gpu_eligible_dtype(),
-                        "generate GPU fast-path guard check"
                     );
                     let use_gpu =
                         self.routed_expert_backend().is_gpu() && self.gpu_eligible_dtype();

--- a/rust-engine/src/engine.rs
+++ b/rust-engine/src/engine.rs
@@ -1107,13 +1107,10 @@ pub(crate) struct EngineCore {
     /// failure to acquire drops the prefetch and increments
     /// `EngineMetrics::counters::prefetch_dropped_concurrency`.
     pub(super) prefetch_semaphore: Arc<tokio::sync::Semaphore>,
-    /// Math backend used for the Phase 3 GPU expert FFN fast-path. When
-    /// the expert is VRAM-resident, [`Engine::moe_step`] / [`Engine::generate`]
-    /// route the per-expert SwiGLU forward through this backend instead
-    /// of `dispatch_expert_forward`. `BackendBox::init_blocking` returns
-    /// `BackendBox::Cpu` automatically if no GPU is available, so this
-    /// field is always installed (see gist Phase 3, CHANGE 3).
-    pub(super) backend: Arc<crate::backend::BackendBox>,
+    /// Immutable execution plan plus the sole backend context used by this
+    /// engine and its associated real model. Routed-expert dispatch reads the
+    /// backend selected by this context; it never reconstructs one privately.
+    pub(super) execution_context: Arc<crate::backend::ExecutionContext>,
     /// **Tier 4 — adaptive prefetch admission controller.** Always
     /// present; constructed in the transparent pass-through state unless
     /// [`EngineOptions::prefetch_governor`] is set, in which case it
@@ -1329,6 +1326,7 @@ impl EngineCore {
         predictor: Arc<PredictiveLoader>,
         shape: ModelShape,
         options: EngineOptions,
+        execution_context: Arc<crate::backend::ExecutionContext>,
     ) -> Self {
         // Bound the speculative-prefetch semaphore by the buffer
         // pool's *actual* headroom (`pool_slots − cache_slots`), not
@@ -1403,12 +1401,7 @@ impl EngineCore {
             gpu_promotion_tx: None,
             in_flight: Arc::new(DashMap::new()),
             prefetch_semaphore: Arc::new(tokio::sync::Semaphore::new(prefetch_permits)),
-            // Default to the CPU backend; `install_gpu_cache` swaps in a
-            // real `GpuBackend` (or leaves CPU when no adapter is available)
-            // once a `GpuExpertCache` is wired up.
-            backend: Arc::new(crate::backend::BackendBox::Cpu(
-                crate::backend::CandleBackend::new(),
-            )),
+            execution_context,
             governor,
         }
     }
@@ -1725,12 +1718,72 @@ impl Engine {
         shape: ModelShape,
         options: EngineOptions,
     ) -> Self {
+        Self::with_options_and_execution_context(
+            cache,
+            pool,
+            storage,
+            router,
+            predictor,
+            shape,
+            options,
+            crate::backend::cpu_execution_context(),
+        )
+    }
+
+    /// Construct an engine that consumes an already-resolved authoritative
+    /// execution context. Production startup uses this path so planning,
+    /// reporting, real-model attention, and routed-expert dispatch all share
+    /// the same context identity and backend instances.
+    #[allow(clippy::too_many_arguments)]
+    pub fn with_options_and_execution_context(
+        cache: Arc<MultiLayerExpertCache>,
+        pool: BufferPool,
+        storage: Arc<NvmeStorage>,
+        router: Router,
+        predictor: Arc<PredictiveLoader>,
+        shape: ModelShape,
+        options: EngineOptions,
+        execution_context: Arc<crate::backend::ExecutionContext>,
+    ) -> Self {
+        let engine_expert_spec = crate::backend::RoutedExpertGpuSpec {
+            dtype: options.dtype,
+            d_model: shape.d_model,
+            d_ff: shape.d_ff,
+        };
+        if execution_context.plan().routed_experts() == crate::backend::ExecutionPlane::Gpu {
+            assert_eq!(
+                execution_context.plan().routed_expert_gpu_spec(),
+                engine_expert_spec,
+                "resolved GPU routed-expert plan does not match Engine dtype/geometry"
+            );
+            assert!(
+                crate::backend::routed_expert_gpu_compatibility(engine_expert_spec).is_ok(),
+                "resolved GPU routed-expert plan is incompatible with Engine dtype/geometry"
+            );
+        }
         let speculator_topk_default = router.top_k();
         Self {
-            core: EngineCore::new(cache, pool, storage, router, predictor, shape, options),
+            core: EngineCore::new(
+                cache,
+                pool,
+                storage,
+                router,
+                predictor,
+                shape,
+                options,
+                execution_context,
+            ),
             speculation: EngineSpeculation::new(speculator_topk_default),
             metrics: EngineMetrics::new(),
         }
+    }
+
+    pub fn execution_context(&self) -> &Arc<crate::backend::ExecutionContext> {
+        &self.core.execution_context
+    }
+
+    fn routed_expert_backend(&self) -> &Arc<crate::backend::BackendBox> {
+        self.core.execution_context.routed_expert_backend()
     }
 
     /// Whether the configured expert dtype is eligible for the GPU
@@ -1742,14 +1795,14 @@ impl Engine {
     /// walks `k / 32` blocks per row. All other dtypes stay on the
     /// CPU path.
     fn gpu_eligible_dtype(&self) -> bool {
-        match self.core.options.dtype {
-            WeightDtype::F32 => true,
-            WeightDtype::Q4_0 => {
-                self.core.shape.d_model % Q4_0_BLOCK_ELEMS == 0
-                    && self.core.shape.d_ff % Q4_0_BLOCK_ELEMS == 0
-            }
-            _ => false,
-        }
+        crate::backend::routed_expert_gpu_compatibility(
+            crate::backend::RoutedExpertGpuSpec {
+                dtype: self.core.options.dtype,
+                d_model: self.core.shape.d_model,
+                d_ff: self.core.shape.d_ff,
+            },
+        )
+        .is_ok()
     }
 
     /// Synchronously promote a freshly-loaded RAM resident into the
@@ -1784,7 +1837,7 @@ impl Engine {
         // one the GPU kernels can actually consume; otherwise the
         // promotion would just waste a VRAM slot on bytes the fast
         // path can never use.
-        if !self.core.backend.is_gpu() || !self.gpu_eligible_dtype() {
+        if !self.routed_expert_backend().is_gpu() || !self.gpu_eligible_dtype() {
             return;
         }
         let Some(gpu) = self.core.gpu_cache.as_ref() else {
@@ -1824,7 +1877,8 @@ impl Engine {
     ///
     /// Updates the `mer_vram_used_bytes` Prometheus gauge after every
     /// successful promotion.
-    pub fn install_gpu_cache(&mut self, gpu: Arc<GpuExpertCache>) {
+    pub fn install_gpu_cache(&mut self) {
+        let gpu = self.core.execution_context.gpu_expert_cache().clone();
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<(u32, Arc<ExpertResident>)>();
         let gpu_for_task = gpu.clone();
         let prom_for_task = self.metrics.prom.clone();
@@ -1866,20 +1920,6 @@ impl Engine {
         });
         self.core.gpu_cache = Some(gpu.clone());
         self.core.gpu_promotion_tx = Some(tx);
-
-        // Phase 3: try to bring up a real `GpuBackend` now that a
-        // `GpuExpertCache` is available. The `num_layers`/`max_seq_len`/
-        // `num_heads`/`head_dim` parameters drive `GpuKvCache` sizing,
-        // which is **not** on the expert-FFN dispatch path.
-        // `BackendBox::init_blocking` returns `BackendBox::Cpu`
-        // automatically when no adapter is present, so this never
-        // panics.
-        let backend = crate::backend::BackendBox::init_blocking(
-            /* num_layers   = */ 1, /* max_seq_len  = */ 1, /* num_heads    = */ 1,
-            /* num_kv_heads = */ 1, /* head_dim     = */ 1, /* v_head_dim   = */ 1, gpu,
-            self.core.options.policy.expert_size_tolerance(),
-        );
-        self.core.backend = Arc::new(backend);
     }
 
     /// **Test-only** wiring of the GPU promotion channel without
@@ -2505,16 +2545,18 @@ impl Engine {
                     // `Engine::gpu_eligible_dtype`.
                     debug!(
                         expert = r.id,
-                        is_gpu = self.core.backend.is_gpu(),
+                        is_gpu = self.routed_expert_backend().is_gpu(),
                         gpu_eligible_dtype = self.gpu_eligible_dtype(),
                         "generate GPU fast-path guard"
                     );
                     info!(
-                        is_gpu = self.core.backend.is_gpu(),
+                        is_gpu = self.routed_expert_backend().is_gpu(),
                         gpu_eligible = self.gpu_eligible_dtype(),
                         "generate GPU fast-path guard check"
                     );
-                    let gpu_result = if self.core.backend.is_gpu() && self.gpu_eligible_dtype() {
+                    let use_gpu =
+                        self.routed_expert_backend().is_gpu() && self.gpu_eligible_dtype();
+                    let gpu_result = if use_gpu {
                         let mut out_f16 = vec![half::f16::ZERO; self.core.shape.d_model];
                         let x_f16: Vec<half::f16> =
                             x.iter().map(|&f| half::f16::from_f32(f)).collect();
@@ -2534,11 +2576,11 @@ impl Engine {
                         // (the trait API takes it only for future logging).
                         debug!(
                             expert = r.id,
-                            is_gpu = self.core.backend.is_gpu(),
+                            is_gpu = self.routed_expert_backend().is_gpu(),
                             dtype = ?self.core.options.dtype,
                             "calling backend.expert_matmul"
                         );
-                        let matmul_res = self.core.backend.expert_matmul(
+                        let matmul_res = self.routed_expert_backend().expert_matmul(
                             0,
                             r.id,
                             x_view,
@@ -2548,7 +2590,7 @@ impl Engine {
                         );
                         debug!(
                             expert = r.id,
-                            is_gpu = self.core.backend.is_gpu(),
+                            is_gpu = self.routed_expert_backend().is_gpu(),
                             dtype = ?self.core.options.dtype,
                             ok = matmul_res.is_ok(),
                             "returned from backend.expert_matmul"
@@ -3892,7 +3934,7 @@ impl Engine {
         // miss returns Err and we fall through to the CPU path below.
         // Both F32 and (block-aligned) Q4_0 experts are eligible —
         // see `Engine::gpu_eligible_dtype`.
-        if self.core.backend.is_gpu() && self.gpu_eligible_dtype() {
+        if self.routed_expert_backend().is_gpu() && self.gpu_eligible_dtype() {
             let mut out_f16 = vec![half::f16::ZERO; self.core.shape.d_model];
             let x_f16: Vec<half::f16> = x.iter().map(|&f| half::f16::from_f32(f)).collect();
             let x_view = crate::backend::TensorView {
@@ -3905,7 +3947,7 @@ impl Engine {
                 rows: 1,
                 cols: self.core.shape.d_model,
             };
-            let matmul_res = self.core.backend.expert_matmul(
+            let matmul_res = self.routed_expert_backend().expert_matmul(
                 layer as usize,
                 r.id,
                 x_view,
@@ -5244,6 +5286,69 @@ mod tests {
             )
             .with_speculator(spec, top_k),
         )
+    }
+
+    #[tokio::test]
+    async fn engine_consumes_the_exact_resolved_hybrid_context() {
+        let dir = TempDir::new("execution-context-identity");
+        let base = build_engine(&dir.path, 4, 8, 16, 2, 2, 0, 7);
+        let gpu_backend = Arc::new(crate::backend::BackendBox::TestGpu(
+            crate::backend::CandleBackend::new(),
+        ));
+        let expected_backend = gpu_backend.clone();
+        let gpu_expert_cache = Arc::new(crate::expert_cache::GpuExpertCache::new(1024, 0.5, 16));
+        let expected_gpu_expert_cache = gpu_expert_cache.clone();
+        let context = crate::backend::resolve_execution_context_with(
+            crate::backend::ComputeOffload::Hybrid,
+            true,
+            crate::backend::GpuBackendGeometry {
+                num_layers: 1,
+                max_seq_len: 16,
+                num_heads: 1,
+                num_kv_heads: 1,
+                head_dim: 8,
+                v_head_dim: 8,
+                q4_truncation_tolerance: 0,
+            },
+            crate::backend::RoutedExpertGpuSpec {
+                dtype: WeightDtype::F32,
+                d_model: 8,
+                d_ff: 16,
+            },
+            gpu_expert_cache,
+            |_| Ok(gpu_backend),
+        )
+        .unwrap();
+
+        let mut engine = Engine::with_options_and_execution_context(
+            base.core.cache.clone(),
+            base.core.pool.clone(),
+            base.core.storage.clone(),
+            base.core.router.clone(),
+            base.core.predictor.clone(),
+            base.core.shape,
+            base.core.options.clone(),
+            context.clone(),
+        );
+
+        assert!(Arc::ptr_eq(engine.execution_context(), &context));
+        assert_eq!(engine.execution_context().id(), context.plan().context_id());
+        assert!(Arc::ptr_eq(
+            engine.routed_expert_backend(),
+            &expected_backend
+        ));
+        assert!(Arc::ptr_eq(
+            engine.execution_context().gpu_expert_cache(),
+            &expected_gpu_expert_cache
+        ));
+        engine.install_gpu_cache();
+        assert!(Arc::ptr_eq(
+            engine.core.gpu_cache.as_ref().unwrap(),
+            &expected_gpu_expert_cache
+        ));
+
+        let other = crate::backend::cpu_execution_context();
+        assert_ne!(engine.execution_context().id(), other.id());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -1981,6 +1981,15 @@ fn install_run_gpu_backend(
     let compute_plane = backend.compute_plane().to_string();
     crate::backend::set_execution_context(execution_context.clone())
         .map_err(|e| format!("explicit --gpu request failed: context installation failed ({e})"))?;
+    if execution_context.plan().routed_experts() != crate::backend::ExecutionPlane::Gpu {
+        warn!(
+            dtype = routed_expert_gpu_spec.dtype.as_str(),
+            d_model = routed_expert_gpu_spec.d_model,
+            d_ff = routed_expert_gpu_spec.d_ff,
+            routed_expert_plane = execution_context.plan().routed_experts().as_str(),
+            "run --gpu resolved routed experts to CPU; expert compute is not GPU-offloaded"
+        );
+    }
     info!(
         device = device_name,
         compute_plane,

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -1595,31 +1595,26 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // before they go looking for missing AVX-512 perf.
     crate::kernels::log_backend();
 
-    // Install the default plugin-system math backend (gist Task 2).
+    // Install the default plugin-system execution context (gist Task 2).
     // Logged on the same boot line so ops can see both the low-level
-    // CPU-feature dispatch and the high-level Backend in one place.
+    // CPU-feature dispatch and the high-level backend in one place.
     //
     // For the `serve` subcommand we **defer** the default install
     // until `cmd_serve` has loaded the TOML config — the hybrid
     // compute offload (`[real_transformer].compute_offload`, gist
-    // Part 2 fix #5) is selected from there, and it must run
+    // Part 2 fix #5) is resolved there, and it must run
     // *before* `install_default` claims the OnceLock. Other
     // subcommands keep the immediate install so their math path is
     // ready as soon as `main` returns into them.
     //
     // The `run` subcommand grows one extra wrinkle: when invoked with
-    // `--gpu` it must initialise the GPU compute backend *before* the
-    // default CPU backend claims the `OnceLock` (gist Fix 2), mirroring
-    // `cmd_serve`. `--gpu` is an explicit request, so a failed GPU init is
-    // fatal (fail closed) — it never silently falls back to CPU.
-    let run_gpu_cache = if let Cmd::Run {
-        gpu: true,
-        gpu_cache_mb,
-        ..
-    } = &cli.cmd
-    {
-        install_run_gpu_backend(*gpu_cache_mb)?
-    } else if !matches!(cli.cmd, Cmd::Serve { .. }) {
+    // `--gpu` it must leave the execution-context `OnceLock` free until
+    // `cmd_run` has applied any dataset metadata and can resolve against
+    // the effective expert dtype/geometry. GPU initialization failure is
+    // fatal; legacy deterministic dtype/geometry bypass remains visible in
+    // the resolved component plan.
+    let run_gpu_requested = matches!(cli.cmd, Cmd::Run { gpu: true, .. });
+    if !matches!(cli.cmd, Cmd::Serve { .. }) && !run_gpu_requested {
         crate::backend::install_default();
         let b = crate::backend::current();
         info!(
@@ -1627,10 +1622,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             compute_plane = b.compute_plane(),
             "math backend installed"
         );
-        None
-    } else {
-        None
-    };
+    }
 
     match cli.cmd {
         Cmd::GenData {
@@ -1715,7 +1707,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     gate_weights,
                     trace_out,
                     gpu,
-                    gpu_cache_mb: _,
+                    gpu_cache_mb,
                     pipeline_depth,
                     speculator,
                     speculator_hidden_dim,
@@ -1782,7 +1774,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             router_matrix,
                             gate_weights,
                             trace_out,
-                            gpu_expert_cache: if gpu { run_gpu_cache.clone() } else { None },
+                            gpu_cache_mb: gpu.then_some(gpu_cache_mb),
                             pipeline_depth,
                             speculator,
                             speculator_hidden_dim,
@@ -1936,23 +1928,25 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// Install the GPU compute backend for the `run` subcommand (gist
 /// Fix 2).
 ///
-/// Mirrors the GPU init path in [`cmd_serve`]: it builds a
-/// bounded [`GpuExpertCache`] and initialises a
-/// [`BackendBox`](crate::backend::BackendBox) before the default CPU
-/// backend claims the `OnceLock`. On any failure — no GPU device or a
-/// `set_backend` race — it falls back to
-/// [`install_default`](crate::backend::install_default) with a
-/// warning so the benchmark still runs on CPU.
-/// Install the GPU compute backend for an explicit `run --gpu` request.
+/// Builds a bounded [`GpuExpertCache`], resolves one execution context, and
+/// installs that same context for the engine to consume. `run --gpu` is an
+/// explicit request, so initialization or installation failure is fatal.
 ///
-/// Finding 5 (fail-closed GPU): `--gpu` is an explicit request, so both GPU
-/// initialisation failure and backend-installation failure are fatal. We never
-/// silently continue on CPU — that would produce a "GPU" benchmark measuring
-/// the CPU path. Operators who want best-effort GPU with CPU fallback use the
-/// serving `compute_offload = "auto"` path instead.
+/// Finding 5 (fail-closed GPU initialization): `--gpu` is an explicit request,
+/// so both GPU initialisation failure and backend-installation failure are
+/// fatal. Legacy deterministic expert compatibility bypass remains represented
+/// by the resolved component plan. Operators who want best-effort GPU
+/// initialization with CPU fallback use serving `compute_offload = "auto"`.
 fn install_run_gpu_backend(
     gpu_cache_mb: usize,
-) -> Result<Option<Arc<crate::expert_cache::GpuExpertCache>>, Box<dyn std::error::Error>> {
+    routed_expert_gpu_spec: crate::backend::RoutedExpertGpuSpec,
+) -> Result<Arc<crate::backend::ExecutionContext>, Box<dyn std::error::Error>> {
+    if gpu_cache_mb == 0 {
+        return Err(
+            "explicit run --gpu requires --gpu-cache-mb > 0 so routed experts can execute on GPU"
+                .into(),
+        );
+    }
     // The KV-cache geometry below only sizes the dense-backbone cache,
     // which the synthetic `run` benchmark does not exercise — it routes
     // everything through `expert_matmul`.
@@ -1966,43 +1960,36 @@ fn install_run_gpu_backend(
         0.5,
         16,
     ));
-    let backend_box = crate::backend::BackendBox::init_blocking(
-        1, // num_layers
-        1, // max_seq_len
-        1, // num_heads
-        1, // num_kv_heads
-        1, // head_dim
-        1, // v_head_dim
+    let execution_context = crate::backend::resolve_execution_context(
+        crate::backend::ComputeOffload::Gpu,
+        false,
+        crate::backend::GpuBackendGeometry {
+            num_layers: 1,
+            max_seq_len: 1,
+            num_heads: 1,
+            num_kv_heads: 1,
+            head_dim: 1,
+            v_head_dim: 1,
+            q4_truncation_tolerance: 0,
+        },
+        routed_expert_gpu_spec,
         gpu_expert_cache.clone(),
-        // The synthetic GPU tool path never serves real checkpoints;
-        // strict payload sizing (tolerance 0) always applies here.
-        0,
-    );
-    if !backend_box.is_gpu() {
-        return Err(
-            "explicit --gpu request failed: GPU backend initialization did not \
-                    produce a GPU device; refusing to run on CPU (use serving \
-                    compute_offload = \"auto\" for best-effort GPU with CPU fallback)"
-                .into(),
-        );
-    }
-    let device_name = backend_box.device_name().to_string();
-    let compute_plane = backend_box.compute_plane().to_string();
-    let gpu = std::sync::Arc::new(backend_box);
-    if let Err(e) = crate::backend::set_backend(gpu) {
-        return Err(format!(
-            "explicit --gpu request failed: GPU backend installation failed ({e}); \
-             refusing to run on CPU"
-        )
-        .into());
-    }
+    )
+    .map_err(|e| format!("explicit --gpu request failed: {e}"))?;
+    let backend = execution_context.primary_backend();
+    let device_name = backend.device_name().to_string();
+    let compute_plane = backend.compute_plane().to_string();
+    crate::backend::set_execution_context(execution_context.clone())
+        .map_err(|e| format!("explicit --gpu request failed: context installation failed ({e})"))?;
     info!(
         device = device_name,
         compute_plane,
+        routed_expert_plane = execution_context.plan().routed_experts().as_str(),
+        context_id = %execution_context.id(),
         vram_capacity_mb = gpu_cache_mb,
-        "GpuBackend installed for run benchmark"
+        "GPU execution context installed for run benchmark"
     );
-    Ok(Some(gpu_expert_cache))
+    Ok(execution_context)
 }
 
 /// **Tier 2.** Attach a packed expert blob to `storage` when both the blob
@@ -3481,7 +3468,7 @@ async fn build_bench_real_runtime(
     );
     let router = crate::gating::Router::Linear(Arc::new(model.layers[0].gate.clone()));
     let metrics = Metrics::new();
-    let mut engine_builder = Engine::with_options(
+    let mut engine_builder = Engine::with_options_and_execution_context(
         cache,
         pool,
         storage,
@@ -3509,6 +3496,7 @@ async fn build_bench_real_runtime(
             collect_route_profile: false,
             policy: cfg.real_transformer.inference_policy(),
         },
+        crate::backend::current_execution_context(),
     );
     engine_builder = engine_builder.with_pipeline_depth(cfg.storage.pipeline_depth);
     if cfg.predictive.locality_enabled {
@@ -4430,20 +4418,14 @@ async fn cmd_serve(config_path: PathBuf) -> Result<(), Box<dyn std::error::Error
         "loaded server config"
     );
 
-    // Hybrid compute offload (gist Part 2, fix #6). Selects which
-    // `Backend` instance owns the dense transformer body; runs
-    // *before* `install_default` so the OnceLock keeps our pointer.
-    // The startup log below reports the actual device runtime
-    // (`cpu-fallback` / `cuda-0` / `wgpu-vulkan`) as `GpuBackend::name`
-    // surfaces it — no more stale hardcoded `"gpu-fallback"` strings.
+    // Resolve requested mode once into the authoritative component plan and
+    // backend context before constructing the model or engine.
     //
     // The GPU expert cache is constructed up-front so the same `Arc`
     // can be threaded into both `GpuBackend` (which checks VRAM
     // residency before falling back to NVMe streaming) and
-    // `Engine::install_gpu_cache` further below. When
-    // `[gpu_cache].enabled = false` we still allocate a zero-capacity
-    // cache to satisfy the `BackendBox::init_blocking` signature —
-    // the cache simply never promotes anything in that mode.
+    // `Engine::install_gpu_cache` further below. When `[gpu_cache].enabled =
+    // false` the zero-capacity cache never promotes anything.
     let gpu_expert_cache = {
         let capacity_bytes = if cfg.gpu_cache.enabled {
             (cfg.gpu_cache.vram_capacity_mb as usize) * 1024 * 1024
@@ -4456,7 +4438,6 @@ async fn cmd_serve(config_path: PathBuf) -> Result<(), Box<dyn std::error::Error
             cfg.gpu_cache.promote_after_hits,
         ))
     };
-    let mut backend_fallback_occurred = false;
     // Strict attention numerics (the production default) can only be
     // validated on the checked CPU softmax path, so backend resolution is
     // strictness-aware (hardening pass, strict GPU behaviour): an explicit
@@ -4468,151 +4449,72 @@ async fn cmd_serve(config_path: PathBuf) -> Result<(), Box<dyn std::error::Error
             .real_transformer
             .inference_policy()
             .allow_nonfinite_attention_fallback;
-    let mut backend_attention_plane: &'static str = "cpu";
-    let mut backend_expert_plane: &'static str = "cpu";
-    if matches!(
-        cfg.real_transformer.compute_offload,
-        crate::backend::ComputeOffload::Gpu
-            | crate::backend::ComputeOffload::Auto
-            | crate::backend::ComputeOffload::Hybrid
-    ) {
-        // Resolve the request *before* touching the device so unsupported
-        // combinations (explicit gpu + strict numerics, hybrid + legacy
-        // attention fallback) fail startup without a partial init, and
-        // `auto` under strict numerics skips GPU init entirely.
-        let precheck = crate::backend::resolve_backend_selection_with_numerics(
-            cfg.real_transformer.compute_offload,
-            strict_attention,
-            || Ok(()),
-        )?;
-        if !precheck.install_gpu_backend() {
-            // `auto` resolved to CPU under strict numerics: record why and
-            // keep the CPU backend (never report GPU while strict
-            // attention runs on CPU).
-            if let Some(reason) = precheck.reason.as_deref() {
-                info!(
-                    requested = ?precheck.requested,
-                    resolved = ?precheck.resolved,
-                    reason,
-                    "compute backend resolved to CPU"
-                );
-            }
+    let num_heads = cfg.real_transformer.num_heads;
+    let head_dim = if cfg.real_transformer.head_dim == 0 {
+        if num_heads > 0 {
+            cfg.model.d_model / num_heads
         } else {
-            let num_layers = cfg.model.num_layers;
-            let max_seq_len = if cfg.real_transformer.window_size == 0 {
+            64
+        }
+    } else {
+        cfg.real_transformer.head_dim
+    };
+    let execution_context = crate::backend::resolve_execution_context(
+        cfg.real_transformer.compute_offload,
+        strict_attention,
+        crate::backend::GpuBackendGeometry {
+            num_layers: cfg.model.num_layers,
+            max_seq_len: if cfg.real_transformer.window_size == 0 {
                 4096
             } else {
                 cfg.real_transformer.window_size
-            };
-            let num_heads = cfg.real_transformer.num_heads;
-            let num_kv_heads = if cfg.real_transformer.num_kv_heads == 0 {
-                num_heads
-            } else {
-                cfg.real_transformer.num_kv_heads
-            };
-            let head_dim = if cfg.real_transformer.head_dim == 0 {
-                if num_heads > 0 {
-                    cfg.model.d_model / num_heads
-                } else {
-                    64
-                }
-            } else {
-                cfg.real_transformer.head_dim
-            };
-            let backend_box = crate::backend::BackendBox::init_blocking(
-                num_layers,
-                max_seq_len,
-                num_heads,
-                num_kv_heads,
-                head_dim,
-                // Finding 12: the run path does not surface an asymmetric
-                // `v_head_dim` here; pass 0 (auto → head_dim). Asymmetric-V
-                // models force the CPU attention path via the eligibility guard
-                // in transformer.rs, so the symmetric GPU sizing is never used
-                // for them.
-                0,
-                gpu_expert_cache.clone(),
-                cfg.real_transformer
-                    .inference_policy()
-                    .expert_size_tolerance(),
-            );
-            let has_device = backend_box.is_gpu();
-            // Reconcile the operator's request with the observed init result
-            // (Finding 5). An explicit `gpu`/`hybrid` request fails closed;
-            // `auto` demotes to CPU and records a fallback. `is_gpu()` is the
-            // signal because `init_blocking` internally swallows GPU errors
-            // and returns a CPU backend.
-            let resolution = crate::backend::resolve_backend_selection_with_numerics(
-                cfg.real_transformer.compute_offload,
-                strict_attention,
-                || {
-                    if has_device {
-                        Ok(())
-                    } else {
-                        Err("GPU backend initialization did not produce a GPU device".to_string())
-                    }
-                },
-            )?;
-            backend_fallback_occurred = resolution.fallback_occurred;
-            let device_name = backend_box.device_name().to_string();
-            let compute_plane = backend_box.compute_plane().to_string();
-            if resolution.fallback_occurred {
-                warn!(
-                    requested = ?resolution.requested,
-                    resolved = ?resolution.resolved,
-                    reason = resolution.reason.as_deref().unwrap_or(""),
-                    "compute_offload = \"auto\": GPU initialization failed; resolved to CPU"
-                );
-            }
-            if resolution.install_gpu_backend() {
-                let gpu = std::sync::Arc::new(backend_box);
-                if let Err(e) = crate::backend::set_backend(gpu) {
-                    // Finding 5 (fail-closed GPU): installation failure is fatal for an
-                    // explicit `gpu`/`hybrid` request — we must never silently continue
-                    // on CPU. Under `auto` it is a recorded fallback instead.
-                    if matches!(
-                        resolution.requested,
-                        crate::backend::ComputeOffload::Gpu
-                            | crate::backend::ComputeOffload::Hybrid
-                    ) {
-                        return Err(format!(
-                            "explicit compute_offload = {:?}: GpuBackend installation failed \
-                             ({e}); refusing to fall back to CPU",
-                            resolution.requested
-                        )
-                        .into());
-                    }
-                    backend_fallback_occurred = true;
-                    warn!(
-                        error = e,
-                        "compute_offload = \"auto\": GpuBackend installation failed; falling back to CPU"
-                    );
-                } else {
-                    backend_attention_plane = resolution.attention_plane();
-                    backend_expert_plane = resolution.expert_plane();
-                    info!(
-                        device = device_name,
-                        compute_plane,
-                        has_device,
-                        requested = ?resolution.requested,
-                        resolved = ?resolution.resolved,
-                        attention_plane = backend_attention_plane,
-                        expert_plane = backend_expert_plane,
-                        reason = resolution.reason.as_deref().unwrap_or(""),
-                        "math backend installed for dense backbone"
-                    );
-                }
-            }
-        }
-    }
-    crate::backend::install_default();
+            },
+            num_heads,
+            num_kv_heads: cfg.real_transformer.num_kv_heads,
+            head_dim,
+            // Finding 12: asymmetric-V models keep the CPU attention path;
+            // zero retains the existing symmetric GPU sizing contract.
+            v_head_dim: 0,
+            q4_truncation_tolerance: cfg
+                .real_transformer
+                .inference_policy()
+                .expert_size_tolerance(),
+        },
+        crate::backend::RoutedExpertGpuSpec {
+            dtype: cfg.model.dtype,
+            d_model: cfg.model.d_model,
+            d_ff: cfg.model.d_ff,
+        },
+        gpu_expert_cache.clone(),
+    )?;
+    crate::backend::set_execution_context(execution_context.clone())
+        .map_err(|e| format!("failed to install resolved execution context: {e}"))?;
     {
-        let b = crate::backend::current();
+        let plan = execution_context.plan();
+        let backend = execution_context.primary_backend();
+        if plan.fallback_occurred() {
+            warn!(
+                requested = ?plan.requested(),
+                resolved = ?plan.resolved(),
+                reason = plan.reason().unwrap_or(""),
+                "compute_offload = \"auto\": GPU initialization failed; resolved to CPU"
+            );
+        }
         info!(
-            backend = b.device_name(),
-            compute_plane = b.compute_plane(),
-            compute_offload = ?cfg.real_transformer.compute_offload,
-            "math backend installed"
+            context_id = %execution_context.id(),
+            backend = backend.device_name(),
+            compute_plane = backend.compute_plane(),
+            requested = ?plan.requested(),
+            resolved = ?plan.resolved(),
+            embeddings_plane = plan.embeddings().as_str(),
+            lm_head_plane = plan.lm_head().as_str(),
+            dense_projections_plane = plan.dense_projections().as_str(),
+            attention_plane = plan.attention().as_str(),
+            kv_plane = plan.kv().as_str(),
+            router_plane = plan.router().as_str(),
+            expert_plane = plan.routed_experts().as_str(),
+            reason = plan.reason().unwrap_or(""),
+            "resolved execution context installed"
         );
     }
 
@@ -4927,16 +4829,8 @@ async fn cmd_serve(config_path: PathBuf) -> Result<(), Box<dyn std::error::Error
     };
 
     let metrics = Metrics::new();
-    // Surface any auto GPU->CPU demotion decided above now that metrics
-    // exist (Finding 5).
-    if backend_fallback_occurred {
-        metrics.record_gpu_cpu_fallback(1);
-    }
-    // Per-component compute planes (hardening pass, strict GPU
-    // behaviour): make an intentional hybrid split (checked CPU
-    // attention + GPU experts) observable in /metrics.
-    metrics.set_backend_component_planes(backend_attention_plane, backend_expert_plane);
-    let mut engine_builder = Engine::with_options(
+    metrics.set_backend_component_planes(execution_context.plan());
+    let mut engine_builder = Engine::with_options_and_execution_context(
         cache,
         pool,
         storage,
@@ -4964,6 +4858,7 @@ async fn cmd_serve(config_path: PathBuf) -> Result<(), Box<dyn std::error::Error
             collect_route_profile: false,
             policy: cfg.real_transformer.inference_policy(),
         },
+        execution_context.clone(),
     );
     // Apply the configured look-ahead pipeline depth (`[storage]
     // pipeline_depth`). Controls how many layers ahead
@@ -5076,7 +4971,7 @@ async fn cmd_serve(config_path: PathBuf) -> Result<(), Box<dyn std::error::Error
             dtype_advisory = %dtype_for_logging.as_str(),
             "VRAM (GPU) expert cache enabled — 3-tier SSD→RAM→VRAM hierarchy active (dtype is advisory; bytes copied as-is)"
         );
-        engine_builder.install_gpu_cache(gpu_expert_cache.clone());
+        engine_builder.install_gpu_cache();
     }
     let engine = Arc::new(engine_builder.with_metrics(metrics.clone()));
 
@@ -5657,7 +5552,7 @@ struct RunArgs {
     router_matrix: Option<PathBuf>,
     gate_weights: Option<PathBuf>,
     trace_out: Option<PathBuf>,
-    gpu_expert_cache: Option<Arc<crate::expert_cache::GpuExpertCache>>,
+    gpu_cache_mb: Option<usize>,
     pipeline_depth: u32,
     speculator: bool,
     speculator_hidden_dim: usize,
@@ -5698,6 +5593,19 @@ async fn cmd_run(
     //    detect "user didn't override" by comparing against clap defaults
     //    — anyone who actually passes a flag overrides the metadata.
     apply_metadata_if_present(&mut args);
+
+    let execution_context = if let Some(gpu_cache_mb) = args.gpu_cache_mb {
+        install_run_gpu_backend(
+            gpu_cache_mb,
+            crate::backend::RoutedExpertGpuSpec {
+                dtype: args.dtype,
+                d_model: args.d_model,
+                d_ff: args.d_ff,
+            },
+        )?
+    } else {
+        crate::backend::current_execution_context()
+    };
 
     let weight_bytes = expert_weight_bytes_for(args.d_model, args.d_ff, args.dtype);
     let reported_weight_bytes = if args.dtype == crate::inference::WeightDtype::Mixed {
@@ -6033,7 +5941,7 @@ async fn cmd_run(
     ));
 
     let engine = Arc::new({
-        let mut base = Engine::with_options(
+        let mut base = Engine::with_options_and_execution_context(
             cache.clone(),
             pool.clone(),
             storage.clone(),
@@ -6067,9 +5975,10 @@ async fn cmd_run(
                     ..crate::inference::RealInferencePolicy::STRICT
                 },
             },
+            execution_context.clone(),
         );
-        if let Some(gpu_cache) = args.gpu_expert_cache.clone() {
-            base.install_gpu_cache(gpu_cache);
+        if execution_context.plan().routed_experts() == crate::backend::ExecutionPlane::Gpu {
+            base.install_gpu_cache();
         }
         // Apply the configured look-ahead pipeline depth (sized in tandem
         // with the shadow buffer-pool budget above). No-op for the legacy

--- a/rust-engine/src/metrics.rs
+++ b/rust-engine/src/metrics.rs
@@ -113,10 +113,11 @@ struct MetricsInner {
     pub nonfinite_softmax_fallbacks: IntGauge,
     /// **Gauge** of the resolved per-component compute plane
     /// (hardening pass, strict GPU behaviour). Labels: `component`
-    /// (`attention` / `experts`) and `plane` (`cpu` / `gpu`); the active
+    /// (`embeddings`, `lm_head`, `dense_projections`, `attention`, `kv`,
+    /// `router`, or `experts`) and `plane` (`cpu` / `gpu`); the active
     /// combination is set to `1`. Makes an intentional hybrid split
-    /// (checked CPU attention + GPU experts) observable instead of a
-    /// single ambiguous "gpu" device string.
+    /// observable instead of collapsing execution into one ambiguous device
+    /// string.
     pub backend_component_plane: IntGaugeVec,
     pub resident_expert_buffer_bytes: IntGauge,
     pub expert_buffer_pool_allocated_bytes: IntGauge,
@@ -315,7 +316,7 @@ impl Metrics {
         .expect("metric registration: mer_nonfinite_softmax_fallbacks");
         let backend_component_plane = register_int_gauge_vec_with_registry!(
             "mer_backend_component_plane",
-            "Resolved compute plane per model component (1 = active). Components: attention, experts; planes: cpu, gpu.",
+            "Resolved compute plane per model component (1 = active). Components: embeddings, lm_head, dense_projections, attention, kv, router, experts; planes: cpu, gpu.",
             &["component", "plane"],
             registry
         )
@@ -548,13 +549,13 @@ impl Metrics {
     /// startup after backend resolution). Sets the active
     /// `{component, plane}` combinations to `1` and the inactive plane
     /// of each component to `0`.
-    pub fn set_backend_component_planes(&self, attention_plane: &str, expert_plane: &str) {
-        for (component, plane) in [("attention", attention_plane), ("experts", expert_plane)] {
+    pub fn set_backend_component_planes(&self, plan: &crate::backend::ResolvedExecutionPlan) {
+        for (component, plane) in plan.component_planes() {
             for candidate in ["cpu", "gpu"] {
                 self.inner
                     .backend_component_plane
                     .with_label_values(&[component, candidate])
-                    .set(i64::from(candidate == plane));
+                    .set(i64::from(candidate == plane.as_str()));
             }
         }
     }
@@ -663,8 +664,34 @@ mod tests {
     #[test]
     fn backend_component_plane_gauge_reports_resolved_planes() {
         let m = Metrics::new();
-        // Hybrid: checked CPU attention + GPU experts.
-        m.set_backend_component_planes("cpu", "gpu");
+        let geometry = crate::backend::GpuBackendGeometry {
+            num_layers: 1,
+            max_seq_len: 1,
+            num_heads: 1,
+            num_kv_heads: 1,
+            head_dim: 1,
+            v_head_dim: 1,
+            q4_truncation_tolerance: 0,
+        };
+        // Hybrid: all named components stay on CPU except routed experts.
+        let hybrid = crate::backend::resolve_execution_context_with(
+            crate::backend::ComputeOffload::Hybrid,
+            true,
+            geometry,
+            crate::backend::RoutedExpertGpuSpec {
+                dtype: crate::inference::WeightDtype::F32,
+                d_model: 32,
+                d_ff: 64,
+            },
+            std::sync::Arc::new(crate::expert_cache::GpuExpertCache::new(1024, 0.5, 16)),
+            |_| {
+                Ok(std::sync::Arc::new(crate::backend::BackendBox::TestGpu(
+                    crate::backend::CandleBackend::new(),
+                )))
+            },
+        )
+        .unwrap();
+        m.set_backend_component_planes(hybrid.plan());
         let body = String::from_utf8(m.render().unwrap()).unwrap();
         let want_one = [
             r#"mer_backend_component_plane{component="attention",plane="cpu"} 1"#,
@@ -675,17 +702,56 @@ mod tests {
             r#"mer_backend_component_plane{component="experts",plane="cpu"} 0"#,
         ];
         for needle in want_one.iter().chain(&want_zero) {
-            assert!(body.contains(needle), "missing {needle} in:
-{body}");
+            assert!(
+                body.contains(needle),
+                "missing {needle} in:
+{body}"
+            );
         }
-        // Re-resolution to full CPU flips both components.
-        m.set_backend_component_planes("cpu", "cpu");
+        for component in ["embeddings", "lm_head", "dense_projections", "kv", "router"] {
+            assert!(body.contains(&format!(
+                "mer_backend_component_plane{{component=\"{component}\",plane=\"cpu\"}} 1"
+            )));
+        }
+        // A CPU plan flips expert reporting without re-reading config flags.
+        let cpu = crate::backend::cpu_execution_context();
+        m.set_backend_component_planes(cpu.plan());
         let body = String::from_utf8(m.render().unwrap()).unwrap();
+        assert!(body.contains(r#"mer_backend_component_plane{component="experts",plane="cpu"} 1"#));
+        assert!(body.contains(r#"mer_backend_component_plane{component="experts",plane="gpu"} 0"#));
+    }
+
+    #[test]
+    fn startup_auto_fallback_does_not_increment_runtime_expert_fallback_counter() {
+        let context = crate::backend::resolve_execution_context_with(
+            crate::backend::ComputeOffload::Auto,
+            false,
+            crate::backend::GpuBackendGeometry {
+                num_layers: 1,
+                max_seq_len: 1,
+                num_heads: 1,
+                num_kv_heads: 1,
+                head_dim: 1,
+                v_head_dim: 1,
+                q4_truncation_tolerance: 0,
+            },
+            crate::backend::RoutedExpertGpuSpec {
+                dtype: crate::inference::WeightDtype::F32,
+                d_model: 32,
+                d_ff: 64,
+            },
+            std::sync::Arc::new(crate::expert_cache::GpuExpertCache::new(1024, 0.5, 16)),
+            |_| Err("no compatible adapter".to_string()),
+        )
+        .unwrap();
+        assert!(context.plan().fallback_occurred());
+
+        let metrics = Metrics::new();
+        metrics.set_backend_component_planes(context.plan());
+        let body = String::from_utf8(metrics.render().unwrap()).unwrap();
+        assert!(body.contains("mer_gpu_cpu_fallbacks_total 0"));
         assert!(body.contains(
             r#"mer_backend_component_plane{component="experts",plane="cpu"} 1"#
-        ));
-        assert!(body.contains(
-            r#"mer_backend_component_plane{component="experts",plane="gpu"} 0"#
         ));
     }
 

--- a/rust-engine/src/model.rs
+++ b/rust-engine/src/model.rs
@@ -2616,7 +2616,7 @@ impl RealModel {
             crate::stage_timing::time_optional(timings, crate::stage_timing::EMBEDDING, || {
                 self.try_embed(token_id)
             })?;
-        let backend = crate::backend::current();
+        let backend = engine.execution_context().attention_backend();
         let mut layer_scratch = crate::transformer::TransformerLayerScratch::new();
         let mut next_x = Vec::with_capacity(self.config.d_model);
         // Fail-closed numerical propagation (hardening pass, A3
@@ -2644,7 +2644,7 @@ impl RealModel {
                         pos,
                         layer_idx,
                         &mut kv[layer_idx],
-                        &*backend,
+                        &**backend,
                         &mut layer_scratch,
                         &mut next_x,
                         timings,
@@ -2662,7 +2662,7 @@ impl RealModel {
                     pos,
                     layer_idx,
                     &mut kv[layer_idx],
-                    &*backend,
+                    &**backend,
                     &mut layer_scratch,
                     &mut next_x,
                     timings,

--- a/rust-engine/src/server.rs
+++ b/rust-engine/src/server.rs
@@ -2104,7 +2104,7 @@ pub async fn run_engine_warmup(state: &AppState) {
             }
         }
         // JIT-warm the math backend kernels regardless.
-        let backend = crate::backend::current();
+        let backend = state.engine.execution_context().routed_expert_backend();
         let gate_f16 = vec![half::f16::from_f32(0.1); 16];
         let up_f16 = vec![half::f16::from_f32(0.2); 16];
         let mut out_f16 = vec![half::f16::ZERO; 16];


### PR DESCRIPTION
## Summary

Introduces one authoritative resolved execution plan and execution context for MER's CPU, GPU, Auto, and Hybrid compute modes.

Previously, startup backend resolution, the real model, and the engine's private expert backend could diverge. This PR resolves execution once and injects the same immutable context into runtime consumers and reporting.

## What changed

- Added `ResolvedExecutionPlan` with explicit execution planes for:
  - embeddings
  - LM head
  - dense projections
  - attention
  - KV
  - router
  - routed experts
- Added `ExecutionContext`, owning:
  - the immutable resolved plan
  - CPU backend
  - optional sole GPU backend
  - exact GPU expert-cache `Arc`
- Removed independent GPU backend construction from `Engine`.
- Real-model attention now consumes the backend selected by the same execution context.
- Engine routed-expert dispatch consumes the same context.
- Component-plane metrics now derive from the resolved plan instead of reinterpreting config.
- Hybrid explicitly resolves to:
  - CPU embeddings
  - CPU LM head
  - CPU dense projections
  - CPU attention
  - CPU KV
  - CPU router
  - GPU routed experts

## Fail-closed behavior

Explicit GPU/Hybrid initialization remains fail-closed.

Hybrid additionally fails before GPU initialization when:

- no executable GPU expert cache exists
- routed-expert dtype is unsupported by the current GPU path
- Q4_0 expert geometry is not block-aligned

The routed-expert GPU compatibility rule is centralized and shared by resolution and engine execution.

Currently supported routed-expert GPU formats are:

- F32
- Q4_0 when `d_model` and `d_ff` are block-aligned

Legacy GPU/Auto modes report routed experts as CPU when the expert path is deterministically incompatible rather than falsely reporting GPU execution.

## Auto fallback metrics

Auto GPU initialization failure remains represented by the resolved plan, startup logging, requested/resolved mode, reason, and component-plane metrics.

It does **not** increment `mer_gpu_cpu_fallbacks_total`, which remains reserved for actual runtime expert GPU-dispatch fallback.

## CPU compatibility

Existing CPU behavior and `bench-real` CPU-only policy are preserved.

## Validation

Local validation at:

f2ecf633e4ab831af6586cb3fd2c0b2dfc7ad30f


- backend tests: 36 passed
- focused Engine context identity test: passed
- metrics tests: 5 passed
- bench-real tests: 10 passed
- shared serve/bench-real validation: passed
- full suite: 818 passed, 0 failed, 2 ignored
- `cargo clippy --all-targets`: passed with existing repository warnings
- `git diff --check`: passed

## Scope

This PR intentionally does not implement:

- PR3 runtime GPU expert fail-closed dispatch
- physical VRAM residency/accounting redesign
- strict Hybrid benchmark schema
- GPU attention/KV migration
- batched top-k GPU execution
- CUDA backend redesign
- scheduler/predictor changes
- performance tuning

Hybrid's current GPU backend still allocates GPU KV resources even though the resolved Hybrid KV execution plane is CPU. That physical-resource inefficiency is explicitly deferred; it does not change the execution plan or runtime component authority established here.

No live GPU execution or performance claim is made by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added centralized CPU, GPU, and hybrid execution planning.
  * Added GPU geometry and routed-expert compatibility validation.
  * Added shared execution contexts for consistent backend and cache selection.
  * Expanded metrics to show CPU/GPU placement for model components, including attention, KV cache, routing, and experts.

* **Bug Fixes**
  * Improved GPU fallback behavior for unsupported configurations.
  * Prevented incompatible expert formats from using unsupported GPU paths.
  * Ensured runtime components consistently follow the resolved execution plan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->