### PR TITLE
feat: add strict routed-expert GPU dispatch policy

### DIFF
--- a/rust-engine/src/backend/mod.rs
+++ b/rust-engine/src/backend/mod.rs
@@ -3,7 +3,7 @@
 use anyhow::{anyhow, Result};
 use parking_lot::Mutex as ParkingMutex;
 use std::fmt;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::sync::OnceLock;
 
@@ -200,6 +200,76 @@ pub struct TensorViewMut<'a> {
     pub rows: usize,
     pub cols: usize,
 }
+
+/// Failure stage for one routed-expert GPU activation.
+///
+/// `wgpu` 0.20 exposes buffer-map results and a device-loss callback, but
+/// `Queue::submit` itself returns only a submission index. Validation and
+/// submission therefore remain typed boundaries that hardware-independent
+/// tests can inject; production does not claim synchronous detection where
+/// the API cannot attribute an error to one concurrent expert dispatch.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GpuExpertDispatchErrorKind {
+    ResidencyMiss,
+    Upload,
+    #[allow(dead_code)] // wgpu 0.20 has no per-dispatch synchronous validation result.
+    ValidationDispatch,
+    #[allow(dead_code)] // Queue::submit returns only a SubmissionIndex in wgpu 0.20.
+    Submission,
+    ReadbackChannel,
+    ReadbackMap,
+    DeviceLost,
+    RuntimeInvariant,
+}
+
+impl fmt::Display for GpuExpertDispatchErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match self {
+            Self::ResidencyMiss => "residency-miss",
+            Self::Upload => "upload",
+            Self::ValidationDispatch => "validation-dispatch",
+            Self::Submission => "submission",
+            Self::ReadbackChannel => "readback-channel",
+            Self::ReadbackMap => "readback-map",
+            Self::DeviceLost => "device-lost",
+            Self::RuntimeInvariant => "runtime-invariant",
+        };
+        f.write_str(name)
+    }
+}
+
+/// Typed boundary between GPU routed-expert execution and the engine's
+/// strict-vs-serving recovery policy.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GpuExpertDispatchError {
+    pub layer: u32,
+    pub expert_id: u32,
+    pub kind: GpuExpertDispatchErrorKind,
+    pub detail: String,
+}
+
+impl GpuExpertDispatchError {
+    pub(crate) fn new(
+        layer: u32,
+        expert_id: u32,
+        kind: GpuExpertDispatchErrorKind,
+        detail: impl Into<String>,
+    ) -> Self {
+        Self { layer, expert_id, kind, detail: detail.into() }
+    }
+}
+
+impl fmt::Display for GpuExpertDispatchError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "GPU routed expert {} (layer {}) failed at {}: {}",
+            self.expert_id, self.layer, self.kind, self.detail
+        )
+    }
+}
+
+impl std::error::Error for GpuExpertDispatchError {}
 
 /// Abstraction over GPU-resident storage for expert weight buffers.
 ///
@@ -487,9 +557,38 @@ struct ExpertWorkspace {
     scratch: Vec<f32>,
 }
 
+#[derive(Default)]
+struct DeviceLossState {
+    lost: AtomicBool,
+    detail: ParkingMutex<Option<String>>,
+}
+
+impl DeviceLossState {
+    fn record(&self, reason: wgpu::DeviceLostReason, message: String) {
+        *self.detail.lock() = Some(format!("{reason:?}: {message}"));
+        self.lost.store(true, Ordering::Release);
+    }
+
+    fn detail(&self) -> Option<String> {
+        if self.lost.load(Ordering::Acquire) {
+            Some(
+                self.detail
+                    .lock()
+                    .clone()
+                    .unwrap_or_else(|| "wgpu device-loss callback fired".to_string()),
+            )
+        } else {
+            None
+        }
+    }
+}
+
 pub struct GpuBackend {
     device: wgpu::Device,
     queue: wgpu::Queue,
+    /// `wgpu` 0.20 has no synchronous device-loss return from submit, so
+    /// dispatch checks this per-device callback state at entry and after poll.
+    device_loss: Arc<DeviceLossState>,
     device_name: String,
     compute_plane: String,
 
@@ -754,6 +853,12 @@ impl GpuBackend {
                 unsupported.join(" | ")
             ));
         };
+
+        let device_loss = Arc::new(DeviceLossState::default());
+        let device_loss_callback = device_loss.clone();
+        device.set_device_lost_callback(move |reason, message| {
+            device_loss_callback.record(reason, message);
+        });
 
         let compute_plane = wgpu_compute_plane(info.backend);
         let device_name = format!("{}-{}", compute_plane, info.name);
