### PR TITLE
feat: make GPU expert residency physically authoritative

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,8 +612,9 @@ when the GPU cache is enabled:
   logs, metrics, and runtime metadata; under `compute_offload = "gpu"`
   the same failure is **fatal and never continues on CPU** (explicit GPU
   does not transparently fall back). SSD-streamed MoE experts use the CPU
-  path unless they are promoted into the VRAM tier and dispatched through
-  the wgpu expert path; `--features cuda` is a separate candle CUDA path,
+  path unless they are logically admitted, materialized in the bounded
+  physical registry, and dispatched through the wgpu expert path;
+  `--features cuda` is a separate candle CUDA path,
   see [Building with CUDA](#building-with-cuda). The
   backend logs the **actual device runtime** (`cpu-fallback`,
   `cuda-0`, `wgpu-vulkan` …) at startup, gist Part 2 retired the
@@ -675,7 +676,7 @@ The Rust crate (`rust-engine/`) is organised into single-responsibility modules:
 |---|---|
 | `aligned_buffer` | Heap-allocated, page-aligned buffer (`std::alloc::alloc` with a `Layout`). The defining requirement of `O_DIRECT`: kernel rejects unaligned buffers with `EINVAL`. Reused by [`AlignedKvCache`](#page-aligned-kv-cache-buffer) so the session-scoped K/V state can be snapshotted to NVMe with no extra copy. |
 | `buffer_pool` | Fixed-capacity slab of `AlignedBuffer`s, optionally split into **primary** + **shadow** halves sharing one `Notify`. Hands out `PooledBuffer` RAII guards; `try_acquire`/`try_acquire_shadow` route to the corresponding free list; dropping a guard returns the buffer to its originating list and wakes waiters. `promote_shadow` does the zero-copy slot-tag swap when a speculative prefetch is confirmed. The literal "pre-allocated RAM buffer" the spec asks for. |
-| `expert_cache` | LRU map `expert_id → Arc<ExpertResident>`, with a separate **pin set** so frequency-pinned and locality-hot experts skip eviction. Also owns the optional `GpuExpertCache` VRAM tier: hot RAM residents can promote into Anchor Core + LRU Edge regions, wgpu can materialize promoted experts as device buffers, and the CPU path remains the fallback when GPU execution is unavailable. |
+| `expert_cache` | LRU map `expert_id → Arc<ExpertResident>`, with a separate **pin set** so frequency-pinned and locality-hot experts skip eviction. Also owns the optional host-side `GpuExpertCache` logical admission policy (Anchor Core + LRU Edge). `GpuBackend` separately owns the generation-validated, capacity-bounded physical wgpu expert registry. |
 | `multi_layer_cache` | Per-layer `ExpertCache` wrapper keyed on `(layer, expert)`. Lets multi-layer Mixtral / DeepSeek configurations give each layer its own LRU budget instead of sharing one global cache. **Now wired into the engine hot path** (gist Part 1 fix #2): `EngineCore::cache` is an `Arc<MultiLayerExpertCache>` and `run`/`serve` distribute `--cache-slots` across `num_layers` (uniform per-layer caps via `MultiLayerExpertCache::with_capacities`, with any remainder going to the lowest-indexed layers). Single-layer / `--io-only` mode collapses to `MultiLayerExpertCache::single_layer(cap)` so existing benchmark paths are byte-identical. |
 | `block_pool` | Server-wide physical block pool for the **paged KV cache**. A pre-allocated slab plus a heap-backed overflow slab that grows on demand, with O(1) free-list alloc/release. The `BlockManager` is a per-request handle that auto-returns all of its blocks on `Drop`. Exposes `utilization()` and a three-level `PressureLevel { Normal, High, Critical }` whose soft-cap / critical ratios default to `SOFT_CAP_RATIO = 0.90` / `CRITICAL_PRESSURE_RATIO = 0.98` but are **operator-configurable** via `[real_transformer].pressure_high_threshold` / `pressure_critical_threshold` in `config.toml` (gist Part 1 fix #4), the [batch scheduler](#continuous-batching) reads the current level every batch to drive **preemptive idle-block eviction** and **speculation-depth clamping**. The overflow slab is **bounded** by `[real_transformer].max_overflow_capacity` (`PressureThresholds::with_max_overflow_capacity`, gist Part 1 fix #5): once the pool grows past the cap, `allocate` returns `None` so `BlockManager` surfaces `BlockAllocError::Exhausted` to the admission path instead of letting overflow grow unboundedly. |
 | `io_provider` | NVMe storage layer. Opens each expert as its own file (`O_DIRECT` on Linux), keeps fds resident, and reads via `tokio::task::block_in_place` + `pread(2)` (`FileExt::read_at`) routed through the **fault-tolerant `read_at_with_retries` path**: three-tier exponential backoff on transient errors (EIO / EINTR / `WouldBlock` / `TimedOut` / `EAGAIN`; short reads / `UnexpectedEof` fail fast) plus a per-expert **circuit breaker** that trips after `STORAGE_BREAKER_THRESHOLD = 3` consecutive failures and short-circuits to a structured `HardwareFailure::ExpertUnavailable`. A **per-drive** breaker (`STORAGE_DRIVE_BREAKER_THRESHOLD = 3`, sticky `DriveBreakerState`) sums failures across all experts sharded onto the same shard and short-circuits to `HardwareFailure::DriveUnavailable` so the engine stops routing to a known-bad drive without ever issuing the syscall, gist Phase 3. Both breakers transition to **half-open** after `STORAGE_BREAKER_PROBE_INTERVAL = 500 ms`, admitting exactly one probe read per interval via a `compare_exchange` on `tripped_at_ms` so a recovered drive can actually reach the `note_read_success` path and clear the breaker. Supports **multi-drive striping** (`NvmeStorage::striped`), experts are sharded across `N` mountpoints by `id % N`. A startup [`Manifest::scan`](#cold-start-manifest) walks every `expert_<id>.bin` once, reads each header into RAM, and lets `NvmeStorage::with_manifest` short-circuit per-fetch path resolution and dtype lookup. Includes synthetic test generators (for every dtype) and a portable Unix fallback for development on macOS. |
@@ -701,7 +702,7 @@ The Rust crate (`rust-engine/`) is organised into single-responsibility modules:
 | `numa` | Startup CPU placement helpers. By default MER applies no artificial CPU mask. Operators can opt in with global `--cpu-mask <CPULIST>` or `[performance].cpu_mask`; legacy `MER_PIN_CORES=N` remains a lower-precedence fallback. On Linux this uses `sched_setaffinity(2)` best-effort; elsewhere MER logs and continues. |
 | `metrics` | Prometheus `Registry` + handles for every counter / histogram exported on `/metrics`. |
 | `config` | TOML schema for `serve --config`: `[server]`, `[security]`, `[sampling]`, `[model]`, `[storage]`, `[tokenizer]`, `[real_transformer]`, `[predictive]`, `[gpu_cache]`. Validated at startup. |
-| `tui` (with `--features tui`) | Native "Amalgafy"-style terminal dashboard rendered with `ratatui` + `crossterm`. The `monitor` subcommand (`micro-expert-router monitor --url http://127.0.0.1:8080 --refresh-ms 250`) polls `/v1/admin/health/experts` and draws a header (status / uptime / TPS, with restart-recovery: TPS resets to zero on a backwards jump of `tokens_generated`), a 3-tier hit grid with one **delta-calculated** sparkline per tier (VRAM / RAM / SSD, pulse per refresh tick, not a cumulative staircase), a VRAM/RAM utilisation gauge, and an I/O reactor stall pulse driven by the per-tick SSD-miss delta. All sparkline histories are capped at 60 points to bound memory growth. Uses a hand-rolled minimal HTTP/1.1 client over `tokio::net::TcpStream` to avoid pulling in `reqwest`. |
+| `tui` (with `--features tui`) | Native "Amalgafy"-style terminal dashboard rendered with `ratatui` + `crossterm`. The `monitor` subcommand (`micro-expert-router monitor --url http://127.0.0.1:8080 --refresh-ms 250`) polls `/v1/admin/health/experts` and draws a header (status / uptime / TPS, with restart-recovery: TPS resets to zero on a backwards jump of `tokens_generated`), a hit grid with one **delta-calculated** sparkline per tier (logical GPU admission / RAM / SSD, pulse per refresh tick, not a cumulative staircase), a logical-admission/RAM utilisation gauge, and an I/O reactor stall pulse driven by the per-tick SSD-miss delta. All sparkline histories are capped at 60 points to bound memory growth. Uses a hand-rolled minimal HTTP/1.1 client over `tokio::net::TcpStream` to avoid pulling in `reqwest`. |
 | `server` | OpenAI-compatible HTTP server (`axum`): `/health`, `/metrics`, `/v1/completions`, `/v1/chat/completions` (both streaming SSE and one-shot), `DELETE /v1/sessions/{id}`, plus the operator endpoints `GET /v1/admin/health/experts` and `POST /v1/admin/evict`. Calls `run_engine_warmup` before binding the listener so the first user token never pays the cold-start cost (best-effort; failures only `tracing::warn!`). |
 | `middleware` | Production-readiness HTTP middleware layered onto the `server` router via `axum::middleware::from_fn_with_state`: per-request UUID tracing span, optional **API-key gate** (`[security].api_keys`; `401` when configured and missing/unknown), optional **per-key token-bucket rate limit** (`rate_limit_rps` / `rate_limit_burst`; `429` on overflow), and **admission control** (`[server].max_concurrent_requests`, `[server].admission_min_free_blocks` against the paged-KV pool; `503` when saturated). Defaults are fully permissive so legacy benchmark / development flows are byte-identical. |
 | `rpc` | Sharded `RouteExperts` RPC frames (gist Part 4): the deterministic `shard_for_expert` routing function plus the packed `RouteExpertsRequest` / `RouteExpertsResponse` f16 wire frames documented in `docs/distributed.md`. Dependency-free so the default build stays slim; the real `tonic`/`prost` gRPC transport in `grpc` (behind `--features grpc`) reuses these frames and their f16 pack/unpack helpers as the single source of truth for the on-wire layout. |
@@ -1146,7 +1147,7 @@ Endpoints:
 | -------- | -------------------------- | -------------------------------------------------- |
 | `GET`    | `/health`                  | liveness probe (`{"status":"ok"...}`)             |
 | `GET`    | `/metrics`                 | Prometheus text format: cache hit rate, request latency histograms, tokens generated, per-token I/O wait, and, when the predictive arms are enabled, `mer_locality_hits_total`, `mer_locality_misses_total`, `mer_speculator_hits_total`, `mer_speculator_misses_total`, `mer_speculator_accuracy_total`, `mer_speculator_evaluations_total`, and the `mer_ssd_stall_seconds` histogram. When `[gpu_cache] enabled = true`, also exports `mer_vram_used_bytes`, `mer_vram_capacity_bytes`, `mer_gpu_cache_hits_total`, `mer_gpu_cache_misses_total`, and `mer_promotions_total` |
-| `GET`    | `/v1/admin/health/experts` | JSON snapshot of the 3-tier hierarchy: per-tier hit/miss counters (SSD, RAM, VRAM), VRAM used / capacity bytes, total RAM→VRAM promotions, and engine status fields. Consumed by `micro-expert-router monitor`. |
+| `GET`    | `/v1/admin/health/experts` | JSON snapshot with SSD/RAM/logical-GPU-admission counters and compatibility `vram_*` logical admission bytes. Consumed by `micro-expert-router monitor`; exact physical bytes use the Rust snapshot API. |
 | `POST`   | `/v1/admin/evict`          | One-shot reclaim pass on the paged-KV pool's overflow slab. Returns `{"reclaimed_overflow_blocks": N}`. Useful after a transient burst inflated the heap-backed fallback, returns memory to the allocator immediately rather than waiting for the periodic background sweep. |
 | `POST`   | `/v1/completions`          | OpenAI text-completion shape (`prompt`, `max_tokens`...) |
 | `POST`   | `/v1/chat/completions`     | OpenAI chat-completion shape (`messages`...)       |
@@ -2158,9 +2159,9 @@ micro-expert-router run
   --io-only                  Skip the SwiGLU FFN; XOR every byte to isolate I/O cost
   --gpu                      Initialise the GPU compute backend before the
                               benchmark so the FFN forward uses GPU matmul
-                              where available, and install a bounded VRAM
-                              `GpuExpertCache` so hot experts can promote and
-                              be served from device memory. This is an
+                              where available, and install bounded logical GPU
+                              admission plus physical expert-weight residency.
+                              This is an
                               explicit fail-closed request: GPU init or
                               backend installation failure aborts the run
                               rather than silently measuring the CPU path.
@@ -2336,7 +2337,7 @@ micro-expert-router monitor          # requires `--features tui` (on by default)
   --url <URL>                Base URL of a running `serve` instance
                               (default `http://127.0.0.1:8080`). Polls
                               `/v1/admin/health/experts` and renders the
-                              live SSD → RAM → VRAM dashboard described in
+                              live SSD/RAM/GPU-admission dashboard described in
                               the `monitor` subcommand section below.
   --refresh-ms <MS>          Dashboard refresh interval (default 500).
 ```
@@ -2864,12 +2865,14 @@ get wrong with a handful of hand-picked unit tests:
 `(expert_id, ExpertResident)` message on the
 `gpu_promotion_tx` mpsc channel after `promote_after_hits` RAM hits
 on the same expert, the crossing is edge-triggered so subsequent
-hits must NOT re-fire the promotion. A dedicated unit test
-(`moe_step_emits_exactly_one_gpu_promotion_after_threshold_hits`)
-installs the channel via a test-only helper that skips spawning the
-background consumer task, then drives `moe_step` past the threshold
-and asserts on the raw mpsc traffic. This guards against silent
-regressions in the three-tier SSD → RAM → VRAM promotion logic.
+hits must not flood duplicate promotion requests. After logical eviction,
+the already-hot expert can claim one new request without requiring its
+monotonic RAM hit count to cross the threshold again. The
+`moe_step_emits_exactly_one_gpu_promotion_after_threshold_hits` test installs
+the channel via a test-only helper, drives `moe_step` past the threshold, and
+asserts on raw mpsc traffic. The
+`promotion_claim_rearms_after_logical_eviction_above_hit_threshold` test covers
+the re-admission edge.
 
 
 ---
@@ -3221,10 +3224,10 @@ counters / a histogram on `/metrics`:
 | `mer_locality_hits_total` | Routed experts that were already in the locality monitor's hot set at routing time (would-be cache miss avoided by pinning). |
 | `mer_locality_misses_total` | Routed experts that were not. |
 | `mer_ssd_stall_seconds` | Histogram of cumulative SSD critical-path stall time per token, the wall-clock window the engine spent blocked waiting for cache-miss reads to land. The headline number the L / M arms aim to drive down. |
-| `mer_vram_used_bytes` | Bytes currently resident in the optional GPU/VRAM tier of the 3-tier hierarchy (`[gpu_cache] enabled = true`). Updated by the background promotion task installed via `Engine::install_gpu_cache`. |
-| `mer_vram_capacity_bytes` | VRAM budget the `GpuExpertCache` was sized with (`[gpu_cache] vram_capacity_mb * 1 MiB`). Constant for the lifetime of the process. |
-| `mer_gpu_cache_hits_total` / `mer_gpu_cache_misses_total` | Counters incremented on every probe of the VRAM tier during routing. A non-zero hit count is the proof point that hot experts have actually been promoted off RAM. |
-| `mer_promotions_total` | Total number of RAM → VRAM promotions completed by the background promotion task since startup. |
+| `mer_vram_used_bytes` | Compatibility metric: logical host payload bytes admitted by `GpuExpertCache` (`[gpu_cache] enabled = true`), not physical wgpu allocation bytes. |
+| `mer_vram_capacity_bytes` | Compatibility metric: logical admission budget (`vram_capacity_mb * 1 MiB`), also used as the physical expert-weight cap; fixed workspaces are separate. |
+| `mer_gpu_cache_hits_total` / `mer_gpu_cache_misses_total` | Counters incremented on every logical `GpuExpertCache` admission probe during routing; they do not prove physical device residency. |
+| `mer_promotions_total` | Total RAM → logical-GPU-admission promotions completed by the background task. |
 
 The CLI run summary (`print_summary`) appends an extra line when
 either arm is enabled, e.g.:
@@ -3481,39 +3484,42 @@ cost_aware_eviction            = true
 
 The legacy 2-tier `SSD → RAM` substrate is bit-for-bit unchanged when
 `[gpu_cache] enabled = false` (the default). With `enabled = true`,
-the engine layers an Anchor + LRU-Edge **VRAM tier** on top of it:
+the engine layers host-side logical GPU admission over RAM, while the GPU
+backend separately materializes generation-matched physical weights:
 
 ```
-   ┌──────────┐         ┌──────────────┐          ┌──────────────────────┐
-   │   SSD    │ ──read─▶│  ExpertCache │ ─promote▶│   GpuExpertCache     │
-   │ (NVMe)   │  pread  │   (RAM, LRU) │  hot     │ Anchor Core + LRU Edge│
-   └──────────┘         └──────────────┘          └──────────────────────┘
+   SSD ──read──▶ ExpertCache (RAM) ──promote──▶ GpuExpertCache (host admission)
+                                                  │ current generation
+                                                  ▼
+                                  PhysicalGpuExpertRegistry (wgpu weights)
 ```
 
-* **RAM hits are still authoritative.** On a VRAM hit we still resolve
-  from RAM; VRAM shadows the bytes so the inference contract is
-  identical to the 2-tier path. With the wgpu backend active, promoted
-  experts can be materialized as device buffers for GPU expert matmul;
-  otherwise the cache remains a RAM-side promotion/observability tier
+* **Logical and physical ownership are separate.** `GpuExpertCache` retains
+  host payloads and assigns admission generations. The wgpu backend validates
+  that generation before every physical hit, lazily uploads exact device
+  buffers, and evicts them under the configured expert-weight cap. Otherwise
+  the admission cache remains a RAM-side promotion/observability tier
   and execution falls back to CPU. The optional `cuda` cargo feature is
   a separate candle CUDA path via
   [`run_inference_gpu`](rust-engine/src/inference.rs).
 * **Anchor Core.** A HashMap pinning the experts whose RAM hit count
   has crossed `[gpu_cache] promote_after_hits`. Sized to
   `vram_anchor_ratio * vram_capacity_mb`.
-* **LRU Edge.** Tracks topical experts that haven't pinned yet, evicted
-  by an `lru::LruCache` driven by the remaining VRAM budget.
+* **LRU Edge.** Tracks topical logical admissions that have not pinned yet,
+  evicted by an `lru::LruCache` under the remaining admission budget.
 * **Async promotion.** `Engine::install_gpu_cache` spawns a background
   tokio task that drains an unbounded `mpsc` of promotion intents off
-  the hot path, copies the RAM bytes into the VRAM tier, and bumps
+  the hot path, copies RAM bytes into logical admission, and bumps
   `mer_vram_used_bytes` + `mer_promotions_total`.
 * **Configured via [`[gpu_cache]`](config.toml)**, see the annotated
   TOML for every field.
-* **Observability.** Four new Prometheus metrics (`mer_vram_used_bytes`,
+* **Observability.** Compatibility Prometheus metrics (`mer_vram_used_bytes`,
   `mer_vram_capacity_bytes`, `mer_gpu_cache_hits_total` /
   `_misses_total`, `mer_promotions_total`) and the extended
-  `/v1/admin/health/experts` JSON. The latter is what the
-  [`monitor` subcommand](#monitor-subcommand) consumes.
+  `/v1/admin/health/experts` JSON explicitly describe logical admission. The
+  exact physical expert/live/workspace ledger is exposed through the Rust
+  `gpu_expert_memory_snapshot` API for qualification work. The health JSON is
+  what the [`monitor` subcommand](#monitor-subcommand) consumes.
 
 ### `monitor` subcommand
 
@@ -3530,11 +3536,11 @@ the Amalgafy-style monochromatic tech-noir layout:
 * a header with status / uptime / TPS, the TPS counter resets to
   zero when `tokens_generated` jumps backwards (server restart) so
   the rate stays meaningful across engine restarts;
-* a 3-tier hit grid with one sparkline per tier (VRAM / RAM / SSD).
+* a hit grid with one sparkline per tier (logical GPU admission / RAM / SSD).
   Each sparkline plots the **delta** of the tier's cumulative
   counter per refresh tick, so the trace shows real load pulse, not
   a cumulative staircase;
-* a VRAM utilisation gauge (anchor + LRU regions) and a RAM
+* a logical GPU-admission gauge (anchor + LRU regions) and a RAM
   occupancy gauge driven by the `/metrics` companion gauges; and
 * an I/O reactor stall pulse, a sparkline of the per-tick SSD-miss
   delta, surfacing backpressure on the inference critical path.

--- a/README.md
+++ b/README.md
@@ -702,7 +702,7 @@ The Rust crate (`rust-engine/`) is organised into single-responsibility modules:
 | `numa` | Startup CPU placement helpers. By default MER applies no artificial CPU mask. Operators can opt in with global `--cpu-mask <CPULIST>` or `[performance].cpu_mask`; legacy `MER_PIN_CORES=N` remains a lower-precedence fallback. On Linux this uses `sched_setaffinity(2)` best-effort; elsewhere MER logs and continues. |
 | `metrics` | Prometheus `Registry` + handles for every counter / histogram exported on `/metrics`. |
 | `config` | TOML schema for `serve --config`: `[server]`, `[security]`, `[sampling]`, `[model]`, `[storage]`, `[tokenizer]`, `[real_transformer]`, `[predictive]`, `[gpu_cache]`. Validated at startup. |
-| `tui` (with `--features tui`) | Native "Amalgafy"-style terminal dashboard rendered with `ratatui` + `crossterm`. The `monitor` subcommand (`micro-expert-router monitor --url http://127.0.0.1:8080 --refresh-ms 250`) polls `/v1/admin/health/experts` and draws a header (status / uptime / TPS, with restart-recovery: TPS resets to zero on a backwards jump of `tokens_generated`), a hit grid with one **delta-calculated** sparkline per tier (logical GPU admission / RAM / SSD, pulse per refresh tick, not a cumulative staircase), a logical-admission/RAM utilisation gauge, and an I/O reactor stall pulse driven by the per-tick SSD-miss delta. All sparkline histories are capped at 60 points to bound memory growth. Uses a hand-rolled minimal HTTP/1.1 client over `tokio::net::TcpStream` to avoid pulling in `reqwest`. |
+| `tui` (with `--features tui`) | Native "Amalgafy"-style terminal dashboard rendered with `ratatui` + `crossterm`. The `monitor` subcommand (`micro-expert-router monitor --url http://127.0.0.1:8080 --refresh-ms 250`) polls `/v1/admin/health/experts` and draws a header (status / uptime / TPS, with restart-recovery: TPS resets to zero on a backwards jump of `tokens_generated`), an activity grid with **delta-calculated** sparklines for logical GPU-admission hits, RAM hits, and SSD reads (pulse per refresh tick, not a cumulative staircase), a logical-admission/RAM utilisation gauge, and an I/O reactor stall pulse driven by the per-tick SSD-read delta. All sparkline histories are capped at 60 points to bound memory growth. Uses a hand-rolled minimal HTTP/1.1 client over `tokio::net::TcpStream` to avoid pulling in `reqwest`. |
 | `server` | OpenAI-compatible HTTP server (`axum`): `/health`, `/metrics`, `/v1/completions`, `/v1/chat/completions` (both streaming SSE and one-shot), `DELETE /v1/sessions/{id}`, plus the operator endpoints `GET /v1/admin/health/experts` and `POST /v1/admin/evict`. Calls `run_engine_warmup` before binding the listener so the first user token never pays the cold-start cost (best-effort; failures only `tracing::warn!`). |
 | `middleware` | Production-readiness HTTP middleware layered onto the `server` router via `axum::middleware::from_fn_with_state`: per-request UUID tracing span, optional **API-key gate** (`[security].api_keys`; `401` when configured and missing/unknown), optional **per-key token-bucket rate limit** (`rate_limit_rps` / `rate_limit_burst`; `429` on overflow), and **admission control** (`[server].max_concurrent_requests`, `[server].admission_min_free_blocks` against the paged-KV pool; `503` when saturated). Defaults are fully permissive so legacy benchmark / development flows are byte-identical. |
 | `rpc` | Sharded `RouteExperts` RPC frames (gist Part 4): the deterministic `shard_for_expert` routing function plus the packed `RouteExpertsRequest` / `RouteExpertsResponse` f16 wire frames documented in `docs/distributed.md`. Dependency-free so the default build stays slim; the real `tonic`/`prost` gRPC transport in `grpc` (behind `--features grpc`) reuses these frames and their f16 pack/unpack helpers as the single source of truth for the on-wire layout. |
@@ -3487,7 +3487,7 @@ The legacy 2-tier `SSD → RAM` substrate is bit-for-bit unchanged when
 the engine layers host-side logical GPU admission over RAM, while the GPU
 backend separately materializes generation-matched physical weights:
 
-```
+```text
    SSD ──read──▶ ExpertCache (RAM) ──promote──▶ GpuExpertCache (host admission)
                                                   │ current generation
                                                   ▼
@@ -3536,13 +3536,14 @@ the Amalgafy-style monochromatic tech-noir layout:
 * a header with status / uptime / TPS, the TPS counter resets to
   zero when `tokens_generated` jumps backwards (server restart) so
   the rate stays meaningful across engine restarts;
-* a hit grid with one sparkline per tier (logical GPU admission / RAM / SSD).
-  Each sparkline plots the **delta** of the tier's cumulative
-  counter per refresh tick, so the trace shows real load pulse, not
-  a cumulative staircase;
+* an activity grid with sparklines for logical GPU-admission hits, RAM hits,
+  and SSD reads. Each sparkline plots the **delta** of its cumulative counter
+  per refresh tick, so the trace shows real load pulse, not a cumulative
+  staircase. A zero SSD-read delta means only that no SSD read was recorded
+  during that tick; physical GPU residency can also avoid a read;
 * a logical GPU-admission gauge (anchor + LRU regions) and a RAM
   occupancy gauge driven by the `/metrics` companion gauges; and
-* an I/O reactor stall pulse, a sparkline of the per-tick SSD-miss
+* an I/O reactor stall pulse, a sparkline of the per-tick SSD-read
   delta, surfacing backpressure on the inference critical path.
 
 All sparkline histories are capped at 60 points to bound memory

--- a/config.toml
+++ b/config.toml
@@ -335,20 +335,22 @@ static_residency_warmup_tokens = 0
 # cache instead of deriving the hot set online.
 # static_residency_profile = "hot_experts.json"
 
-# 3-tier heterogeneous memory cache (SSD → RAM → VRAM).
+# Logical GPU admission plus bounded physical routed-expert residency.
 #
 # When `enabled = false` (the default), the engine runs the legacy
 # 2-tier (SSD → RAM) path bit-for-bit. When `enabled = true`, hot
 # experts are promoted from the RAM-resident `ExpertCache` into an
-# Anchor + LRU-Edge VRAM cache (`GpuExpertCache`) on a background
-# tokio task, exposed via:
+# Anchor + LRU-Edge host admission cache (`GpuExpertCache`) on a
+# background tokio task. Compatibility telemetry is exposed via:
 #   * `mer_vram_used_bytes` / `mer_vram_capacity_bytes` gauges
 #   * `mer_gpu_cache_hits_total` / `mer_gpu_cache_misses_total`
 #   * `mer_promotions_total` counter
 #   * extended `/v1/admin/health/experts` JSON
 #
-# With `[real_transformer].compute_offload = "gpu"`, the wgpu backend can
-# materialize promoted experts as device buffers. Explicit GPU mode fails
+# Those `vram_*` gauges report logical host admission bytes, not physical
+# wgpu allocations. With routed-expert GPU execution, the backend lazily
+# materializes current-generation admissions into its bounded physical
+# expert registry. Explicit GPU mode fails
 # closed if a device cannot be acquired. Use
 # `[real_transformer].compute_offload = "auto"` when CPU fallback should be
 # allowed and recorded.
@@ -357,19 +359,18 @@ static_residency_warmup_tokens = 0
 # candle CUDA path.
 [gpu_cache]
 enabled = false
-# VRAM budget in MiB. 0 ⇒ cache created with zero capacity, every
-# lookup misses through to RAM. Leave headroom for the dense body
-# and KV cache; a 16 GiB card typically uses 4096–8192 here.
+# Logical admission budget and physical expert-weight cap, in MiB. Fixed
+# routed-expert workspaces are reported separately. 0 ⇒ zero capacity and
+# every lookup misses through to RAM. Leave headroom for dense/KV allocations.
 vram_capacity_mb = 0
 # Hit count an expert must accumulate in RAM before it is pinned
 # into the Anchor Core. 0 disables promotion (LRU Edge only).
 promote_after_hits = 16
-# Fraction of VRAM reserved for the Anchor Core; the remainder is
-# the LRU Edge. 0.0..=1.0.
+# Fraction of the logical admission budget reserved for the Anchor Core;
+# the remainder is the LRU Edge. 0.0..=1.0.
 vram_anchor_ratio = 0.5
-# On-device dtype for resident bytes: "f32", "f16", "int8", "q4k",
-# "q4_0", "q8_0". "f16" typically halves the VRAM footprint of
-# "f32" with no perceptible quality loss.
+# Advisory resident dtype label: "f32", "f16", "int8", "q4k", "q4_0",
+# "q8_0". Promotion does not convert the stored payload.
 dtype = "f16"
 
 # -- Distributed expert partitioning (multi-node, optional) ----------

--- a/rust-engine/src/backend/mod.rs
+++ b/rust-engine/src/backend/mod.rs
@@ -2669,17 +2669,15 @@ impl GpuBackend {
         d_ff: usize,
         out: &mut TensorViewMut<'_>,
     ) -> std::result::Result<(), GpuExpertDispatchError> {
-        use crate::expert_cache::GpuLookup;
-
         if let Some(detail) = self.device_loss.detail() {
             return Err(GpuExpertDispatchError::new(
                 layer, expert_id, GpuExpertDispatchErrorKind::DeviceLost, detail,
             ));
         }
 
-        let admission = match self.gpu_expert_cache.get(expert_id) {
-            GpuLookup::AnchorHit(admission) | GpuLookup::LruHit(admission) => admission,
-            GpuLookup::Miss => {
+        let admission = match self.gpu_expert_cache.current_admission(expert_id) {
+            Some(admission) => admission,
+            None => {
                 self.physical_expert_registry
                     .retire_logical_miss(expert_id);
                 return Err(GpuExpertDispatchError::new(

--- a/rust-engine/src/backend/mod.rs
+++ b/rust-engine/src/backend/mod.rs
@@ -2,6 +2,7 @@
 
 use anyhow::{anyhow, Result};
 use parking_lot::Mutex as ParkingMutex;
+use std::collections::HashMap;
 use std::fmt;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
@@ -211,6 +212,7 @@ pub struct TensorViewMut<'a> {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum GpuExpertDispatchErrorKind {
     ResidencyMiss,
+    PhysicalCapacity,
     Upload,
     #[allow(dead_code)] // wgpu 0.20 has no per-dispatch synchronous validation result.
     ValidationDispatch,
@@ -226,6 +228,7 @@ impl fmt::Display for GpuExpertDispatchErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match self {
             Self::ResidencyMiss => "residency-miss",
+            Self::PhysicalCapacity => "physical-capacity",
             Self::Upload => "upload",
             Self::ValidationDispatch => "validation-dispatch",
             Self::Submission => "submission",
@@ -270,6 +273,457 @@ impl fmt::Display for GpuExpertDispatchError {
 }
 
 impl std::error::Error for GpuExpertDispatchError {}
+
+/// PR4's exact MER-owned routed-expert GPU memory snapshot. Its scope is
+/// deliberately narrower than process/device memory: physical expert weight
+/// buffers plus the fixed routed-expert workspace buffers. Dense, attention,
+/// KV, driver, and allocator overhead remain outside this internal ledger.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[allow(dead_code)] // Public PR5 seam; PR4 validates it through backend-local tests.
+pub struct GpuExpertMemorySnapshot {
+    /// Host payload bytes admitted by [`crate::expert_cache::GpuExpertCache`].
+    pub logical_admitted_bytes: u64,
+    /// All live physical expert weight buffers, including evicted entries
+    /// retained by an in-flight `Arc`.
+    pub expert_live_bytes: u64,
+    /// Physical expert bytes still addressable through the registry.
+    pub expert_registry_bytes: u64,
+    /// Fixed device buffers owned by the routed-expert workspace pool.
+    pub workspace_bytes: u64,
+    /// `expert_live_bytes + workspace_bytes`.
+    pub total_tracked_bytes: u64,
+    /// Configured capacity for physical expert weight buffers only.
+    pub expert_capacity_bytes: u64,
+    pub physical_entries: usize,
+    pub physical_installs: u64,
+    pub physical_evictions: u64,
+    pub stale_retirements: u64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct PhysicalExpertKey {
+    expert_id: u32,
+    generation: u64,
+}
+
+trait PhysicalRegistryEntry: Send + Sync + 'static {
+    fn physical_key(&self) -> PhysicalExpertKey;
+    fn device_bytes(&self) -> u64;
+}
+
+#[allow(dead_code)] // `workspace_bytes` is consumed through the PR5 snapshot seam.
+struct GpuMemoryLedger {
+    expert_live_bytes: AtomicU64,
+    workspace_bytes: u64,
+    expert_capacity_bytes: u64,
+}
+
+impl GpuMemoryLedger {
+    fn new(workspace_bytes: u64, expert_capacity_bytes: u64) -> Arc<Self> {
+        Arc::new(Self {
+            expert_live_bytes: AtomicU64::new(0),
+            workspace_bytes,
+            expert_capacity_bytes,
+        })
+    }
+
+    fn expert_live_bytes(&self) -> u64 {
+        self.expert_live_bytes.load(Ordering::Acquire)
+    }
+
+    fn acquire(self: &Arc<Self>, bytes: u64) -> std::result::Result<ExpertAllocationLease, String> {
+        if bytes == 0 {
+            return Err("physical expert allocation must be non-zero".to_string());
+        }
+        self.expert_live_bytes
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |live| {
+                live.checked_add(bytes)
+                    .filter(|next| *next <= self.expert_capacity_bytes)
+            })
+            .map_err(|live| {
+                format!(
+                    "physical expert live-byte ledger capacity/overflow: capacity={} live={live} add={bytes}",
+                    self.expert_capacity_bytes
+                )
+            })?;
+        Ok(ExpertAllocationLease {
+            ledger: self.clone(),
+            bytes,
+        })
+    }
+}
+
+/// Non-cloneable charge owned by one physical allocation. An entry may be
+/// removed from the registry while in flight; only the final entry `Arc` drop
+/// releases this lease and decrements live bytes.
+struct ExpertAllocationLease {
+    ledger: Arc<GpuMemoryLedger>,
+    bytes: u64,
+}
+
+impl Drop for ExpertAllocationLease {
+    fn drop(&mut self) {
+        self.ledger
+            .expert_live_bytes
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |live| {
+                live.checked_sub(self.bytes)
+            })
+            .expect("physical expert live-byte ledger underflow");
+    }
+}
+
+#[derive(Clone, Copy)]
+struct InstallReservation {
+    bytes: u64,
+    charged: bool,
+}
+
+struct PhysicalRegistryInner<T: PhysicalRegistryEntry> {
+    entries: lru::LruCache<u32, Arc<T>>,
+    registry_bytes: u64,
+    reserved_bytes: u64,
+    installing: HashMap<PhysicalExpertKey, InstallReservation>,
+    installs: u64,
+    evictions: u64,
+    stale_retirements: u64,
+}
+
+struct PhysicalGpuExpertRegistry<T: PhysicalRegistryEntry> {
+    inner: ParkingMutex<PhysicalRegistryInner<T>>,
+    install_cv: parking_lot::Condvar,
+    ledger: Arc<GpuMemoryLedger>,
+}
+
+#[derive(Debug)]
+struct PhysicalCapacityError {
+    requested_bytes: u64,
+    expert_capacity_bytes: u64,
+    expert_live_bytes: u64,
+    expert_registry_bytes: u64,
+    reserved_bytes: u64,
+}
+
+impl fmt::Display for PhysicalCapacityError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "physical expert allocation of {} bytes exceeds available capacity: capacity={} live={} registry={} reserved={}",
+            self.requested_bytes,
+            self.expert_capacity_bytes,
+            self.expert_live_bytes,
+            self.expert_registry_bytes,
+            self.reserved_bytes
+        )
+    }
+}
+
+enum PhysicalRegistryAcquire<T: PhysicalRegistryEntry> {
+    Hit(Arc<T>),
+    Install(PhysicalInstallPermit<T>),
+}
+
+struct PhysicalInstallPermit<T: PhysicalRegistryEntry> {
+    registry: Arc<PhysicalGpuExpertRegistry<T>>,
+    key: PhysicalExpertKey,
+    bytes: u64,
+    active: bool,
+    charged: bool,
+}
+
+impl<T: PhysicalRegistryEntry> PhysicalGpuExpertRegistry<T> {
+    fn new(ledger: Arc<GpuMemoryLedger>) -> Arc<Self> {
+        Arc::new(Self {
+            inner: ParkingMutex::new(PhysicalRegistryInner {
+                entries: lru::LruCache::unbounded(),
+                registry_bytes: 0,
+                reserved_bytes: 0,
+                installing: HashMap::new(),
+                installs: 0,
+                evictions: 0,
+                stale_retirements: 0,
+            }),
+            install_cv: parking_lot::Condvar::new(),
+            ledger,
+        })
+    }
+
+    fn capacity_bytes(&self) -> u64 {
+        self.ledger.expert_capacity_bytes
+    }
+
+    /// Return an addressable physical entry only when its logical generation
+    /// still matches. This is the routed-expert fast path: it performs one
+    /// registry lock and no upload planning or host-weight copy.
+    fn lookup_current(&self, key: PhysicalExpertKey) -> Option<Arc<T>> {
+        let mut inner = self.inner.lock();
+        Self::lookup_current_locked(&mut inner, key)
+    }
+
+    fn lookup_current_locked(
+        inner: &mut PhysicalRegistryInner<T>,
+        key: PhysicalExpertKey,
+    ) -> Option<Arc<T>> {
+        let existing = inner.entries.peek(&key.expert_id).cloned()?;
+        if existing.physical_key() == key {
+            return inner.entries.get(&key.expert_id).cloned();
+        }
+
+        Self::retire_entry_locked(inner, key.expert_id);
+        None
+    }
+
+    fn retire_entry_locked(inner: &mut PhysicalRegistryInner<T>, expert_id: u32) {
+        let stale = inner
+            .entries
+            .pop(&expert_id)
+            .expect("validated physical entry must remain present under lock");
+        inner.registry_bytes = inner
+            .registry_bytes
+            .checked_sub(stale.device_bytes())
+            .expect("physical registry byte underflow retiring stale entry");
+        inner.stale_retirements = inner.stale_retirements.saturating_add(1);
+        drop(stale);
+    }
+
+    /// Validate `(id, generation)` and either return the current physical
+    /// entry or reserve exact capacity for one keyed install. Concurrent
+    /// demand for the same id waits on the keyed in-progress state and then
+    /// reuses the winner; the registry lock is never held during upload.
+    fn acquire_or_reserve(
+        self: &Arc<Self>,
+        key: PhysicalExpertKey,
+        bytes: u64,
+    ) -> std::result::Result<PhysicalRegistryAcquire<T>, PhysicalCapacityError> {
+        let capacity = self.capacity_bytes();
+        if bytes == 0 || bytes > capacity {
+            return Err(self.capacity_error(bytes, 0, 0));
+        }
+
+        let mut inner = self.inner.lock();
+        loop {
+            if let Some(hit) = Self::lookup_current_locked(&mut inner, key) {
+                return Ok(PhysicalRegistryAcquire::Hit(hit));
+            }
+
+            if inner
+                .installing
+                .keys()
+                .any(|installing| installing.expert_id == key.expert_id)
+            {
+                self.install_cv.wait(&mut inner);
+                continue;
+            }
+
+            while !self.install_fits(&inner, bytes) {
+                let Some((_, victim)) = inner.entries.pop_lru() else {
+                    return Err(self.capacity_error(
+                        bytes,
+                        inner.registry_bytes,
+                        inner.reserved_bytes,
+                    ));
+                };
+                inner.registry_bytes = inner
+                    .registry_bytes
+                    .checked_sub(victim.device_bytes())
+                    .expect("physical registry byte underflow during eviction");
+                inner.evictions = inner.evictions.saturating_add(1);
+                // Release registry ownership before re-reading live bytes. If
+                // an activation still owns the Arc, the RAII lease remains.
+                drop(victim);
+            }
+
+            inner.reserved_bytes = inner
+                .reserved_bytes
+                .checked_add(bytes)
+                .expect("physical install reservation byte overflow");
+            let previous = inner.installing.insert(
+                key,
+                InstallReservation {
+                    bytes,
+                    charged: false,
+                },
+            );
+            debug_assert!(previous.is_none());
+            return Ok(PhysicalRegistryAcquire::Install(PhysicalInstallPermit {
+                registry: self.clone(),
+                key,
+                bytes,
+                active: true,
+                charged: false,
+            }));
+        }
+    }
+
+    fn install_fits(&self, inner: &PhysicalRegistryInner<T>, bytes: u64) -> bool {
+        inner
+            .registry_bytes
+            .checked_add(inner.reserved_bytes)
+            .and_then(|used| used.checked_add(bytes))
+            .is_some_and(|used| used <= self.capacity_bytes())
+            && self
+                .ledger
+                .expert_live_bytes()
+                .checked_add(inner.reserved_bytes)
+                .and_then(|used| used.checked_add(bytes))
+                .is_some_and(|used| used <= self.capacity_bytes())
+    }
+
+    fn capacity_error(
+        &self,
+        requested_bytes: u64,
+        expert_registry_bytes: u64,
+        reserved_bytes: u64,
+    ) -> PhysicalCapacityError {
+        PhysicalCapacityError {
+            requested_bytes,
+            expert_capacity_bytes: self.capacity_bytes(),
+            expert_live_bytes: self.ledger.expert_live_bytes(),
+            expert_registry_bytes,
+            reserved_bytes,
+        }
+    }
+
+    /// Logical miss retirement is O(1): remove only this id. Unrelated stale
+    /// entries remain accounted and capacity-evictable, but cannot execute
+    /// because every routed lookup starts with logical admission validation.
+    fn retire_logical_miss(&self, expert_id: u32) {
+        let mut inner = self.inner.lock();
+        if inner.entries.peek(&expert_id).is_some() {
+            Self::retire_entry_locked(&mut inner, expert_id);
+        }
+    }
+
+    /// Retire only the stale allocation this dispatch observed. If another
+    /// thread has already installed a newer generation, leave it addressable.
+    fn retire_key_if_present(&self, key: PhysicalExpertKey) {
+        let mut inner = self.inner.lock();
+        if inner
+            .entries
+            .peek(&key.expert_id)
+            .is_some_and(|entry| entry.physical_key() == key)
+        {
+            Self::retire_entry_locked(&mut inner, key.expert_id);
+        }
+    }
+
+    #[allow(dead_code)] // Public snapshot callers arrive in PR5; PR4 tests invariants here.
+    fn snapshot(&self, logical_admitted_bytes: u64) -> GpuExpertMemorySnapshot {
+        let inner = self.inner.lock();
+        let expert_live_bytes = self.ledger.expert_live_bytes();
+        let workspace_bytes = self.ledger.workspace_bytes;
+        GpuExpertMemorySnapshot {
+            logical_admitted_bytes,
+            expert_live_bytes,
+            expert_registry_bytes: inner.registry_bytes,
+            workspace_bytes,
+            total_tracked_bytes: expert_live_bytes
+                .checked_add(workspace_bytes)
+                .expect("tracked GPU byte total overflow"),
+            expert_capacity_bytes: self.capacity_bytes(),
+            physical_entries: inner.entries.len(),
+            physical_installs: inner.installs,
+            physical_evictions: inner.evictions,
+            stale_retirements: inner.stale_retirements,
+        }
+    }
+
+    #[cfg(test)]
+    fn contains_key(&self, key: PhysicalExpertKey) -> bool {
+        self.inner
+            .lock()
+            .entries
+            .peek(&key.expert_id)
+            .is_some_and(|entry| entry.physical_key() == key)
+    }
+}
+
+impl<T: PhysicalRegistryEntry> PhysicalInstallPermit<T> {
+    /// Transfer this permit's capacity reservation into an exact live-byte
+    /// lease immediately after the device allocation is successfully created.
+    fn charge_allocation(
+        &mut self,
+    ) -> std::result::Result<ExpertAllocationLease, String> {
+        if !self.active || self.charged {
+            return Err("physical install permit is not chargeable".to_string());
+        }
+        let mut inner = self.registry.inner.lock();
+        let reservation = *inner
+            .installing
+            .get(&self.key)
+            .ok_or_else(|| "physical install reservation disappeared".to_string())?;
+        if reservation.charged || reservation.bytes != self.bytes {
+            return Err("physical install reservation state mismatch".to_string());
+        }
+        let lease = self.registry.ledger.acquire(self.bytes)?;
+        inner.reserved_bytes = inner
+            .reserved_bytes
+            .checked_sub(self.bytes)
+            .ok_or_else(|| "physical install reserved-byte underflow".to_string())?;
+        inner
+            .installing
+            .get_mut(&self.key)
+            .expect("validated physical install reservation disappeared under lock")
+            .charged = true;
+        self.charged = true;
+        Ok(lease)
+    }
+
+    fn install(mut self, entry: Arc<T>) -> std::result::Result<Arc<T>, String> {
+        if !self.active || !self.charged {
+            return Err("physical install permit was not charged".to_string());
+        }
+        if entry.physical_key() != self.key || entry.device_bytes() != self.bytes {
+            return Err("physical install entry does not match its reservation".to_string());
+        }
+        let mut inner = self.registry.inner.lock();
+        let reservation = *inner
+            .installing
+            .get(&self.key)
+            .ok_or_else(|| "physical install reservation disappeared".to_string())?;
+        if !reservation.charged || reservation.bytes != self.bytes {
+            return Err("physical install reservation state mismatch".to_string());
+        }
+        if inner.entries.peek(&self.key.expert_id).is_some() {
+            return Err("physical entry appeared while its keyed install was reserved".to_string());
+        }
+        let new_registry_bytes = inner
+            .registry_bytes
+            .checked_add(self.bytes)
+            .ok_or_else(|| "physical registry byte overflow".to_string())?;
+        if new_registry_bytes > self.registry.capacity_bytes() {
+            return Err("physical registry exceeded configured capacity".to_string());
+        }
+        inner.installing.remove(&self.key);
+        let previous = inner.entries.put(self.key.expert_id, entry.clone());
+        debug_assert!(previous.is_none());
+        inner.registry_bytes = new_registry_bytes;
+        inner.installs = inner.installs.saturating_add(1);
+        self.active = false;
+        drop(inner);
+        self.registry.install_cv.notify_all();
+        Ok(entry)
+    }
+}
+
+impl<T: PhysicalRegistryEntry> Drop for PhysicalInstallPermit<T> {
+    fn drop(&mut self) {
+        if !self.active {
+            return;
+        }
+        let mut inner = self.registry.inner.lock();
+        if let Some(reservation) = inner.installing.remove(&self.key) {
+            if !reservation.charged {
+                inner.reserved_bytes = inner
+                    .reserved_bytes
+                    .checked_sub(reservation.bytes)
+                    .expect("physical install reserved-byte underflow on cancellation");
+            }
+        }
+        self.active = false;
+        drop(inner);
+        self.registry.install_cv.notify_all();
+    }
+}
 
 /// Abstraction over GPU-resident storage for expert weight buffers.
 ///
@@ -481,12 +935,42 @@ enum VramWeightLayout {
     Q4_0,
 }
 
+#[derive(Clone, Copy)]
+struct F32ExpertUploadPlan {
+    device_bytes: u64,
+    projection_offset: u64,
+}
+
+#[derive(Clone, Copy)]
+struct Q4ExpertUploadPlan {
+    device_bytes: u64,
+    required_bytes: usize,
+    up_block_offset: u32,
+    down_block_offset: u32,
+}
+
+#[derive(Clone, Copy)]
+enum ExpertUploadPlan {
+    F32(F32ExpertUploadPlan),
+    Q4_0(Q4ExpertUploadPlan),
+}
+
+impl ExpertUploadPlan {
+    fn device_bytes(self) -> u64 {
+        match self {
+            Self::F32(plan) => plan.device_bytes,
+            Self::Q4_0(plan) => plan.device_bytes,
+        }
+    }
+}
+
 /// A fully-initialized VRAM expert: weight buffer + shape/layout
 /// metadata for the four FFN dispatch passes (the dispatch-time bind
 /// groups are built per call against the checked-out
 /// [`ExpertWorkspace`]). Created once per expert on first promotion;
 /// reused on every subsequent token.
 struct VramExpertEntry {
+    key: PhysicalExpertKey,
     /// Raw weight buffer in VRAM. Layout: [gate_proj | up_proj | down_proj],
     /// either dense f32 LE or packed Q4_0 blocks — see [`VramWeightLayout`].
     /// gate_proj: [d_ff, d_model], up_proj: [d_ff, d_model], down_proj: [d_model, d_ff].
@@ -506,11 +990,25 @@ struct VramExpertEntry {
     up_block_off:   u32,
     /// First-block index of the down projection (Q4_0 layout only; 0 for F32).
     down_block_off: u32,
+    /// Exact descriptor size of `weight_buf`.
+    device_bytes: u64,
+    /// Final-Arc live-byte accounting charge for `weight_buf`.
+    _allocation: ExpertAllocationLease,
+}
+
+impl PhysicalRegistryEntry for VramExpertEntry {
+    fn physical_key(&self) -> PhysicalExpertKey {
+        self.key
+    }
+
+    fn device_bytes(&self) -> u64 {
+        self.device_bytes
+    }
 }
 
 impl GpuStorage for VramExpertEntry {
     fn byte_len(&self) -> usize {
-        self.weight_buf.size() as usize
+        self.device_bytes as usize
     }
     fn as_wgpu_buffer(&self) -> Option<&wgpu::Buffer> {
         Some(&self.weight_buf)
@@ -522,9 +1020,17 @@ impl GpuStorage for VramExpertEntry {
 /// lifetime, so up to this many expert FFNs can be in flight on the
 /// queue **concurrently** — the per-dispatch wait below only blocks
 /// on its own submission index, never on the whole queue. Sized at
-/// 5 × ~64 KiB buffers per workspace (≈ 1.3 MiB total for the pool):
-/// negligible VRAM for a 4-way overlap window.
+/// five device buffers per workspace. PR4 derives their exact descriptor
+/// bytes and excludes the host scratch vector from the GPU ledger.
 const EXPERT_WORKSPACE_POOL: usize = 4;
+const EXPERT_WORKSPACE_DEVICE_BUFFERS: u64 = 5;
+
+fn expert_workspace_device_bytes(buffer_bytes: u64, workspace_count: usize) -> u64 {
+    buffer_bytes
+        .checked_mul(EXPERT_WORKSPACE_DEVICE_BUFFERS)
+        .and_then(|per_workspace| per_workspace.checked_mul(workspace_count as u64))
+        .expect("routed-expert workspace byte calculation overflow")
+}
 
 /// Private buffer set for one in-flight expert FFN dispatch.
 ///
@@ -555,6 +1061,18 @@ struct ExpertWorkspace {
     /// per-workspace, so expert dispatches never contend on the
     /// backend-global `conversion_scratch` either.
     scratch: Vec<f32>,
+}
+
+impl ExpertWorkspace {
+    fn device_bytes(&self) -> u64 {
+        self.x_buf
+            .size()
+            .checked_add(self.mid_1.size())
+            .and_then(|bytes| bytes.checked_add(self.mid_2.size()))
+            .and_then(|bytes| bytes.checked_add(self.ffn_out.size()))
+            .and_then(|bytes| bytes.checked_add(self.staging.size()))
+            .expect("routed-expert workspace device-byte total overflow")
+    }
 }
 
 #[derive(Default)]
@@ -642,16 +1160,13 @@ pub struct GpuBackend {
     /// architectures; drives the V slice / attention-output geometry.
     v_head_dim: usize,
 
-    /// VRAM buffers for hot experts. Keyed by expert_id. Populated lazily
-    /// on first access after GpuExpertCache promotes an expert. Entries
-    /// are `Arc`-wrapped so the fast path can clone a handle and release
-    /// this lock *before* the (blocking) GPU dispatch — holding the map
-    /// lock across `expert_matmul_from_vram` would serialize all expert
-    /// lookups behind a multi-millisecond submit + readback.
-    vram_expert_bufs: ParkingMutex<std::collections::HashMap<u32, Arc<VramExpertEntry>>>,
+    /// Sole authoritative owner/index for physical routed-expert weight
+    /// buffers. Identity is `(expert_id, logical_generation)`; bounded LRU
+    /// lookup/install locks are released before GPU dispatch.
+    physical_expert_registry: Arc<PhysicalGpuExpertRegistry<VramExpertEntry>>,
 
-    /// Reference to the VRAM expert cache. Used to check whether an expert
-    /// is GPU-resident before falling back to the NVMe → CPU path.
+    /// Host-side logical admission policy. Every physical lookup is validated
+    /// against its current admission generation before GPU execution.
     gpu_expert_cache: Arc<crate::expert_cache::GpuExpertCache>,
     /// Checked-out-on-dispatch workspaces for the expert FFN path —
     /// see [`ExpertWorkspace`]. Replaces the `expert_execution_lock`
@@ -1111,6 +1626,23 @@ impl GpuBackend {
                 scratch: vec![0.0f32; MAX_EXPERT_D_FF],
             })
             .collect();
+        let actual_expert_workspace_bytes = expert_workspaces
+            .iter()
+            .map(ExpertWorkspace::device_bytes)
+            .try_fold(0u64, u64::checked_add)
+            .expect("routed-expert workspace byte total overflow");
+        debug_assert_eq!(
+            actual_expert_workspace_bytes,
+            expert_workspace_device_bytes(workspace_bytes, EXPERT_WORKSPACE_POOL)
+        );
+        let expert_capacity_bytes = u64::try_from(gpu_expert_cache.capacity_bytes())
+            .map_err(|_| anyhow!("GPU expert capacity does not fit u64"))?;
+        let expert_memory_ledger = GpuMemoryLedger::new(
+            actual_expert_workspace_bytes,
+            expert_capacity_bytes,
+        );
+        let physical_expert_registry =
+            PhysicalGpuExpertRegistry::new(expert_memory_ledger);
 
         let staging_up = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("staging_up"),
@@ -1216,7 +1748,7 @@ impl GpuBackend {
             num_kv_heads,
             head_dim,
             v_head_dim,
-            vram_expert_bufs: ParkingMutex::new(std::collections::HashMap::new()),
+            physical_expert_registry,
             gpu_expert_cache,
             expert_workspaces: ParkingMutex::new(expert_workspaces),
             expert_workspace_cv: parking_lot::Condvar::new(),
@@ -1224,20 +1756,31 @@ impl GpuBackend {
         })
     }
 
-    /// Upload expert weight bytes to VRAM and validate the projection
-    /// sub-range offsets for the per-dispatch bind groups.
-    ///
-    /// Weight layout (verify against `dispatch_expert_forward` before shipping):
-    ///   gate_proj bytes: [0,                   d_ff * d_model * 4)
-    ///   up_proj bytes:   [d_ff * d_model * 4,  2 * d_ff * d_model * 4)
-    ///   down_proj bytes: [2 * d_ff * d_model * 4, 3 * d_ff * d_model * 4)
-    /// All weights are f32 little-endian.
-    fn build_expert_entry(
+    /// Validate every PR1/PR2 upload invariant and compute the exact wgpu
+    /// buffer descriptor bytes before the physical registry reserves space.
+    fn plan_expert_upload(
+        &self,
+        dtype: crate::inference::WeightDtype,
+        weight_bytes: &[u8],
+        d_model: usize,
+        d_ff: usize,
+    ) -> anyhow::Result<ExpertUploadPlan> {
+        match dtype {
+            crate::inference::WeightDtype::Q4_0 => self
+                .plan_expert_upload_q4_0(weight_bytes, d_model, d_ff)
+                .map(ExpertUploadPlan::Q4_0),
+            _ => self
+                .plan_expert_upload_f32(weight_bytes, d_model, d_ff)
+                .map(ExpertUploadPlan::F32),
+        }
+    }
+
+    fn plan_expert_upload_f32(
         &self,
         weight_bytes: &[u8],
-        d_model:      usize,
-        d_ff:         usize,
-    ) -> anyhow::Result<VramExpertEntry> {
+        d_model: usize,
+        d_ff: usize,
+    ) -> anyhow::Result<F32ExpertUploadPlan> {
         anyhow::ensure!(
             d_model > 0 && d_ff > 0,
             "invalid expert shape: d_ff={} d_model={} produces zero-byte projections",
@@ -1262,24 +1805,118 @@ impl GpuBackend {
             "expert weight buffer too small: got {} bytes, need {} (3 × d_ff={} × d_model={} × 4)",
             weight_bytes.len(), layout.required_bytes, d_ff, d_model
         );
+        let device_bytes = u64::try_from(weight_bytes.len())
+            .map_err(|_| anyhow!("F32 expert buffer length does not fit u64"))?;
+        Ok(F32ExpertUploadPlan {
+            device_bytes,
+            projection_offset: layout.projection_offset,
+        })
+    }
+
+    fn plan_expert_upload_q4_0(
+        &self,
+        weight_bytes: &[u8],
+        d_model: usize,
+        d_ff: usize,
+    ) -> anyhow::Result<Q4ExpertUploadPlan> {
+        use crate::inference::{Q4_0_BLOCK_BYTES, Q4_0_BLOCK_ELEMS};
+
+        anyhow::ensure!(
+            d_model > 0 && d_ff > 0,
+            "invalid expert shape: d_ff={} d_model={}",
+            d_ff, d_model
+        );
+        routed_expert_gpu_compatibility(RoutedExpertGpuSpec {
+            dtype: crate::inference::WeightDtype::Q4_0,
+            d_model,
+            d_ff,
+        })
+        .map_err(|e| anyhow!(e))?;
+        let proj_elems = d_ff
+            .checked_mul(d_model)
+            .ok_or_else(|| anyhow!("Q4_0 expert shape overflow: d_ff={d_ff} d_model={d_model}"))?;
+        let blocks_per_projection = proj_elems / Q4_0_BLOCK_ELEMS;
+        let projection_bytes = blocks_per_projection
+            .checked_mul(Q4_0_BLOCK_BYTES)
+            .ok_or_else(|| anyhow!(
+                "Q4_0 expert projection byte size overflow: {blocks_per_projection} blocks × {Q4_0_BLOCK_BYTES}B"
+            ))?;
+        let required_bytes = projection_bytes
+            .checked_mul(3)
+            .ok_or_else(|| anyhow!(
+                "Q4_0 expert total byte size overflow: 3 × {projection_bytes}B"
+            ))?;
+        let tolerance = self.q4_truncation_tolerance;
+        anyhow::ensure!(
+            weight_bytes.len() >= required_bytes
+                || (required_bytes > tolerance
+                    && tolerance > 0
+                    && required_bytes - weight_bytes.len() <= tolerance),
+            "Q4_0 expert weight buffer too small: got {} bytes, need {} (3 × {} blocks × {}B); \
+             missing logical bytes are never zero-filled in strict mode \
+             (allow_truncated_expert_payloads = false)",
+            weight_bytes.len(),
+            required_bytes,
+            blocks_per_projection,
+            Q4_0_BLOCK_BYTES
+        );
+        let down_block_offset = blocks_per_projection
+            .checked_mul(2)
+            .ok_or_else(|| anyhow!("Q4_0 expert block offset overflow"))?;
+        anyhow::ensure!(
+            down_block_offset <= u32::MAX as usize,
+            "Q4_0 expert block count {} exceeds u32 push-constant range",
+            down_block_offset
+        );
+        let padded_bytes = required_bytes
+            .checked_add(3)
+            .ok_or_else(|| anyhow!("Q4_0 padded device byte size overflow"))?
+            / 4
+            * 4;
+        Ok(Q4ExpertUploadPlan {
+            device_bytes: u64::try_from(padded_bytes)
+                .map_err(|_| anyhow!("Q4_0 padded buffer length does not fit u64"))?,
+            required_bytes,
+            up_block_offset: blocks_per_projection as u32,
+            down_block_offset: down_block_offset as u32,
+        })
+    }
+
+    /// Upload validated F32 bytes after capacity has been reserved. Weight
+    /// layout is `[gate | up | down]`; `projection_offset` was checked against
+    /// the selected device's storage-offset alignment by the upload plan.
+    fn build_expert_entry(
+        &self,
+        key: PhysicalExpertKey,
+        weight_bytes: &[u8],
+        d_model: usize,
+        d_ff: usize,
+        plan: F32ExpertUploadPlan,
+        permit: &mut PhysicalInstallPermit<VramExpertEntry>,
+    ) -> anyhow::Result<VramExpertEntry> {
 
         // ── Upload weights to VRAM ────────────────────────────────────────────
         let weight_buf = self.device.create_buffer(&wgpu::BufferDescriptor {
             label:              Some("vram_expert_weights"),
-            size:               weight_bytes.len() as u64,
+            size:               plan.device_bytes,
             usage:              wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
+        debug_assert_eq!(weight_buf.size(), plan.device_bytes);
         self.queue.write_buffer(&weight_buf, 0, weight_bytes);
+        let allocation = permit.charge_allocation().map_err(|e| anyhow!(e))?;
 
         Ok(VramExpertEntry {
+            key,
             weight_buf,
             d_model,
             d_ff,
             layout: VramWeightLayout::F32,
-            proj_bytes: layout.projection_offset,
+            proj_bytes: plan.projection_offset,
             up_block_off: 0,
             down_block_off: 0,
+            device_bytes: plan.device_bytes,
+            _allocation: allocation,
         })
     }
 
@@ -1299,78 +1936,27 @@ impl GpuBackend {
     /// mirroring the CPU loader's `q4_expert_bytes_with_tolerance`.
     fn build_expert_entry_q4_0(
         &self,
+        key: PhysicalExpertKey,
         weight_bytes: &[u8],
-        d_model:      usize,
-        d_ff:         usize,
+        d_model: usize,
+        d_ff: usize,
+        plan: Q4ExpertUploadPlan,
+        permit: &mut PhysicalInstallPermit<VramExpertEntry>,
     ) -> anyhow::Result<VramExpertEntry> {
-        use crate::inference::{Q4_0_BLOCK_BYTES, Q4_0_BLOCK_ELEMS};
-
-        anyhow::ensure!(
-            d_model > 0 && d_ff > 0,
-            "invalid expert shape: d_ff={} d_model={}",
-            d_ff, d_model
-        );
-        // Re-run the shared block-alignment and workspace checks at upload so
-        // startup validation never replaces this defensive boundary.
-        routed_expert_gpu_compatibility(RoutedExpertGpuSpec {
-            dtype: crate::inference::WeightDtype::Q4_0,
-            d_model,
-            d_ff,
-        })
-        .map_err(|e| anyhow!(e))?;
-
-        // `checked_mul` guards against `usize` overflow on user-configurable
-        // dims; the division is exact (block alignment is enforced above and
-        // `Q4_0_BLOCK_ELEMS` is a nonzero constant).
-        let proj_elems = d_ff
-            .checked_mul(d_model)
-            .ok_or_else(|| anyhow::anyhow!(
-                "Q4_0 expert shape overflow: d_ff={} d_model={}",
-                d_ff, d_model
-            ))?;
-        let blocks_per_proj = proj_elems / Q4_0_BLOCK_ELEMS;
-        let proj_bytes = blocks_per_proj
-            .checked_mul(Q4_0_BLOCK_BYTES)
-            .ok_or_else(|| anyhow::anyhow!(
-                "Q4_0 expert proj byte size overflow: {} blocks × {}B",
-                blocks_per_proj, Q4_0_BLOCK_BYTES
-            ))?;
-        let need = proj_bytes
-            .checked_mul(3)
-            .ok_or_else(|| anyhow::anyhow!(
-                "Q4_0 expert total byte size overflow: 3 × {}B",
-                proj_bytes
-            ))?;
-        // Strict mode requires the exact logical payload; the ≤ one-page
-        // zero-fill shortfall survives only behind the explicitly named
-        // `allow_truncated_expert_payloads` development flag.
-        let tol = self.q4_truncation_tolerance;
-        anyhow::ensure!(
-            weight_bytes.len() >= need
-                || (need > tol && tol > 0 && need - weight_bytes.len() <= tol),
-            "Q4_0 expert weight buffer too small: got {} bytes, need {} (3 × {} blocks × {}B); \
-             missing logical bytes are never zero-filled in strict mode \
-             (allow_truncated_expert_payloads = false)",
-            weight_bytes.len(), need, blocks_per_proj, Q4_0_BLOCK_BYTES
-        );
-        anyhow::ensure!(
-            2 * blocks_per_proj <= u32::MAX as usize,
-            "Q4_0 expert block count {} exceeds u32 push-constant range",
-            2 * blocks_per_proj
-        );
-
         // wgpu requires buffer sizes / write lengths to be 4-byte
-        // multiples; `need` is only guaranteed even (18-byte blocks), so
+        // multiples; the logical payload is only guaranteed even, so
         // round up and zero-fill the tail (also covers the ≤ one-page
         // shortfall tolerance above).
-        let padded_len = need.div_ceil(4) * 4;
+        let padded_len = usize::try_from(plan.device_bytes)
+            .map_err(|_| anyhow!("Q4_0 device buffer size does not fit usize"))?;
         let weight_buf = self.device.create_buffer(&wgpu::BufferDescriptor {
             label:              Some("vram_expert_weights_q4_0"),
-            size:               padded_len as u64,
+            size:               plan.device_bytes,
             usage:              wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
-        let avail = weight_bytes.len().min(need);
+        debug_assert_eq!(weight_buf.size(), plan.device_bytes);
+        let avail = weight_bytes.len().min(plan.required_bytes);
         if avail == padded_len {
             // Fast path: the source covers the full (already 4-byte-
             // aligned) buffer, so write it directly without a copy.
@@ -1384,19 +1970,23 @@ impl GpuBackend {
             padded.resize(padded_len, 0);
             self.queue.write_buffer(&weight_buf, 0, &padded);
         }
+        let allocation = permit.charge_allocation().map_err(|e| anyhow!(e))?;
 
         // The projection base is selected via the `w_block_off` push
         // constant (Q4_0 blocks are 18 bytes and cannot honour
         // min_storage_buffer_offset_alignment), so the per-dispatch
         // matmul bind groups bind the entire weight buffer.
         Ok(VramExpertEntry {
+            key,
             weight_buf,
             d_model,
             d_ff,
             layout: VramWeightLayout::Q4_0,
             proj_bytes: 0,
-            up_block_off: blocks_per_proj as u32,
-            down_block_off: (2 * blocks_per_proj) as u32,
+            up_block_off: plan.up_block_offset,
+            down_block_off: plan.down_block_offset,
+            device_bytes: plan.device_bytes,
+            _allocation: allocation,
         })
     }
 
@@ -2087,39 +2677,140 @@ impl GpuBackend {
             ));
         }
 
-        let cached_entry = self.vram_expert_bufs.lock().get(&expert_id).cloned();
-        if let Some(entry) = cached_entry {
+        let admission = match self.gpu_expert_cache.get(expert_id) {
+            GpuLookup::AnchorHit(admission) | GpuLookup::LruHit(admission) => admission,
+            GpuLookup::Miss => {
+                self.physical_expert_registry
+                    .retire_logical_miss(expert_id);
+                return Err(GpuExpertDispatchError::new(
+                    layer,
+                    expert_id,
+                    GpuExpertDispatchErrorKind::ResidencyMiss,
+                    "expert has no current logical GPU admission",
+                ));
+            }
+        };
+        let key = PhysicalExpertKey {
+            expert_id,
+            generation: admission.generation(),
+        };
+        if let Some(entry) = self.physical_expert_registry.lookup_current(key) {
+            if !self
+                .gpu_expert_cache
+                .contains_generation(expert_id, key.generation)
+            {
+                self.physical_expert_registry.retire_key_if_present(key);
+                return Err(GpuExpertDispatchError::new(
+                    layer,
+                    expert_id,
+                    GpuExpertDispatchErrorKind::ResidencyMiss,
+                    "logical GPU admission changed before physical dispatch",
+                ));
+            }
             return self.expert_matmul_from_vram(layer, expert_id, &entry, x, out);
         }
 
-        self.vram_expert_bufs
-            .lock()
-            .retain(|id, _| self.gpu_expert_cache.contains(*id));
-
-        match self.gpu_expert_cache.get(expert_id) {
-            GpuLookup::AnchorHit(r) | GpuLookup::LruHit(r) => {
-                // Re-run every PR2 compatibility check at the actual
-                // on-demand allocation/upload boundary.
-                let entry = match r.dtype() {
-                    crate::inference::WeightDtype::Q4_0 => {
-                        self.build_expert_entry_q4_0(r.data(), d_model, d_ff)
-                    }
-                    _ => self.build_expert_entry(r.data(), d_model, d_ff),
+        let resident = admission.resident();
+        let plan = self
+            .plan_expert_upload(resident.dtype(), resident.data(), d_model, d_ff)
+            .map_err(|e| GpuExpertDispatchError::new(
+                layer,
+                expert_id,
+                GpuExpertDispatchErrorKind::Upload,
+                e.to_string(),
+            ))?;
+        let acquisition = self
+            .physical_expert_registry
+            .acquire_or_reserve(key, plan.device_bytes())
+            .map_err(|e| GpuExpertDispatchError::new(
+                layer,
+                expert_id,
+                GpuExpertDispatchErrorKind::PhysicalCapacity,
+                e.to_string(),
+            ))?;
+        let entry = match acquisition {
+            PhysicalRegistryAcquire::Hit(entry) => entry,
+            PhysicalRegistryAcquire::Install(mut permit) => {
+                if !self
+                    .gpu_expert_cache
+                    .contains_generation(expert_id, key.generation)
+                {
+                    return Err(GpuExpertDispatchError::new(
+                        layer,
+                        expert_id,
+                        GpuExpertDispatchErrorKind::ResidencyMiss,
+                        "logical GPU admission changed before physical upload",
+                    ));
+                }
+                let entry = match plan {
+                    ExpertUploadPlan::F32(plan) => self.build_expert_entry(
+                        key,
+                        resident.data(),
+                        d_model,
+                        d_ff,
+                        plan,
+                        &mut permit,
+                    ),
+                    ExpertUploadPlan::Q4_0(plan) => self.build_expert_entry_q4_0(
+                        key,
+                        resident.data(),
+                        d_model,
+                        d_ff,
+                        plan,
+                        &mut permit,
+                    ),
                 }
                 .map_err(|e| GpuExpertDispatchError::new(
-                    layer, expert_id, GpuExpertDispatchErrorKind::Upload, e.to_string(),
+                    layer,
+                    expert_id,
+                    GpuExpertDispatchErrorKind::Upload,
+                    e.to_string(),
                 ))?;
-                let entry = Arc::new(entry);
-                self.vram_expert_bufs.lock().insert(expert_id, entry.clone());
-                self.expert_matmul_from_vram(layer, expert_id, &entry, x, out)
+                if !self
+                    .gpu_expert_cache
+                    .contains_generation(expert_id, key.generation)
+                {
+                    drop(entry);
+                    return Err(GpuExpertDispatchError::new(
+                        layer,
+                        expert_id,
+                        GpuExpertDispatchErrorKind::ResidencyMiss,
+                        "logical GPU admission changed during physical upload",
+                    ));
+                }
+                permit.install(Arc::new(entry)).map_err(|detail| {
+                    GpuExpertDispatchError::new(
+                        layer,
+                        expert_id,
+                        GpuExpertDispatchErrorKind::RuntimeInvariant,
+                        detail,
+                    )
+                })?
             }
-            GpuLookup::Miss => Err(GpuExpertDispatchError::new(
+        };
+        // The generation may change between the post-upload check and the
+        // registry install. Retire any just-installed stale entry before it
+        // can become a dispatch result; an eviction after this point treats
+        // this Arc as the already-in-flight activation it represents.
+        if !self
+            .gpu_expert_cache
+            .contains_generation(expert_id, key.generation)
+        {
+            self.physical_expert_registry.retire_key_if_present(key);
+            return Err(GpuExpertDispatchError::new(
                 layer,
                 expert_id,
                 GpuExpertDispatchErrorKind::ResidencyMiss,
-                "expert is not present in the GPU expert cache",
-            )),
+                "logical GPU admission changed before physical dispatch",
+            ));
         }
+        self.expert_matmul_from_vram(layer, expert_id, &entry, x, out)
+    }
+
+    #[allow(dead_code)] // Public snapshot callers arrive in PR5.
+    fn gpu_expert_memory_snapshot(&self) -> GpuExpertMemorySnapshot {
+        self.physical_expert_registry
+            .snapshot(self.gpu_expert_cache.used_bytes())
     }
 
     fn compute_plane(&self) -> &str {
@@ -2353,6 +3044,19 @@ impl BackendBox {
             BackendBox::Cpu(_) => "cpu-fallback",
             #[cfg(test)]
             BackendBox::TestGpu(_) => "test-gpu",
+        }
+    }
+
+    /// Exact PR4 routed-expert physical-memory ledger when this is a
+    /// production GPU backend. CPU and hardware-independent test backends do
+    /// not own physical wgpu expert allocations.
+    #[allow(dead_code)] // Public snapshot callers arrive in PR5.
+    pub fn gpu_expert_memory_snapshot(&self) -> Option<GpuExpertMemorySnapshot> {
+        match self {
+            Self::Gpu(gpu) => Some(gpu.gpu_expert_memory_snapshot()),
+            Self::Cpu(_) => None,
+            #[cfg(test)]
+            Self::TestGpu(_) => None,
         }
     }
 
@@ -2901,7 +3605,7 @@ impl ExecutionContext {
         );
         assert!(
             plan.routed_experts() != ExecutionPlane::Gpu || gpu_expert_cache.capacity_bytes() > 0,
-            "GPU routed-expert plane requires a non-zero VRAM expert cache"
+            "GPU routed-expert plane requires non-zero expert-weight capacity"
         );
         Self {
             plan,
@@ -2939,6 +3643,16 @@ impl ExecutionContext {
 
     pub fn gpu_expert_cache(&self) -> &Arc<crate::expert_cache::GpuExpertCache> {
         &self.gpu_expert_cache
+    }
+
+    /// Narrow snapshot seam for PR5. Existing compatibility telemetry remains
+    /// logical-admission based; this API exposes exact MER-owned physical
+    /// expert and workspace bytes without log parsing.
+    #[allow(dead_code)] // Public snapshot callers arrive in PR5.
+    pub fn gpu_expert_memory_snapshot(&self) -> Option<GpuExpertMemorySnapshot> {
+        self.gpu_backend
+            .as_ref()
+            .and_then(|backend| backend.gpu_expert_memory_snapshot())
     }
 
     pub fn primary_backend(&self) -> &Arc<BackendBox> {
@@ -3022,7 +3736,7 @@ pub enum BackendResolutionError {
     /// Invalid GPU sizing or attention geometry detected before adapter or
     /// device initialization.
     InvalidGeometry { detail: String },
-    /// Hybrid selects GPU routed experts, but no non-zero VRAM expert cache
+    /// Hybrid selects GPU routed experts, but no non-zero expert-weight capacity
     /// was configured to make that plane executable.
     RoutedExpertGpuCacheRequired,
     /// Explicit Hybrid requested GPU routed experts, but the current expert
@@ -3474,6 +4188,247 @@ pub fn current() -> Arc<BackendBox> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    struct TestPhysicalEntry {
+        key: PhysicalExpertKey,
+        bytes: u64,
+        _allocation: ExpertAllocationLease,
+    }
+
+    impl PhysicalRegistryEntry for TestPhysicalEntry {
+        fn physical_key(&self) -> PhysicalExpertKey {
+            self.key
+        }
+
+        fn device_bytes(&self) -> u64 {
+            self.bytes
+        }
+    }
+
+    fn test_physical_registry(
+        capacity_bytes: u64,
+        workspace_bytes: u64,
+    ) -> Arc<PhysicalGpuExpertRegistry<TestPhysicalEntry>> {
+        PhysicalGpuExpertRegistry::new(GpuMemoryLedger::new(
+            workspace_bytes,
+            capacity_bytes,
+        ))
+    }
+
+    fn install_test_physical_entry(
+        registry: &Arc<PhysicalGpuExpertRegistry<TestPhysicalEntry>>,
+        key: PhysicalExpertKey,
+        bytes: u64,
+    ) -> std::result::Result<Arc<TestPhysicalEntry>, String> {
+        match registry
+            .acquire_or_reserve(key, bytes)
+            .map_err(|e| e.to_string())?
+        {
+            PhysicalRegistryAcquire::Hit(entry) => Ok(entry),
+            PhysicalRegistryAcquire::Install(mut permit) => {
+                let allocation = permit.charge_allocation()?;
+                permit.install(Arc::new(TestPhysicalEntry {
+                    key,
+                    bytes,
+                    _allocation: allocation,
+                }))
+            }
+        }
+    }
+
+    fn physical_key(expert_id: u32, generation: u64) -> PhysicalExpertKey {
+        PhysicalExpertKey {
+            expert_id,
+            generation,
+        }
+    }
+
+    #[test]
+    fn physical_registry_matching_generation_hits_without_reinstall() {
+        let registry = test_physical_registry(128, 0);
+        let key = physical_key(7, 1);
+        let first = install_test_physical_entry(&registry, key, 32).unwrap();
+        let second = install_test_physical_entry(&registry, key, 32).unwrap();
+        assert!(Arc::ptr_eq(&first, &second));
+        let snapshot = registry.snapshot(32);
+        assert_eq!(snapshot.physical_installs, 1);
+        assert_eq!(snapshot.physical_entries, 1);
+        assert_eq!(snapshot.expert_registry_bytes, 32);
+    }
+
+    #[test]
+    fn physical_registry_retires_stale_generation_before_reinstall() {
+        let registry = test_physical_registry(128, 0);
+        let g1 = physical_key(7, 1);
+        let old = install_test_physical_entry(&registry, g1, 32).unwrap();
+        let g2 = physical_key(7, 2);
+        let current = install_test_physical_entry(&registry, g2, 32).unwrap();
+        registry.retire_key_if_present(g1);
+        assert!(!registry.contains_key(g1));
+        assert!(registry.contains_key(g2));
+        let snapshot = registry.snapshot(32);
+        assert_eq!(snapshot.physical_installs, 2);
+        assert_eq!(snapshot.stale_retirements, 1);
+        assert_eq!(snapshot.expert_registry_bytes, 32);
+        assert_eq!(snapshot.expert_live_bytes, 64);
+        drop(old);
+        assert_eq!(registry.snapshot(32).expert_live_bytes, 32);
+        drop(current);
+    }
+
+    #[test]
+    fn logical_miss_removes_physical_addressability_but_not_inflight_charge() {
+        let registry = test_physical_registry(64, 0);
+        let key = physical_key(9, 1);
+        let in_flight = install_test_physical_entry(&registry, key, 40).unwrap();
+        registry.retire_logical_miss(9);
+        let snapshot = registry.snapshot(0);
+        assert!(!registry.contains_key(key));
+        assert_eq!(snapshot.physical_entries, 0);
+        assert_eq!(snapshot.expert_registry_bytes, 0);
+        assert_eq!(snapshot.expert_live_bytes, 40);
+        drop(in_flight);
+        assert_eq!(registry.snapshot(0).expert_live_bytes, 0);
+    }
+
+    #[test]
+    fn physical_capacity_evicts_lru_and_never_exceeds_cap() {
+        let registry = test_physical_registry(60, 0);
+        drop(install_test_physical_entry(&registry, physical_key(1, 1), 30).unwrap());
+        drop(install_test_physical_entry(&registry, physical_key(2, 1), 30).unwrap());
+        let exact = registry.snapshot(60);
+        assert_eq!(exact.expert_registry_bytes, 60);
+        assert_eq!(exact.physical_entries, 2);
+
+        drop(install_test_physical_entry(&registry, physical_key(3, 1), 30).unwrap());
+        let snapshot = registry.snapshot(60);
+        assert!(!registry.contains_key(physical_key(1, 1)));
+        assert!(registry.contains_key(physical_key(2, 1)));
+        assert!(registry.contains_key(physical_key(3, 1)));
+        assert_eq!(snapshot.expert_registry_bytes, 60);
+        assert!(snapshot.expert_registry_bytes <= snapshot.expert_capacity_bytes);
+        assert_eq!(snapshot.physical_evictions, 1);
+    }
+
+    #[test]
+    fn oversized_physical_expert_fails_without_any_charge() {
+        let registry = test_physical_registry(50, 0);
+        let err = registry
+            .acquire_or_reserve(physical_key(1, 1), 51)
+            .err()
+            .expect("oversized expert must fail");
+        assert_eq!(err.requested_bytes, 51);
+        assert_eq!(err.expert_capacity_bytes, 50);
+        let snapshot = registry.snapshot(51);
+        assert_eq!(snapshot.physical_entries, 0);
+        assert_eq!(snapshot.expert_registry_bytes, 0);
+        assert_eq!(snapshot.expert_live_bytes, 0);
+    }
+
+    #[test]
+    fn inflight_eviction_keeps_live_charge_and_blocks_overcommit() {
+        let registry = test_physical_registry(60, 0);
+        let in_flight =
+            install_test_physical_entry(&registry, physical_key(1, 1), 40).unwrap();
+        let err = registry
+            .acquire_or_reserve(physical_key(2, 1), 40)
+            .err()
+            .expect("in-flight live bytes must prevent overcommit");
+        assert_eq!(err.expert_live_bytes, 40);
+        let evicted = registry.snapshot(40);
+        assert_eq!(evicted.physical_entries, 0);
+        assert_eq!(evicted.expert_registry_bytes, 0);
+        assert_eq!(evicted.expert_live_bytes, 40);
+        drop(in_flight);
+        assert_eq!(registry.snapshot(0).expert_live_bytes, 0);
+        drop(install_test_physical_entry(&registry, physical_key(2, 1), 40).unwrap());
+    }
+
+    #[test]
+    fn eviction_and_new_generation_perform_real_second_install() {
+        let registry = test_physical_registry(64, 0);
+        let first = install_test_physical_entry(&registry, physical_key(4, 1), 32).unwrap();
+        registry.retire_logical_miss(4);
+        drop(first);
+        drop(install_test_physical_entry(&registry, physical_key(4, 2), 32).unwrap());
+        let snapshot = registry.snapshot(32);
+        assert_eq!(snapshot.physical_installs, 2);
+        assert_eq!(snapshot.physical_entries, 1);
+        assert!(registry.contains_key(physical_key(4, 2)));
+    }
+
+    #[test]
+    fn failed_construction_or_charged_loser_cannot_leak_bytes() {
+        let registry = test_physical_registry(64, 0);
+        let key = physical_key(5, 1);
+        let permit = match registry.acquire_or_reserve(key, 32).unwrap() {
+            PhysicalRegistryAcquire::Install(permit) => permit,
+            PhysicalRegistryAcquire::Hit(_) => panic!("unexpected physical hit"),
+        };
+        drop(permit);
+        assert_eq!(registry.snapshot(0).expert_live_bytes, 0);
+
+        let mut permit = match registry.acquire_or_reserve(key, 32).unwrap() {
+            PhysicalRegistryAcquire::Install(permit) => permit,
+            PhysicalRegistryAcquire::Hit(_) => panic!("unexpected physical hit"),
+        };
+        let allocation = permit.charge_allocation().unwrap();
+        drop(permit);
+        assert_eq!(registry.snapshot(0).expert_live_bytes, 32);
+        drop(allocation);
+        let snapshot = registry.snapshot(0);
+        assert_eq!(snapshot.expert_live_bytes, 0);
+        assert_eq!(snapshot.expert_registry_bytes, 0);
+        assert_eq!(snapshot.physical_installs, 0);
+    }
+
+    #[test]
+    fn concurrent_same_expert_demand_installs_once_and_accounts_once() {
+        let registry = test_physical_registry(64, 0);
+        let key = physical_key(6, 1);
+        let barrier = Arc::new(std::sync::Barrier::new(3));
+        let mut handles = Vec::new();
+        for _ in 0..2 {
+            let registry = registry.clone();
+            let barrier = barrier.clone();
+            handles.push(std::thread::spawn(move || {
+                barrier.wait();
+                install_test_physical_entry(&registry, key, 32).unwrap()
+            }));
+        }
+        barrier.wait();
+        let a = handles.remove(0).join().unwrap();
+        let b = handles.remove(0).join().unwrap();
+        assert!(Arc::ptr_eq(&a, &b));
+        let snapshot = registry.snapshot(32);
+        assert_eq!(snapshot.physical_installs, 1);
+        assert_eq!(snapshot.physical_entries, 1);
+        assert_eq!(snapshot.expert_registry_bytes, 32);
+        assert_eq!(snapshot.expert_live_bytes, 32);
+    }
+
+    #[test]
+    fn workspace_and_snapshot_accounting_are_exact_and_exclude_host_scratch() {
+        let buffer_bytes = (MAX_EXPERT_D_FF * std::mem::size_of::<f32>()) as u64;
+        let workspace_bytes = expert_workspace_device_bytes(buffer_bytes, EXPERT_WORKSPACE_POOL);
+        assert_eq!(
+            workspace_bytes,
+            buffer_bytes * EXPERT_WORKSPACE_DEVICE_BUFFERS * EXPERT_WORKSPACE_POOL as u64
+        );
+        // `Vec<f32>` scratch has the same logical length as one device buffer,
+        // but is intentionally absent from the five-buffer formula above.
+        let host_scratch_bytes = buffer_bytes * EXPERT_WORKSPACE_POOL as u64;
+        assert_ne!(workspace_bytes, workspace_bytes + host_scratch_bytes);
+
+        let registry = test_physical_registry(64, workspace_bytes);
+        drop(install_test_physical_entry(&registry, physical_key(1, 1), 32).unwrap());
+        let snapshot = registry.snapshot(32);
+        assert_eq!(snapshot.workspace_bytes, workspace_bytes);
+        assert_eq!(snapshot.total_tracked_bytes, 32 + workspace_bytes);
+        assert_eq!(snapshot.total_tracked_bytes, snapshot.expert_live_bytes + snapshot.workspace_bytes);
+        assert!(snapshot.expert_registry_bytes <= snapshot.expert_live_bytes);
+        assert!(snapshot.expert_registry_bytes <= snapshot.expert_capacity_bytes);
+    }
 
     #[test]
     fn kv_offset_symmetric_matches_shared_stride() {
@@ -3990,7 +4945,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "GPU routed-expert plane requires a non-zero VRAM expert cache")]
+    #[should_panic(expected = "GPU routed-expert plane requires non-zero expert-weight capacity")]
     fn execution_context_rejects_gpu_experts_without_cache() {
         let plan = ResolvedExecutionPlan::from_resolution(
             BackendResolution {

--- a/rust-engine/src/backend/mod.rs
+++ b/rust-engine/src/backend/mod.rs
@@ -420,6 +420,16 @@ impl fmt::Display for PhysicalCapacityError {
 enum PhysicalRegistryAcquire<T: PhysicalRegistryEntry> {
     Hit(Arc<T>),
     Install(PhysicalInstallPermit<T>),
+    StaleRequester,
+}
+
+/// Directional generation result for one expert-id lookup. A newer request
+/// may retire an older stored generation; an older request must never disturb
+/// a newer stored generation.
+enum PhysicalRegistryLookup<T: PhysicalRegistryEntry> {
+    Hit(Arc<T>),
+    Miss,
+    StaleRequester,
 }
 
 struct PhysicalInstallPermit<T: PhysicalRegistryEntry> {
@@ -454,7 +464,7 @@ impl<T: PhysicalRegistryEntry> PhysicalGpuExpertRegistry<T> {
     /// Return an addressable physical entry only when its logical generation
     /// still matches. This is the routed-expert fast path: it performs one
     /// registry lock and no upload planning or host-weight copy.
-    fn lookup_current(&self, key: PhysicalExpertKey) -> Option<Arc<T>> {
+    fn lookup_current(&self, key: PhysicalExpertKey) -> PhysicalRegistryLookup<T> {
         let mut inner = self.inner.lock();
         Self::lookup_current_locked(&mut inner, key)
     }
@@ -462,14 +472,27 @@ impl<T: PhysicalRegistryEntry> PhysicalGpuExpertRegistry<T> {
     fn lookup_current_locked(
         inner: &mut PhysicalRegistryInner<T>,
         key: PhysicalExpertKey,
-    ) -> Option<Arc<T>> {
-        let existing = inner.entries.peek(&key.expert_id).cloned()?;
-        if existing.physical_key() == key {
-            return inner.entries.get(&key.expert_id).cloned();
+    ) -> PhysicalRegistryLookup<T> {
+        let Some(existing) = inner.entries.peek(&key.expert_id).cloned() else {
+            return PhysicalRegistryLookup::Miss;
+        };
+        let stored_key = existing.physical_key();
+        debug_assert_eq!(stored_key.expert_id, key.expert_id);
+        if stored_key.generation == key.generation {
+            return PhysicalRegistryLookup::Hit(
+                inner
+                    .entries
+                    .get(&key.expert_id)
+                    .cloned()
+                    .expect("validated physical entry must remain present under lock"),
+            );
+        }
+        if stored_key.generation > key.generation {
+            return PhysicalRegistryLookup::StaleRequester;
         }
 
         Self::retire_entry_locked(inner, key.expert_id);
-        None
+        PhysicalRegistryLookup::Miss
     }
 
     fn retire_entry_locked(inner: &mut PhysicalRegistryInner<T>, expert_id: u32) {
@@ -501,8 +524,14 @@ impl<T: PhysicalRegistryEntry> PhysicalGpuExpertRegistry<T> {
 
         let mut inner = self.inner.lock();
         loop {
-            if let Some(hit) = Self::lookup_current_locked(&mut inner, key) {
-                return Ok(PhysicalRegistryAcquire::Hit(hit));
+            match Self::lookup_current_locked(&mut inner, key) {
+                PhysicalRegistryLookup::Hit(hit) => {
+                    return Ok(PhysicalRegistryAcquire::Hit(hit));
+                }
+                PhysicalRegistryLookup::Miss => {}
+                PhysicalRegistryLookup::StaleRequester => {
+                    return Ok(PhysicalRegistryAcquire::StaleRequester);
+                }
             }
 
             if inner
@@ -676,6 +705,8 @@ impl<T: PhysicalRegistryEntry> PhysicalInstallPermit<T> {
             return Err("physical install entry does not match its reservation".to_string());
         }
         let mut inner = self.registry.inner.lock();
+        // On every error below, this local guard must drop before the by-value
+        // permit argument runs `Drop` and re-locks the same registry.
         let reservation = *inner
             .installing
             .get(&self.key)
@@ -1800,17 +1831,7 @@ impl GpuBackend {
             self.min_storage_buffer_offset_alignment(),
         )
         .map_err(|e| anyhow!(e))?;
-        anyhow::ensure!(
-            weight_bytes.len() >= layout.required_bytes,
-            "expert weight buffer too small: got {} bytes, need {} (3 × d_ff={} × d_model={} × 4)",
-            weight_bytes.len(), layout.required_bytes, d_ff, d_model
-        );
-        let device_bytes = u64::try_from(weight_bytes.len())
-            .map_err(|_| anyhow!("F32 expert buffer length does not fit u64"))?;
-        Ok(F32ExpertUploadPlan {
-            device_bytes,
-            projection_offset: layout.projection_offset,
-        })
+        f32_expert_upload_plan(layout, weight_bytes.len(), d_model, d_ff)
     }
 
     fn plan_expert_upload_q4_0(
@@ -1903,7 +1924,10 @@ impl GpuBackend {
             mapped_at_creation: false,
         });
         debug_assert_eq!(weight_buf.size(), plan.device_bytes);
-        self.queue.write_buffer(&weight_buf, 0, weight_bytes);
+        let upload_bytes = usize::try_from(plan.device_bytes)
+            .map_err(|_| anyhow!("F32 device buffer size does not fit usize"))?;
+        self.queue
+            .write_buffer(&weight_buf, 0, &weight_bytes[..upload_bytes]);
         let allocation = permit.charge_allocation().map_err(|e| anyhow!(e))?;
 
         Ok(VramExpertEntry {
@@ -2692,20 +2716,31 @@ impl GpuBackend {
             expert_id,
             generation: admission.generation(),
         };
-        if let Some(entry) = self.physical_expert_registry.lookup_current(key) {
-            if !self
-                .gpu_expert_cache
-                .contains_generation(expert_id, key.generation)
-            {
-                self.physical_expert_registry.retire_key_if_present(key);
+        match self.physical_expert_registry.lookup_current(key) {
+            PhysicalRegistryLookup::Hit(entry) => {
+                if !self
+                    .gpu_expert_cache
+                    .contains_generation(expert_id, key.generation)
+                {
+                    self.physical_expert_registry.retire_key_if_present(key);
+                    return Err(GpuExpertDispatchError::new(
+                        layer,
+                        expert_id,
+                        GpuExpertDispatchErrorKind::ResidencyMiss,
+                        "logical GPU admission changed before physical dispatch",
+                    ));
+                }
+                return self.expert_matmul_from_vram(layer, expert_id, &entry, x, out);
+            }
+            PhysicalRegistryLookup::Miss => {}
+            PhysicalRegistryLookup::StaleRequester => {
                 return Err(GpuExpertDispatchError::new(
                     layer,
                     expert_id,
                     GpuExpertDispatchErrorKind::ResidencyMiss,
-                    "logical GPU admission changed before physical dispatch",
+                    "physical GPU residency has a newer logical generation",
                 ));
             }
-            return self.expert_matmul_from_vram(layer, expert_id, &entry, x, out);
         }
 
         let resident = admission.resident();
@@ -2728,6 +2763,14 @@ impl GpuBackend {
             ))?;
         let entry = match acquisition {
             PhysicalRegistryAcquire::Hit(entry) => entry,
+            PhysicalRegistryAcquire::StaleRequester => {
+                return Err(GpuExpertDispatchError::new(
+                    layer,
+                    expert_id,
+                    GpuExpertDispatchErrorKind::ResidencyMiss,
+                    "physical GPU residency advanced before acquisition",
+                ));
+            }
             PhysicalRegistryAcquire::Install(mut permit) => {
                 if !self
                     .gpu_expert_cache
@@ -3402,6 +3445,31 @@ fn f32_expert_projection_layout(
         projection_bytes,
         projection_offset,
         required_bytes,
+    })
+}
+
+/// Convert a validated F32 projection layout into the exact device upload
+/// plan. Host payloads may include storage padding beyond the three logical
+/// projections; that padding is neither allocated nor copied to the GPU.
+fn f32_expert_upload_plan(
+    layout: F32ExpertProjectionLayout,
+    host_bytes: usize,
+    d_model: usize,
+    d_ff: usize,
+) -> anyhow::Result<F32ExpertUploadPlan> {
+    anyhow::ensure!(
+        host_bytes >= layout.required_bytes,
+        "expert weight buffer too small: got {} bytes, need {} (3 × d_ff={} × d_model={} × 4)",
+        host_bytes,
+        layout.required_bytes,
+        d_ff,
+        d_model
+    );
+    let device_bytes = u64::try_from(layout.required_bytes)
+        .map_err(|_| anyhow!("F32 expert buffer length does not fit u64"))?;
+    Ok(F32ExpertUploadPlan {
+        device_bytes,
+        projection_offset: layout.projection_offset,
     })
 }
 
@@ -4231,6 +4299,9 @@ mod tests {
                     _allocation: allocation,
                 }))
             }
+            PhysicalRegistryAcquire::StaleRequester => {
+                Err("physical install requester generation is stale".to_string())
+            }
         }
     }
 
@@ -4261,17 +4332,64 @@ mod tests {
         let old = install_test_physical_entry(&registry, g1, 32).unwrap();
         let g2 = physical_key(7, 2);
         let current = install_test_physical_entry(&registry, g2, 32).unwrap();
-        registry.retire_key_if_present(g1);
         assert!(!registry.contains_key(g1));
         assert!(registry.contains_key(g2));
-        let snapshot = registry.snapshot(32);
-        assert_eq!(snapshot.physical_installs, 2);
-        assert_eq!(snapshot.stale_retirements, 1);
-        assert_eq!(snapshot.expert_registry_bytes, 32);
-        assert_eq!(snapshot.expert_live_bytes, 64);
+        let after_reinstall = registry.snapshot(32);
+        assert_eq!(after_reinstall.physical_installs, 2);
+        assert_eq!(after_reinstall.stale_retirements, 1);
+        assert_eq!(after_reinstall.expert_registry_bytes, 32);
+        assert_eq!(after_reinstall.expert_live_bytes, 64);
+
+        registry.retire_key_if_present(g1);
+        assert_eq!(
+            registry.snapshot(32),
+            after_reinstall,
+            "retiring the old key must be a no-op against stored G2"
+        );
+        assert!(registry.contains_key(g2));
         drop(old);
         assert_eq!(registry.snapshot(32).expert_live_bytes, 32);
         drop(current);
+    }
+
+    #[test]
+    fn physical_registry_stale_requester_cannot_retire_newer_generation() {
+        let registry = test_physical_registry(128, 0);
+        let g1 = physical_key(7, 1);
+        let g2 = physical_key(7, 2);
+        let current = install_test_physical_entry(&registry, g2, 32).unwrap();
+        let before = registry.snapshot(32);
+
+        assert!(matches!(
+            registry.lookup_current(g1),
+            PhysicalRegistryLookup::StaleRequester
+        ));
+        assert_eq!(registry.snapshot(32), before);
+        assert!(registry.contains_key(g2));
+        assert!(!registry.contains_key(g1));
+        assert_eq!(current.physical_key(), g2);
+    }
+
+    #[test]
+    fn physical_registry_acquire_rejects_request_staled_after_fast_miss() {
+        let registry = test_physical_registry(128, 0);
+        let g1 = physical_key(7, 1);
+        let g2 = physical_key(7, 2);
+        assert!(matches!(
+            registry.lookup_current(g1),
+            PhysicalRegistryLookup::Miss
+        ));
+
+        let current = install_test_physical_entry(&registry, g2, 32).unwrap();
+        let before = registry.snapshot(32);
+        assert!(matches!(
+            registry.acquire_or_reserve(g1, 32).unwrap(),
+            PhysicalRegistryAcquire::StaleRequester
+        ));
+        assert_eq!(registry.snapshot(32), before);
+        assert!(registry.contains_key(g2));
+        assert!(!registry.contains_key(g1));
+        assert_eq!(current.physical_key(), g2);
     }
 
     #[test]
@@ -4306,6 +4424,28 @@ mod tests {
         assert_eq!(snapshot.expert_registry_bytes, 60);
         assert!(snapshot.expert_registry_bytes <= snapshot.expert_capacity_bytes);
         assert_eq!(snapshot.physical_evictions, 1);
+    }
+
+    #[test]
+    fn matching_physical_lookup_updates_registry_lru_recency() {
+        let registry = test_physical_registry(60, 0);
+        let g1 = physical_key(1, 1);
+        let g2 = physical_key(2, 1);
+        let g3 = physical_key(3, 1);
+        drop(install_test_physical_entry(&registry, g1, 30).unwrap());
+        drop(install_test_physical_entry(&registry, g2, 30).unwrap());
+
+        let hit = match registry.lookup_current(g1) {
+            PhysicalRegistryLookup::Hit(hit) => hit,
+            PhysicalRegistryLookup::Miss => panic!("expected physical hit"),
+            PhysicalRegistryLookup::StaleRequester => panic!("unexpected stale requester"),
+        };
+        drop(hit);
+        drop(install_test_physical_entry(&registry, g3, 30).unwrap());
+
+        assert!(registry.contains_key(g1), "matched lookup must make G1 MRU");
+        assert!(!registry.contains_key(g2), "G2 must remain the LRU victim");
+        assert!(registry.contains_key(g3));
     }
 
     #[test]
@@ -4362,6 +4502,7 @@ mod tests {
         let permit = match registry.acquire_or_reserve(key, 32).unwrap() {
             PhysicalRegistryAcquire::Install(permit) => permit,
             PhysicalRegistryAcquire::Hit(_) => panic!("unexpected physical hit"),
+            PhysicalRegistryAcquire::StaleRequester => panic!("unexpected stale requester"),
         };
         drop(permit);
         assert_eq!(registry.snapshot(0).expert_live_bytes, 0);
@@ -4369,6 +4510,7 @@ mod tests {
         let mut permit = match registry.acquire_or_reserve(key, 32).unwrap() {
             PhysicalRegistryAcquire::Install(permit) => permit,
             PhysicalRegistryAcquire::Hit(_) => panic!("unexpected physical hit"),
+            PhysicalRegistryAcquire::StaleRequester => panic!("unexpected stale requester"),
         };
         let allocation = permit.charge_allocation().unwrap();
         drop(permit);
@@ -4666,6 +4808,21 @@ mod tests {
         assert_eq!(layout.projection_bytes, 32 * 64 * 4);
         assert_eq!(layout.projection_offset, (32 * 64 * 4) as u64);
         assert_eq!(layout.required_bytes, 3 * 32 * 64 * 4);
+    }
+
+    #[test]
+    fn f32_upload_plan_excludes_trailing_host_padding() {
+        let layout = f32_expert_projection_layout(
+            test_routed_expert_gpu_spec(crate::inference::WeightDtype::F32),
+            256,
+        )
+        .unwrap();
+        let host_bytes = layout.required_bytes + 4096;
+        let plan = f32_expert_upload_plan(layout, host_bytes, 32, 64).unwrap();
+
+        assert_eq!(plan.device_bytes, layout.required_bytes as u64);
+        assert_eq!(plan.projection_offset, layout.projection_offset);
+        assert!(plan.device_bytes < host_bytes as u64);
     }
 
     #[test]

--- a/rust-engine/src/config.rs
+++ b/rust-engine/src/config.rs
@@ -479,9 +479,9 @@ pub struct RealTransformerConfig {
     /// CPU while selecting the GPU plane only for routed experts. `"hybrid"`
     /// requires strict attention semantics
     /// (`allow_nonfinite_attention_fallback = false`), an enabled GPU expert
-    /// cache with a non-zero VRAM budget, and a routed-expert dtype/geometry
-    /// supported by the current GPU expert implementation. Invalid Hybrid
-    /// combinations are hard startup errors.
+    /// cache with non-zero expert-weight capacity, and a routed-expert
+    /// dtype/geometry supported by the current GPU expert implementation.
+    /// Invalid Hybrid combinations are hard startup errors.
     #[serde(default)]
     pub compute_offload: crate::backend::ComputeOffload,
 
@@ -821,13 +821,12 @@ impl Default for PredictiveConfig {
     }
 }
 
-/// `[gpu_cache]` — Phase 1/2 of the 3-Tier Heterogeneous Memory
-/// Orchestrator (SSD → RAM → VRAM).
+/// `[gpu_cache]` — logical GPU admission plus bounded physical expert weights.
 ///
 /// Off by default. When `enabled = true`, the server is configured to
 /// layer a [`GpuExpertCache`](crate::expert_cache::GpuExpertCache) on
-/// top of the existing RAM `ExpertCache`. The VRAM cache is split into
-/// an **Anchor Core** (high-frequency experts permanently pinned once
+/// top of the existing RAM `ExpertCache`. This host admission cache is split
+/// into an **Anchor Core** (high-frequency experts permanently pinned once
 /// they cross `promote_after_hits`) and an **LRU Edge** (O(1) LRU
 /// queue handling temporal topic shifts). The `vram_anchor_ratio`
 /// controls the split between the two regions.
@@ -843,12 +842,10 @@ pub struct GpuCacheConfig {
     #[serde(default)]
     pub enabled: bool,
 
-    /// VRAM budget, in mebibytes (1 MiB = 1024 × 1024 bytes), available
-    /// to the expert cache. Defaults to 0 — i.e. the cache is created
-    /// with zero capacity and every lookup misses straight through to
-    /// the RAM tier. Operators sizing the cache should leave headroom
-    /// for the dense transformer body and the KV cache; a typical
-    /// 16 GiB consumer card might allocate 4096–8192 here.
+    /// Logical admission budget and physical routed-expert weight cap, in
+    /// mebibytes (1 MiB = 1024 × 1024 bytes). Fixed routed-expert workspaces
+    /// are accounted separately. Defaults to 0, so every admission lookup
+    /// misses through to RAM. Leave headroom for dense and KV allocations.
     #[serde(default)]
     pub vram_capacity_mb: usize,
 
@@ -859,27 +856,24 @@ pub struct GpuCacheConfig {
     #[serde(default = "default_promote_after_hits")]
     pub promote_after_hits: u64,
 
-    /// Fraction of `vram_capacity_mb` reserved for the Anchor Core
+    /// Fraction of `vram_capacity_mb` reserved for the logical Anchor Core
     /// (the rest is the LRU Edge). Range `0.0..=1.0`. Defaults to
-    /// `0.5` — half the VRAM is pinned to the hottest experts, half
+    /// `0.5` — half the admission budget is pinned to hottest experts, half
     /// floats with topical shifts.
     #[serde(default = "default_vram_anchor_ratio")]
     pub vram_anchor_ratio: f32,
 
-    /// Advisory on-device dtype label for the resident expert bytes.
+    /// Advisory dtype label for logically admitted expert bytes.
     /// Accepts the same spellings as [`WeightDtype::as_str`]: `"f32"`,
     /// `"f16"`, `"int8"`, `"q4k"`, `"q4_0"`, `"q8_0"`; defaults to
     /// `"f16"`.
     ///
     /// **Currently advisory only.** The promotion path copies the
-    /// on-disk expert bytes into VRAM as-is — it does not yet convert
-    /// or repack between dtypes, and VRAM accounting is driven by the
-    /// raw byte length of each [`ExpertResident`] rather than by this
-    /// field. The value is validated at startup (so typos fail fast)
-    /// and logged for observability, and is reserved for a future
-    /// promotion-time conversion/sizing path. Operators should size
-    /// `vram_capacity_mb` against the on-disk footprint, not against
-    /// the dtype label here.
+    /// on-disk payload into host logical admission as-is; the backend later
+    /// uploads supported formats without conversion. Compatibility `vram_*`
+    /// telemetry uses logical payload length, while the PR4 physical ledger
+    /// uses exact wgpu descriptor bytes. The value is validated and logged,
+    /// but does not drive promotion-time conversion or sizing.
     #[serde(default = "default_gpu_dtype")]
     pub dtype: String,
 }
@@ -981,8 +975,8 @@ pub struct Config {
     /// HTTP) to preserve the legacy behaviour bit-for-bit.
     #[serde(default)]
     pub security: SecurityConfig,
-    /// Optional `[gpu_cache]` section — Phase 1/2 of the 3-tier
-    /// heterogeneous memory orchestrator (SSD → RAM → VRAM). Off by
+    /// Optional `[gpu_cache]` section — logical GPU admission and physical
+    /// routed-expert weight capacity. Off by
     /// default; the binary behaves identically to the 2-tier engine
     /// when this section is absent.
     #[serde(default)]
@@ -1127,7 +1121,7 @@ impl Config {
                 )));
             }
             // Parse the dtype string against the WeightDtype contract so
-            // we fail fast on a typo rather than at first VRAM
+            // we fail fast on a typo rather than at first logical
             // promotion.
             if WeightDtype::from_str_opt(&self.gpu_cache.dtype).is_none() {
                 return Err(ConfigError::Invalid(format!(

--- a/rust-engine/src/engine.rs
+++ b/rust-engine/src/engine.rs
@@ -3182,7 +3182,7 @@ impl Engine {
                     // stage the host bytes into the admission LRU *now* instead
                     // of waiting for `promote_after_hits` RAM hits — the
                     // lazy path can leave a predicted expert on the CPU
-                    // fallback for its first N activations (one CPU
+                    // fallback path for its first few activations.
                     // Only attempt eager admission when the logical cache has room;
                     // otherwise we would copy ~expert_size bytes into a Vec only to have the
                     // non-evicting promotion path immediately reject it.

--- a/rust-engine/src/engine.rs
+++ b/rust-engine/src/engine.rs
@@ -839,8 +839,8 @@ pub(crate) struct Counters {
     /// predictive arm is misconfigured and contributing nothing.
     speculator_dmodel_mismatch: AtomicU64,
     /// Expert activations that fell back from the GPU fast path to the
-    /// CPU path because the VRAM dispatch errored (typically a VRAM
-    /// miss). Invisible mixed GPU/CPU execution is a major source of
+    /// CPU path because physical routed-expert dispatch errored. Invisible
+    /// mixed GPU/CPU execution is a major source of
     /// inconsistent token latency, so make it countable.
     gpu_cpu_fallbacks: AtomicU64,
     /// Hardware-independent CPU routed-expert forward spy. Test-only so the
@@ -1087,14 +1087,13 @@ pub(crate) struct EngineCore {
     pub(super) predictor: Arc<PredictiveLoader>,
     pub(super) shape: ModelShape,
     pub(super) options: EngineOptions,
-    /// Optional VRAM (GPU) expert cache — Phase 2 of the three-tier
-    /// memory hierarchy (SSD → RAM → VRAM). `None` (default) leaves
+    /// Optional logical GPU-admission cache. `None` (default) leaves
     /// the engine in its legacy 2-tier posture. When `Some`, every
     /// cache lookup in [`Engine::generate`] / [`Engine::moe_step`]
-    /// first probes the VRAM tier; misses fall through to the RAM
+    /// first probes logical admission; misses fall through to the RAM
     /// `MultiLayerExpertCache` and then to NVMe.
     pub(super) gpu_cache: Option<Arc<GpuExpertCache>>,
-    /// One-shot sender that feeds the background RAM → VRAM
+    /// One-shot sender that feeds background RAM → logical-GPU-admission
     /// promotion task. The receiver lives on a dedicated Tokio task
     /// spawned by [`Engine::install_gpu_cache`]; the inference hot
     /// path never blocks on this channel — promotions are pure
@@ -1841,19 +1840,24 @@ impl Engine {
         self.core.routed_expert_gpu_failure_policy
     }
 
-    /// Synchronously promote a freshly-loaded RAM resident into the
-    /// VRAM (GPU) expert cache, if one is installed and the expert's
-    /// dtype is GPU-eligible.
+    /// Exact MER-owned routed-expert GPU weight/workspace ledger for PR5.
+    /// Returns `None` when the resolved execution context has no GPU backend.
+    #[allow(dead_code)] // Public snapshot callers arrive in PR5.
+    pub fn gpu_expert_memory_snapshot(
+        &self,
+    ) -> Option<crate::backend::GpuExpertMemorySnapshot> {
+        self.core.execution_context.gpu_expert_memory_snapshot()
+    }
+
+    /// Synchronously copy a freshly-loaded RAM resident into the logical GPU
+    /// admission cache, if installed and GPU-compatible. Device upload remains
+    /// lazy and authoritative in `GpuBackend`'s physical registry.
     ///
     /// This is the warm-up counterpart to the background promotion
     /// task wired up in [`Engine::install_gpu_cache`]: the background
     /// task only fires after an expert crosses the RAM-hit promotion
-    /// threshold, which means the *first* loads of an expert always
-    /// miss VRAM and `GpuBackend::expert_matmul` returns `Err(Miss)`,
-    /// forcing the CPU fallback for the entire warm-up window. Calling
-    /// this immediately after an NVMe load pins the expert in VRAM so
-    /// the *next* dispatch of the same expert hits the GPU fast path
-    /// instead.
+    /// threshold. Calling this after an NVMe load makes the payload eligible
+    /// for a lazy physical upload on the next routed GPU dispatch.
     ///
     /// The byte handling mirrors the background task exactly: both
     /// F32 and Q4_0 experts are promoted byte-for-byte — Q4_0 bytes
@@ -1871,7 +1875,7 @@ impl Engine {
     fn try_promote_resident_to_gpu(&self, resident: &Arc<ExpertResident>) {
         // Only meaningful when a GPU backend is live and the dtype is
         // one the GPU kernels can actually consume; otherwise the
-        // promotion would just waste a VRAM slot on bytes the fast
+        // promotion would waste logical admission budget on bytes the fast
         // path can never use.
         if !self.routed_expert_backend().is_gpu() || !self.gpu_eligible_dtype() {
             return;
@@ -1880,14 +1884,14 @@ impl Engine {
             return;
         };
         let id = resident.id;
-        // Already VRAM-resident: nothing to do (and the LRU helper
+        // Already logically admitted: nothing to do (and the LRU helper
         // would short-circuit anyway). Skip the byte copy entirely.
         if gpu.contains(id) {
             return;
         }
         // Bytes are promoted verbatim and dtype-tagged: Q4_0 experts
         // stay in native GGUF blocks (~8× fewer bytes across PCIe and
-        // in VRAM than a dequantised F32 stream) and are unpacked
+        // as a physical buffer than a dequantised F32 stream) and are unpacked
         // inline by the GPU's `matmul_q4_0.wgsl` pipeline.
         let gpu_res = Arc::new(GpuResident::new_with_dtype(
             id,
@@ -1902,7 +1906,7 @@ impl Engine {
         }
     }
 
-    /// Attach a VRAM (GPU) expert cache — Phase 2 three-tier hierarchy.
+    /// Attach the logical GPU-admission cache — Phase 2 hierarchy policy.
     ///
     /// Spawns a background Tokio task that drains an MPSC channel of
     /// `(expert_id, ram_resident)` promotion requests fed by the
@@ -1911,19 +1915,17 @@ impl Engine {
     /// has no impact on per-token latency. When the channel is
     /// disconnected (engine drop) the background task exits.
     ///
-    /// Updates the `mer_vram_used_bytes` Prometheus gauge after every
-    /// successful promotion.
+    /// Updates the compatibility `mer_vram_used_bytes` gauge with logical
+    /// admitted host payload bytes after every successful promotion.
     pub fn install_gpu_cache(&mut self) {
         let gpu = self.core.execution_context.gpu_expert_cache().clone();
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<(u32, Arc<ExpertResident>)>();
         let gpu_for_task = gpu.clone();
         let prom_for_task = self.metrics.prom.clone();
         // Snapshot the (immutable) expert dtype so each promoted
-        // resident is dtype-tagged. Q4_0 experts land in VRAM as raw
-        // GGUF blocks (~8× fewer bytes than a dequantised F32 stream)
-        // and are unpacked inline by the GPU's `matmul_q4_0.wgsl`
-        // pipeline (see `backend::build_expert_entry_q4_0`); the F32
-        // path is byte-for-byte unchanged.
+        // resident is dtype-tagged. Q4_0 logical admissions retain raw GGUF
+        // blocks; the backend later uploads and unpacks them inline via
+        // `matmul_q4_0.wgsl`. The F32 path remains byte-for-byte unchanged.
         let promote_dtype = self.core.options.dtype;
         // Capacity is constant for the lifetime of the cache; publish
         // it once so `mer_vram_capacity_bytes` is available on the
@@ -1934,8 +1936,8 @@ impl Engine {
         }
         tokio::spawn(async move {
             while let Some((id, resident)) = rx.recv().await {
-                // `promote_sync` copies the resident bytes into the
-                // anchor/LRU edge under the parking_lot mutex; safe to
+                // `promote_sync` copies resident bytes into the host logical
+                // admission Anchor/LRU under the parking_lot mutex; safe to
                 // call from a Tokio worker because it never .awaits.
                 // Bytes are promoted verbatim; the dtype tag tells the
                 // GPU backend which matmul pipeline to dispatch (shared
@@ -2326,13 +2328,13 @@ impl Engine {
             usize,
             tokio::task::JoinHandle<Result<Arc<ExpertResident>, ExpertReadError>>,
         )> = Vec::new();
-        // VRAM (GPU) tier — aggregate hits/misses across this routing
+        // Logical GPU-admission tier — aggregate hits/misses across this routing
         // decision and record once, rather than incrementing Prometheus
         // counters per activation on the hot path.
         let mut gpu_hits_acc: u64 = 0;
         let mut gpu_misses_acc: u64 = 0;
         for (i, &id) in target.iter().enumerate() {
-            // VRAM (GPU) tier — Phase 2 three-tier hierarchy. The cache
+            // Logical GPU-admission tier. The cache
             // shadows RAM; on hit we still resolve the authoritative
             // `ExpertResident` from RAM below, but the counter reflects
             // the promotion-policy decision.
@@ -2350,9 +2352,8 @@ impl Engine {
                 debug!(expert = id, "cache hit");
                 cache_hits_per_expert[i] = true;
                 // RAM hit: bump the per-expert hit counter and, if we
-                // have a VRAM tier configured, enqueue a fire-and-forget
-                // promotion only on the threshold crossing, and only if
-                // the expert is not already resident in the GPU cache.
+                // have GPU admission configured, claim one fire-and-forget
+                // promotion request after the threshold.
                 let new_hits = r.record_hit();
                 // Tier 4 precision feedback: the first hit on a
                 // shadow-backed resident means a speculative prefetch
@@ -2365,10 +2366,10 @@ impl Engine {
                     self.core.gpu_cache.as_ref(),
                     self.core.gpu_promotion_tx.as_ref(),
                 ) {
-                    let crossed_promote_threshold = gpu.should_promote(new_hits)
-                        && !gpu.should_promote(new_hits.saturating_sub(1));
-                    if crossed_promote_threshold && !gpu.get(id).is_hit() {
-                        let _ = tx.send((id, r.clone()));
+                    if gpu.claim_promotion(id, new_hits)
+                        && tx.send((id, r.clone())).is_err()
+                    {
+                        gpu.cancel_promotion(id);
                     }
                 }
                 residents[i] = Some(r);
@@ -2380,7 +2381,7 @@ impl Engine {
                 miss_handles.push((i, tokio::spawn(async move { me.fetch(id).await })));
             }
         }
-        // Aggregate VRAM-tier outcome for this routing decision.
+        // Aggregate logical GPU-admission outcome for this routing decision.
         if let Some(p) = self.metrics.prom.as_ref() {
             if gpu_hits_acc > 0 || gpu_misses_acc > 0 {
                 p.record_gpu_cache(gpu_hits_acc, gpu_misses_acc);
@@ -2474,13 +2475,8 @@ impl Engine {
             // it again — that would double-count every miss after
             // SSD-read dedup (gist Phase 1) was introduced.
             stats.bytes_read += r.buffer.len() as u64;
-            // Synchronous VRAM promotion: this miss just paid the full
-            // NVMe load cost, so pin the freshly-loaded expert into the
-            // GpuExpertCache now (budget permitting). The *next* dispatch
-            // of this expert then hits `GpuBackend::expert_matmul`'s VRAM
-            // fast path instead of returning `Err(Miss)` and falling back
-            // to CPU. No-op when no GPU cache is installed or the dtype
-            // is not GPU-eligible; never touches the CPU fallback path.
+            // Synchronous logical admission after the NVMe load; the next GPU
+            // routed dispatch performs authoritative physical lookup/upload.
             self.try_promote_resident_to_gpu(&r);
             residents[i] = Some(r);
         }
@@ -2578,7 +2574,7 @@ impl Engine {
                     // infrastructure, not strict-hybrid qualification. PR3's
                     // policy applies only to real-model `moe_step`.
                     // CandleBackend::expert_matmul bails unconditionally, so we
-                    // always guard behind is_gpu(). A VRAM miss returns Err
+                    // always guard behind is_gpu(). A logical/physical miss returns Err
                     // and we fall through to the CPU path below. Both F32 and
                     // (block-aligned) Q4_0 experts are eligible — see
                     // `Engine::gpu_eligible_dtype`.
@@ -3181,13 +3177,13 @@ impl Engine {
                         );
                         return;
                     }
-                    // **Eager VRAM promotion.** A speculative prefetch is
+                    // **Eager logical GPU admission.** A speculative prefetch is
                     // a strong "about to be routed" signal, so try to
-                    // stage the bytes into the GPU LRU Edge *now* instead
+                    // stage the host bytes into the admission LRU *now* instead
                     // of waiting for `promote_after_hits` RAM hits — the
                     // lazy path can leave a predicted expert on the CPU
                     // fallback for its first N activations (one CPU
-                    // Only attempt eager VRAM promotion when the cache definitely has room;
+                    // Only attempt eager admission when the logical cache has room;
                     // otherwise we would copy ~expert_size bytes into a Vec only to have the
                     // non-evicting promotion path immediately reject it.
                     if let Some(gpu) = me.core.gpu_cache.as_ref() {
@@ -4243,7 +4239,7 @@ impl Engine {
             tokio::task::JoinHandle<Result<Arc<ExpertResident>, ExpertReadError>>,
         )> = Vec::new();
         let mut cache_hits_per_expert: Vec<bool> = Vec::with_capacity(target.len());
-        // VRAM (GPU) tier — aggregate hits/misses across this routing
+        // Logical GPU-admission tier — aggregate hits/misses across this routing
         // decision and record once, rather than incrementing Prometheus
         // counters per activation on the hot path.
         let mut gpu_hits_acc: u64 = 0;
@@ -4269,20 +4265,14 @@ impl Engine {
                     self.core.gpu_cache.as_ref(),
                     self.core.gpu_promotion_tx.as_ref(),
                 ) {
-                    // Edge-triggered: only enqueue a promotion on the
-                    // single hit that *crosses* `promote_after_hits`,
-                    // not on every subsequent hit. Mirrors the same
-                    // crossing check in `Engine::generate` — without
-                    // it, every hot-path hit after the threshold
-                    // floods the unbounded mpsc with redundant
-                    // promotions (each one paying a `to_vec()` copy +
-                    // mutex-guarded insert on the background worker).
-                    // See gist feedback #2 (`moe_step` level- vs.
-                    // edge-trigger).
-                    let crossed_promote_threshold = gpu.should_promote(new_hits)
-                        && !gpu.should_promote(new_hits.saturating_sub(1));
-                    if crossed_promote_threshold && !gpu.get(id).is_hit() {
-                        let _ = tx.send((id, r.clone()));
+                    // One outstanding claim prevents queue flooding while
+                    // allowing a new request after logical eviction, even
+                    // though the RAM resident's hit count no longer has a
+                    // fresh threshold-crossing edge.
+                    if gpu.claim_promotion(id, new_hits)
+                        && tx.send((id, r.clone())).is_err()
+                    {
+                        gpu.cancel_promotion(id);
                     }
                 }
                 residents[i] = Some(r);
@@ -4302,7 +4292,7 @@ impl Engine {
             crate::stage_timing::EXPERT_CACHE_LOOKUP,
             cache_lookup_start.elapsed(),
         );
-        // Aggregate VRAM-tier outcome for this routing decision.
+        // Aggregate logical GPU-admission outcome for this routing decision.
         if let Some(p) = self.metrics.prom.as_ref() {
             if gpu_hits_acc > 0 || gpu_misses_acc > 0 {
                 p.record_gpu_cache(gpu_hits_acc, gpu_misses_acc);
@@ -5147,30 +5137,28 @@ pub struct EngineReport {
     /// nothing.
     pub speculator_dmodel_mismatch: u64,
     /// Expert activations that fell back from the GPU fast path to the
-    /// CPU path because the VRAM dispatch errored (typically a VRAM
-    /// miss). Non-zero rates explain mixed GPU/CPU token latency.
+    /// CPU path because physical GPU expert dispatch errored. Non-zero rates
+    /// explain mixed GPU/CPU token latency in serving-fallback mode.
     pub gpu_cpu_fallbacks: u64,
-    /// Phase 2 / 3-tier hierarchy: whether the engine has a VRAM (GPU)
-    /// expert cache attached. `false` keeps the historical 2-tier
-    /// behaviour bit-for-bit; `true` adds the SSD → RAM → VRAM tier.
+    /// Whether the engine has a logical GPU-admission cache attached.
     pub gpu_cache_enabled: bool,
-    /// Bytes currently resident in the VRAM tier (sum of anchor + LRU).
-    /// `0` when no VRAM cache is attached.
+    /// Compatibility field: logical host payload bytes admitted across the
+    /// GPU Anchor + LRU. Not physical wgpu allocation bytes.
     pub vram_used_bytes: u64,
-    /// Total bytes addressable in the VRAM tier (anchor + LRU budget).
-    /// `0` when no VRAM cache is attached.
+    /// Compatibility field: logical admission budget. The same configured
+    /// value caps physical expert weights; fixed workspaces are separate.
     pub vram_capacity_bytes: u64,
-    /// Cumulative RAM → VRAM promotions performed by the background
+    /// Cumulative RAM → logical-admission promotions performed by the background
     /// promotion task. Promotions are gated by the per-expert
     /// `promote_after_hits` threshold.
     pub gpu_promotions: u64,
-    /// VRAM cache hit count (anchor + LRU).
+    /// Logical GPU-admission hit count (anchor + LRU).
     pub gpu_cache_hits: u64,
-    /// VRAM cache miss count.
+    /// Logical GPU-admission miss count.
     pub gpu_cache_misses: u64,
-    /// Number of experts in the VRAM anchor (hot-pin) region.
+    /// Number of experts in the logical admission anchor region.
     pub gpu_anchor_count: usize,
-    /// Number of experts in the VRAM LRU (cold-edge) region.
+    /// Number of experts in the logical admission LRU region.
     pub gpu_lru_count: usize,
     /// **Tier 4.** Speculative prefetches that landed in cache and were
     /// then consumed by a hit before eviction (precision numerator).
@@ -5519,6 +5507,7 @@ mod tests {
         use crate::backend::GpuExpertDispatchErrorKind as Kind;
         for (label, kind) in [
             ("residency", Kind::ResidencyMiss),
+            ("physical-capacity", Kind::PhysicalCapacity),
             ("upload", Kind::Upload),
             ("validation", Kind::ValidationDispatch),
             ("submission", Kind::Submission),
@@ -5645,6 +5634,10 @@ mod tests {
         assert_eq!(test_gpu.expert_calls(), 0);
         assert_eq!(cpu_expert_forward_calls(&engine), 1);
         assert_eq!(engine.report().gpu_cpu_fallbacks, 0);
+        assert!(
+            engine.gpu_expert_memory_snapshot().is_none(),
+            "CPU plans must not depend on a physical GPU expert registry"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/rust-engine/src/expert_cache.rs
+++ b/rust-engine/src/expert_cache.rs
@@ -806,6 +806,18 @@ impl GpuExpertCache {
         GpuLookup::Miss
     }
 
+    /// Clone the current logical admission without recording a routing probe
+    /// or changing logical LRU recency. Physical backends use this to validate
+    /// identity after routing has already performed the authoritative
+    /// telemetry/recency lookup.
+    pub fn current_admission(&self, id: u32) -> Option<GpuAdmission> {
+        let g = self.inner.lock();
+        g.anchor
+            .get(&id)
+            .or_else(|| g.lru.peek(&id))
+            .cloned()
+    }
+
     /// Check whether an expert is currently resident in either the
     /// anchor or LRU regions, without mutating recency or counters.
     pub fn contains(&self, id: u32) -> bool {
@@ -1356,6 +1368,72 @@ mod tests {
         assert!(!cache.try_promote_lru_no_evict(gpu_res(9, 32)));
         assert_eq!(cache.promotions(), 1);
         assert_eq!(cache.used_bytes(), 32);
+    }
+
+    #[test]
+    fn current_admission_anchor_does_not_change_counters() {
+        let cache = GpuExpertCache::new(100, 1.0, 0);
+        let resident = gpu_res(1, 32);
+        assert!(cache.promote_sync(resident.clone()));
+        assert_eq!(cache.anchor_len(), 1);
+
+        let admission = cache.current_admission(1).expect("anchor admission");
+        assert!(Arc::ptr_eq(admission.resident(), &resident));
+        assert_eq!(admission.generation(), cache.current_generation(1).unwrap());
+        assert_eq!(cache.hits(), 0);
+        assert_eq!(cache.misses(), 0);
+    }
+
+    #[test]
+    fn current_admission_lru_does_not_change_counters() {
+        let cache = GpuExpertCache::new(100, 0.0, 0);
+        let resident = gpu_res(2, 32);
+        assert!(cache.promote_sync(resident.clone()));
+        assert_eq!(cache.lru_len(), 1);
+
+        let admission = cache.current_admission(2).expect("LRU admission");
+        assert!(Arc::ptr_eq(admission.resident(), &resident));
+        assert_eq!(admission.generation(), cache.current_generation(2).unwrap());
+        assert_eq!(cache.hits(), 0);
+        assert_eq!(cache.misses(), 0);
+    }
+
+    #[test]
+    fn current_admission_lru_does_not_update_recency() {
+        let cache = GpuExpertCache::new(20, 0.0, 0);
+        assert!(cache.promote_sync(gpu_res(1, 10)));
+        assert!(cache.promote_sync(gpu_res(2, 10)));
+
+        assert!(cache.current_admission(1).is_some());
+        assert!(cache.promote_sync(gpu_res(3, 10)));
+        assert!(!cache.contains(1), "non-mutating lookup must leave id 1 LRU");
+        assert!(cache.contains(2));
+        assert!(cache.contains(3));
+    }
+
+    #[test]
+    fn current_admission_miss_does_not_increment_misses() {
+        let cache = GpuExpertCache::new(20, 0.0, 0);
+        assert!(cache.current_admission(99).is_none());
+        assert_eq!(cache.hits(), 0);
+        assert_eq!(cache.misses(), 0);
+    }
+
+    #[test]
+    fn get_retains_counter_and_lru_recency_behavior() {
+        let cache = GpuExpertCache::new(20, 0.0, 0);
+        assert!(cache.promote_sync(gpu_res(1, 10)));
+        assert!(cache.promote_sync(gpu_res(2, 10)));
+
+        assert!(matches!(cache.get(1), GpuLookup::LruHit(_)));
+        assert!(matches!(cache.get(99), GpuLookup::Miss));
+        assert_eq!(cache.hits(), 1);
+        assert_eq!(cache.misses(), 1);
+
+        assert!(cache.promote_sync(gpu_res(3, 10)));
+        assert!(cache.contains(1), "mutating get must make id 1 MRU");
+        assert!(!cache.contains(2), "id 2 must remain the LRU victim");
+        assert!(cache.contains(3));
     }
 
     #[test]

--- a/rust-engine/src/expert_cache.rs
+++ b/rust-engine/src/expert_cache.rs
@@ -66,7 +66,7 @@ pub struct ExpertResident {
     /// Bumped by [`GpuExpertCache::observe_ram_hit`] / engine routing
     /// every time a RAM lookup resolves to this resident. Read by the
     /// promotion controller — once `hits >= promote_after_hits`, the
-    /// expert becomes a candidate for the **Anchor Core** in VRAM.
+    /// expert becomes a candidate for logical GPU admission.
     ///
     /// Stored as an `AtomicU64` so the engine's lock-free routing hot
     /// path can update it with a single relaxed atomic increment.
@@ -535,29 +535,15 @@ impl ExpertCache {
 }
 
 // =====================================================================
-// Phase 2 — GPU (VRAM) expert cache: Segmented Hybrid Policy.
+// Phase 2 — logical GPU expert admission: Segmented Hybrid Policy.
 // =====================================================================
 
-/// One VRAM-resident expert. Bytes are owned by the cache and
-/// (conceptually) live in device memory; on the default build —
-/// where the `gpu` cargo feature is **not** compiled in — VRAM is
-/// emulated with a host-side `Vec<u8>` so the rest of the engine
-/// (engine.rs, server.rs, batch_scheduler.rs) sees the same
-/// `Arc<GpuResident>` shape regardless of whether real CUDA is
-/// available.
-///
-/// The cache surface is identical to [`ExpertResident::data`]: callers
-/// get a `&[u8]` weight payload that can be fed directly into the
-/// existing `run_inference_*` family. When a real CUDA device is
-/// active, [`GpuResident::data`] performs the device-to-host copy
-/// lazily (see Phase 3's `run_inference_gpu`), so the inference loop
-/// never blocks on the cache itself.
+/// One host-side logical GPU admission. The payload remains a `Vec<u8>` in
+/// process memory; physical routed-expert device buffers are owned and
+/// accounted by `GpuBackend`'s physical registry.
 pub struct GpuResident {
     pub id: u32,
-    /// Device-resident bytes. On builds without a real GPU runtime
-    /// this is just a host `Vec<u8>`; on `gpu`-feature builds the
-    /// init path replaces it with a `candle_core::Tensor` reference
-    /// (see Phase 3 / `inference::run_inference_gpu`).
+    /// Host payload retained by the logical admission policy.
     bytes: Vec<u8>,
     /// On-disk encoding of `bytes`. `F32` residents feed the dense
     /// matmul pipeline; `Q4_0` residents stay in native GGUF blocks
@@ -595,8 +581,7 @@ impl GpuResident {
         self.dtype
     }
 
-    /// Size in bytes of the VRAM footprint owned by this resident.
-    /// Aggregated by the cache to track `mer_vram_used_bytes`.
+    /// Size of the logical host payload admitted for future GPU upload.
     #[inline]
     pub fn byte_len(&self) -> usize {
         self.bytes.len()
@@ -612,15 +597,41 @@ impl crate::backend::GpuStorage for GpuResident {
     }
 }
 
-/// Outcome of a VRAM-tier lookup. The variants double as the
+/// One installed logical GPU admission. Generations are allocated by
+/// [`GpuExpertCache`] and change only when an id is evicted and admitted
+/// again; ordinary hits preserve the generation.
+#[derive(Clone)]
+pub struct GpuAdmission {
+    resident: Arc<GpuResident>,
+    generation: u64,
+}
+
+impl GpuAdmission {
+    #[inline]
+    pub fn resident(&self) -> &Arc<GpuResident> {
+        &self.resident
+    }
+
+    #[inline]
+    pub fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    #[inline]
+    pub fn byte_len(&self) -> usize {
+        self.resident.byte_len()
+    }
+}
+
+/// Outcome of a logical GPU-admission lookup. The variants double as the
 /// instrumentation discriminator for `mer_gpu_cache_hits_total` and
 /// the engine's three-tier reporting in `/v1/admin/health/experts`.
 pub enum GpuLookup {
     /// Hit on the **Anchor Core** — high-frequency, permanently
     /// pinned expert. No LRU recency update.
-    AnchorHit(Arc<GpuResident>),
+    AnchorHit(GpuAdmission),
     /// Hit on the **LRU Edge** — temporal locality. Recency updated.
-    LruHit(Arc<GpuResident>),
+    LruHit(GpuAdmission),
     /// Miss. Caller falls through to the RAM tier.
     Miss,
 }
@@ -631,13 +642,13 @@ impl GpuLookup {
     }
 }
 
-/// Thread-safe VRAM expert cache implementing the **Segmented Hybrid
-/// Policy** from the Phase 2 spec:
+/// Thread-safe logical GPU-admission cache implementing the **Segmented
+/// Hybrid Policy** from the Phase 2 spec:
 ///
-/// * **Anchor Core** — `HashMap<u32, Arc<GpuResident>>` for experts
+/// * **Anchor Core** — `HashMap<u32, GpuAdmission>` for experts
 ///   that have crossed `promote_after_hits`. Pinned, never evicted.
 ///   Sized by `anchor_ratio * capacity_bytes`.
-/// * **LRU Edge** — `LruCache<u32, Arc<GpuResident>>` for temporal
+/// * **LRU Edge** — `LruCache<u32, GpuAdmission>` for temporal
 ///   topic shifts. O(1) recency tracking, byte-budgeted evictions.
 ///
 /// Concurrency contract (gist "Zero-Contention" critical constraint):
@@ -648,13 +659,11 @@ impl GpuLookup {
 /// * Hit counters on individual `ExpertResident`s are
 ///   [`AtomicU64`](std::sync::atomic::AtomicU64); the inference hot
 ///   path bumps them lock-free.
-/// * `mer_vram_used_bytes` is an atomic `IntGauge` updated inside the
-///   same critical section so external scrapes never observe a
-///   torn value.
+/// * The compatibility `mer_vram_used_bytes` gauge is logical admitted host
+///   payload bytes, not physical wgpu allocation bytes.
 pub struct GpuExpertCache {
     inner: Mutex<GpuExpertCacheInner>,
-    /// Capacity of the **Anchor Core**, in bytes. The total VRAM
-    /// budget is `anchor_capacity_bytes + lru_capacity_bytes`.
+    /// Logical host-payload capacity of the **Anchor Core**, in bytes.
     anchor_capacity_bytes: usize,
     /// Capacity of the **LRU Edge**, in bytes.
     lru_capacity_bytes: usize,
@@ -667,34 +676,53 @@ pub struct GpuExpertCache {
     /// the admin health endpoint can render the value without going
     /// through the Prometheus registry.
     promotions: AtomicU64,
-    /// VRAM bytes resident across Anchor + LRU. Read by the admin
-    /// health endpoint and the TUI dashboard.
-    vram_used: AtomicU64,
-    /// Cumulative VRAM (GPU) cache hits — mirrors the
+    /// Logical host payload bytes admitted across Anchor + LRU.
+    logical_admitted_bytes: AtomicU64,
+    /// Cumulative logical GPU-admission hits — mirrors the
     /// `mer_gpu_cache_hits_total` Prometheus counter.
     hits: AtomicU64,
-    /// Cumulative VRAM (GPU) cache misses — mirrors
+    /// Cumulative logical GPU-admission misses — mirrors
     /// `mer_gpu_cache_misses_total`.
     misses: AtomicU64,
 }
 
 struct GpuExpertCacheInner {
     /// **Anchor Core** — permanently pinned high-frequency experts.
-    anchor: HashMap<u32, Arc<GpuResident>>,
+    anchor: HashMap<u32, GpuAdmission>,
     anchor_used_bytes: usize,
     /// **LRU Edge** — temporal locality region.
-    lru: LruCache<u32, Arc<GpuResident>>,
+    lru: LruCache<u32, GpuAdmission>,
     lru_used_bytes: usize,
+    /// Next logical admission generation. Exhaustion cleanly refuses a new
+    /// admission rather than reusing an identity.
+    next_generation: u64,
+    /// Ids with one threshold-triggered promotion request in flight. This is
+    /// cleared when promotion completes or enqueueing fails, so eviction can
+    /// retrigger exactly one request even when the RAM hit count is already
+    /// above the threshold.
+    promotion_pending: HashSet<u32>,
+    /// Logically evicted ids that may claim one new promotion attempt without
+    /// a fresh hit-count edge. Consuming this marker prevents a failed or
+    /// oversized promotion from retrying on every later RAM hit.
+    promotion_rearm: HashSet<u32>,
+}
+
+impl GpuExpertCacheInner {
+    fn allocate_generation(&mut self) -> Option<u64> {
+        let generation = self.next_generation;
+        self.next_generation = generation.checked_add(1)?;
+        Some(generation)
+    }
 }
 
 impl GpuExpertCache {
-    /// Construct a new VRAM expert cache.
+    /// Construct a new logical GPU-admission cache.
     ///
-    /// * `capacity_bytes` — total VRAM budget for the cache
-    ///   (anchor + LRU regions combined).
+    /// * `capacity_bytes` — logical host-admission budget (anchor + LRU),
+    ///   also passed to the backend as its physical expert-weight cap.
     /// * `anchor_ratio` — fraction of `capacity_bytes` reserved for
     ///   the Anchor Core. Clamped to `[0.0, 1.0]`.
-    /// * `promote_after_hits` — threshold for RAM → VRAM promotion.
+    /// * `promote_after_hits` — threshold for RAM → GPU admission.
     ///   `0` disables Anchor Core promotion.
     pub fn new(capacity_bytes: usize, anchor_ratio: f32, promote_after_hits: u64) -> Self {
         let ratio = anchor_ratio.clamp(0.0, 1.0);
@@ -711,48 +739,53 @@ impl GpuExpertCache {
                 anchor_used_bytes: 0,
                 lru: LruCache::unbounded(),
                 lru_used_bytes: 0,
+                next_generation: 1,
+                promotion_pending: HashSet::new(),
+                promotion_rearm: HashSet::new(),
             }),
             anchor_capacity_bytes,
             lru_capacity_bytes,
             promote_after_hits,
             promotions: AtomicU64::new(0),
-            vram_used: AtomicU64::new(0),
+            logical_admitted_bytes: AtomicU64::new(0),
             hits: AtomicU64::new(0),
             misses: AtomicU64::new(0),
         }
     }
 
-    /// Total VRAM budget (anchor + LRU), in bytes.
+    /// Logical admission budget (anchor + LRU host payloads), in bytes. The
+    /// same configured value is also the physical expert-weight capacity.
     #[inline]
     pub fn capacity_bytes(&self) -> usize {
         self.anchor_capacity_bytes + self.lru_capacity_bytes
     }
 
-    /// Currently-resident VRAM bytes (anchor + LRU).
+    /// Logical admitted host payload bytes (anchor + LRU). Retained for API
+    /// compatibility; physical wgpu bytes come from the backend ledger.
     #[inline]
     pub fn used_bytes(&self) -> u64 {
-        self.vram_used.load(Ordering::Relaxed)
+        self.logical_admitted_bytes.load(Ordering::Relaxed)
     }
 
-    /// Cumulative RAM → VRAM promotions.
+    /// Cumulative RAM → logical GPU-admission promotions.
     #[inline]
     pub fn promotions(&self) -> u64 {
         self.promotions.load(Ordering::Relaxed)
     }
 
-    /// Cumulative VRAM cache hits.
+    /// Cumulative logical GPU-admission hits.
     #[inline]
     pub fn hits(&self) -> u64 {
         self.hits.load(Ordering::Relaxed)
     }
 
-    /// Cumulative VRAM cache misses.
+    /// Cumulative logical GPU-admission misses.
     #[inline]
     pub fn misses(&self) -> u64 {
         self.misses.load(Ordering::Relaxed)
     }
 
-    /// Look up an expert in VRAM. Returns the [`GpuLookup`] discriminator
+    /// Look up a logical GPU admission. Returns the [`GpuLookup`] discriminator
     /// (anchor / LRU / miss) plus the resident handle on hit.
     ///
     /// **LRU Edge** hits update recency; **Anchor Core** hits do not
@@ -780,6 +813,20 @@ impl GpuExpertCache {
         g.anchor.contains_key(&id) || g.lru.peek(&id).is_some()
     }
 
+    /// Current admission generation without changing recency or counters.
+    pub fn current_generation(&self, id: u32) -> Option<u64> {
+        let g = self.inner.lock();
+        g.anchor
+            .get(&id)
+            .or_else(|| g.lru.peek(&id))
+            .map(GpuAdmission::generation)
+    }
+
+    /// O(1) identity validation used by the physical registry after upload.
+    pub fn contains_generation(&self, id: u32, generation: u64) -> bool {
+        self.current_generation(id) == Some(generation)
+    }
+
     /// Should the resident's current hit count promote it to the
     /// Anchor Core? Cheap relaxed-atomic compare against the
     /// configured threshold; safe to call from the hot path before
@@ -789,9 +836,41 @@ impl GpuExpertCache {
         self.promote_after_hits > 0 && ram_hits >= self.promote_after_hits
     }
 
-    /// Synchronous promotion entry point — copy a RAM resident's
-    /// bytes into VRAM and place it in the Anchor Core if budget
-    /// allows, otherwise in the LRU Edge.
+    /// Claim the single outstanding promotion request for an id. Unlike a
+    /// hit-count edge alone, this becomes claimable again after logical
+    /// eviction, even when the RAM resident's monotonic hit count is already
+    /// above the threshold.
+    pub fn claim_promotion(&self, id: u32, ram_hits: u64) -> bool {
+        if !self.should_promote(ram_hits) {
+            return false;
+        }
+        let mut g = self.inner.lock();
+        if g.anchor.contains_key(&id)
+            || g.lru.peek(&id).is_some()
+            || g.promotion_pending.contains(&id)
+        {
+            return false;
+        }
+        let threshold_crossed = ram_hits == self.promote_after_hits;
+        let rearmed_after_eviction = g.promotion_rearm.remove(&id);
+        if !threshold_crossed && !rearmed_after_eviction {
+            return false;
+        }
+        g.promotion_pending.insert(id)
+    }
+
+    /// Release a promotion claim when channel enqueueing fails.
+    pub fn cancel_promotion(&self, id: u32) {
+        let mut g = self.inner.lock();
+        if g.promotion_pending.remove(&id) {
+            g.promotion_rearm.insert(id);
+        }
+    }
+
+    /// Synchronous promotion entry point — copy a RAM resident's bytes into
+    /// the host-side logical admission cache and place it in the Anchor Core
+    /// if budget allows, otherwise in the LRU Edge. Physical upload remains
+    /// lazy and is owned by `GpuBackend`.
     ///
     /// **Hot-path callers must not invoke this directly** — instead
     /// hand the resident off to the engine's background promotion
@@ -799,15 +878,17 @@ impl GpuExpertCache {
     /// exists for the warm-up sequence (where blocking is the
     /// expected behaviour) and for tests.
     ///
-    /// Returns `true` when the expert landed in VRAM, `false` if it
+    /// Returns `true` when the expert was admitted, `false` if it
     /// could not fit even after eviction (e.g. payload exceeds the
     /// LRU budget entirely).
     pub fn promote_sync(&self, resident: Arc<GpuResident>) -> bool {
         let bytes = resident.byte_len();
+        let mut g = self.inner.lock();
+        g.promotion_pending.remove(&resident.id);
+        g.promotion_rearm.remove(&resident.id);
         if bytes == 0 {
             return false;
         }
-        let mut g = self.inner.lock();
         // Already resident: nothing to promote. Touch the LRU entry so
         // it becomes MRU, but don't count this as a new promotion nor
         // re-account bytes (the existing entry already owns them).
@@ -822,37 +903,52 @@ impl GpuExpertCache {
         // any explicit promote_sync as "hot" (the engine only calls
         // this after threshold), but still prefer Anchor only when
         // there's room without evicting another anchor entry.
-        if bytes <= self.anchor_capacity_bytes
-            && g.anchor_used_bytes + bytes <= self.anchor_capacity_bytes
-        {
-            g.anchor.insert(resident.id, resident.clone());
-            g.anchor_used_bytes += bytes;
+        let use_anchor = bytes <= self.anchor_capacity_bytes
+            && g.anchor_used_bytes
+                .checked_add(bytes)
+                .is_some_and(|used| used <= self.anchor_capacity_bytes);
+        if !use_anchor && bytes > self.lru_capacity_bytes {
+            return false;
+        }
+        let Some(generation) = g.allocate_generation() else {
+            return false;
+        };
+        let admission = GpuAdmission { resident, generation };
+        if use_anchor {
+            g.anchor.insert(admission.resident.id, admission);
+            g.anchor_used_bytes = g
+                .anchor_used_bytes
+                .checked_add(bytes)
+                .expect("logical GPU anchor byte overflow after capacity check");
             drop(g);
             self.promotions.fetch_add(1, Ordering::Relaxed);
             self.refresh_used_bytes();
             return true;
         }
-        if bytes > self.lru_capacity_bytes {
-            // Won't fit even after evicting everything in the LRU
-            // region. Don't try.
-            return false;
-        }
         // Evict LRU entries until there is room. `LruCache::pop_lru`
         // returns the least-recently-used (k, v).
-        while g.lru_used_bytes + bytes > self.lru_capacity_bytes {
+        while g
+            .lru_used_bytes
+            .checked_add(bytes)
+            .is_none_or(|used| used > self.lru_capacity_bytes)
+        {
             match g.lru.pop_lru() {
-                Some((_, victim)) => {
+                Some((evicted_id, victim)) => {
                     g.lru_used_bytes = g.lru_used_bytes.saturating_sub(victim.byte_len());
+                    g.promotion_rearm.insert(evicted_id);
                 }
                 None => break,
             }
         }
-        let already = g.lru.put(resident.id, resident.clone());
+        let already = g.lru.put(admission.resident.id, admission);
         if let Some(prev) = already {
             // Replacing an existing entry — subtract the old footprint.
             g.lru_used_bytes = g.lru_used_bytes.saturating_sub(prev.byte_len());
         }
-        g.lru_used_bytes += bytes;
+        g.lru_used_bytes = g
+            .lru_used_bytes
+            .checked_add(bytes)
+            .expect("logical GPU LRU byte overflow after capacity check");
         drop(g);
         self.promotions.fetch_add(1, Ordering::Relaxed);
         self.refresh_used_bytes();
@@ -866,7 +962,7 @@ impl GpuExpertCache {
     ///
     /// This is the warm-up counterpart to [`Self::promote_sync`]: the
     /// synchronous NVMe-miss path in the engine uses it to pin a freshly
-    /// loaded expert in VRAM without (a) evicting threshold-promoted
+    /// loaded expert in the logical admission LRU without (a) evicting threshold-promoted
     /// hot experts already resident in the LRU Edge, or (b) consuming
     /// Anchor Core slots that the hit-threshold policy reserves for
     /// genuinely hot experts. Anchor Core promotion remains the
@@ -879,10 +975,12 @@ impl GpuExpertCache {
     /// eviction.
     pub fn try_promote_lru_no_evict(&self, resident: Arc<GpuResident>) -> bool {
         let bytes = resident.byte_len();
+        let mut g = self.inner.lock();
+        g.promotion_pending.remove(&resident.id);
+        g.promotion_rearm.remove(&resident.id);
         if bytes == 0 {
             return false;
         }
-        let mut g = self.inner.lock();
         // Already resident anywhere: nothing to do. Don't touch LRU
         // recency — the caller is a warm-up path, not a real access.
         if g.anchor.contains_key(&resident.id) || g.lru.peek(&resident.id).is_some() {
@@ -890,11 +988,22 @@ impl GpuExpertCache {
         }
         // Strictly non-evicting: must fit in whatever LRU budget is
         // currently free.
-        if g.lru_used_bytes + bytes > self.lru_capacity_bytes {
+        if g
+            .lru_used_bytes
+            .checked_add(bytes)
+            .is_none_or(|used| used > self.lru_capacity_bytes)
+        {
             return false;
         }
-        g.lru.put(resident.id, resident.clone());
-        g.lru_used_bytes += bytes;
+        let Some(generation) = g.allocate_generation() else {
+            return false;
+        };
+        let admission = GpuAdmission { resident, generation };
+        g.lru.put(admission.resident.id, admission);
+        g.lru_used_bytes = g
+            .lru_used_bytes
+            .checked_add(bytes)
+            .expect("logical GPU LRU byte overflow after capacity check");
         drop(g);
         self.promotions.fetch_add(1, Ordering::Relaxed);
         self.refresh_used_bytes();
@@ -913,9 +1022,13 @@ impl GpuExpertCache {
 
     fn refresh_used_bytes(&self) {
         let g = self.inner.lock();
-        let total = (g.anchor_used_bytes + g.lru_used_bytes) as u64;
+        let total = g
+            .anchor_used_bytes
+            .checked_add(g.lru_used_bytes)
+            .and_then(|bytes| u64::try_from(bytes).ok())
+            .expect("logical GPU admitted-byte total overflow");
         drop(g);
-        self.vram_used.store(total, Ordering::Relaxed);
+        self.logical_admitted_bytes.store(total, Ordering::Relaxed);
     }
 }
 
@@ -1243,5 +1356,40 @@ mod tests {
         assert!(!cache.try_promote_lru_no_evict(gpu_res(9, 32)));
         assert_eq!(cache.promotions(), 1);
         assert_eq!(cache.used_bytes(), 32);
+    }
+
+    #[test]
+    fn logical_admission_generation_changes_only_after_eviction_and_readmission() {
+        let cache = GpuExpertCache::new(16, 0.0, 0);
+        assert!(cache.promote_sync(gpu_res(7, 8)));
+        let g1 = cache.current_generation(7).expect("first admission generation");
+        let hit_generation = match cache.get(7) {
+            GpuLookup::LruHit(admission) => admission.generation(),
+            _ => panic!("expected logical LRU hit"),
+        };
+        assert_eq!(hit_generation, g1, "ordinary hits preserve generation");
+
+        assert!(cache.promote_sync(gpu_res(8, 16)));
+        assert!(!cache.contains(7), "larger admission evicts old generation");
+        assert!(cache.promote_sync(gpu_res(7, 8)));
+        let g2 = cache.current_generation(7).expect("readmission generation");
+        assert_ne!(g2, g1, "readmission must never reuse physical identity");
+    }
+
+    #[test]
+    fn promotion_claim_rearms_after_logical_eviction_above_hit_threshold() {
+        let cache = GpuExpertCache::new(16, 0.0, 3);
+        assert!(cache.promote_sync(gpu_res(7, 8)));
+        assert!(!cache.claim_promotion(7, 99), "admitted id needs no request");
+        assert!(cache.promote_sync(gpu_res(8, 16)));
+        assert!(!cache.contains(7));
+
+        assert!(
+            cache.claim_promotion(7, 99),
+            "evicted id can claim again without a fresh RAM-hit edge"
+        );
+        assert!(!cache.claim_promotion(7, 100), "only one request may be pending");
+        assert!(cache.promote_sync(gpu_res(7, 8)));
+        assert!(cache.contains(7));
     }
 }

--- a/rust-engine/src/expert_cache.rs
+++ b/rust-engine/src/expert_cache.rs
@@ -988,14 +988,15 @@ impl GpuExpertCache {
     pub fn try_promote_lru_no_evict(&self, resident: Arc<GpuResident>) -> bool {
         let bytes = resident.byte_len();
         let mut g = self.inner.lock();
-        g.promotion_pending.remove(&resident.id);
-        g.promotion_rearm.remove(&resident.id);
         if bytes == 0 {
             return false;
         }
         // Already resident anywhere: nothing to do. Don't touch LRU
-        // recency — the caller is a warm-up path, not a real access.
+        // recency — the caller is a warm-up path, not a real access. Any
+        // promotion markers for this already-satisfied id are stale.
         if g.anchor.contains_key(&resident.id) || g.lru.peek(&resident.id).is_some() {
+            g.promotion_pending.remove(&resident.id);
+            g.promotion_rearm.remove(&resident.id);
             return false;
         }
         // Strictly non-evicting: must fit in whatever LRU budget is
@@ -1011,6 +1012,8 @@ impl GpuExpertCache {
             return false;
         };
         let admission = GpuAdmission { resident, generation };
+        g.promotion_pending.remove(&admission.resident.id);
+        g.promotion_rearm.remove(&admission.resident.id);
         g.lru.put(admission.resident.id, admission);
         g.lru_used_bytes = g
             .lru_used_bytes
@@ -1368,6 +1371,36 @@ mod tests {
         assert!(!cache.try_promote_lru_no_evict(gpu_res(9, 32)));
         assert_eq!(cache.promotions(), 1);
         assert_eq!(cache.used_bytes(), 32);
+    }
+
+    #[test]
+    fn failed_no_evict_promotion_preserves_eviction_rearm() {
+        let cache = GpuExpertCache::new(20, 0.0, 3);
+        assert!(cache.promote_sync(gpu_res(1, 8)));
+        assert!(cache.promote_sync(gpu_res(2, 20)));
+        assert!(!cache.contains(1), "id 1 must be rearmed by logical eviction");
+
+        assert!(!cache.try_promote_lru_no_evict(gpu_res(1, 8)));
+        assert!(
+            cache.claim_promotion(1, 99),
+            "failed opportunistic admission must leave one rearm claim"
+        );
+        assert!(!cache.claim_promotion(1, 100), "rearm remains one-shot");
+    }
+
+    #[test]
+    fn failed_no_evict_promotion_preserves_pending_claim() {
+        let cache = GpuExpertCache::new(20, 0.0, 3);
+        assert!(cache.promote_sync(gpu_res(1, 8)));
+        assert!(cache.promote_sync(gpu_res(2, 20)));
+        assert!(!cache.contains(1));
+        assert!(cache.claim_promotion(1, 3));
+
+        assert!(!cache.try_promote_lru_no_evict(gpu_res(1, 8)));
+        assert!(
+            !cache.claim_promotion(1, 3),
+            "failed opportunistic admission must keep the existing claim pending"
+        );
     }
 
     #[test]

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -576,15 +576,13 @@ enum Cmd {
         trace_out: Option<PathBuf>,
         /// Initialise the GPU compute backend before running the
         /// benchmark so the FFN forward pass uses GPU matmul where
-        /// available. The run path also installs a bounded VRAM
-        /// `GpuExpertCache` so hot experts can promote and be served
-        /// from device memory. Falls back to the default CPU backend
+        /// available. The run path also installs bounded logical admission
+        /// plus physical expert-weight residency. Falls back to the default CPU backend
         /// with a warning if GPU init fails.
         #[arg(long)]
         gpu: bool,
-        /// VRAM budget, in MiB, for the run-mode GPU expert cache
-        /// (only with `--gpu`). Hot experts promote into this cache and
-        /// are served from device memory. The 4 GiB default fits ~40
+        /// Physical expert-weight cap and logical admission budget, in MiB
+        /// (only with `--gpu`). The 4 GiB default fits ~40
         /// Mixtral-8x7B Q4 experts (~99 MiB each — 512 MiB would hold
         /// barely 5); lower it on cards with less free VRAM.
         #[arg(long, default_value_t = 4096)]
@@ -926,10 +924,9 @@ enum Cmd {
         #[arg(long)]
         json: bool,
     },
-    /// Native terminal dashboard — Phase 4 of the three-tier memory
-    /// hierarchy. Polls a running `serve` instance and renders a live
-    /// ratatui view of the SSD → RAM → VRAM hit grid, current cache
-    /// state, VRAM utilisation, and I/O reactor activity. Pure
+    /// Native terminal dashboard. Polls a running `serve` instance and renders
+    /// SSD/RAM/logical-GPU-admission hits, cache state, admission utilisation,
+    /// and I/O reactor activity. Pure
     /// observability; the dashboard does not mutate engine state.
     ///
     /// Requires the binary to be built with the `tui` cargo feature
@@ -1952,7 +1949,8 @@ fn install_run_gpu_backend(
     // everything through `expert_matmul`.
     //
     // Give run-mode GPU promotion a bounded (but non-zero) budget so
-    // repeated experts can become true GPU hits. Sized by
+    // repeated experts can become logically admitted and then physically
+    // uploaded by the backend on demand. Sized by
     // `--gpu-cache-mb` (default 4 GiB — a single Mixtral-8x7B Q4
     // expert is ~99 MiB, so anything much smaller thrashes).
     let gpu_expert_cache = std::sync::Arc::new(crate::expert_cache::GpuExpertCache::new(
@@ -4430,9 +4428,9 @@ async fn cmd_serve(config_path: PathBuf) -> Result<(), Box<dyn std::error::Error
     // Resolve requested mode once into the authoritative component plan and
     // backend context before constructing the model or engine.
     //
-    // The GPU expert cache is constructed up-front so the same `Arc`
-    // can be threaded into both `GpuBackend` (which checks VRAM
-    // residency before falling back to NVMe streaming) and
+    // The logical GPU-admission cache is constructed up-front so the same
+    // `Arc` can be threaded into both `GpuBackend` (which validates admission
+    // generations before physical lookup/upload) and
     // `Engine::install_gpu_cache` further below. When `[gpu_cache].enabled =
     // false` the zero-capacity cache never promotes anything.
     let gpu_expert_cache = {
@@ -4961,14 +4959,14 @@ async fn cmd_serve(config_path: PathBuf) -> Result<(), Box<dyn std::error::Error
         ));
         engine_builder = engine_builder.with_pregate(pregate);
     }
-    // Phase 2: optional VRAM (GPU) expert cache (3-tier hierarchy
-    // SSD → RAM → VRAM). When `[gpu_cache].enabled = false` (default)
+    // Phase 2: optional logical GPU-admission cache. Physical wgpu expert
+    // residency is owned separately by the backend registry. When disabled,
     // the engine retains its historical 2-tier posture.
     if cfg.gpu_cache.enabled {
         // `gpu_cache.dtype` is currently advisory — it is validated by
         // `AppConfig::validate` (so typos fail fast) and surfaced here
         // for observability, but the promotion path copies on-disk
-        // bytes into VRAM without conversion or repacking. Parse it
+        // bytes into logical host admission without conversion or repacking. Parse it
         // here purely so the startup log records the operator's
         // declared intent.
         let dtype_for_logging = crate::inference::WeightDtype::from_str_opt(&cfg.gpu_cache.dtype)
@@ -4978,7 +4976,7 @@ async fn cmd_serve(config_path: PathBuf) -> Result<(), Box<dyn std::error::Error
             anchor_ratio = cfg.gpu_cache.vram_anchor_ratio,
             promote_after_hits = cfg.gpu_cache.promote_after_hits,
             dtype_advisory = %dtype_for_logging.as_str(),
-            "VRAM (GPU) expert cache enabled — 3-tier SSD→RAM→VRAM hierarchy active (dtype is advisory; bytes copied as-is)"
+            "logical GPU expert admission enabled (dtype is advisory; physical upload is lazy and backend-owned)"
         );
         engine_builder.install_gpu_cache();
     }

--- a/rust-engine/src/metrics.rs
+++ b/rust-engine/src/metrics.rs
@@ -67,19 +67,20 @@ struct MetricsInner {
     /// path that was actually waiting on the storage device, as
     /// distinct from the total I/O time which can overlap compute).
     pub ssd_stall_seconds: Histogram,
-    /// VRAM tier probe hits — lookups for which the requested expert
+    /// Logical GPU-admission probe hits — lookups for which the requested expert
     /// was already present in
     /// [`GpuExpertCache`](crate::expert_cache::GpuExpertCache)
     /// at probe time (Phase 1).
     pub gpu_cache_hits_total: Counter,
-    /// VRAM tier probe misses — lookups for which the requested expert
-    /// was not present in VRAM at probe time and therefore required
+    /// Logical GPU-admission probe misses — lookups for which the requested
+    /// expert was not admitted at probe time and therefore required
     /// lower-tier resolution/promotion logic (Phase 1).
     pub gpu_cache_misses_total: Counter,
-    /// **Gauge** of currently-resident VRAM bytes across the Anchor +
-    /// LRU regions. Phase 1.
+    /// Compatibility gauge of logical host payload bytes admitted across the
+    /// Anchor + LRU regions. It is not physical wgpu memory; PR4 physical
+    /// accounting is exposed by `GpuExpertMemorySnapshot`.
     pub vram_used_bytes: IntGauge,
-    /// **Gauge** of the total VRAM byte budget for the
+    /// Compatibility gauge of the logical admission byte budget for the
     /// [`GpuExpertCache`](crate::expert_cache::GpuExpertCache)
     /// (Anchor + LRU capacity). Set once when the GPU cache is
     /// installed so dashboards can compute utilisation as
@@ -87,7 +88,7 @@ struct MetricsInner {
     /// relying on the `/v1/admin/health/experts` admin endpoint.
     /// Stays at `0` when the GPU cache is disabled. Phase 1.
     pub vram_capacity_bytes: IntGauge,
-    /// Total RAM → VRAM promotions performed since startup. Each
+    /// Total RAM → logical GPU-admission promotions performed since startup. Each
     /// promotion is the result of an `ExpertResident` crossing
     /// `gpu_cache.promote_after_hits` and being copied into the
     /// Anchor Core (or the LRU Edge as a fallback). Phase 1.
@@ -101,7 +102,7 @@ struct MetricsInner {
     /// a hidden-state / `d_model` mismatch.
     pub speculator_disabled_total: Counter,
     /// Expert activations that fell back from the GPU fast path to the
-    /// CPU path because the VRAM dispatch errored.
+    /// CPU path because physical GPU routed-expert dispatch errored.
     pub gpu_cpu_fallbacks_total: Counter,
     /// **Gauge** mirroring the process-wide cumulative count of
     /// attention-softmax non-finite fallbacks
@@ -262,31 +263,31 @@ impl Metrics {
         .expect("metric registration: mer_ssd_stall_seconds");
         let gpu_cache_hits_total = register_counter_with_registry!(
             "mer_gpu_cache_hits_total",
-            "VRAM-tier expert cache hits (lookups served out of GpuExpertCache).",
+            "Logical GPU-admission hits served by GpuExpertCache.",
             registry
         )
         .expect("metric registration: mer_gpu_cache_hits_total");
         let gpu_cache_misses_total = register_counter_with_registry!(
             "mer_gpu_cache_misses_total",
-            "VRAM-tier expert cache misses (lookups that fell through to RAM/NVMe).",
+            "Logical GPU-admission misses that fell through to RAM/NVMe.",
             registry
         )
         .expect("metric registration: mer_gpu_cache_misses_total");
         let vram_used_bytes = register_int_gauge_with_registry!(
             "mer_vram_used_bytes",
-            "Currently-resident VRAM bytes across the Anchor Core + LRU Edge regions.",
+            "Compatibility metric: logical host payload bytes admitted across GpuExpertCache Anchor + LRU; not physical wgpu allocation bytes.",
             registry
         )
         .expect("metric registration: mer_vram_used_bytes");
         let vram_capacity_bytes = register_int_gauge_with_registry!(
             "mer_vram_capacity_bytes",
-            "Total VRAM byte budget configured for the GpuExpertCache (Anchor + LRU). 0 when the GPU cache is disabled.",
+            "Compatibility metric: logical GpuExpertCache admission budget (also the physical expert-weight cap); excludes fixed workspaces. 0 when disabled.",
             registry
         )
         .expect("metric registration: mer_vram_capacity_bytes");
         let promotions_total = register_counter_with_registry!(
             "mer_promotions_total",
-            "Total RAM-to-VRAM promotions performed since startup.",
+            "Total RAM-to-logical-GPU-admission promotions performed since startup.",
             registry
         )
         .expect("metric registration: mer_promotions_total");
@@ -520,7 +521,7 @@ impl Metrics {
         self.inner.ssd_stall_seconds.observe(seconds);
     }
 
-    /// Record one VRAM (GPU) tier cache lookup outcome. Mirrors
+    /// Record one logical GPU-admission lookup outcome. Mirrors
     /// `record_cache` for the new top-tier in the 3-tier hierarchy.
     pub fn record_gpu_cache(&self, hits: u64, misses: u64) {
         if hits > 0 {
@@ -531,16 +532,15 @@ impl Metrics {
         }
     }
 
-    /// Set the currently-resident VRAM bytes gauge. Called by the
-    /// `GpuExpertCache` whenever the resident set changes (insert /
-    /// promote / evict).
+    /// Set the compatibility logical-admission byte gauge. Physical wgpu
+    /// expert/workspace bytes are available from `GpuExpertMemorySnapshot`.
     pub fn set_vram_used_bytes(&self, bytes: u64) {
         self.inner.vram_used_bytes.set(bytes as i64);
     }
 
-    /// Set the total VRAM byte budget gauge. Called once when the
-    /// `GpuExpertCache` is installed (constant for the lifetime of
-    /// the process); stays at `0` when the GPU cache is disabled.
+    /// Set the compatibility logical-admission budget gauge. The same
+    /// configured value caps physical expert weights, while fixed workspaces
+    /// are reported separately by the PR4 ledger.
     pub fn set_vram_capacity_bytes(&self, bytes: u64) {
         self.inner.vram_capacity_bytes.set(bytes as i64);
     }
@@ -560,7 +560,7 @@ impl Metrics {
         }
     }
 
-    /// Record `n` RAM → VRAM promotions.
+    /// Record `n` RAM → logical GPU-admission promotions.
     pub fn record_promotions(&self, n: u64) {
         if n > 0 {
             self.inner.promotions_total.inc_by(n as f64);
@@ -693,6 +693,12 @@ mod tests {
         .unwrap();
         m.set_backend_component_planes(hybrid.plan());
         let body = String::from_utf8(m.render().unwrap()).unwrap();
+        assert!(body.contains(
+            "# HELP mer_vram_used_bytes Compatibility metric: logical host payload bytes"
+        ));
+        assert!(body.contains(
+            "# HELP mer_vram_capacity_bytes Compatibility metric: logical GpuExpertCache admission budget"
+        ));
         let want_one = [
             r#"mer_backend_component_plane{component="attention",plane="cpu"} 1"#,
             r#"mer_backend_component_plane{component="experts",plane="gpu"} 1"#,

--- a/rust-engine/src/server.rs
+++ b/rust-engine/src/server.rs
@@ -1205,14 +1205,16 @@ struct ExpertHealth {
     block_pool_capacity: Option<usize>,
     block_pool_overflow_in_use: Option<usize>,
     tokens_generated: u64,
-    /// Phase 1 / 3-tier hierarchy: whether the VRAM (GPU) expert
-    /// cache is configured. When `false` the remaining `vram_*` and
-    /// `gpu_*` fields are still present (0) for stable schema.
+    /// Whether the logical GPU-admission cache is configured. Compatibility
+    /// `vram_*` fields remain present for stable schema but describe logical
+    /// host admission bytes; exact physical bytes use the PR4 Rust snapshot.
     gpu_cache_enabled: bool,
     gpu_cache_hits: u64,
     gpu_cache_misses: u64,
     gpu_promotions_total: u64,
+    /// Logical admitted host payload bytes (compatibility field name).
     vram_used_bytes: u64,
+    /// Logical admission budget, also used as the physical expert-weight cap.
     vram_capacity_bytes: u64,
     gpu_anchor_count: usize,
     gpu_lru_count: usize,

--- a/rust-engine/src/tui.rs
+++ b/rust-engine/src/tui.rs
@@ -1,5 +1,5 @@
 //! Native terminal dashboard for `mer-cli monitor` — Phase 4 of the
-//! three-tier (SSD → RAM → VRAM) memory hierarchy.
+//! SSD/RAM plus logical GPU-admission hierarchy.
 //!
 //! This module is compiled only when the `tui` cargo feature is on
 //! (the default), in which case it pulls in `ratatui` + `crossterm`
@@ -16,11 +16,10 @@
 //! * Header strip with status pill, uptime, and per-second throughput
 //!   (with restart-recovery: TPS resets to zero on a backwards jump
 //!   of `tokens_generated`);
-//! * 3-tier hit-grid (VRAM / RAM / SSD) rendered as three side-by-side
+//! * hit-grid (GPU admission / RAM / SSD) rendered as three side-by-side
 //!   sparklines plotting the **delta** of each tier's hit counter
 //!   per refresh tick — i.e. pulse/load, not a cumulative staircase;
-//! * VRAM and RAM utilisation bars (anchor + LRU regions for the
-//!   VRAM tier; logical occupancy for the RAM tier);
+//! * logical GPU-admission and RAM utilisation bars;
 //! * I/O reactor pulse — a sparkline of the per-tick miss delta
 //!   (i.e. SSD reads required this tick), surfacing backpressure
 //!   and stall on the inference critical path.
@@ -365,7 +364,7 @@ fn draw_tiers(f: &mut ratatui::Frame, area: Rect, app: &AppState) {
     draw_tier_sparkline(
         f,
         columns[0],
-        "VRAM",
+        "GPU ADM",
         vram_hits,
         &app.vram_hits_history,
         ACCENT,
@@ -388,7 +387,7 @@ fn draw_tiers(f: &mut ratatui::Frame, area: Rect, app: &AppState) {
     );
 }
 
-/// Render one tier column: a label line ("VRAM 12345 Δ7") above a
+/// Render one tier column: a label line ("GPU ADM 12345 Δ7") above a
 /// sparkline drawn from the supplied delta history. Each panel owns
 /// its own border so the three tiers visually segment cleanly even
 /// in narrow terminals.
@@ -423,7 +422,7 @@ fn draw_vram(f: &mut ratatui::Frame, area: Rect, app: &AppState) {
         .borders(Borders::ALL)
         .border_style(Style::default().fg(ACCENT))
         .title(Span::styled(
-            " VRAM UTILISATION ",
+            " GPU ADMISSION UTILISATION ",
             Style::default().fg(ACCENT).add_modifier(Modifier::BOLD),
         ));
     f.render_widget(block, area);
@@ -449,7 +448,7 @@ fn draw_vram(f: &mut ratatui::Frame, area: Rect, app: &AppState) {
         .split(inner);
 
     let vram_label = format!(
-        "VRAM  {} / {} MiB   anchor={}  lru={}  promotions={}",
+        "logical  {} / {} MiB   anchor={}  lru={}  promotions={}",
         app.last.vram_used_bytes / (1024 * 1024),
         app.last.vram_capacity_bytes / (1024 * 1024),
         app.last.gpu_anchor_count,
@@ -472,7 +471,7 @@ fn draw_vram(f: &mut ratatui::Frame, area: Rect, app: &AppState) {
     f.render_widget(vram, rows[0]);
     f.render_widget(ram, rows[1]);
     let footer = if app.last.gpu_cache_enabled {
-        "[gpu_cache] ACTIVE — RAM→VRAM promotions on hit threshold"
+        "[gpu_cache] ACTIVE — RAM→logical-GPU admission on hit threshold"
     } else {
         "[gpu_cache] DISABLED — running 2-tier SSD→RAM"
     };
@@ -485,7 +484,7 @@ fn draw_vram(f: &mut ratatui::Frame, area: Rect, app: &AppState) {
 fn draw_pulse(f: &mut ratatui::Frame, area: Rect, app: &AppState) {
     // Reactor pulse — per-tick SSD-miss delta sourced from
     // `ssd_hits_history` (a RAM miss == an SSD read). A flat-zero
-    // line means every routed expert was served out of RAM/VRAM
+    // line means every routed expert was served from RAM/logical admission
     // (no I/O stall); tall bars are direct evidence of backpressure
     // on the inference critical path.
     let last_delta = app.ssd_hits_history.back().copied().unwrap_or(0);

--- a/rust-engine/src/tui.rs
+++ b/rust-engine/src/tui.rs
@@ -16,9 +16,9 @@
 //! * Header strip with status pill, uptime, and per-second throughput
 //!   (with restart-recovery: TPS resets to zero on a backwards jump
 //!   of `tokens_generated`);
-//! * hit-grid (GPU admission / RAM / SSD) rendered as three side-by-side
-//!   sparklines plotting the **delta** of each tier's hit counter
-//!   per refresh tick — i.e. pulse/load, not a cumulative staircase;
+//! * activity grid rendered as three side-by-side sparklines plotting the
+//!   per-refresh **delta** of logical GPU-admission hits, RAM hits, and SSD
+//!   reads — i.e. pulse/load, not a cumulative staircase;
 //! * logical GPU-admission and RAM utilisation bars;
 //! * I/O reactor pulse — a sparkline of the per-tick miss delta
 //!   (i.e. SSD reads required this tick), surfacing backpressure
@@ -84,7 +84,7 @@ struct AppState {
     last: HealthSnapshot,
     last_tokens: u64,
     tokens_per_sec: u64,
-    /// Per-tier hit *delta* history (cap 60). Each push is
+    /// Per-series activity *delta* history (cap 60). Each push is
     /// `current_counter - prev_counter` so the sparkline shows the
     /// pulse/load per refresh tick rather than the cumulative
     /// staircase the previous revision rendered. Phase 1 telemetry
@@ -340,13 +340,13 @@ fn draw_tiers(f: &mut ratatui::Frame, area: Rect, app: &AppState) {
     // panel renders **delta** sparklines below (gist Phase 1).
     let vram_hits = app.last.gpu_cache_hits;
     let ram_hits = app.last.cache_hits;
-    let ssd_hits = app.last.cache_misses;
+    let ssd_reads = app.last.cache_misses;
 
     let block = Block::default()
         .borders(Borders::ALL)
         .border_style(Style::default().fg(ACCENT))
         .title(Span::styled(
-            " 3-TIER HIT GRID · Δ per tick ",
+            " 3-TIER ACTIVITY · Δ per tick ",
             Style::default().fg(ACCENT).add_modifier(Modifier::BOLD),
         ));
     f.render_widget(block, area);
@@ -380,8 +380,8 @@ fn draw_tiers(f: &mut ratatui::Frame, area: Rect, app: &AppState) {
     draw_tier_sparkline(
         f,
         columns[2],
-        "SSD ",
-        ssd_hits,
+        "SSD READ",
+        ssd_reads,
         &app.ssd_hits_history,
         Color::LightYellow,
     );
@@ -482,11 +482,11 @@ fn draw_vram(f: &mut ratatui::Frame, area: Rect, app: &AppState) {
 }
 
 fn draw_pulse(f: &mut ratatui::Frame, area: Rect, app: &AppState) {
-    // Reactor pulse — per-tick SSD-miss delta sourced from
+    // Reactor pulse — per-tick SSD-read delta sourced from
     // `ssd_hits_history` (a RAM miss == an SSD read). A flat-zero
-    // line means every routed expert was served from RAM/logical admission
-    // (no I/O stall); tall bars are direct evidence of backpressure
-    // on the inference critical path.
+    // line means only that no SSD read was recorded during the tick; RAM,
+    // logical admission, or physical GPU residency may have served work.
+    // Tall bars are direct evidence of critical-path I/O backpressure.
     let last_delta = app.ssd_hits_history.back().copied().unwrap_or(0);
     let title = format!(" I/O REACTOR · stall pulse · last Δ {last_delta} ");
     let block = Block::default()


### PR DESCRIPTION
## Summary

Makes physical routed-expert GPU residency authoritative and explicitly
separates it from MER's existing host-side logical GPU-admission policy.

Previously `GpuExpertCache` tracked logical Anchor/LRU admission using host
payload bytes, while a separate `vram_expert_bufs` map owned actual wgpu
expert buffers. Physical entries were not independently capacity bounded or
generation validated, and compatibility `vram_*` telemetry could be mistaken
for actual device allocation.

PR4 replaces that arrangement with a generation-aware, capacity-bounded
physical expert registry owned by the authoritative GPU backend.

## Logical admission vs physical residency

`GpuExpertCache` remains the logical policy layer:

- Anchor Core + LRU Edge
- host-side admitted expert payloads
- logical admission hit/miss telemetry
- logical LRU recency
- promotion policy

`GpuBackend` now owns the physical policy layer:

- actual wgpu routed-expert weight buffers
- `(expert_id, logical_generation)` identity
- deterministic physical LRU
- physical capacity enforcement
- exact physical expert accounting
- stale-entry retirement

The two layers are no longer treated as the same thing.

## Admission generations

Every new logical GPU admission receives a monotonically increasing generation.

Normal hits preserve that generation.

Eviction followed by re-admission of the same expert receives a new generation.

Physical entries are keyed by:

`(expert_id, generation)`

A physical entry is executable only when it matches the current logical
admission generation.

Logical misses and generation mismatches cannot execute stale physical buffers.

## Physical registry

Adds one backend-local authoritative `PhysicalGpuExpertRegistry`.

The registry:

- provides O(1) current-entry lookup
- maintains physical LRU recency
- enforces the configured expert-weight capacity
- retires stale entries
- serializes same-expert physical installation through keyed singleflight
- never holds its lock across GPU upload, submission, readback, or dispatch

The previous independent physical buffer map is removed/replaced by this
authoritative registry.

## Exact physical memory accounting

Adds an internal routed-expert GPU memory ledger.

It distinguishes:

- logical admitted host bytes
- physical registry expert bytes
- live physical expert bytes
- fixed routed-expert workspace bytes
- configured physical expert capacity
- physical entry count
- physical installs
- physical evictions
- stale retirements

`expert_live_bytes` uses a non-cloneable RAII allocation lease.

Removing an expert from the physical registry immediately decreases
registry-addressable bytes, but the physical allocation remains charged while
an in-flight `Arc` still owns it.

The live charge is released only when the final owning physical entry drops.

This prevents qualification telemetry from understating device ownership
during concurrent/in-flight eviction.

## Workspace accounting

The fixed routed-expert workspace pool is included in the internal ledger.

The accounting uses the actual descriptor sizes of the five wgpu buffers in
each of the four expert workspaces.

The host-side `scratch: Vec<f32>` is intentionally excluded.

Internal PR4 ledger scope is therefore:

physical routed-expert weight buffers
+
fixed routed-expert workspace buffers

Dense, attention, KV, driver and allocator overhead are outside this internal
ledger and will be externally cross-checked by later qualification work.

## Capacity behavior

The configured GPU expert capacity applies to physical routed-expert weight
buffers.

Fixed routed-expert workspaces are reported separately.

Before a new physical install, the registry:

- determines exact device bytes
- rejects an expert larger than the physical capacity
- retires physical LRU victims as necessary
- accounts for in-flight evicted buffers that remain physically live
- refuses unsafe overcommit rather than waiting or silently exceeding the cap

Capacity failures use the typed `PhysicalCapacity` GPU dispatch error.

PR3 continues to own strict-vs-serving recovery semantics.

## Upload/install concurrency

Concurrent requests for the same current logical expert use keyed singleflight
reservation.

The registry cannot expose two current physical entries for one
`(expert_id, generation)`.

Failed construction/install paths cancel reservations and release any acquired
live-byte lease without leaking registry or live accounting.

## Generation race handling

Logical identity is validated:

1. before physical upload
2. after physical upload
3. after registry installation and before dispatch

A generation change during those windows therefore cannot turn an old physical
entry into a valid dispatch result.

## Logical telemetry review fix

Physical dispatch does not mutate logical GPU-admission telemetry or recency.

Routing remains the sole authoritative logical probe through
`GpuExpertCache::get()`.

The physical backend uses a new non-mutating:

`GpuExpertCache::current_admission()`

which:

- does not increment hit/miss counters
- uses `peek()` for LRU entries
- does not alter logical LRU order
- still returns the current resident and generation needed for physical
  validation

This keeps logical-admission LRU order independent from parallel GPU compute
scheduling.

## Existing telemetry

Existing compatibility names such as:

- `vram_used_bytes`
- `vram_capacity_bytes`
- `mer_vram_used_bytes`
- `mer_vram_capacity_bytes`

remain available but are now explicitly documented as logical GPU-admission
telemetry where applicable.

Exact physical routed-expert ownership is exposed through the new Rust
`gpu_expert_memory_snapshot()` seam for PR5.

No qualification schema or NVML integration is added here.

## PR2 / PR3 preservation

PR2 authoritative execution-context ownership remains unchanged.

PR3 strict GPU routed-expert behavior remains unchanged:

- strict GPU failure performs zero CPU expert recovery
- strict failure does not increment the GPU→CPU fallback counter
- serving fallback still executes CPU exactly once and increments the
  fallback counter exactly once

CPU routed-expert execution remains independent of the physical GPU registry.

## Validation

Final PR4 head:

`94c2a758e3f54be6f1562df99d241b948f9906c2`

Implementation commit:

`d4b9150c87663a599280370ac866f830bb8df142`

Review fix:

`94c2a758e3f54be6f1562df99d241b948f9906c2`

Validation:

- focused PR2/PR3/PR4 regressions: passed
- full suite: 843 passed, 0 failed, 2 ignored
- `cargo clippy --all-targets`: passed with existing warning backlog
- `git diff --check`: passed
- worktree clean
- exactly two commits above the PR3 merge base

## Scope

This PR intentionally does not add:

- PR5 strict-hybrid qualification schema
- NVML integration
- live L4 qualification
- batched top-K GPU execution
- CUDA redesign
- GPU attention/KV/dense migration
- scheduler redesign
- predictor changes
- quantization changes
- throughput tuning
- performance claims

No live GPU or TPS claim is made by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detailed GPU memory monitoring, including capacity, workspace usage, residency, evictions, and generation status.
  * Added generation-aware GPU admissions and promotion rearming after eviction.
  * Added clearer reporting for physical dispatch-capacity failures.

* **Bug Fixes**
  * Prevented duplicate promotions and improved concurrent upload and cancellation handling.
  * Improved GPU memory accounting, capacity enforcement, and fallback behavior.

* **Documentation**
  * Updated CLI, metrics, health output, TUI, and configuration terminology to distinguish logical GPU admission from physical residency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->