@@ -1087,6 +1192,7 @@ impl GpuBackend {
         Ok(Self {
             device,
             queue,
+            device_loss,
             device_name,
             compute_plane,
             matmul_pipeline,
@@ -1337,12 +1443,14 @@ impl GpuBackend {
     /// encode and submit.
     fn expert_matmul_from_vram(
         &self,
+        layer:  u32,
+        expert_id: u32,
         entry: &VramExpertEntry,
         x:     TensorView<'_>,
         out:   &mut TensorViewMut<'_>,
-    ) -> Result<()> {
+    ) -> std::result::Result<(), GpuExpertDispatchError> {
         let mut ws = self.acquire_expert_workspace();
-        let result = self.expert_ffn_dispatch(entry, x, out, &mut ws);
+        let result = self.expert_ffn_dispatch(layer, expert_id, entry, x, out, &mut ws);
         // Always return the workspace — including on error paths — or
         // the pool would leak a slot per failed dispatch.
         self.release_expert_workspace(ws);
@@ -1351,23 +1459,46 @@ impl GpuBackend {
 
     fn expert_ffn_dispatch(
         &self,
+        layer:  u32,
+        expert_id: u32,
         entry: &VramExpertEntry,
         x:     TensorView<'_>,
         out:   &mut TensorViewMut<'_>,
         ws:    &mut ExpertWorkspace,
-    ) -> Result<()> {
+    ) -> std::result::Result<(), GpuExpertDispatchError> {
         use std::num::NonZeroU64;
 
         let d_model = entry.d_model;
         let d_ff    = entry.d_ff;
 
-        debug_assert_eq!(x.data.len(),   d_model);
-        debug_assert_eq!(out.data.len(), d_model);
+        if let Some(detail) = self.device_loss.detail() {
+            return Err(GpuExpertDispatchError::new(
+                layer, expert_id, GpuExpertDispatchErrorKind::DeviceLost, detail,
+            ));
+        }
+        if x.data.len() != d_model || out.data.len() != d_model {
+            return Err(GpuExpertDispatchError::new(
+                layer,
+                expert_id,
+                GpuExpertDispatchErrorKind::RuntimeInvariant,
+                format!(
+                    "dispatch buffers disagree with resident geometry: x={} out={} d_model={d_model}",
+                    x.data.len(), out.data.len()
+                ),
+            ));
+        }
 
         // ── Upload x to the workspace's private x_buf ─────────────────────────
         // Per-workspace scratch: no contention with other dispatches or
         // with the dense ops' backend-global conversion scratch.
-        assert!(d_model <= ws.scratch.len());
+        if d_model > ws.scratch.len() {
+            return Err(GpuExpertDispatchError::new(
+                layer,
+                expert_id,
+                GpuExpertDispatchErrorKind::RuntimeInvariant,
+                format!("d_model {d_model} exceeds GPU expert workspace {}", ws.scratch.len()),
+            ));
+        }
         for i in 0..d_model {
             ws.scratch[i] = x.data[i].to_f32();
         }
@@ -1542,9 +1673,25 @@ impl GpuBackend {
         slice.map_async(wgpu::MapMode::Read, move |res| { let _ = tx.send(res); });
         self.device.poll(wgpu::Maintain::wait_for(submission));
 
+        if let Some(detail) = self.device_loss.detail() {
+            return Err(GpuExpertDispatchError::new(
+                layer, expert_id, GpuExpertDispatchErrorKind::DeviceLost, detail,
+            ));
+        }
+
         rx.recv()
-            .map_err(|e| anyhow::anyhow!("channel error on expert readback: {e:?}"))?
-            .map_err(|e| anyhow::anyhow!("buffer map error on expert readback: {e:?}"))?;
+            .map_err(|e| GpuExpertDispatchError::new(
+                layer,
+                expert_id,
+                GpuExpertDispatchErrorKind::ReadbackChannel,
+                format!("expert readback callback channel failed: {e:?}"),
+            ))?
+            .map_err(|e| GpuExpertDispatchError::new(
+                layer,
+                expert_id,
+                GpuExpertDispatchErrorKind::ReadbackMap,
+                format!("expert readback buffer map failed: {e:?}"),
+            ))?;
 
         {
             use half::slice::HalfFloatSliceExt;
@@ -1915,48 +2062,66 @@ impl Backend for GpuBackend {
         d_ff:     usize,
         out:      &mut TensorViewMut<'_>,
     ) -> Result<()> {
-        use crate::expert_cache::GpuLookup;
-        let _ = layer_idx;
-
-        // ── Fast path: expert weights already VRAM-resident ──────────────────
-        // Clone the Arc handle and release the map lock *before* the
-        // GPU dispatch so concurrent callers can probe / install
-        // other experts while this one executes.
-        let cached_entry = self.vram_expert_bufs.lock().get(&expert_id).cloned();
-        if let Some(entry) = cached_entry {
-            return self.expert_matmul_from_vram(&entry, x, out);
-        }
-
-        // Slow path: evict stale entries whose GpuExpertCache slot was reclaimed.
-        self.vram_expert_bufs
-            .lock()
-            .retain(|id, _| self.gpu_expert_cache.contains(*id));
-
-        // ── Promote from GpuExpertCache bytes → VRAM entry ────────────────────
-        match self.gpu_expert_cache.get(expert_id) {
-            GpuLookup::AnchorHit(r) | GpuLookup::LruHit(r) => {
-                // Native Q4_0 residents go through the inline-dequant
-                // pipeline; everything else is the dense F32 layout.
-                let entry = Arc::new(match r.dtype() {
-                    crate::inference::WeightDtype::Q4_0 => {
-                        self.build_expert_entry_q4_0(r.data(), d_model, d_ff)?
-                    }
-                    _ => self.build_expert_entry(r.data(), d_model, d_ff)?,
-                });
-                self.vram_expert_bufs.lock().insert(expert_id, entry.clone());
-                self.expert_matmul_from_vram(&entry, x, out)
-            }
-            GpuLookup::Miss => {
-                anyhow::bail!(
-                    "expert {} not VRAM-resident; caller must fall back to CPU path",
-                    expert_id
-                )
-            }
-        }
+        let layer = u32::try_from(layer_idx)
+            .map_err(|_| anyhow!("expert layer index {layer_idx} exceeds u32"))?;
+        self.routed_expert_matmul(layer, expert_id, x, d_model, d_ff, out)
+            .map_err(anyhow::Error::new)
     }
 }
 
 impl GpuBackend {
+    fn routed_expert_matmul(
+        &self,
+        layer: u32,
+        expert_id: u32,
+        x: TensorView<'_>,
+        d_model: usize,
+        d_ff: usize,
+        out: &mut TensorViewMut<'_>,
+    ) -> std::result::Result<(), GpuExpertDispatchError> {
+        use crate::expert_cache::GpuLookup;
+
+        if let Some(detail) = self.device_loss.detail() {
+            return Err(GpuExpertDispatchError::new(
+                layer, expert_id, GpuExpertDispatchErrorKind::DeviceLost, detail,
+            ));
+        }
+
+        let cached_entry = self.vram_expert_bufs.lock().get(&expert_id).cloned();
+        if let Some(entry) = cached_entry {
+            return self.expert_matmul_from_vram(layer, expert_id, &entry, x, out);
+        }
+
+        self.vram_expert_bufs
+            .lock()
+            .retain(|id, _| self.gpu_expert_cache.contains(*id));
+
+        match self.gpu_expert_cache.get(expert_id) {
+            GpuLookup::AnchorHit(r) | GpuLookup::LruHit(r) => {
+                // Re-run every PR2 compatibility check at the actual
+                // on-demand allocation/upload boundary.
+                let entry = match r.dtype() {
+                    crate::inference::WeightDtype::Q4_0 => {
+                        self.build_expert_entry_q4_0(r.data(), d_model, d_ff)
+                    }
+                    _ => self.build_expert_entry(r.data(), d_model, d_ff),
+                }
+                .map_err(|e| GpuExpertDispatchError::new(
+                    layer, expert_id, GpuExpertDispatchErrorKind::Upload, e.to_string(),
+                ))?;
+                let entry = Arc::new(entry);
+                self.vram_expert_bufs.lock().insert(expert_id, entry.clone());
+                self.expert_matmul_from_vram(layer, expert_id, &entry, x, out)
+            }
+            GpuLookup::Miss => Err(GpuExpertDispatchError::new(
+                layer,
+                expert_id,
+                GpuExpertDispatchErrorKind::ResidencyMiss,
+                "expert is not present in the GPU expert cache",
+            )),
+        }
+    }
+
     fn compute_plane(&self) -> &str {
         &self.compute_plane
     }
@@ -2113,6 +2278,63 @@ impl Backend for CandleBackend {
     }
 }
 
+/// Hardware-independent routed-expert GPU boundary used only by unit tests.
+#[cfg(test)]
+#[derive(Clone)]
+pub(crate) struct TestGpuBackend {
+    cpu: CandleBackend,
+    outcome: TestGpuExpertOutcome,
+    expert_calls: Arc<AtomicU64>,
+}
+
+#[cfg(test)]
+#[derive(Clone)]
+enum TestGpuExpertOutcome {
+    Success(f32),
+    Failure(GpuExpertDispatchErrorKind),
+}
+
+#[cfg(test)]
+impl TestGpuBackend {
+    pub(crate) fn success(value: f32) -> Self {
+        Self {
+            cpu: CandleBackend::new(),
+            outcome: TestGpuExpertOutcome::Success(value),
+            expert_calls: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    pub(crate) fn failure(kind: GpuExpertDispatchErrorKind) -> Self {
+        Self {
+            cpu: CandleBackend::new(),
+            outcome: TestGpuExpertOutcome::Failure(kind),
+            expert_calls: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    pub(crate) fn expert_calls(&self) -> u64 {
+        self.expert_calls.load(Ordering::Relaxed)
+    }
+
+    fn routed_expert_matmul(
+        &self,
+        layer: u32,
+        expert_id: u32,
+        out: &mut TensorViewMut<'_>,
+    ) -> std::result::Result<(), GpuExpertDispatchError> {
+        self.expert_calls.fetch_add(1, Ordering::Relaxed);
+        match self.outcome {
+            TestGpuExpertOutcome::Success(value) => {
+                out.data.fill(half::f16::from_f32(value));
+                Ok(())
+            }
+            TestGpuExpertOutcome::Failure(kind) => Err(GpuExpertDispatchError::new(
+                layer, expert_id, kind, format!("injected {kind} failure"),
+            )),
+        }
+    }
+}
+
 // =====================================================================
 // BackendBox Dispatch Enum (Zero-cost dispatch, no dyn/vtable)
 // =====================================================================
@@ -2121,7 +2343,7 @@ pub enum BackendBox {
     Gpu(GpuBackend),
     Cpu(CandleBackend),
     #[cfg(test)]
-    TestGpu(CandleBackend),
+    TestGpu(TestGpuBackend),
 }
 
 impl BackendBox {
@@ -2131,6 +2353,31 @@ impl BackendBox {
             BackendBox::Cpu(_) => "cpu-fallback",
             #[cfg(test)]
             BackendBox::TestGpu(_) => "test-gpu",
+        }
+    }
+
+    /// Typed dispatch for real-model routed experts. The legacy trait method
+    /// maps this to anyhow only for synthetic compatibility diagnostics.
+    #[allow(clippy::too_many_arguments)]
+    pub fn routed_expert_matmul(
+        &self,
+        layer: u32,
+        expert_id: u32,
+        x: TensorView<'_>,
+        d_model: usize,
+        d_ff: usize,
+        out: &mut TensorViewMut<'_>,
+    ) -> std::result::Result<(), GpuExpertDispatchError> {
+        match self {
+            Self::Gpu(gpu) => gpu.routed_expert_matmul(layer, expert_id, x, d_model, d_ff, out),
+            Self::Cpu(_) => Err(GpuExpertDispatchError::new(
+                layer,
+                expert_id,
+                GpuExpertDispatchErrorKind::RuntimeInvariant,
+                "resolved GPU routed-expert plan selected a CPU backend",
+            )),
+            #[cfg(test)]
+            Self::TestGpu(gpu) => gpu.routed_expert_matmul(layer, expert_id, out),
         }
     }
 }
@@ -2159,7 +2406,7 @@ impl Backend for BackendBox {
             BackendBox::Gpu(gpu) => gpu.matmul_into(a, b, out),
             BackendBox::Cpu(cpu) => cpu.matmul_into(a, b, out),
             #[cfg(test)]
-            BackendBox::TestGpu(cpu) => cpu.matmul_into(a, b, out),
+            BackendBox::TestGpu(gpu) => gpu.cpu.matmul_into(a, b, out),
         }
     }
 
@@ -2168,7 +2415,7 @@ impl Backend for BackendBox {
             BackendBox::Gpu(gpu) => gpu.swiglu_into(gate, up, out),
             BackendBox::Cpu(cpu) => cpu.swiglu_into(gate, up, out),
             #[cfg(test)]
-            BackendBox::TestGpu(cpu) => cpu.swiglu_into(gate, up, out),
+            BackendBox::TestGpu(gpu) => gpu.cpu.swiglu_into(gate, up, out),
         }
     }
 
@@ -2177,7 +2424,7 @@ impl Backend for BackendBox {
             BackendBox::Gpu(gpu) => gpu.softmax(x),
             BackendBox::Cpu(cpu) => cpu.softmax(x),
             #[cfg(test)]
-            BackendBox::TestGpu(cpu) => cpu.softmax(x),
+            BackendBox::TestGpu(gpu) => gpu.cpu.softmax(x),
         }
     }
 
@@ -2192,7 +2439,7 @@ impl Backend for BackendBox {
             BackendBox::Gpu(gpu) => gpu.kv_cache_insert(layer, position, k, v),
             BackendBox::Cpu(cpu) => cpu.kv_cache_insert(layer, position, k, v),
             #[cfg(test)]
-            BackendBox::TestGpu(cpu) => cpu.kv_cache_insert(layer, position, k, v),
+            BackendBox::TestGpu(gpu) => gpu.cpu.kv_cache_insert(layer, position, k, v),
         }
     }
 
@@ -2207,7 +2454,7 @@ impl Backend for BackendBox {
             BackendBox::Gpu(gpu) => gpu.kv_attend(layer, q, seq_len, out),
             BackendBox::Cpu(cpu) => cpu.kv_attend(layer, q, seq_len, out),
             #[cfg(test)]
-            BackendBox::TestGpu(cpu) => cpu.kv_attend(layer, q, seq_len, out),
+            BackendBox::TestGpu(gpu) => gpu.cpu.kv_attend(layer, q, seq_len, out),
         }
     }
 
@@ -2220,12 +2467,10 @@ impl Backend for BackendBox {
         d_ff:     usize,
         out:      &mut TensorViewMut<'_>,
     ) -> Result<()> {
-        match self {
-            Self::Gpu(g) => g.expert_matmul(layer_idx, expert_id, x, d_model, d_ff, out),
-            Self::Cpu(c) => c.expert_matmul(layer_idx, expert_id, x, d_model, d_ff, out),
-            #[cfg(test)]
-            Self::TestGpu(c) => c.expert_matmul(layer_idx, expert_id, x, d_model, d_ff, out),
-        }
+        let layer = u32::try_from(layer_idx)
+            .map_err(|_| anyhow!("expert layer index {layer_idx} exceeds u32"))?;
+        self.routed_expert_matmul(layer, expert_id, x, d_model, d_ff, out)
+            .map_err(anyhow::Error::new)
     }
 }
 
@@ -3057,6 +3302,33 @@ where
     )
 }
 
+/// Intentionally unchecked context for the one engine invariant regression
+/// proving that a strict GPU plan cannot silently execute through CPU.
+#[cfg(test)]
+pub(crate) fn test_gpu_execution_context_unchecked(
+    routed_expert_backend: Arc<BackendBox>,
+    routed_expert_gpu_spec: RoutedExpertGpuSpec,
+) -> Arc<ExecutionContext> {
+    let context_id = next_execution_context_id();
+    let plan = ResolvedExecutionPlan::from_resolution(
+        BackendResolution {
+            requested: ComputeOffload::Hybrid,
+            resolved: ResolvedBackend::HybridCpuAttentionGpuExperts,
+            fallback_occurred: false,
+            reason: None,
+        },
+        context_id,
+        true,
+        routed_expert_gpu_spec,
+        true,
+    );
+    Arc::new(ExecutionContext::new(
+        plan,
+        Some(routed_expert_backend),
+        Arc::new(crate::expert_cache::GpuExpertCache::new(1024, 0.5, 16)),
+    ))
+}
+
 fn resolve_execution_context_with_device_limits<F>(
     requested: ComputeOffload,
     strict_attention: bool,
@@ -3311,7 +3583,7 @@ mod tests {
     }
 
     fn test_gpu_backend() -> Arc<BackendBox> {
-        Arc::new(BackendBox::TestGpu(CandleBackend::new()))
+        Arc::new(BackendBox::TestGpu(TestGpuBackend::success(1.0)))
     }
 
     fn test_gpu_expert_cache(capacity_bytes: usize) -> Arc<crate::expert_cache::GpuExpertCache> {

--- a/rust-engine/src/engine.rs
+++ b/rust-engine/src/engine.rs
@@ -843,6 +843,10 @@ pub(crate) struct Counters {
     /// miss). Invisible mixed GPU/CPU execution is a major source of
     /// inconsistent token latency, so make it countable.
     gpu_cpu_fallbacks: AtomicU64,
+    /// Hardware-independent CPU routed-expert forward spy. Test-only so the
+    /// public fallback metric keeps its production schema and meaning.
+    #[cfg(test)]
+    cpu_expert_forward_calls: AtomicU64,
 }
 
 /// Shape parameters of the SwiGLU expert FFN executed by the engine.
@@ -882,6 +886,16 @@ pub enum ExpertExecutionPolicy {
     Auto,
     SequentialExpertsRowParallel,
     ParallelExpertsSingleThread,
+}
+
+/// Runtime recovery contract after the authoritative plan selects GPU routed
+/// experts. PR3 keeps this engine-scoped: current entry points retain the
+/// compatibility default, while qualification can opt in before inference.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum RoutedExpertGpuFailurePolicy {
+    StrictFailClosed,
+    #[default]
+    ServingCpuFallback,
 }
 
 /// Run-time options that affect how `Engine::generate` executes a token.
@@ -1111,6 +1125,8 @@ pub(crate) struct EngineCore {
     /// engine and its associated real model. Routed-expert dispatch reads the
     /// backend selected by this context; it never reconstructs one privately.
     pub(super) execution_context: Arc<crate::backend::ExecutionContext>,
+    /// Immutable once the engine is shared for inference.
+    pub(super) routed_expert_gpu_failure_policy: RoutedExpertGpuFailurePolicy,
     /// **Tier 4 — adaptive prefetch admission controller.** Always
     /// present; constructed in the transparent pass-through state unless
     /// [`EngineOptions::prefetch_governor`] is set, in which case it
@@ -1402,6 +1418,7 @@ impl EngineCore {
             in_flight: Arc::new(DashMap::new()),
             prefetch_semaphore: Arc::new(tokio::sync::Semaphore::new(prefetch_permits)),
             execution_context,
+            routed_expert_gpu_failure_policy: RoutedExpertGpuFailurePolicy::default(),
             governor,
         }
     }
@@ -1536,7 +1553,12 @@ pub enum MoeStepError {
     ExpertCompute {
         layer: u32,
         expert: u32,
-        detail: String,
+        source: ExpertWeightsError,
+    },
+    /// Strict GPU routed-expert dispatch failure, kept distinct from storage,
+    /// CPU weight, attention, degraded-substitution, and startup errors.
+    GpuExpertDispatch {
+        source: crate::backend::GpuExpertDispatchError,
     },
 }
 
@@ -1554,11 +1576,12 @@ impl std::fmt::Display for MoeStepError {
             MoeStepError::ExpertCompute {
                 layer,
                 expert,
-                detail,
+                source,
             } => write!(
                 f,
-                "routed expert {expert} (layer {layer}) failed to execute: {detail}"
+                "routed expert {expert} (layer {layer}) failed to execute: {source}"
             ),
+            MoeStepError::GpuExpertDispatch { source } => write!(f, "{source}"),
         }
     }
 }
@@ -1567,7 +1590,8 @@ impl std::error::Error for MoeStepError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             MoeStepError::ExpertFetch { source, .. } => Some(source),
-            MoeStepError::ExpertCompute { .. } => None,
+            MoeStepError::ExpertCompute { source, .. } => Some(source),
+            MoeStepError::GpuExpertDispatch { source } => Some(source),
         }
     }
 }
@@ -1801,6 +1825,20 @@ impl Engine {
             },
         )
         .is_ok()
+    }
+
+    /// Select the policy before placing the engine behind an `Arc`; there is
+    /// intentionally no runtime setter.
+    pub fn with_routed_expert_gpu_failure_policy(
+        mut self,
+        policy: RoutedExpertGpuFailurePolicy,
+    ) -> Self {
+        self.core.routed_expert_gpu_failure_policy = policy;
+        self
+    }
+
+    pub fn routed_expert_gpu_failure_policy(&self) -> RoutedExpertGpuFailurePolicy {
+        self.core.routed_expert_gpu_failure_policy
     }
 
     /// Synchronously promote a freshly-loaded RAM resident into the
@@ -2536,6 +2574,9 @@ impl Engine {
                 let mut outputs: Vec<InferenceOutput> = Vec::with_capacity(residents.len());
                 for r in &residents {
                     // ── Phase 3: GPU fast path ────────────────────────────────
+                    // This synthetic path is compatibility/diagnostic
+                    // infrastructure, not strict-hybrid qualification. PR3's
+                    // policy applies only to real-model `moe_step`.
                     // CandleBackend::expert_matmul bails unconditionally, so we
                     // always guard behind is_gpu(). A VRAM miss returns Err
                     // and we fall through to the CPU path below. Both F32 and
@@ -3919,15 +3960,14 @@ impl Engine {
         r: &ExpertResident,
         x: &HiddenState,
         timings: Option<&crate::stage_timing::StageTimings>,
-    ) -> Result<HiddenState, ExpertWeightsError> {
-        // ── Phase 3: GPU fast path ────────────────────────────────────
-        // If the backend is GPU and the expert is VRAM-resident, dispatch
-        // the SwiGLU FFN via wgpu. CandleBackend::expert_matmul bails
-        // unconditionally, so we always guard behind is_gpu(). A VRAM
-        // miss returns Err and we fall through to the CPU path below.
-        // Both F32 and (block-aligned) Q4_0 experts are eligible —
-        // see `Engine::gpu_eligible_dtype`.
-        if self.routed_expert_backend().is_gpu() && self.gpu_eligible_dtype() {
+    ) -> Result<HiddenState, MoeStepError> {
+        // The authoritative plan decides the execution plane. CPU plans never
+        // invoke the GPU boundary; GPU plans must produce GPU output or take
+        // the explicitly configured strict-vs-serving branch.
+        if self.execution_context().plan().routed_experts()
+            == crate::backend::ExecutionPlane::Gpu
+        {
+            let backend = self.routed_expert_backend();
             let mut out_f16 = vec![half::f16::ZERO; self.core.shape.d_model];
             let x_f16: Vec<half::f16> = x.iter().map(|&f| half::f16::from_f32(f)).collect();
             let x_view = crate::backend::TensorView {
@@ -3940,23 +3980,46 @@ impl Engine {
                 rows: 1,
                 cols: self.core.shape.d_model,
             };
-            let matmul_res = self.routed_expert_backend().expert_matmul(
-                layer as usize,
-                r.id,
-                x_view,
-                self.core.shape.d_model,
-                self.core.shape.d_ff,
-                &mut out_view,
-            );
+            let matmul_res = if !backend.is_gpu() {
+                Err(crate::backend::GpuExpertDispatchError::new(
+                    layer,
+                    r.id,
+                    crate::backend::GpuExpertDispatchErrorKind::RuntimeInvariant,
+                    "authoritative GPU routed-expert plan resolved to a non-GPU backend",
+                ))
+            } else if !self.gpu_eligible_dtype() {
+                Err(crate::backend::GpuExpertDispatchError::new(
+                    layer,
+                    r.id,
+                    crate::backend::GpuExpertDispatchErrorKind::RuntimeInvariant,
+                    format!(
+                        "authoritative GPU plan is incompatible with dtype {:?}, d_model={}, d_ff={}",
+                        self.core.options.dtype, self.core.shape.d_model, self.core.shape.d_ff
+                    ),
+                ))
+            } else {
+                backend.routed_expert_matmul(
+                    layer,
+                    r.id,
+                    x_view,
+                    self.core.shape.d_model,
+                    self.core.shape.d_ff,
+                    &mut out_view,
+                )
+            };
             match matmul_res {
                 Ok(()) => {
                     return Ok(out_f16.iter().map(|h| h.to_f32()).collect::<Vec<f32>>());
                 }
-                Err(e) => {
-                    // VRAM miss — fall through to CPU. Count it:
-                    // invisible mixed GPU/CPU execution (one CPU
-                    // expert dominating an otherwise-GPU token)
-                    // is a major source of inconsistent TPS.
+                Err(source)
+                    if self.core.routed_expert_gpu_failure_policy
+                        == RoutedExpertGpuFailurePolicy::StrictFailClosed =>
+                {
+                    return Err(MoeStepError::GpuExpertDispatch { source });
+                }
+                Err(source) => {
+                    // Only an actual serving-mode CPU recovery increments the
+                    // fallback counter.
                     let prev = self
                         .metrics
                         .counters
@@ -3968,7 +4031,7 @@ impl Engine {
                     if prev == 0 {
                         warn!(
                             expert = r.id,
-                            error = %e,
+                            error = %source,
                             "GPU expert dispatch fell back to CPU \
                              (further fallbacks counted in mer_gpu_cpu_fallbacks_total)"
                         );
@@ -3976,6 +4039,12 @@ impl Engine {
                 }
             }
         }
+
+        #[cfg(test)]
+        self.metrics
+            .counters
+            .cpu_expert_forward_calls
+            .fetch_add(1, Ordering::Relaxed);
 
         dispatch_expert_forward(
             self.core.options.dtype,
@@ -3989,6 +4058,11 @@ impl Engine {
             timings,
         )
         .map(|(_out, y)| y)
+        .map_err(|source| MoeStepError::ExpertCompute {
+            layer,
+            expert: r.id,
+            source,
+        })
     }
 
     pub async fn moe_step_with_timing(
@@ -4357,6 +4431,7 @@ impl Engine {
                                 };
                                 match self.forward_moe_resident(token_idx, layer, r, x, timings) {
                                     Ok(y) => Ok(y),
+                                    Err(e @ MoeStepError::GpuExpertDispatch { .. }) => Err(e),
                                     Err(e) if allow_degraded => {
                                         self.metrics
                                             .counters
@@ -4374,11 +4449,7 @@ impl Engine {
                                         // that combine outside the engine.
                                         Ok(vec![0.0f32; self.core.shape.d_model])
                                     }
-                                    Err(e) => Err(MoeStepError::ExpertCompute {
-                                        layer,
-                                        expert: r.id,
-                                        detail: e.to_string(),
-                                    }),
+                                    Err(e) => Err(e),
                                 }
                             };
                             let per_expert_y: Result<Vec<HiddenState>, MoeStepError> =
@@ -4417,6 +4488,7 @@ impl Engine {
                                         }
                                         Ok(())
                                     }
+                                    Err(e @ MoeStepError::GpuExpertDispatch { .. }) => Err(e),
                                     Err(e) if allow_degraded => {
                                         self.metrics
                                             .counters
@@ -4432,11 +4504,7 @@ impl Engine {
                                         );
                                         Ok(())
                                     }
-                                    Err(e) => Err(MoeStepError::ExpertCompute {
-                                        layer,
-                                        expert: r.id,
-                                        detail: e.to_string(),
-                                    }),
+                                    Err(e) => Err(e),
                                 }
                             };
                             match expert_policy {
@@ -5172,7 +5240,7 @@ mod tests {
     use crate::io_provider::{generate_synthetic_experts, NvmeStorage, StorageConfig};
     use crate::router::{PredictiveLoader, TopKRouter};
     use std::path::PathBuf;
-    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 
     /// Self-cleaning unique temp directory for test fixtures.
     struct TempDir {
@@ -5281,12 +5349,89 @@ mod tests {
         )
     }
 
+    fn rebuild_with_test_gpu(
+        base: &Arc<Engine>,
+        test_gpu: crate::backend::TestGpuBackend,
+        failure_policy: Option<RoutedExpertGpuFailurePolicy>,
+        expert_execution_policy: ExpertExecutionPolicy,
+        allow_degraded_experts: bool,
+    ) -> Arc<Engine> {
+        let gpu_expert_cache = Arc::new(crate::expert_cache::GpuExpertCache::new(
+            1024, 0.5, 16,
+        ));
+        let backend = Arc::new(crate::backend::BackendBox::TestGpu(test_gpu));
+        let context = crate::backend::resolve_execution_context_with(
+            crate::backend::ComputeOffload::Hybrid,
+            true,
+            crate::backend::GpuBackendGeometry {
+                num_layers: 1,
+                max_seq_len: 16,
+                num_heads: 1,
+                num_kv_heads: 1,
+                head_dim: base.core.shape.d_model,
+                v_head_dim: base.core.shape.d_model,
+                q4_truncation_tolerance: 0,
+            },
+            crate::backend::RoutedExpertGpuSpec {
+                dtype: base.core.options.dtype,
+                d_model: base.core.shape.d_model,
+                d_ff: base.core.shape.d_ff,
+            },
+            gpu_expert_cache,
+            |_| Ok(backend),
+        )
+        .expect("test hybrid execution context");
+
+        let mut options = base.core.options;
+        options.expert_execution_policy = expert_execution_policy;
+        options.policy.allow_degraded_experts = allow_degraded_experts;
+        let engine = Engine::with_options_and_execution_context(
+            base.core.cache.clone(),
+            base.core.pool.clone(),
+            base.core.storage.clone(),
+            base.core.router.clone(),
+            base.core.predictor.clone(),
+            base.core.shape,
+            options,
+            context,
+        );
+        Arc::new(match failure_policy {
+            Some(policy) => engine.with_routed_expert_gpu_failure_policy(policy),
+            None => engine,
+        })
+    }
+
+    fn cpu_expert_forward_calls(engine: &Engine) -> u64 {
+        engine
+            .metrics
+            .counters
+            .cpu_expert_forward_calls
+            .load(Ordering::Relaxed)
+    }
+
+    fn assert_gpu_dispatch_error(
+        error: MoeStepError,
+        expected_kind: crate::backend::GpuExpertDispatchErrorKind,
+        expected_layer: u32,
+        expected_expert: u32,
+    ) {
+        match error {
+            MoeStepError::GpuExpertDispatch { source } => {
+                assert_eq!(source.kind, expected_kind);
+                assert_eq!(source.layer, expected_layer);
+                assert_eq!(source.expert_id, expected_expert);
+                assert!(!source.detail.is_empty());
+            }
+            other => panic!("expected typed GPU expert dispatch error, got: {other}"),
+        }
+    }
+
     #[tokio::test]
     async fn engine_consumes_the_exact_resolved_hybrid_context() {
         let dir = TempDir::new("execution-context-identity");
         let base = build_engine(&dir.path, 4, 8, 16, 2, 2, 0, 7);
         let gpu_backend = Arc::new(crate::backend::BackendBox::TestGpu(
-            crate::backend::CandleBackend::new(),
+            crate::backend::TestGpuBackend::success(1.0),
         ));
         let expected_backend = gpu_backend.clone();
         let gpu_expert_cache = Arc::new(crate::expert_cache::GpuExpertCache::new(1024, 0.5, 16));
@@ -5342,6 +5487,288 @@ mod tests {
 
         let other = crate::backend::cpu_execution_context();
         assert_ne!(engine.execution_context().id(), other.id());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn strict_gpu_expert_success_never_enters_cpu_or_fallback_accounting() {
+        let dir = TempDir::new("strict-gpu-success");
+        let base = build_engine(&dir.path, 8, 16, 32, 4, 2, 1, 0x301);
+        let test_gpu = crate::backend::TestGpuBackend::success(0.25);
+        let engine = rebuild_with_test_gpu(
+            &base,
+            test_gpu.clone(),
+            Some(RoutedExpertGpuFailurePolicy::StrictFailClosed),
+            ExpertExecutionPolicy::SequentialExpertsRowParallel,
+            false,
+        );
+        let hidden = crate::inference::synth_hidden_state(0, 16, 0x301);
+        let output = engine
+            .moe_step(0, 3, &hidden, &[2])
+            .await
+            .expect("injected GPU success must complete");
+        let expected = half::f16::from_f32(0.25).to_f32();
+        assert_eq!(output.len(), 1);
+        assert!(output[0].iter().all(|&value| value == expected));
+        assert_eq!(test_gpu.expert_calls(), 1);
+        assert_eq!(cpu_expert_forward_calls(&engine), 0);
+        assert_eq!(engine.report().gpu_cpu_fallbacks, 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn strict_gpu_expert_failures_are_typed_and_never_recover_on_cpu() {
+        use crate::backend::GpuExpertDispatchErrorKind as Kind;
+        for (label, kind) in [
+            ("residency", Kind::ResidencyMiss),
+            ("upload", Kind::Upload),
+            ("validation", Kind::ValidationDispatch),
+            ("submission", Kind::Submission),
+            ("readback-channel", Kind::ReadbackChannel),
+            ("readback-map", Kind::ReadbackMap),
+            ("device-loss", Kind::DeviceLost),
+        ] {
+            let dir = TempDir::new(label);
+            let base = build_engine(&dir.path, 8, 16, 32, 4, 2, 1, 0x302);
+            let test_gpu = crate::backend::TestGpuBackend::failure(kind);
+            let engine = rebuild_with_test_gpu(
+                &base,
+                test_gpu.clone(),
+                Some(RoutedExpertGpuFailurePolicy::StrictFailClosed),
+                ExpertExecutionPolicy::SequentialExpertsRowParallel,
+                false,
+            );
+            let hidden = crate::inference::synth_hidden_state(0, 16, 0x302);
+            let error = engine
+                .moe_step(0, 7, &hidden, &[3])
+                .await
+                .expect_err("strict injected GPU failure must fail the MoE step");
+            assert_gpu_dispatch_error(error, kind, 7, 3);
+            assert_eq!(test_gpu.expert_calls(), 1, "{label}");
+            assert_eq!(cpu_expert_forward_calls(&engine), 0, "{label}");
+            let report = engine.report();
+            assert_eq!(report.gpu_cpu_fallbacks, 0, "{label}");
+            assert_eq!(report.degraded_expert_substitutions, 0, "{label}");
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn serving_gpu_failure_falls_back_once_and_returns_cpu_result() {
+        let dir = TempDir::new("serving-gpu-fallback");
+        let base = build_engine(&dir.path, 8, 16, 32, 4, 2, 1, 0x303);
+        let test_gpu = crate::backend::TestGpuBackend::failure(
+            crate::backend::GpuExpertDispatchErrorKind::ValidationDispatch,
+        );
+        let engine = rebuild_with_test_gpu(
+            &base,
+            test_gpu.clone(),
+            None,
+            ExpertExecutionPolicy::SequentialExpertsRowParallel,
+            false,
+        );
+        assert_eq!(
+            engine.routed_expert_gpu_failure_policy(),
+            RoutedExpertGpuFailurePolicy::ServingCpuFallback
+        );
+        let hidden = crate::inference::synth_hidden_state(0, 16, 0x303);
+        let output = engine
+            .moe_step(0, 0, &hidden, &[3])
+            .await
+            .expect("serving mode must recover on CPU");
+        let resident = engine.core.cache.get(3).expect("expert resident after step");
+        let expected = dispatch_expert_forward(
+            engine.core.options.dtype,
+            engine.core.options.use_qmm_for_q4,
+            0,
+            &resident,
+            &hidden,
+            engine.core.shape.d_model,
+            engine.core.shape.d_ff,
+            engine.core.options.policy.expert_size_tolerance(),
+            None,
+        )
+        .expect("reference CPU expert forward")
+        .1;
+        assert_eq!(output, vec![expected]);
+        assert_eq!(test_gpu.expert_calls(), 1);
+        assert_eq!(cpu_expert_forward_calls(&engine), 1);
+        assert_eq!(engine.report().gpu_cpu_fallbacks, 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cpu_plan_never_invokes_gpu_routed_expert_dispatch() {
+        let dir = TempDir::new("cpu-plan-no-gpu-dispatch");
+        let base = build_engine(&dir.path, 8, 16, 32, 4, 2, 1, 0x304);
+        let test_gpu = crate::backend::TestGpuBackend::success(9.0);
+        let backend = Arc::new(crate::backend::BackendBox::TestGpu(test_gpu.clone()));
+        let gpu_init_calls = Arc::new(AtomicU64::new(0));
+        let init_calls = gpu_init_calls.clone();
+        let context = crate::backend::resolve_execution_context_with(
+            crate::backend::ComputeOffload::Auto,
+            true,
+            crate::backend::GpuBackendGeometry {
+                num_layers: 1,
+                max_seq_len: 16,
+                num_heads: 1,
+                num_kv_heads: 1,
+                head_dim: 16,
+                v_head_dim: 16,
+                q4_truncation_tolerance: 0,
+            },
+            crate::backend::RoutedExpertGpuSpec {
+                dtype: WeightDtype::F32,
+                d_model: 16,
+                d_ff: 32,
+            },
+            Arc::new(crate::expert_cache::GpuExpertCache::new(1024, 0.5, 16)),
+            move |_| {
+                init_calls.fetch_add(1, Ordering::Relaxed);
+                Ok(backend)
+            },
+        )
+        .expect("Auto + strict attention resolves to CPU");
+        assert_eq!(context.plan().routed_experts(), crate::backend::ExecutionPlane::Cpu);
+        assert_eq!(gpu_init_calls.load(Ordering::Relaxed), 0);
+        let engine = Arc::new(Engine::with_options_and_execution_context(
+            base.core.cache.clone(),
+            base.core.pool.clone(),
+            base.core.storage.clone(),
+            base.core.router.clone(),
+            base.core.predictor.clone(),
+            base.core.shape,
+            base.core.options,
+            context,
+        ));
+        let hidden = crate::inference::synth_hidden_state(0, 16, 0x304);
+        engine
+            .moe_step(0, 0, &hidden, &[1])
+            .await
+            .expect("CPU plan remains unchanged");
+        assert_eq!(test_gpu.expert_calls(), 0);
+        assert_eq!(cpu_expert_forward_calls(&engine), 1);
+        assert_eq!(engine.report().gpu_cpu_fallbacks, 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn strict_gpu_plan_with_cpu_runtime_backend_fails_closed() {
+        let dir = TempDir::new("strict-plan-runtime-invariant");
+        let base = build_engine(&dir.path, 8, 16, 32, 4, 2, 1, 0x305);
+        let context = crate::backend::test_gpu_execution_context_unchecked(
+            Arc::new(crate::backend::BackendBox::Cpu(
+                crate::backend::CandleBackend::new(),
+            )),
+            crate::backend::RoutedExpertGpuSpec {
+                dtype: WeightDtype::F32,
+                d_model: 16,
+                d_ff: 32,
+            },
+        );
+        let engine = Arc::new(
+            Engine::with_options_and_execution_context(
+                base.core.cache.clone(),
+                base.core.pool.clone(),
+                base.core.storage.clone(),
+                base.core.router.clone(),
+                base.core.predictor.clone(),
+                base.core.shape,
+                base.core.options,
+                context,
+            )
+            .with_routed_expert_gpu_failure_policy(
+                RoutedExpertGpuFailurePolicy::StrictFailClosed,
+            ),
+        );
+        let hidden = crate::inference::synth_hidden_state(0, 16, 0x305);
+        let error = engine
+            .moe_step(0, 4, &hidden, &[2])
+            .await
+            .expect_err("runtime/backend mismatch must fail closed");
+        assert_gpu_dispatch_error(
+            error,
+            crate::backend::GpuExpertDispatchErrorKind::RuntimeInvariant,
+            4,
+            2,
+        );
+        assert_eq!(cpu_expert_forward_calls(&engine), 0);
+        assert_eq!(engine.report().gpu_cpu_fallbacks, 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn degraded_expert_policy_cannot_swallow_strict_gpu_failure() {
+        let dir = TempDir::new("strict-gpu-beats-degraded");
+        let base = build_engine(&dir.path, 8, 16, 32, 4, 2, 1, 0x306);
+        let test_gpu = crate::backend::TestGpuBackend::failure(
+            crate::backend::GpuExpertDispatchErrorKind::Upload,
+        );
+        let engine = rebuild_with_test_gpu(
+            &base,
+            test_gpu,
+            Some(RoutedExpertGpuFailurePolicy::StrictFailClosed),
+            ExpertExecutionPolicy::SequentialExpertsRowParallel,
+            true,
+        );
+        let hidden = crate::inference::synth_hidden_state(0, 16, 0x306);
+        let error = engine
+            .moe_step(0, 5, &hidden, &[3])
+            .await
+            .expect_err("allow_degraded_experts must not swallow strict GPU failure");
+        assert_gpu_dispatch_error(
+            error,
+            crate::backend::GpuExpertDispatchErrorKind::Upload,
+            5,
+            3,
+        );
+        assert_eq!(cpu_expert_forward_calls(&engine), 0);
+        assert_eq!(engine.report().gpu_cpu_fallbacks, 0);
+        assert_eq!(engine.report().degraded_expert_substitutions, 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn parallel_top_k_strict_gpu_failure_has_no_cpu_recovery() {
+        let dir = TempDir::new("strict-gpu-parallel-top-k");
+        let base = build_engine(&dir.path, 8, 16, 32, 4, 2, 1, 0x307);
+        let test_gpu = crate::backend::TestGpuBackend::failure(
+            crate::backend::GpuExpertDispatchErrorKind::ReadbackMap,
+        );
+        let engine = rebuild_with_test_gpu(
+            &base,
+            test_gpu.clone(),
+            Some(RoutedExpertGpuFailurePolicy::StrictFailClosed),
+            ExpertExecutionPolicy::ParallelExpertsSingleThread,
+            false,
+        );
+        let hidden = crate::inference::synth_hidden_state(0, 16, 0x307);
+        let error = engine
+            .moe_step(0, 6, &hidden, &[1, 2])
+            .await
+            .expect_err("one parallel GPU failure must fail the whole step");
+        match error {
+            MoeStepError::GpuExpertDispatch { source } => {
+                assert_eq!(source.kind, crate::backend::GpuExpertDispatchErrorKind::ReadbackMap);
+                assert_eq!(source.layer, 6);
+                assert!([1, 2].contains(&source.expert_id));
+            }
+            other => panic!("expected typed parallel GPU failure, got: {other}"),
+        }
+        assert!(test_gpu.expert_calls() >= 1);
+        assert_eq!(cpu_expert_forward_calls(&engine), 0);
+        assert_eq!(engine.report().gpu_cpu_fallbacks, 0);
+    }
+
+    #[test]
+    fn real_inference_error_preserves_typed_gpu_dispatch_source() {
+        let gpu_error = crate::backend::GpuExpertDispatchError::new(
+            9,
+            17,
+            crate::backend::GpuExpertDispatchErrorKind::DeviceLost,
+            "injected request-boundary device loss",
+        );
+        let real_error: crate::model::RealInferenceError =
+            MoeStepError::GpuExpertDispatch { source: gpu_error.clone() }.into();
+        match real_error {
+            crate::model::RealInferenceError::MoeStep(
+                MoeStepError::GpuExpertDispatch { source },
+            ) => assert_eq!(source, gpu_error),
+            other => panic!("typed GPU source was flattened at real inference boundary: {other}"),
+        }
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/rust-engine/src/metrics.rs
+++ b/rust-engine/src/metrics.rs
@@ -686,7 +686,7 @@ mod tests {
             std::sync::Arc::new(crate::expert_cache::GpuExpertCache::new(1024, 0.5, 16)),
             |_| {
                 Ok(std::sync::Arc::new(crate::backend::BackendBox::TestGpu(
-                    crate::backend::CandleBackend::new(),
+                    crate::backend::TestGpuBackend::success(1.0),
                 )))
             },
         )


### PR DESCRIPTION
## Summary

Adds an explicit fail-closed runtime policy for routed-expert GPU execution.

PR2 made the resolved execution plan authoritative. This PR establishes the next invariant: once that plan selects the GPU routed-expert plane, strict execution can never silently recover by re-running a failed expert on CPU.

## Runtime policy

Adds:

- `StrictFailClosed`
- `ServingCpuFallback`

`ServingCpuFallback` remains the default, preserving existing serving and diagnostic behavior.

Under `StrictFailClosed`:

- successful GPU expert execution returns normally
- any GPU expert dispatch failure returns a typed error
- the expert is not re-run on CPU
- the expert is not dropped from the mixture
- no zero contribution is substituted
- `mer_gpu_cpu_fallbacks_total` is not incremented

This policy is engine-scoped and immutable once the engine is shared. PR5 can opt the future strict Hybrid qualification path into it without another execution-path redesign.

## Typed GPU expert errors

Adds `GpuExpertDispatchError` with:

- layer
- expert id
- typed failure kind
- operator-facing detail

Current failure kinds include:

- residency miss
- upload
- validation/dispatch boundary
- submission boundary
- readback channel
- readback map
- device loss
- runtime invariant

`GpuLookup::Miss` is now a first-class `ResidencyMiss`.

On-demand F32/Q4_0 entry-construction failures are surfaced as typed upload failures while preserving all PR2 compatibility and geometry checks.

wgpu 0.20 does not provide a synchronous per-dispatch result for every validation/submission failure. Those categories remain explicit hardware-independent injection boundaries rather than claiming production attribution that the API cannot guarantee.

Device loss uses the per-device loss callback and is checked around routed-expert dispatch.

## Real inference propagation

Strict GPU failures propagate through:

`GpuBackend`
→ `BackendBox`
→ `Engine::forward_moe_resident`
→ `MoeStepError::GpuExpertDispatch`
→ `RealInferenceError::MoeStep`

Both sequential and parallel top-K execution preserve the strict contract.

`allow_degraded_experts` cannot override a strict GPU dispatch failure.

## Fallback metric semantics

`mer_gpu_cpu_fallbacks_total` continues to mean an expert activation actually recovered from GPU execution onto CPU.

It increments for `ServingCpuFallback`.

It does not increment for:

- strict GPU failure
- startup Auto→CPU resolution
- a plan that selected CPU from the beginning

## Compatibility

Existing behavior remains unchanged by default:

- CPU routed-expert execution remains CPU-only
- existing serving paths retain GPU→CPU fallback
- `bench-real` configuration and CLI semantics are unchanged
- synthetic `generate` / `run --gpu` remains a compatibility and diagnostic path, not strict qualification

## Validation

Validated at:

`8bd2362cd01f3a8ff647cf278d266ee6ab854ea1`

- focused PR3/PR2 regression tests: passed
- full suite: 826 passed, 0 failed, 2 ignored
- `cargo clippy --all-targets`: passed with existing repository warnings
- `git diff origin/main..HEAD --check`: passed
- worktree clean
- exactly one commit above PR2 merge base

No live GPU execution or performance claim is made by this PR.

## Scope

This PR intentionally does not implement:

- physical GPU residency/accounting redesign
- strict Hybrid benchmark schema
- NVML qualification telemetry
- live GPU qualification
- batched top-K GPU execution
- CUDA redesign
- GPU attention/KV/dense migration
- scheduler or predictor changes
- performance tuning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable handling for routed-expert GPU failures, including strict failure and CPU fallback modes.
  - Added clearer GPU dispatch error reporting with execution stage and expert details.
  - Added validation for GPU device status and tensor dimensions before execution.

- **Bug Fixes**
  - GPU failures now propagate correctly instead of being silently suppressed.
  - Serving mode can continue inference through CPU fallback when GPU expert execution fails.
  - Improved error reporting for expert computation and readback failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->