### PR TITLE
feat: add strict Hybrid Q4 qualification contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -1940,6 +1940,41 @@ optimal.
   --greedy
 ```
 
+#### Strict Hybrid native-Q4_0 qualification
+
+`bench-real` remains the CPU real-transformer benchmark compatibility command.
+`qualify-hybrid-q4` is a separate, fail-closed execution-integrity check for an
+exact Hybrid plan: embeddings, LM head, dense projections, attention, KV, and
+router on CPU, with native-Q4_0 routed experts on a hardware GPU.
+
+```bash
+./target/release/micro-expert-router qualify-hybrid-q4 \
+  --config ./path/to/strict-hybrid-q4.toml \
+  --prompt "Write a small Rust function." \
+  --output-tokens 32 \
+  --warmup-runs 0 \
+  --report-out qualification.json
+```
+
+The command always uses greedy decoding and measures exactly one real
+autoregressive request after any warmups. PASS proves the execution contract;
+it does not prove or require 10 generated tokens/s. CPU routed-expert recovery
+is forbidden. Synthetic `run` throughput is not qualification throughput.
+
+The report's `decode_tps` and `real_generated_tps` fields both measure steady
+autoregressive decode throughput as
+`generated_tokens.saturating_sub(1) / decode_seconds`, matching `bench-real`.
+The first generated token is excluded because it is produced before decode
+timing begins. `end_to_end_generated_tps` instead divides all actual generated
+tokens by `total_seconds`; it includes prompt processing and time to first token
+and is not the commercial decode-TPS metric.
+
+The report's internal GPU-memory fields cover only MER-owned physical routed-
+expert buffers and fixed routed-expert workspaces. They are not total driver or
+device memory. `--external-gpu-memory-artifact <STRING>` stores an opaque
+reference to separately collected PR6 evidence; this command does not invoke
+NVML or `nvidia-smi`.
+
 Increase log verbosity:
 
 ```bash
@@ -2332,6 +2367,16 @@ micro-expert-router bench-real
                               Cache reset policy between runs.
   --greedy                   Force deterministic greedy decoding.
   --format <human|json>      Output format.
+
+micro-expert-router qualify-hybrid-q4
+  --config <PATH>            Strict Hybrid native-Q4_0 TOML config.
+  --prompt <TEXT>            Prompt text; conflicts with --request-json.
+  --request-json <PATH>      OpenAI-style prompt/messages request JSON.
+  --output-tokens <N>        Completion tokens; overrides request max_tokens.
+  --warmup-runs <N>          Strict greedy warmups (default 0).
+  --report-out <PATH>        Write typed JSON there (default: stdout).
+  --external-gpu-memory-artifact <STRING>
+                              Opaque reference to separate external evidence.
 
 micro-expert-router monitor          # requires `--features tui` (on by default)
   --url <URL>                Base URL of a running `serve` instance

--- a/rust-engine/Cargo.lock
+++ b/rust-engine/Cargo.lock
@@ -2022,6 +2022,7 @@ dependencies = [
  "safetensors 0.4.5",
  "serde",
  "serde_json",
+ "sha2",
  "tokenizers 0.20.4",
  "tokio",
  "toml",

--- a/rust-engine/Cargo.toml
+++ b/rust-engine/Cargo.toml
@@ -23,6 +23,7 @@ lru = "0.12"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
+sha2 = "0.10"
 
 # HTTP server for the OpenAI-compatible API. Pin minor versions; both are
 # 0.x and follow strict semver, so a wildcard would break us.

--- a/rust-engine/build.rs
+++ b/rust-engine/build.rs
@@ -1,0 +1,58 @@
+use std::path::Path;
+use std::process::Command;
+
+fn git_output(repo: &Path, args: &[&str]) -> Option<String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn main() {
+    let manifest_dir = std::env::var_os("CARGO_MANIFEST_DIR")
+        .map(std::path::PathBuf::from)
+        .expect("CARGO_MANIFEST_DIR is set by Cargo");
+    let repo = manifest_dir.parent().unwrap_or(&manifest_dir);
+
+    let sha = git_output(repo, &["rev-parse", "HEAD"])
+        .filter(|sha| sha.len() == 40 && sha.bytes().all(|b| b.is_ascii_hexdigit()));
+    let dirty = git_output(repo, &["status", "--porcelain", "--untracked-files=no"])
+        .map(|status| !status.is_empty());
+
+    println!(
+        "cargo:rustc-env=MER_BUILD_GIT_SHA={}",
+        sha.as_deref().unwrap_or("unavailable")
+    );
+    println!(
+        "cargo:rustc-env=MER_BUILD_GIT_DIRTY={}",
+        dirty
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "unavailable".to_string())
+    );
+
+    // A commit or staged/unstaged tracked-source change must invalidate the
+    // embedded provenance. These paths work for the normal checkout used by
+    // this repository; Cargo still has explicit unavailable semantics if Git
+    // metadata cannot be read.
+    println!(
+        "cargo:rerun-if-changed={}",
+        repo.join(".git/HEAD").display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        repo.join(".git/index").display()
+    );
+    // Once any `rerun-if-changed` directive is emitted Cargo stops using its
+    // broad package-directory fallback. Watch every tracked path so a dirty
+    // tracked file cannot reuse provenance captured by an earlier clean build.
+    if let Some(tracked) = git_output(repo, &["ls-files"]) {
+        for path in tracked.lines().filter(|path| !path.is_empty()) {
+            println!("cargo:rerun-if-changed={}", repo.join(path).display());
+        }
+    }
+}

--- a/rust-engine/build.rs
+++ b/rust-engine/build.rs
@@ -45,6 +45,10 @@ fn main() {
     );
     println!(
         "cargo:rerun-if-changed={}",
+        repo.join(".git/logs/HEAD").display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
         repo.join(".git/index").display()
     );
     // Once any `rerun-if-changed` directive is emitted Cargo stops using its

--- a/rust-engine/src/backend/mod.rs
+++ b/rust-engine/src/backend/mod.rs
@@ -720,7 +720,6 @@ impl<T: PhysicalRegistryEntry> PhysicalGpuExpertRegistry<T> {
         }
     }
 
-    #[allow(dead_code)] // Public snapshot callers arrive in PR5; PR4 tests invariants here.
     fn snapshot(&self, logical_admitted_bytes: u64) -> GpuExpertMemorySnapshot {
         let inner = self.inner.lock();
         let expert_live_bytes = self.ledger.expert_live_bytes();
@@ -2967,7 +2966,6 @@ impl GpuBackend {
         self.expert_matmul_from_vram(layer, expert_id, &entry, x, out)
     }
 
-    #[allow(dead_code)] // Public snapshot callers arrive in PR5.
     fn gpu_expert_memory_snapshot(&self) -> GpuExpertMemorySnapshot {
         self.physical_expert_registry
             .snapshot(self.gpu_expert_cache.used_bytes())
@@ -3218,7 +3216,6 @@ impl BackendBox {
     /// Exact PR4 routed-expert physical-memory ledger when this is a
     /// production GPU backend. CPU and hardware-independent test backends do
     /// not own physical wgpu expert allocations.
-    #[allow(dead_code)] // Public snapshot callers arrive in PR5.
     pub fn gpu_expert_memory_snapshot(&self) -> Option<GpuExpertMemorySnapshot> {
         match self {
             Self::Gpu(gpu) => Some(gpu.gpu_expert_memory_snapshot()),
@@ -3859,7 +3856,6 @@ impl ExecutionContext {
     /// Narrow snapshot seam for PR5. Existing compatibility telemetry remains
     /// logical-admission based; this API exposes exact MER-owned physical
     /// expert and workspace bytes without log parsing.
-    #[allow(dead_code)] // Public snapshot callers arrive in PR5.
     pub fn gpu_expert_memory_snapshot(&self) -> Option<GpuExpertMemorySnapshot> {
         self.gpu_backend
             .as_ref()

--- a/rust-engine/src/backend/mod.rs
+++ b/rust-engine/src/backend/mod.rs
@@ -4512,6 +4512,39 @@ mod tests {
     }
 
     #[test]
+    fn logical_lru_to_anchor_move_reuses_matching_physical_generation() {
+        let cache = crate::expert_cache::GpuExpertCache::new(128, 0.5, 3);
+        let resident = Arc::new(crate::expert_cache::GpuResident::new(7, vec![0u8; 32]));
+        assert_eq!(cache.demand_admit_lru(resident.clone()), Ok(true));
+        let generation = cache.current_generation(7).expect("LRU generation");
+        let key = physical_key(7, generation);
+        let registry = test_physical_registry(128, 0);
+        let physical = install_test_physical_entry(&registry, key, 32).unwrap();
+
+        assert!(cache.claim_promotion(7, 3));
+        assert_eq!(
+            cache.promote_hot_existing(7),
+            crate::expert_cache::GpuHotPromotionOutcome::MovedLruToAnchor
+        );
+        assert_eq!(cache.current_generation(7), Some(generation));
+        assert!(Arc::ptr_eq(
+            cache.current_admission(7).unwrap().resident(),
+            &resident
+        ));
+
+        let reused = match registry.lookup_current(key) {
+            PhysicalRegistryLookup::Hit(entry) => entry,
+            _ => panic!("matching physical generation must remain reusable"),
+        };
+        assert!(Arc::ptr_eq(&physical, &reused));
+        let snapshot = registry.snapshot(cache.used_bytes());
+        assert_eq!(snapshot.physical_installs, 1);
+        assert_eq!(snapshot.physical_entries, 1);
+        assert_eq!(snapshot.expert_registry_bytes, 32);
+        assert_eq!(snapshot.stale_retirements, 0);
+    }
+
+    #[test]
     fn physical_registry_retires_stale_generation_before_reinstall() {
         let registry = test_physical_registry(128, 0);
         let g1 = physical_key(7, 1);

--- a/rust-engine/src/backend/mod.rs
+++ b/rust-engine/src/backend/mod.rs
@@ -2,6 +2,7 @@
 
 use anyhow::{anyhow, Result};
 use parking_lot::Mutex as ParkingMutex;
+use serde::Serialize;
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -33,6 +34,38 @@ struct AdapterMetadata {
     driver: String,
     driver_info: String,
     backend: wgpu::Backend,
+}
+
+/// Immutable identity of the adapter selected by the authoritative GPU
+/// backend. This is evidence about the backend that executes work; it does not
+/// enumerate or rediscover a second adapter for reporting.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct GpuDeviceIdentity {
+    pub name: String,
+    pub vendor_id: u32,
+    pub device_id: u32,
+    pub device_type: String,
+    pub wgpu_backend: String,
+    pub driver: String,
+    pub driver_info: String,
+    pub compute_plane: String,
+    pub software_adapter: bool,
+}
+
+impl AdapterMetadata {
+    fn identity(&self, compute_plane: &str) -> GpuDeviceIdentity {
+        GpuDeviceIdentity {
+            name: self.name.clone(),
+            vendor_id: self.vendor,
+            device_id: self.device,
+            device_type: format!("{:?}", self.device_type),
+            wgpu_backend: self.backend.to_str().to_string(),
+            driver: self.driver.clone(),
+            driver_info: self.driver_info.clone(),
+            compute_plane: compute_plane.to_string(),
+            software_adapter: self.is_software(),
+        }
+    }
 }
 
 impl AdapterMetadata {
@@ -278,7 +311,7 @@ impl std::error::Error for GpuExpertDispatchError {}
 /// deliberately narrower than process/device memory: physical expert weight
 /// buffers plus the fixed routed-expert workspace buffers. Dense, attention,
 /// KV, driver, and allocator overhead remain outside this internal ledger.
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize)]
 #[allow(dead_code)] // Public PR5 seam; PR4 validates it through backend-local tests.
 pub struct GpuExpertMemorySnapshot {
     /// Host payload bytes admitted by [`crate::expert_cache::GpuExpertCache`].
@@ -298,6 +331,58 @@ pub struct GpuExpertMemorySnapshot {
     pub physical_installs: u64,
     pub physical_evictions: u64,
     pub stale_retirements: u64,
+}
+
+/// Monotonic counters for only the routed-expert GPU path. Dense and
+/// attention operations are deliberately excluded.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize)]
+pub struct GpuExpertIoSnapshot {
+    /// Actual physical expert-buffer writes; registry hits do not increment it.
+    pub expert_weight_uploads: u64,
+    /// Exact bytes passed to successful expert-buffer write calls.
+    pub expert_weight_upload_bytes: u64,
+    /// Actual routed hidden-state workspace writes.
+    pub hidden_state_uploads: u64,
+    /// Exact bytes passed to routed hidden-state workspace writes.
+    pub hidden_state_upload_bytes: u64,
+    /// Routed command-buffer submissions. A returned `SubmissionIndex` is not
+    /// represented as synchronous wgpu validation success.
+    pub queue_submissions: u64,
+    /// Routed staging-buffer `map_async` requests.
+    pub map_requests: u64,
+    /// Successfully mapped and copied routed readbacks.
+    pub readback_completions: u64,
+    /// Exact output bytes copied by completed routed readbacks.
+    pub readback_bytes: u64,
+}
+
+#[derive(Default)]
+struct GpuExpertIoCounters {
+    expert_weight_uploads: AtomicU64,
+    expert_weight_upload_bytes: AtomicU64,
+    hidden_state_uploads: AtomicU64,
+    hidden_state_upload_bytes: AtomicU64,
+    queue_submissions: AtomicU64,
+    map_requests: AtomicU64,
+    readback_completions: AtomicU64,
+    readback_bytes: AtomicU64,
+}
+
+impl GpuExpertIoCounters {
+    fn snapshot(&self) -> GpuExpertIoSnapshot {
+        GpuExpertIoSnapshot {
+            expert_weight_uploads: self.expert_weight_uploads.load(Ordering::Relaxed),
+            expert_weight_upload_bytes: self
+                .expert_weight_upload_bytes
+                .load(Ordering::Relaxed),
+            hidden_state_uploads: self.hidden_state_uploads.load(Ordering::Relaxed),
+            hidden_state_upload_bytes: self.hidden_state_upload_bytes.load(Ordering::Relaxed),
+            queue_submissions: self.queue_submissions.load(Ordering::Relaxed),
+            map_requests: self.map_requests.load(Ordering::Relaxed),
+            readback_completions: self.readback_completions.load(Ordering::Relaxed),
+            readback_bytes: self.readback_bytes.load(Ordering::Relaxed),
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -1140,6 +1225,8 @@ pub struct GpuBackend {
     device_loss: Arc<DeviceLossState>,
     device_name: String,
     compute_plane: String,
+    adapter_metadata: AdapterMetadata,
+    expert_io: GpuExpertIoCounters,
 
     matmul_pipeline: wgpu::ComputePipeline,
     /// Q4_0 inline-dequant GEMV pipeline (`matmul_q4_0.wgsl`) for expert
@@ -1758,6 +1845,8 @@ impl GpuBackend {
             device_loss,
             device_name,
             compute_plane,
+            adapter_metadata: info,
+            expert_io: GpuExpertIoCounters::default(),
             matmul_pipeline,
             matmul_q4_0_pipeline,
             swiglu_pipeline,
@@ -1928,6 +2017,12 @@ impl GpuBackend {
             .map_err(|_| anyhow!("F32 device buffer size does not fit usize"))?;
         self.queue
             .write_buffer(&weight_buf, 0, &weight_bytes[..upload_bytes]);
+        self.expert_io
+            .expert_weight_uploads
+            .fetch_add(1, Ordering::Relaxed);
+        self.expert_io
+            .expert_weight_upload_bytes
+            .fetch_add(plan.device_bytes, Ordering::Relaxed);
         let allocation = permit.charge_allocation().map_err(|e| anyhow!(e))?;
 
         Ok(VramExpertEntry {
@@ -1994,6 +2089,12 @@ impl GpuBackend {
             padded.resize(padded_len, 0);
             self.queue.write_buffer(&weight_buf, 0, &padded);
         }
+        self.expert_io
+            .expert_weight_uploads
+            .fetch_add(1, Ordering::Relaxed);
+        self.expert_io
+            .expert_weight_upload_bytes
+            .fetch_add(plan.device_bytes, Ordering::Relaxed);
         let allocation = permit.charge_allocation().map_err(|e| anyhow!(e))?;
 
         // The projection base is selected via the `w_block_off` push
@@ -2117,6 +2218,14 @@ impl GpuBackend {
             ws.scratch[i] = x.data[i].to_f32();
         }
         self.queue.write_buffer(&ws.x_buf, 0, bytemuck::cast_slice(&ws.scratch[..d_model]));
+        let hidden_bytes = u64::try_from(d_model * std::mem::size_of::<f32>())
+            .expect("routed-expert hidden upload length fits u64");
+        self.expert_io
+            .hidden_state_uploads
+            .fetch_add(1, Ordering::Relaxed);
+        self.expert_io
+            .hidden_state_upload_bytes
+            .fetch_add(hidden_bytes, Ordering::Relaxed);
 
         // ── Per-dispatch bind groups against the workspace buffers ────────────
         // Bind group creation is microseconds against a millisecond-scale
@@ -2281,9 +2390,13 @@ impl GpuBackend {
         // Wait only for *this* submission — other in-flight expert
         // dispatches (and dense ops) keep making progress on the queue.
         let submission = self.queue.submit(Some(encoder.finish()));
+        self.expert_io
+            .queue_submissions
+            .fetch_add(1, Ordering::Relaxed);
 
         let slice = ws.staging.slice(0..out_bytes);
         let (tx, rx) = std::sync::mpsc::channel();
+        self.expert_io.map_requests.fetch_add(1, Ordering::Relaxed);
         slice.map_async(wgpu::MapMode::Read, move |res| { let _ = tx.send(res); });
         self.device.poll(wgpu::Maintain::wait_for(submission));
 
@@ -2318,6 +2431,12 @@ impl GpuBackend {
             out.data[..d_model].convert_from_f32_slice(&floats[..d_model]);
         }
         ws.staging.unmap();
+        self.expert_io
+            .readback_completions
+            .fetch_add(1, Ordering::Relaxed);
+        self.expert_io
+            .readback_bytes
+            .fetch_add(out_bytes, Ordering::Relaxed);
         Ok(())
     }
 }
@@ -2857,6 +2976,14 @@ impl GpuBackend {
     fn compute_plane(&self) -> &str {
         &self.compute_plane
     }
+
+    fn gpu_device_identity(&self) -> GpuDeviceIdentity {
+        self.adapter_metadata.identity(&self.compute_plane)
+    }
+
+    fn gpu_expert_io_snapshot(&self) -> GpuExpertIoSnapshot {
+        self.expert_io.snapshot()
+    }
 }
 
 // =====================================================================
@@ -3095,6 +3222,24 @@ impl BackendBox {
     pub fn gpu_expert_memory_snapshot(&self) -> Option<GpuExpertMemorySnapshot> {
         match self {
             Self::Gpu(gpu) => Some(gpu.gpu_expert_memory_snapshot()),
+            Self::Cpu(_) => None,
+            #[cfg(test)]
+            Self::TestGpu(_) => None,
+        }
+    }
+
+    pub fn gpu_device_identity(&self) -> Option<GpuDeviceIdentity> {
+        match self {
+            Self::Gpu(gpu) => Some(gpu.gpu_device_identity()),
+            Self::Cpu(_) => None,
+            #[cfg(test)]
+            Self::TestGpu(_) => None,
+        }
+    }
+
+    pub fn gpu_expert_io_snapshot(&self) -> Option<GpuExpertIoSnapshot> {
+        match self {
+            Self::Gpu(gpu) => Some(gpu.gpu_expert_io_snapshot()),
             Self::Cpu(_) => None,
             #[cfg(test)]
             Self::TestGpu(_) => None,
@@ -3721,6 +3866,18 @@ impl ExecutionContext {
             .and_then(|backend| backend.gpu_expert_memory_snapshot())
     }
 
+    pub fn gpu_device_identity(&self) -> Option<GpuDeviceIdentity> {
+        self.gpu_backend
+            .as_ref()
+            .and_then(|backend| backend.gpu_device_identity())
+    }
+
+    pub fn gpu_expert_io_snapshot(&self) -> Option<GpuExpertIoSnapshot> {
+        self.gpu_backend
+            .as_ref()
+            .and_then(|backend| backend.gpu_expert_io_snapshot())
+    }
+
     pub fn primary_backend(&self) -> &Arc<BackendBox> {
         self.gpu_backend.as_ref().unwrap_or(&self.cpu_backend)
     }
@@ -4254,6 +4411,39 @@ pub fn current() -> Arc<BackendBox> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn routed_expert_io_snapshot_reads_each_monotonic_counter() {
+        let counters = GpuExpertIoCounters::default();
+        counters.expert_weight_uploads.fetch_add(1, Ordering::Relaxed);
+        counters
+            .expert_weight_upload_bytes
+            .fetch_add(11, Ordering::Relaxed);
+        counters.hidden_state_uploads.fetch_add(2, Ordering::Relaxed);
+        counters
+            .hidden_state_upload_bytes
+            .fetch_add(22, Ordering::Relaxed);
+        counters.queue_submissions.fetch_add(3, Ordering::Relaxed);
+        counters.map_requests.fetch_add(4, Ordering::Relaxed);
+        counters
+            .readback_completions
+            .fetch_add(5, Ordering::Relaxed);
+        counters.readback_bytes.fetch_add(55, Ordering::Relaxed);
+
+        assert_eq!(
+            counters.snapshot(),
+            GpuExpertIoSnapshot {
+                expert_weight_uploads: 1,
+                expert_weight_upload_bytes: 11,
+                hidden_state_uploads: 2,
+                hidden_state_upload_bytes: 22,
+                queue_submissions: 3,
+                map_requests: 4,
+                readback_completions: 5,
+                readback_bytes: 55,
+            }
+        );
+    }
 
     struct TestPhysicalEntry {
         key: PhysicalExpertKey,

--- a/rust-engine/src/engine.rs
+++ b/rust-engine/src/engine.rs
@@ -16,7 +16,9 @@
 use crate::aligned_buffer::AlignedBuffer;
 use crate::backend::Backend as _;
 use crate::buffer_pool::BufferPool;
-use crate::expert_cache::{ExpertResident, GpuExpertCache, GpuResident};
+use crate::expert_cache::{
+    ExpertResident, GpuExpertCache, GpuHotPromotionOutcome, GpuResident,
+};
 use crate::gating::Router;
 use crate::inference::{
     combine_outputs, run_inference_bf16, run_inference_f16, run_inference_int8,
@@ -2042,6 +2044,43 @@ impl Engine {
         }
     }
 
+    /// Process one threshold-driven promotion request. Existing logical
+    /// admissions are resolved first so an LRU entry can move to Anchor Core
+    /// without copying its multi-megabyte RAM payload. Only an absent id
+    /// requires a payload copy, followed by a locked recheck that preserves a
+    /// foreground demand admission if it won the race.
+    fn complete_background_gpu_promotion(
+        gpu: &GpuExpertCache,
+        prom: Option<&Metrics>,
+        id: u32,
+        resident: &ExpertResident,
+        dtype: WeightDtype,
+    ) -> GpuHotPromotionOutcome {
+        let initial = gpu.promote_hot_existing(id);
+        let outcome = if initial == GpuHotPromotionOutcome::PayloadRequired {
+            // The cache lock was released by `promote_hot_existing` before
+            // this copy. `promote_hot_sync` rechecks under its own lock, so a
+            // concurrent demand admission is moved intact rather than
+            // replaced by this redundant payload.
+            let gpu_resident = Arc::new(GpuResident::new_with_dtype(
+                id,
+                resident.data().to_vec(),
+                dtype,
+            ));
+            gpu.promote_hot_sync(gpu_resident)
+        } else {
+            initial
+        };
+
+        if outcome.is_transition() {
+            if let Some(prom) = prom {
+                prom.record_promotions(1);
+                prom.set_vram_used_bytes(gpu.used_bytes());
+            }
+        }
+        outcome
+    }
+
     /// Attach the logical GPU-admission cache — Phase 2 hierarchy policy.
     ///
     /// Spawns a background Tokio task that drains an MPSC channel of
@@ -2072,24 +2111,16 @@ impl Engine {
         }
         tokio::spawn(async move {
             while let Some((id, resident)) = rx.recv().await {
-                // `promote_sync` copies resident bytes into the host logical
-                // admission Anchor/LRU under the parking_lot mutex; safe to
-                // call from a Tokio worker because it never .awaits.
-                // Bytes are promoted verbatim; the dtype tag tells the
-                // GPU backend which matmul pipeline to dispatch (shared
-                // with the synchronous warm-up promotion path).
-                let gpu_res = Arc::new(GpuResident::new_with_dtype(
+                // Existing LRU admissions graduate atomically without a host
+                // payload copy. Absent ids copy outside the cache mutex and
+                // are rechecked under lock before final hot admission.
+                Self::complete_background_gpu_promotion(
+                    gpu_for_task.as_ref(),
+                    prom_for_task.as_ref(),
                     id,
-                    resident.data().to_vec(),
+                    resident.as_ref(),
                     promote_dtype,
-                ));
-                let promoted = gpu_for_task.promote_sync(gpu_res);
-                if promoted {
-                    if let Some(p) = prom_for_task.as_ref() {
-                        p.record_promotions(1);
-                        p.set_vram_used_bytes(gpu_for_task.used_bytes() as u64);
-                    }
-                }
+                );
             }
         });
         self.core.gpu_cache = Some(gpu.clone());
@@ -5311,9 +5342,9 @@ pub struct EngineReport {
     /// Compatibility field: logical admission budget. The same configured
     /// value caps physical expert weights; fixed workspaces are separate.
     pub vram_capacity_bytes: u64,
-    /// Cumulative RAM → logical-admission promotions performed by the background
-    /// promotion task. Promotions are gated by the per-expert
-    /// `promote_after_hits` threshold.
+    /// Cumulative successful logical GPU-promotion transitions: new
+    /// Anchor/LRU admissions plus LRU-to-Anchor graduation. No-op outcomes are
+    /// excluded; this mirrors `mer_promotions_total` when metrics are enabled.
     pub gpu_promotions: u64,
     /// Logical GPU-admission hit count (anchor + LRU).
     pub gpu_cache_hits: u64,
@@ -5580,6 +5611,18 @@ mod tests {
             .load(Ordering::Relaxed)
     }
 
+    fn rendered_counter(metrics: &Metrics, name: &str) -> u64 {
+        let body = String::from_utf8(metrics.render().expect("render Prometheus metrics"))
+            .expect("metrics are UTF-8");
+        body.lines()
+            .find_map(|line| {
+                let (metric, value) = line.split_once(' ')?;
+                (metric == name)
+                    .then(|| value.parse::<f64>().expect("Prometheus counter value") as u64)
+            })
+            .unwrap_or_else(|| panic!("missing Prometheus counter {name} in:\n{body}"))
+    }
+
     fn assert_gpu_dispatch_error(
         error: MoeStepError,
         expected_kind: crate::backend::GpuExpertDispatchErrorKind,
@@ -5699,6 +5742,184 @@ mod tests {
                 degraded_expert_substitutions: 0,
             }
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn demand_wins_hot_promotion_race_keeps_internal_and_prometheus_equal() {
+        let dir = TempDir::new("hot-promotion-demand-wins");
+        let base = build_engine(&dir.path, 4, 8, 16, 4, 1, 0, 0x30A);
+        let id = 2;
+        base.warm_with(&[id]).await.expect("warm RAM resident");
+        let test_gpu = crate::backend::TestGpuBackend::success(0.25);
+        let rebuilt = rebuild_with_test_gpu(
+            &base,
+            test_gpu,
+            Some(RoutedExpertGpuFailurePolicy::StrictFailClosed),
+            ExpertExecutionPolicy::SequentialExpertsRowParallel,
+            false,
+        );
+        let metrics = Metrics::new();
+        let engine = match Arc::try_unwrap(rebuilt) {
+            Ok(engine) => engine.with_metrics(metrics.clone()),
+            Err(_) => panic!("test owns the sole rebuilt engine Arc"),
+        };
+        let resident = engine.core.cache.get(id).expect("RAM resident");
+        let gpu = engine.execution_context().gpu_expert_cache();
+
+        assert!(gpu.claim_promotion(id, 16));
+        engine
+            .demand_admit_resident_to_gpu(0, resident.as_ref())
+            .expect("foreground demand admission");
+        let demand_admission = gpu.current_admission(id).expect("demand LRU admission");
+        let generation = demand_admission.generation();
+
+        assert_eq!(
+            Engine::complete_background_gpu_promotion(
+                gpu,
+                Some(&metrics),
+                id,
+                resident.as_ref(),
+                engine.core.options.dtype,
+            ),
+            GpuHotPromotionOutcome::MovedLruToAnchor
+        );
+        let current = gpu.current_admission(id).expect("graduated admission");
+        assert_eq!(current.generation(), generation);
+        assert!(Arc::ptr_eq(current.resident(), demand_admission.resident()));
+        assert_eq!(gpu.promotions(), 2, "demand install + Anchor graduation");
+        assert_eq!(rendered_counter(&metrics, "mer_promotions_total"), 2);
+        assert_eq!(gpu.anchor_len(), 1);
+        assert_eq!(gpu.lru_len(), 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn background_wins_hot_promotion_race_keeps_demand_recheck_noop() {
+        let dir = TempDir::new("hot-promotion-background-wins");
+        let base = build_engine(&dir.path, 4, 8, 16, 4, 1, 0, 0x30B);
+        let id = 2;
+        base.warm_with(&[id]).await.expect("warm RAM resident");
+        let test_gpu = crate::backend::TestGpuBackend::success(0.25);
+        let rebuilt = rebuild_with_test_gpu(
+            &base,
+            test_gpu,
+            Some(RoutedExpertGpuFailurePolicy::StrictFailClosed),
+            ExpertExecutionPolicy::SequentialExpertsRowParallel,
+            false,
+        );
+        let metrics = Metrics::new();
+        let engine = match Arc::try_unwrap(rebuilt) {
+            Ok(engine) => engine.with_metrics(metrics.clone()),
+            Err(_) => panic!("test owns the sole rebuilt engine Arc"),
+        };
+        let resident = engine.core.cache.get(id).expect("RAM resident");
+        let gpu = engine.execution_context().gpu_expert_cache();
+
+        assert_eq!(
+            gpu.demand_admission_preflight(id, resident.data().len()),
+            Ok(crate::expert_cache::GpuDemandAdmissionPreflight::NeedsPayload)
+        );
+        assert!(gpu.claim_promotion(id, 16));
+        assert_eq!(
+            Engine::complete_background_gpu_promotion(
+                gpu,
+                Some(&metrics),
+                id,
+                resident.as_ref(),
+                engine.core.options.dtype,
+            ),
+            GpuHotPromotionOutcome::InstalledAnchor
+        );
+        let background_admission = gpu.current_admission(id).expect("Anchor admission");
+        let generation = background_admission.generation();
+
+        engine
+            .demand_admit_resident_to_gpu(0, resident.as_ref())
+            .expect("demand recheck must observe background admission");
+        let current = gpu.current_admission(id).expect("current admission");
+        assert_eq!(current.generation(), generation);
+        assert!(Arc::ptr_eq(current.resident(), background_admission.resident()));
+        assert_eq!(gpu.promotions(), 1);
+        assert_eq!(rendered_counter(&metrics, "mer_promotions_total"), 1);
+        assert_eq!(gpu.anchor_len(), 1);
+        assert_eq!(gpu.lru_len(), 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn serving_demand_admitted_hot_expert_graduates_to_anchor() {
+        let dir = TempDir::new("serving-demand-hot-graduation");
+        let base = build_engine(&dir.path, 4, 8, 16, 4, 1, 0, 0x30C);
+        let test_gpu = crate::backend::TestGpuBackend::success(0.25);
+        let gpu = Arc::new(crate::expert_cache::GpuExpertCache::new(64 * 1024, 0.5, 3));
+        let backend = Arc::new(crate::backend::BackendBox::TestGpu(test_gpu.clone()));
+        let context = crate::backend::resolve_execution_context_with(
+            crate::backend::ComputeOffload::Hybrid,
+            true,
+            crate::backend::GpuBackendGeometry {
+                num_layers: 1,
+                max_seq_len: 16,
+                num_heads: 1,
+                num_kv_heads: 1,
+                head_dim: base.core.shape.d_model,
+                v_head_dim: base.core.shape.d_model,
+                q4_truncation_tolerance: 0,
+            },
+            crate::backend::RoutedExpertGpuSpec {
+                dtype: base.core.options.dtype,
+                d_model: base.core.shape.d_model,
+                d_ff: base.core.shape.d_ff,
+            },
+            gpu.clone(),
+            |_| Ok(backend),
+        )
+        .expect("test Hybrid context");
+        let mut engine = Engine::with_options_and_execution_context(
+            base.core.cache.clone(),
+            base.core.pool.clone(),
+            base.core.storage.clone(),
+            base.core.router.clone(),
+            base.core.predictor.clone(),
+            base.core.shape,
+            base.core.options,
+            context,
+        );
+        assert_eq!(
+            engine.routed_expert_gpu_failure_policy(),
+            RoutedExpertGpuFailurePolicy::ServingCpuFallback
+        );
+        let mut rx = engine.install_gpu_cache_for_test(gpu.clone());
+        let engine = Arc::new(engine);
+        let id = 2;
+        let hidden = crate::inference::synth_hidden_state(0, 8, 0x30C);
+
+        for token in 0..3 {
+            engine
+                .moe_step(token, 0, &hidden, &[id])
+                .await
+                .expect("serving demand GPU execution");
+        }
+        let (queued_id, resident) = rx.try_recv().expect("threshold promotion request");
+        assert_eq!(queued_id, id);
+        assert!(rx.try_recv().is_err(), "only one threshold request is queued");
+        let generation = gpu.current_generation(id).expect("demand LRU generation");
+        assert_eq!(gpu.anchor_len(), 0);
+        assert_eq!(gpu.lru_len(), 1);
+
+        assert_eq!(
+            Engine::complete_background_gpu_promotion(
+                gpu.as_ref(),
+                None,
+                id,
+                resident.as_ref(),
+                engine.core.options.dtype,
+            ),
+            GpuHotPromotionOutcome::MovedLruToAnchor
+        );
+        assert_eq!(gpu.current_generation(id), Some(generation));
+        assert_eq!(gpu.anchor_len(), 1);
+        assert_eq!(gpu.lru_len(), 0);
+        assert_eq!(test_gpu.expert_calls(), 3);
+        assert_eq!(cpu_expert_forward_calls(&engine), 0);
+        assert_eq!(engine.report().gpu_cpu_fallbacks, 0);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/rust-engine/src/engine.rs
+++ b/rust-engine/src/engine.rs
@@ -846,7 +846,9 @@ pub(crate) struct Counters {
     gpu_cpu_fallbacks: AtomicU64,
     /// Routed expert activations selected by the real MoE routing path.
     selected_routed_experts: AtomicU64,
-    /// Physical GPU routed-expert dispatch attempts.
+    /// Routed-expert activations entering the GPU dispatch boundary. This
+    /// includes activations rejected by pre-backend runtime-invariant guards,
+    /// so GPU-plan attempts stay equal to `selected_routed_experts`.
     gpu_dispatch_attempts: AtomicU64,
     /// Physical GPU routed-expert dispatches that returned output.
     gpu_dispatch_successes: AtomicU64,
@@ -1871,7 +1873,6 @@ impl Engine {
 
     /// Exact MER-owned routed-expert GPU weight/workspace ledger for PR5.
     /// Returns `None` when the resolved execution context has no GPU backend.
-    #[allow(dead_code)] // Public snapshot callers arrive in PR5.
     pub fn gpu_expert_memory_snapshot(
         &self,
     ) -> Option<crate::backend::GpuExpertMemorySnapshot> {
@@ -1984,6 +1985,60 @@ impl Engine {
                 p.record_promotions(1);
                 p.set_vram_used_bytes(gpu.used_bytes() as u64);
             }
+        }
+    }
+
+    /// Establish the current selected expert's logical GPU admission at the
+    /// real routed-compute boundary. Routing remains authoritative for normal
+    /// logical hit/miss telemetry and LRU touches; this demand path only fills
+    /// a missing admission and never uses Anchor Core. Physical upload remains
+    /// lazy in `GpuBackend`.
+    fn demand_admit_resident_to_gpu(
+        &self,
+        layer: u32,
+        resident: &ExpertResident,
+    ) -> Result<(), crate::backend::GpuExpertDispatchError> {
+        use crate::expert_cache::GpuDemandAdmissionPreflight;
+
+        let gpu = self.execution_context().gpu_expert_cache();
+        let admission_error = |error| {
+            crate::backend::GpuExpertDispatchError::new(
+                layer,
+                resident.id,
+                crate::backend::GpuExpertDispatchErrorKind::ResidencyMiss,
+                format!("foreground demand admission failed: {error}"),
+            )
+        };
+        match gpu.demand_admission_preflight(resident.id, resident.data().len()) {
+            Ok(GpuDemandAdmissionPreflight::AlreadyAdmitted) => return Ok(()),
+            Ok(GpuDemandAdmissionPreflight::NeedsPayload) => {}
+            Err(error) => return Err(admission_error(error)),
+        }
+
+        // The preflight eliminates copies for admissions already visible at
+        // the probe and for deterministically oversized payloads, then drops
+        // the cache lock before this memcpy. `demand_admit_lru` rechecks under
+        // its own lock for identity/accounting correctness. A concurrent
+        // admission between the probe and install may therefore cause one
+        // redundant host copy followed by `Ok(false)`; avoiding that bounded
+        // race would require reservation/singleflight machinery and is
+        // intentionally deferred unless profiling demonstrates a need.
+        let gpu_resident = Arc::new(GpuResident::new_with_dtype(
+            resident.id,
+            resident.data().to_vec(),
+            self.core.options.dtype,
+        ));
+        match gpu.demand_admit_lru(gpu_resident) {
+            Ok(newly_admitted) => {
+                if newly_admitted {
+                    if let Some(prom) = self.metrics.prom.as_ref() {
+                        prom.record_promotions(1);
+                        prom.set_vram_used_bytes(gpu.used_bytes());
+                    }
+                }
+                Ok(())
+            }
+            Err(error) => Err(admission_error(error)),
         }
     }
 
@@ -4078,6 +4133,8 @@ impl Engine {
                         self.core.options.dtype, self.core.shape.d_model, self.core.shape.d_ff
                     ),
                 ))
+            } else if let Err(source) = self.demand_admit_resident_to_gpu(layer, r) {
+                Err(source)
             } else {
                 backend.routed_expert_matmul(
                     layer,
@@ -5450,8 +5507,28 @@ mod tests {
         expert_execution_policy: ExpertExecutionPolicy,
         allow_degraded_experts: bool,
     ) -> Arc<Engine> {
+        rebuild_with_test_gpu_capacity(
+            base,
+            test_gpu,
+            failure_policy,
+            expert_execution_policy,
+            allow_degraded_experts,
+            64 * 1024,
+        )
+    }
+
+    fn rebuild_with_test_gpu_capacity(
+        base: &Arc<Engine>,
+        test_gpu: crate::backend::TestGpuBackend,
+        failure_policy: Option<RoutedExpertGpuFailurePolicy>,
+        expert_execution_policy: ExpertExecutionPolicy,
+        allow_degraded_experts: bool,
+        gpu_capacity_bytes: usize,
+    ) -> Arc<Engine> {
         let gpu_expert_cache = Arc::new(crate::expert_cache::GpuExpertCache::new(
-            1024, 0.5, 16,
+            gpu_capacity_bytes,
+            0.5,
+            16,
         ));
         let backend = Arc::new(crate::backend::BackendBox::TestGpu(test_gpu));
         let context = crate::backend::resolve_execution_context_with(
@@ -5606,6 +5683,10 @@ mod tests {
         assert_eq!(test_gpu.expert_calls(), 1);
         assert_eq!(cpu_expert_forward_calls(&engine), 0);
         assert_eq!(engine.report().gpu_cpu_fallbacks, 0);
+        let gpu_cache = engine.execution_context().gpu_expert_cache();
+        assert!(gpu_cache.current_admission(2).is_some());
+        assert_eq!(gpu_cache.anchor_len(), 0);
+        assert_eq!(gpu_cache.lru_len(), 1);
         assert_eq!(
             engine.routed_expert_execution_snapshot(),
             RoutedExpertExecutionSnapshot {
@@ -5613,6 +5694,52 @@ mod tests {
                 gpu_dispatch_attempts: 1,
                 gpu_dispatch_successes: 1,
                 gpu_dispatch_failures: 0,
+                cpu_routed_expert_dispatches: 0,
+                gpu_cpu_fallbacks: 0,
+                degraded_expert_substitutions: 0,
+            }
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn strict_gpu_demand_admission_failure_never_reaches_backend_or_cpu() {
+        let dir = TempDir::new("strict-gpu-demand-admission-failure");
+        let base = build_engine(&dir.path, 8, 16, 32, 4, 2, 1, 0x309);
+        let test_gpu = crate::backend::TestGpuBackend::success(0.25);
+        let engine = rebuild_with_test_gpu_capacity(
+            &base,
+            test_gpu.clone(),
+            Some(RoutedExpertGpuFailurePolicy::StrictFailClosed),
+            ExpertExecutionPolicy::SequentialExpertsRowParallel,
+            false,
+            4 * 1024,
+        );
+        let hidden = crate::inference::synth_hidden_state(0, 16, 0x309);
+        let error = engine
+            .moe_step(0, 5, &hidden, &[2])
+            .await
+            .expect_err("oversized foreground demand must fail closed");
+        assert_gpu_dispatch_error(
+            error,
+            crate::backend::GpuExpertDispatchErrorKind::ResidencyMiss,
+            5,
+            2,
+        );
+        assert_eq!(test_gpu.expert_calls(), 0);
+        assert_eq!(cpu_expert_forward_calls(&engine), 0);
+        assert_eq!(engine.report().gpu_cpu_fallbacks, 0);
+        assert!(engine
+            .execution_context()
+            .gpu_expert_cache()
+            .current_admission(2)
+            .is_none());
+        assert_eq!(
+            engine.routed_expert_execution_snapshot(),
+            RoutedExpertExecutionSnapshot {
+                selected_routed_experts: 1,
+                gpu_dispatch_attempts: 1,
+                gpu_dispatch_successes: 0,
+                gpu_dispatch_failures: 1,
                 cpu_routed_expert_dispatches: 0,
                 gpu_cpu_fallbacks: 0,
                 degraded_expert_substitutions: 0,

--- a/rust-engine/src/engine.rs
+++ b/rust-engine/src/engine.rs
@@ -34,6 +34,7 @@ use crate::router::{
 };
 use dashmap::DashMap;
 use hdrhistogram::Histogram;
+use serde::Serialize;
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -843,10 +844,38 @@ pub(crate) struct Counters {
     /// mixed GPU/CPU execution is a major source of
     /// inconsistent token latency, so make it countable.
     gpu_cpu_fallbacks: AtomicU64,
+    /// Routed expert activations selected by the real MoE routing path.
+    selected_routed_experts: AtomicU64,
+    /// Physical GPU routed-expert dispatch attempts.
+    gpu_dispatch_attempts: AtomicU64,
+    /// Physical GPU routed-expert dispatches that returned output.
+    gpu_dispatch_successes: AtomicU64,
+    /// Physical GPU routed-expert dispatches that returned a typed failure.
+    gpu_dispatch_failures: AtomicU64,
+    /// Routed expert activations executed by the CPU backend. This includes
+    /// CPU plans and explicit serving-mode fallbacks, but never strict GPU
+    /// failures.
+    cpu_routed_expert_dispatches: AtomicU64,
     /// Hardware-independent CPU routed-expert forward spy. Test-only so the
     /// public fallback metric keeps its production schema and meaning.
     #[cfg(test)]
     cpu_expert_forward_calls: AtomicU64,
+}
+
+/// Monotonic execution counters for real routed-expert activations.
+///
+/// These counters deliberately exclude the synthetic [`Engine::generate`]
+/// path. They are a qualification seam rather than a second Prometheus
+/// telemetry surface.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize)]
+pub struct RoutedExpertExecutionSnapshot {
+    pub selected_routed_experts: u64,
+    pub gpu_dispatch_attempts: u64,
+    pub gpu_dispatch_successes: u64,
+    pub gpu_dispatch_failures: u64,
+    pub cpu_routed_expert_dispatches: u64,
+    pub gpu_cpu_fallbacks: u64,
+    pub degraded_expert_substitutions: u64,
 }
 
 /// Shape parameters of the SwiGLU expert FFN executed by the engine.
@@ -1847,6 +1876,58 @@ impl Engine {
         &self,
     ) -> Option<crate::backend::GpuExpertMemorySnapshot> {
         self.core.execution_context.gpu_expert_memory_snapshot()
+    }
+
+    /// Identity of the adapter already selected by the authoritative
+    /// execution context. This never performs adapter rediscovery.
+    pub fn gpu_device_identity(&self) -> Option<crate::backend::GpuDeviceIdentity> {
+        self.core.execution_context.gpu_device_identity()
+    }
+
+    /// Monotonic routed-expert GPU transfer/submission counters.
+    pub fn gpu_expert_io_snapshot(&self) -> Option<crate::backend::GpuExpertIoSnapshot> {
+        self.core.execution_context.gpu_expert_io_snapshot()
+    }
+
+    /// Snapshot the qualification-only real routed-expert execution counters.
+    pub fn routed_expert_execution_snapshot(&self) -> RoutedExpertExecutionSnapshot {
+        RoutedExpertExecutionSnapshot {
+            selected_routed_experts: self
+                .metrics
+                .counters
+                .selected_routed_experts
+                .load(Ordering::Relaxed),
+            gpu_dispatch_attempts: self
+                .metrics
+                .counters
+                .gpu_dispatch_attempts
+                .load(Ordering::Relaxed),
+            gpu_dispatch_successes: self
+                .metrics
+                .counters
+                .gpu_dispatch_successes
+                .load(Ordering::Relaxed),
+            gpu_dispatch_failures: self
+                .metrics
+                .counters
+                .gpu_dispatch_failures
+                .load(Ordering::Relaxed),
+            cpu_routed_expert_dispatches: self
+                .metrics
+                .counters
+                .cpu_routed_expert_dispatches
+                .load(Ordering::Relaxed),
+            gpu_cpu_fallbacks: self
+                .metrics
+                .counters
+                .gpu_cpu_fallbacks
+                .load(Ordering::Relaxed),
+            degraded_expert_substitutions: self
+                .metrics
+                .counters
+                .degraded_expert_substitutions
+                .load(Ordering::Relaxed),
+        }
     }
 
     /// Synchronously copy a freshly-loaded RAM resident into the logical GPU
@@ -3963,6 +4044,10 @@ impl Engine {
         if self.execution_context().plan().routed_experts()
             == crate::backend::ExecutionPlane::Gpu
         {
+            self.metrics
+                .counters
+                .gpu_dispatch_attempts
+                .fetch_add(1, Ordering::Relaxed);
             let backend = self.routed_expert_backend();
             let mut out_f16 = vec![half::f16::ZERO; self.core.shape.d_model];
             let x_f16: Vec<half::f16> = x.iter().map(|&f| half::f16::from_f32(f)).collect();
@@ -4005,15 +4090,27 @@ impl Engine {
             };
             match matmul_res {
                 Ok(()) => {
+                    self.metrics
+                        .counters
+                        .gpu_dispatch_successes
+                        .fetch_add(1, Ordering::Relaxed);
                     return Ok(out_f16.iter().map(|h| h.to_f32()).collect::<Vec<f32>>());
                 }
                 Err(source)
                     if self.core.routed_expert_gpu_failure_policy
                         == RoutedExpertGpuFailurePolicy::StrictFailClosed =>
                 {
+                    self.metrics
+                        .counters
+                        .gpu_dispatch_failures
+                        .fetch_add(1, Ordering::Relaxed);
                     return Err(MoeStepError::GpuExpertDispatch { source });
                 }
                 Err(source) => {
+                    self.metrics
+                        .counters
+                        .gpu_dispatch_failures
+                        .fetch_add(1, Ordering::Relaxed);
                     // Only an actual serving-mode CPU recovery increments the
                     // fallback counter.
                     let prev = self
@@ -4035,6 +4132,11 @@ impl Engine {
                 }
             }
         }
+
+        self.metrics
+            .counters
+            .cpu_routed_expert_dispatches
+            .fetch_add(1, Ordering::Relaxed);
 
         #[cfg(test)]
         self.metrics
@@ -4134,6 +4236,10 @@ impl Engine {
         // Resolve aliases up front so the cache + predictor only ever
         // see canonical expert ids (mirrors `generate`).
         let target: Vec<u32> = experts.iter().map(|&id| self.resolve_alias(id)).collect();
+        self.metrics
+            .counters
+            .selected_routed_experts
+            .fetch_add(target.len() as u64, Ordering::Relaxed);
 
         // Locality monitor: observe and reconcile pinning. Same
         // semantics as in `generate`.
@@ -5500,6 +5606,18 @@ mod tests {
         assert_eq!(test_gpu.expert_calls(), 1);
         assert_eq!(cpu_expert_forward_calls(&engine), 0);
         assert_eq!(engine.report().gpu_cpu_fallbacks, 0);
+        assert_eq!(
+            engine.routed_expert_execution_snapshot(),
+            RoutedExpertExecutionSnapshot {
+                selected_routed_experts: 1,
+                gpu_dispatch_attempts: 1,
+                gpu_dispatch_successes: 1,
+                gpu_dispatch_failures: 0,
+                cpu_routed_expert_dispatches: 0,
+                gpu_cpu_fallbacks: 0,
+                degraded_expert_substitutions: 0,
+            }
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -5536,6 +5654,19 @@ mod tests {
             let report = engine.report();
             assert_eq!(report.gpu_cpu_fallbacks, 0, "{label}");
             assert_eq!(report.degraded_expert_substitutions, 0, "{label}");
+            assert_eq!(
+                engine.routed_expert_execution_snapshot(),
+                RoutedExpertExecutionSnapshot {
+                    selected_routed_experts: 1,
+                    gpu_dispatch_attempts: 1,
+                    gpu_dispatch_successes: 0,
+                    gpu_dispatch_failures: 1,
+                    cpu_routed_expert_dispatches: 0,
+                    gpu_cpu_fallbacks: 0,
+                    degraded_expert_substitutions: 0,
+                },
+                "{label}"
+            );
         }
     }
 
@@ -5580,6 +5711,18 @@ mod tests {
         assert_eq!(test_gpu.expert_calls(), 1);
         assert_eq!(cpu_expert_forward_calls(&engine), 1);
         assert_eq!(engine.report().gpu_cpu_fallbacks, 1);
+        assert_eq!(
+            engine.routed_expert_execution_snapshot(),
+            RoutedExpertExecutionSnapshot {
+                selected_routed_experts: 1,
+                gpu_dispatch_attempts: 1,
+                gpu_dispatch_successes: 0,
+                gpu_dispatch_failures: 1,
+                cpu_routed_expert_dispatches: 1,
+                gpu_cpu_fallbacks: 1,
+                degraded_expert_substitutions: 0,
+            }
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -5634,6 +5777,18 @@ mod tests {
         assert_eq!(test_gpu.expert_calls(), 0);
         assert_eq!(cpu_expert_forward_calls(&engine), 1);
         assert_eq!(engine.report().gpu_cpu_fallbacks, 0);
+        assert_eq!(
+            engine.routed_expert_execution_snapshot(),
+            RoutedExpertExecutionSnapshot {
+                selected_routed_experts: 1,
+                gpu_dispatch_attempts: 0,
+                gpu_dispatch_successes: 0,
+                gpu_dispatch_failures: 0,
+                cpu_routed_expert_dispatches: 1,
+                gpu_cpu_fallbacks: 0,
+                degraded_expert_substitutions: 0,
+            }
+        );
         assert!(
             engine.gpu_expert_memory_snapshot().is_none(),
             "CPU plans must not depend on a physical GPU expert registry"
@@ -5858,6 +6013,11 @@ mod tests {
         assert!(
             r.predictor_observations > 0,
             "predictor should have logged at least one transition"
+        );
+        assert_eq!(
+            engine.routed_expert_execution_snapshot(),
+            RoutedExpertExecutionSnapshot::default(),
+            "synthetic Engine::generate traffic must not qualify as real routed execution"
         );
     }
 

--- a/rust-engine/src/expert_cache.rs
+++ b/rust-engine/src/expert_cache.rs
@@ -658,6 +658,43 @@ pub enum GpuDemandAdmissionPreflight {
     NeedsPayload,
 }
 
+/// Precise result of one threshold-driven logical GPU promotion attempt.
+///
+/// `MovedLruToAnchor`, `InstalledAnchor`, and `InstalledLru` are the only
+/// outcomes that change logical cache state and therefore the only outcomes
+/// counted by `GpuExpertCache::promotions` and `mer_promotions_total`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GpuHotPromotionOutcome {
+    /// The existing admission was moved intact from LRU Edge to Anchor Core.
+    MovedLruToAnchor,
+    /// A previously absent expert was installed directly in Anchor Core.
+    InstalledAnchor,
+    /// A previously absent expert was installed in LRU Edge because Anchor
+    /// Core lacked room.
+    InstalledLru,
+    /// The expert was already in Anchor Core; no state changed.
+    AlreadyAnchor,
+    /// The expert remains in LRU Edge because Anchor Core lacks room.
+    AlreadyLruAnchorFull,
+    /// No logical admission exists yet, so the caller must obtain an owned
+    /// host payload before completing the hot promotion.
+    PayloadRequired,
+    /// The payload cannot fit either eligible logical region.
+    NoCapacity,
+    /// A new admission could not allocate a unique logical generation.
+    GenerationExhausted,
+}
+
+impl GpuHotPromotionOutcome {
+    /// Whether this outcome performed exactly one logical cache transition.
+    pub fn is_transition(self) -> bool {
+        matches!(
+            self,
+            Self::MovedLruToAnchor | Self::InstalledAnchor | Self::InstalledLru
+        )
+    }
+}
+
 impl std::fmt::Display for GpuDemandAdmissionError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -704,10 +741,11 @@ pub struct GpuExpertCache {
     /// `0` disables Anchor Core promotions (everything routes to the
     /// LRU Edge).
     promote_after_hits: u64,
-    /// Total promotions performed since startup. Mirror of the
-    /// `mer_promotions_total` Prometheus counter; exposed here too so
-    /// the admin health endpoint can render the value without going
-    /// through the Prometheus registry.
+    /// Total successful logical promotion transitions since startup: new
+    /// Anchor/LRU admissions plus LRU-to-Anchor graduation. Mirror of the
+    /// `mer_promotions_total` Prometheus counter; exposed here too so the
+    /// admin health endpoint can render the value without going through the
+    /// Prometheus registry.
     promotions: AtomicU64,
     /// Logical host payload bytes admitted across Anchor + LRU.
     logical_admitted_bytes: AtomicU64,
@@ -890,10 +928,11 @@ impl GpuExpertCache {
             return false;
         }
         let mut g = self.inner.lock();
-        if g.anchor.contains_key(&id)
-            || g.lru.peek(&id).is_some()
-            || g.promotion_pending.contains(&id)
-        {
+        // An LRU-resident expert may still need to graduate into Anchor Core.
+        // LRU residency is deliberately not a rejection condition: the
+        // ordinary threshold / rearm rules below still ensure at most one
+        // queued request, without touching LRU recency.
+        if g.anchor.contains_key(&id) || g.promotion_pending.contains(&id) {
             return false;
         }
         let threshold_crossed = ram_hits == self.promote_after_hits;
@@ -909,6 +948,154 @@ impl GpuExpertCache {
         let mut g = self.inner.lock();
         if g.promotion_pending.remove(&id) {
             g.promotion_rearm.insert(id);
+        }
+    }
+
+    /// Resolve an already-admitted threshold-hot expert without copying a RAM
+    /// payload. An LRU admission is moved atomically into Anchor Core when
+    /// capacity permits; the exact [`GpuAdmission`] (including generation and
+    /// `Arc<GpuResident>`) is retained. No unrelated LRU recency is touched.
+    ///
+    /// [`GpuHotPromotionOutcome::PayloadRequired`] means the id is absent and
+    /// the caller may copy the RAM payload outside the cache mutex before
+    /// calling [`Self::promote_hot_sync`].
+    pub fn promote_hot_existing(&self, id: u32) -> GpuHotPromotionOutcome {
+        let mut g = self.inner.lock();
+        let outcome = match self.resolve_existing_hot_locked(&mut g, id) {
+            Some(outcome) => outcome,
+            None => return GpuHotPromotionOutcome::PayloadRequired,
+        };
+        drop(g);
+        self.record_hot_transition(outcome);
+        outcome
+    }
+
+    /// Complete a threshold-driven hot promotion after the caller obtained an
+    /// owned payload. The locked existing-admission recheck makes the method
+    /// race-safe: if foreground demand installed the id in LRU after the
+    /// copy-free probe, that exact admission is moved to Anchor and this
+    /// redundant `resident` is dropped without replacing its generation.
+    pub fn promote_hot_sync(&self, resident: Arc<GpuResident>) -> GpuHotPromotionOutcome {
+        let id = resident.id;
+        let bytes = resident.byte_len();
+        let mut g = self.inner.lock();
+
+        if let Some(outcome) = self.resolve_existing_hot_locked(&mut g, id) {
+            drop(g);
+            self.record_hot_transition(outcome);
+            return outcome;
+        }
+
+        if bytes == 0 {
+            g.promotion_pending.remove(&id);
+            g.promotion_rearm.remove(&id);
+            return GpuHotPromotionOutcome::NoCapacity;
+        }
+
+        let use_anchor = bytes <= self.anchor_capacity_bytes
+            && g.anchor_used_bytes
+                .checked_add(bytes)
+                .is_some_and(|used| used <= self.anchor_capacity_bytes);
+        if !use_anchor && bytes > self.lru_capacity_bytes {
+            g.promotion_pending.remove(&id);
+            g.promotion_rearm.remove(&id);
+            return GpuHotPromotionOutcome::NoCapacity;
+        }
+        let Some(generation) = g.allocate_generation() else {
+            g.promotion_pending.remove(&id);
+            g.promotion_rearm.remove(&id);
+            return GpuHotPromotionOutcome::GenerationExhausted;
+        };
+        let admission = GpuAdmission { resident, generation };
+        g.promotion_pending.remove(&id);
+        g.promotion_rearm.remove(&id);
+
+        let outcome = if use_anchor {
+            g.anchor.insert(id, admission);
+            g.anchor_used_bytes = g
+                .anchor_used_bytes
+                .checked_add(bytes)
+                .expect("logical GPU anchor byte overflow after capacity check");
+            GpuHotPromotionOutcome::InstalledAnchor
+        } else {
+            while g
+                .lru_used_bytes
+                .checked_add(bytes)
+                .is_none_or(|used| used > self.lru_capacity_bytes)
+            {
+                let (evicted_id, victim) = g
+                    .lru
+                    .pop_lru()
+                    .expect("hot payload fits an empty LRU by prior capacity check");
+                g.lru_used_bytes = g
+                    .lru_used_bytes
+                    .checked_sub(victim.byte_len())
+                    .expect("logical GPU LRU byte underflow during hot admission");
+                g.promotion_rearm.insert(evicted_id);
+            }
+            let previous = g.lru.put(id, admission);
+            debug_assert!(previous.is_none(), "hot admission rechecked under lock");
+            g.lru_used_bytes = g
+                .lru_used_bytes
+                .checked_add(bytes)
+                .expect("logical GPU LRU byte overflow after capacity check");
+            GpuHotPromotionOutcome::InstalledLru
+        };
+        drop(g);
+
+        self.record_hot_transition(outcome);
+        self.refresh_used_bytes();
+        outcome
+    }
+
+    /// Resolve Anchor/LRU state under the caller's cache lock. `None` means
+    /// the id is absent and a payload is required. Completed attempts always
+    /// clear their pending/rearm markers; an Anchor-full LRU entry is not
+    /// rearmed, preventing retry traffic on every later hit.
+    fn resolve_existing_hot_locked(
+        &self,
+        g: &mut GpuExpertCacheInner,
+        id: u32,
+    ) -> Option<GpuHotPromotionOutcome> {
+        if g.anchor.contains_key(&id) {
+            g.promotion_pending.remove(&id);
+            g.promotion_rearm.remove(&id);
+            return Some(GpuHotPromotionOutcome::AlreadyAnchor);
+        }
+
+        let bytes = g.lru.peek(&id).map(GpuAdmission::byte_len)?;
+        let anchor_has_room = bytes <= self.anchor_capacity_bytes
+            && g.anchor_used_bytes
+                .checked_add(bytes)
+                .is_some_and(|used| used <= self.anchor_capacity_bytes);
+        if !anchor_has_room {
+            g.promotion_pending.remove(&id);
+            g.promotion_rearm.remove(&id);
+            return Some(GpuHotPromotionOutcome::AlreadyLruAnchorFull);
+        }
+
+        let admission = g
+            .lru
+            .pop(&id)
+            .expect("peeked logical GPU LRU admission must remain under lock");
+        g.lru_used_bytes = g
+            .lru_used_bytes
+            .checked_sub(bytes)
+            .expect("logical GPU LRU byte underflow during Anchor graduation");
+        let previous = g.anchor.insert(id, admission);
+        debug_assert!(previous.is_none(), "Anchor presence checked under lock");
+        g.anchor_used_bytes = g
+            .anchor_used_bytes
+            .checked_add(bytes)
+            .expect("logical GPU anchor byte overflow after capacity check");
+        g.promotion_pending.remove(&id);
+        g.promotion_rearm.remove(&id);
+        Some(GpuHotPromotionOutcome::MovedLruToAnchor)
+    }
+
+    fn record_hot_transition(&self, outcome: GpuHotPromotionOutcome) {
+        if outcome.is_transition() {
+            self.promotions.fetch_add(1, Ordering::Relaxed);
         }
     }
 
@@ -1735,6 +1922,187 @@ mod tests {
         assert!(!cache.contains(7), "existing demand lookup must not touch LRU");
         assert!(cache.contains(8));
         assert!(cache.contains(9));
+    }
+
+    #[test]
+    fn demand_admitted_threshold_hot_lru_moves_to_anchor_with_exact_identity() {
+        let cache = GpuExpertCache::new(100, 0.5, 3);
+        let resident = gpu_res(7, 40);
+        assert_eq!(cache.demand_admit_lru(resident.clone()), Ok(true));
+        let admission_before = cache.current_admission(7).expect("LRU admission");
+        let generation = admission_before.generation();
+        let used = cache.used_bytes();
+        let next_generation = cache.inner.lock().next_generation;
+
+        assert!(!cache.claim_promotion(7, 2));
+        assert!(cache.claim_promotion(7, 3));
+        assert!(
+            !cache.claim_promotion(7, 3),
+            "threshold-hot LRU admission must have one pending request"
+        );
+        assert_eq!(
+            cache.promote_hot_existing(7),
+            GpuHotPromotionOutcome::MovedLruToAnchor
+        );
+
+        let admission_after = cache.current_admission(7).expect("Anchor admission");
+        assert_eq!(admission_after.generation(), generation);
+        assert!(Arc::ptr_eq(admission_after.resident(), &resident));
+        assert!(Arc::ptr_eq(
+            admission_after.resident(),
+            admission_before.resident()
+        ));
+        assert_eq!(cache.anchor_len(), 1);
+        assert_eq!(cache.lru_len(), 0);
+        assert_eq!(cache.used_bytes(), used);
+        assert_eq!(cache.promotions(), 2, "demand install + tier graduation");
+        let inner = cache.inner.lock();
+        assert_eq!(inner.anchor_used_bytes, 40);
+        assert_eq!(inner.lru_used_bytes, 0);
+        assert_eq!(inner.next_generation, next_generation);
+        assert!(!inner.promotion_pending.contains(&7));
+        assert!(!inner.promotion_rearm.contains(&7));
+    }
+
+    #[test]
+    fn hot_lru_move_preserves_unrelated_lru_recency() {
+        let cache = GpuExpertCache::new(120, 0.5, 3);
+        assert_eq!(cache.demand_admit_lru(gpu_res(1, 20)), Ok(true));
+        assert_eq!(cache.demand_admit_lru(gpu_res(2, 20)), Ok(true));
+        assert_eq!(cache.demand_admit_lru(gpu_res(3, 20)), Ok(true));
+
+        assert!(cache.claim_promotion(2, 3));
+        assert_eq!(
+            cache.promote_hot_existing(2),
+            GpuHotPromotionOutcome::MovedLruToAnchor
+        );
+        assert_eq!(cache.demand_admit_lru(gpu_res(4, 40)), Ok(true));
+
+        assert!(!cache.contains(1), "oldest unrelated LRU entry must remain victim");
+        assert!(cache.contains(2));
+        assert!(cache.contains(3));
+        assert!(cache.contains(4));
+        assert_eq!(cache.anchor_len(), 1);
+        assert_eq!(cache.lru_len(), 2);
+    }
+
+    #[test]
+    fn anchor_full_hot_lru_is_unchanged_and_does_not_requeue() {
+        let cache = GpuExpertCache::new(100, 0.5, 3);
+        assert_eq!(
+            cache.promote_hot_sync(gpu_res(99, 50)),
+            GpuHotPromotionOutcome::InstalledAnchor
+        );
+        let resident = gpu_res(7, 25);
+        assert_eq!(cache.demand_admit_lru(resident.clone()), Ok(true));
+        assert_eq!(cache.demand_admit_lru(gpu_res(8, 25)), Ok(true));
+        let generation = cache.current_generation(7).unwrap();
+        let used = cache.used_bytes();
+        let promotions = cache.promotions();
+        let next_generation = cache.inner.lock().next_generation;
+
+        assert!(cache.claim_promotion(7, 3));
+        assert_eq!(
+            cache.promote_hot_existing(7),
+            GpuHotPromotionOutcome::AlreadyLruAnchorFull
+        );
+        assert_eq!(cache.current_generation(7), Some(generation));
+        assert!(Arc::ptr_eq(
+            cache.current_admission(7).unwrap().resident(),
+            &resident
+        ));
+        assert_eq!(cache.used_bytes(), used);
+        assert_eq!(cache.promotions(), promotions);
+        assert_eq!(cache.inner.lock().next_generation, next_generation);
+        assert_eq!(cache.anchor_len(), 1);
+        assert_eq!(cache.lru_len(), 2);
+        assert!(!cache.claim_promotion(7, 4));
+        assert!(!cache.claim_promotion(7, 99));
+
+        assert_eq!(cache.demand_admit_lru(gpu_res(9, 25)), Ok(true));
+        assert!(!cache.contains(7), "Anchor-full attempt must not touch LRU recency");
+        assert!(cache.contains(8));
+        assert!(cache.contains(9));
+    }
+
+    #[test]
+    fn already_anchor_hot_promotion_is_uncounted_noop() {
+        let cache = GpuExpertCache::new(100, 0.5, 3);
+        let resident = gpu_res(7, 40);
+        assert_eq!(
+            cache.promote_hot_sync(resident.clone()),
+            GpuHotPromotionOutcome::InstalledAnchor
+        );
+        let generation = cache.current_generation(7).unwrap();
+        let used = cache.used_bytes();
+        let promotions = cache.promotions();
+
+        assert!(!cache.claim_promotion(7, 3));
+        assert_eq!(
+            cache.promote_hot_existing(7),
+            GpuHotPromotionOutcome::AlreadyAnchor
+        );
+        assert_eq!(cache.current_generation(7), Some(generation));
+        assert!(Arc::ptr_eq(
+            cache.current_admission(7).unwrap().resident(),
+            &resident
+        ));
+        assert_eq!(cache.used_bytes(), used);
+        assert_eq!(cache.promotions(), promotions);
+    }
+
+    #[test]
+    fn demand_wins_threshold_race_then_existing_admission_moves_intact() {
+        let cache = GpuExpertCache::new(100, 0.5, 3);
+        assert!(cache.claim_promotion(7, 3));
+        assert_eq!(
+            cache.promote_hot_existing(7),
+            GpuHotPromotionOutcome::PayloadRequired
+        );
+        let demand_resident = gpu_res(7, 40);
+        assert_eq!(cache.demand_admit_lru(demand_resident.clone()), Ok(true));
+        let generation = cache.current_generation(7).unwrap();
+
+        assert_eq!(
+            cache.promote_hot_sync(gpu_res(7, 40)),
+            GpuHotPromotionOutcome::MovedLruToAnchor
+        );
+        let current = cache.current_admission(7).unwrap();
+        assert_eq!(current.generation(), generation);
+        assert!(Arc::ptr_eq(current.resident(), &demand_resident));
+        assert_eq!(cache.anchor_len(), 1);
+        assert_eq!(cache.lru_len(), 0);
+        assert_eq!(cache.promotions(), 2);
+    }
+
+    #[test]
+    fn background_wins_threshold_race_then_demand_recheck_is_noop() {
+        let cache = GpuExpertCache::new(100, 0.5, 3);
+        assert_eq!(
+            cache.demand_admission_preflight(7, 40),
+            Ok(GpuDemandAdmissionPreflight::NeedsPayload)
+        );
+        assert!(cache.claim_promotion(7, 3));
+        assert_eq!(
+            cache.promote_hot_existing(7),
+            GpuHotPromotionOutcome::PayloadRequired
+        );
+        let background_resident = gpu_res(7, 40);
+        assert_eq!(
+            cache.promote_hot_sync(background_resident.clone()),
+            GpuHotPromotionOutcome::InstalledAnchor
+        );
+        let generation = cache.current_generation(7).unwrap();
+        let next_generation = cache.inner.lock().next_generation;
+
+        assert_eq!(cache.demand_admit_lru(gpu_res(7, 40)), Ok(false));
+        let current = cache.current_admission(7).unwrap();
+        assert_eq!(current.generation(), generation);
+        assert!(Arc::ptr_eq(current.resident(), &background_resident));
+        assert_eq!(cache.inner.lock().next_generation, next_generation);
+        assert_eq!(cache.promotions(), 1);
+        assert_eq!(cache.anchor_len(), 1);
+        assert_eq!(cache.lru_len(), 0);
     }
 
     #[test]

--- a/rust-engine/src/expert_cache.rs
+++ b/rust-engine/src/expert_cache.rs
@@ -642,6 +642,39 @@ impl GpuLookup {
     }
 }
 
+/// A selected foreground expert could not be installed in the logical GPU
+/// admission LRU. The engine maps this to its typed routed-GPU failure policy;
+/// this cache never performs a CPU fallback itself.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GpuDemandAdmissionError {
+    EmptyPayload,
+    PayloadExceedsLruCapacity { bytes: usize, capacity: usize },
+    GenerationExhausted,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GpuDemandAdmissionPreflight {
+    AlreadyAdmitted,
+    NeedsPayload,
+}
+
+impl std::fmt::Display for GpuDemandAdmissionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EmptyPayload => f.write_str("expert payload is empty"),
+            Self::PayloadExceedsLruCapacity { bytes, capacity } => write!(
+                f,
+                "expert payload {bytes} bytes exceeds logical GPU demand LRU capacity {capacity} bytes"
+            ),
+            Self::GenerationExhausted => {
+                f.write_str("logical GPU admission generation space exhausted")
+            }
+        }
+    }
+}
+
+impl std::error::Error for GpuDemandAdmissionError {}
+
 /// Thread-safe logical GPU-admission cache implementing the **Segmented
 /// Hybrid Policy** from the Phase 2 spec:
 ///
@@ -1023,6 +1056,99 @@ impl GpuExpertCache {
         self.promotions.fetch_add(1, Ordering::Relaxed);
         self.refresh_used_bytes();
         true
+    }
+
+    /// Check whether a selected foreground expert needs an owned host payload
+    /// before attempting logical LRU admission. This probe never changes
+    /// routing telemetry, LRU recency, generations, or byte accounting.
+    pub fn demand_admission_preflight(
+        &self,
+        expert_id: u32,
+        payload_bytes: usize,
+    ) -> Result<GpuDemandAdmissionPreflight, GpuDemandAdmissionError> {
+        let g = self.inner.lock();
+        if g.anchor.contains_key(&expert_id) || g.lru.peek(&expert_id).is_some() {
+            return Ok(GpuDemandAdmissionPreflight::AlreadyAdmitted);
+        }
+        if payload_bytes == 0 {
+            return Err(GpuDemandAdmissionError::EmptyPayload);
+        }
+        if payload_bytes > self.lru_capacity_bytes {
+            return Err(GpuDemandAdmissionError::PayloadExceedsLruCapacity {
+                bytes: payload_bytes,
+                capacity: self.lru_capacity_bytes,
+            });
+        }
+        Ok(GpuDemandAdmissionPreflight::NeedsPayload)
+    }
+
+    /// Ensure that one selected foreground expert has a current logical GPU
+    /// admission. New demand admissions always enter the evictable LRU Edge;
+    /// they never consume or evict Anchor Core entries. Physical upload stays
+    /// lazy and exclusively owned by `GpuBackend`.
+    ///
+    /// Existing admissions return `Ok(false)` without changing generation,
+    /// byte accounting, hit/miss telemetry, or LRU recency. A new admission
+    /// returns `Ok(true)` after evicting least-recently-used dynamic entries as
+    /// needed. Failures leave the existing admission state unchanged.
+    pub fn demand_admit_lru(
+        &self,
+        resident: Arc<GpuResident>,
+    ) -> Result<bool, GpuDemandAdmissionError> {
+        let bytes = resident.byte_len();
+        if bytes == 0 {
+            return Err(GpuDemandAdmissionError::EmptyPayload);
+        }
+
+        let mut g = self.inner.lock();
+        if g.anchor.contains_key(&resident.id) || g.lru.peek(&resident.id).is_some() {
+            return Ok(false);
+        }
+        if bytes > self.lru_capacity_bytes {
+            return Err(GpuDemandAdmissionError::PayloadExceedsLruCapacity {
+                bytes,
+                capacity: self.lru_capacity_bytes,
+            });
+        }
+        // Allocate identity before eviction so generation exhaustion cannot
+        // disturb any existing admission or byte accounting.
+        let generation = g
+            .allocate_generation()
+            .ok_or(GpuDemandAdmissionError::GenerationExhausted)?;
+
+        while g
+            .lru_used_bytes
+            .checked_add(bytes)
+            .is_none_or(|used| used > self.lru_capacity_bytes)
+        {
+            let (evicted_id, victim) = g
+                .lru
+                .pop_lru()
+                .expect("demand payload fits an empty LRU by prior capacity check");
+            g.lru_used_bytes = g.lru_used_bytes.saturating_sub(victim.byte_len());
+            g.promotion_rearm.insert(evicted_id);
+        }
+
+        let id = resident.id;
+        g.promotion_pending.remove(&id);
+        g.promotion_rearm.remove(&id);
+        let previous = g.lru.put(
+            id,
+            GpuAdmission {
+                resident,
+                generation,
+            },
+        );
+        debug_assert!(previous.is_none(), "demand admission rechecked under lock");
+        g.lru_used_bytes = g
+            .lru_used_bytes
+            .checked_add(bytes)
+            .expect("logical GPU demand LRU byte overflow after capacity check");
+        drop(g);
+
+        self.promotions.fetch_add(1, Ordering::Relaxed);
+        self.refresh_used_bytes();
+        Ok(true)
     }
 
     /// Number of Anchor Core entries.
@@ -1450,6 +1576,214 @@ mod tests {
         assert!(cache.current_admission(99).is_none());
         assert_eq!(cache.hits(), 0);
         assert_eq!(cache.misses(), 0);
+    }
+
+    #[test]
+    fn demand_preflight_detects_anchor_without_state_changes() {
+        let cache = GpuExpertCache::new(100, 0.5, 0);
+        assert!(cache.promote_sync(gpu_res(99, 40)));
+        let generation = cache.current_generation(99).unwrap();
+        let used = cache.used_bytes();
+        let promotions = cache.promotions();
+        let hits = cache.hits();
+        let misses = cache.misses();
+
+        assert_eq!(
+            cache.demand_admission_preflight(99, 40),
+            Ok(GpuDemandAdmissionPreflight::AlreadyAdmitted)
+        );
+        assert!(cache.contains_generation(99, generation));
+        assert_eq!(cache.used_bytes(), used);
+        assert_eq!(cache.promotions(), promotions);
+        assert_eq!(cache.hits(), hits);
+        assert_eq!(cache.misses(), misses);
+        assert_eq!(cache.anchor_len(), 1);
+        assert_eq!(cache.lru_len(), 0);
+    }
+
+    #[test]
+    fn demand_preflight_detects_lru_without_touching_recency() {
+        let cache = GpuExpertCache::new(20, 0.0, 0);
+        assert_eq!(cache.demand_admit_lru(gpu_res(1, 10)), Ok(true));
+        assert_eq!(cache.demand_admit_lru(gpu_res(2, 10)), Ok(true));
+        let hits = cache.hits();
+        let misses = cache.misses();
+
+        assert_eq!(
+            cache.demand_admission_preflight(1, 10),
+            Ok(GpuDemandAdmissionPreflight::AlreadyAdmitted)
+        );
+        assert_eq!(cache.hits(), hits);
+        assert_eq!(cache.misses(), misses);
+        assert_eq!(cache.demand_admit_lru(gpu_res(3, 10)), Ok(true));
+        assert!(!cache.contains(1), "preflight must leave id 1 as LRU");
+        assert!(cache.contains(2));
+        assert!(cache.contains(3));
+    }
+
+    #[test]
+    fn demand_preflight_absent_fit_needs_payload_and_zero_is_typed() {
+        let cache = GpuExpertCache::new(100, 0.5, 0);
+        assert_eq!(
+            cache.demand_admission_preflight(7, 50),
+            Ok(GpuDemandAdmissionPreflight::NeedsPayload)
+        );
+        assert_eq!(
+            cache.demand_admission_preflight(7, 0),
+            Err(GpuDemandAdmissionError::EmptyPayload)
+        );
+    }
+
+    #[test]
+    fn oversized_demand_preflight_preserves_all_logical_state() {
+        let cache = GpuExpertCache::new(100, 0.5, 0);
+        assert!(cache.promote_sync(gpu_res(99, 40)));
+        assert_eq!(cache.demand_admit_lru(gpu_res(1, 25)), Ok(true));
+        let anchor_generation = cache.current_generation(99).unwrap();
+        let lru_generation = cache.current_generation(1).unwrap();
+        let used = cache.used_bytes();
+        let promotions = cache.promotions();
+        let next_generation = cache.inner.lock().next_generation;
+
+        assert_eq!(
+            cache.demand_admission_preflight(2, 51),
+            Err(GpuDemandAdmissionError::PayloadExceedsLruCapacity {
+                bytes: 51,
+                capacity: 50,
+            })
+        );
+        assert!(cache.contains_generation(99, anchor_generation));
+        assert!(cache.contains_generation(1, lru_generation));
+        assert!(!cache.contains(2));
+        assert_eq!(cache.used_bytes(), used);
+        assert_eq!(cache.promotions(), promotions);
+        assert_eq!(cache.inner.lock().next_generation, next_generation);
+        assert_eq!(cache.anchor_len(), 1);
+        assert_eq!(cache.lru_len(), 1);
+    }
+
+    #[test]
+    fn demand_install_rechecks_existing_admission_after_preflight() {
+        let cache = GpuExpertCache::new(100, 0.0, 0);
+        assert_eq!(
+            cache.demand_admission_preflight(7, 32),
+            Ok(GpuDemandAdmissionPreflight::NeedsPayload)
+        );
+        assert_eq!(cache.demand_admit_lru(gpu_res(7, 32)), Ok(true));
+        let generation = cache.current_generation(7).unwrap();
+        let used = cache.used_bytes();
+        let promotions = cache.promotions();
+        let next_generation = cache.inner.lock().next_generation;
+
+        assert_eq!(cache.demand_admit_lru(gpu_res(7, 64)), Ok(false));
+        assert!(cache.contains_generation(7, generation));
+        assert_eq!(cache.used_bytes(), used);
+        assert_eq!(cache.promotions(), promotions);
+        assert_eq!(cache.inner.lock().next_generation, next_generation);
+        assert_eq!(cache.lru_len(), 1);
+    }
+
+    #[test]
+    fn cold_demand_admits_to_lru_without_consuming_anchor() {
+        let cache = GpuExpertCache::new(100, 0.5, 0);
+        assert_eq!(cache.demand_admit_lru(gpu_res(1, 40)), Ok(true));
+        assert!(cache.current_admission(1).is_some());
+        assert_eq!(cache.anchor_len(), 0);
+        assert_eq!(cache.lru_len(), 1);
+        assert_eq!(cache.used_bytes(), 40);
+        assert_eq!(cache.hits(), 0);
+        assert_eq!(cache.misses(), 0);
+    }
+
+    #[test]
+    fn demand_admission_evicts_lru_and_preserves_anchor() {
+        let cache = GpuExpertCache::new(100, 0.5, 0);
+        assert!(cache.promote_sync(gpu_res(99, 40)));
+        let anchor_generation = cache.current_generation(99).unwrap();
+        assert_eq!(cache.demand_admit_lru(gpu_res(1, 25)), Ok(true));
+        assert_eq!(cache.demand_admit_lru(gpu_res(2, 25)), Ok(true));
+
+        assert_eq!(cache.demand_admit_lru(gpu_res(3, 25)), Ok(true));
+        assert!(!cache.contains(1), "oldest dynamic entry must be evicted");
+        assert!(cache.contains(2));
+        assert!(cache.contains(3));
+        assert!(cache.contains_generation(99, anchor_generation));
+        assert_eq!(cache.anchor_len(), 1);
+        assert_eq!(cache.lru_len(), 2);
+    }
+
+    #[test]
+    fn existing_demand_preserves_generation_bytes_and_counters() {
+        let cache = GpuExpertCache::new(96, 0.0, 0);
+        assert_eq!(cache.demand_admit_lru(gpu_res(7, 32)), Ok(true));
+        assert_eq!(cache.demand_admit_lru(gpu_res(8, 32)), Ok(true));
+        let generation = cache.current_generation(7).unwrap();
+        let used = cache.used_bytes();
+        let promotions = cache.promotions();
+        let hits = cache.hits();
+        let misses = cache.misses();
+
+        assert_eq!(cache.demand_admit_lru(gpu_res(7, 48)), Ok(false));
+        assert!(cache.contains_generation(7, generation));
+        assert_eq!(cache.used_bytes(), used);
+        assert_eq!(cache.promotions(), promotions);
+        assert_eq!(cache.hits(), hits);
+        assert_eq!(cache.misses(), misses);
+        assert_eq!(cache.lru_len(), 2);
+
+        assert_eq!(cache.demand_admit_lru(gpu_res(9, 40)), Ok(true));
+        assert!(!cache.contains(7), "existing demand lookup must not touch LRU");
+        assert!(cache.contains(8));
+        assert!(cache.contains(9));
+    }
+
+    #[test]
+    fn demand_readmission_allocates_a_newer_generation() {
+        let cache = GpuExpertCache::new(20, 0.0, 0);
+        assert_eq!(cache.demand_admit_lru(gpu_res(7, 10)), Ok(true));
+        let first = cache.current_generation(7).unwrap();
+        assert_eq!(cache.demand_admit_lru(gpu_res(8, 20)), Ok(true));
+        assert!(!cache.contains(7));
+        assert_eq!(cache.demand_admit_lru(gpu_res(7, 10)), Ok(true));
+        let second = cache.current_generation(7).unwrap();
+        assert!(second > first);
+    }
+
+    #[test]
+    fn oversized_demand_fails_without_mutating_existing_state() {
+        let cache = GpuExpertCache::new(100, 0.5, 0);
+        assert_eq!(cache.demand_admit_lru(gpu_res(1, 25)), Ok(true));
+        let generation = cache.current_generation(1).unwrap();
+        let used = cache.used_bytes();
+        let promotions = cache.promotions();
+
+        assert_eq!(
+            cache.demand_admit_lru(gpu_res(2, 51)),
+            Err(GpuDemandAdmissionError::PayloadExceedsLruCapacity {
+                bytes: 51,
+                capacity: 50,
+            })
+        );
+        assert!(cache.contains_generation(1, generation));
+        assert!(!cache.contains(2));
+        assert_eq!(cache.used_bytes(), used);
+        assert_eq!(cache.promotions(), promotions);
+    }
+
+    #[test]
+    fn generation_exhaustion_does_not_evict_existing_demand() {
+        let cache = GpuExpertCache::new(20, 0.0, 0);
+        assert_eq!(cache.demand_admit_lru(gpu_res(1, 10)), Ok(true));
+        let generation = cache.current_generation(1).unwrap();
+        cache.inner.lock().next_generation = u64::MAX;
+
+        assert_eq!(
+            cache.demand_admit_lru(gpu_res(2, 20)),
+            Err(GpuDemandAdmissionError::GenerationExhausted)
+        );
+        assert!(cache.contains_generation(1, generation));
+        assert!(!cache.contains(2));
+        assert_eq!(cache.used_bytes(), 10);
     }
 
     #[test]

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -2509,6 +2509,26 @@ fn fail_qualification(
     Err(summary.into())
 }
 
+fn qualification_artifact_failure(
+    errors: &[String],
+) -> crate::qualification::QualificationFailure {
+    crate::qualification::QualificationFailure::new(
+        crate::qualification::FailureStage::Preflight,
+        "artifact-identity-unavailable",
+        errors.join("; "),
+    )
+}
+
+fn qualification_metadata_failure(
+    detail: impl Into<String>,
+) -> crate::qualification::QualificationFailure {
+    crate::qualification::QualificationFailure::new(
+        crate::qualification::FailureStage::Preflight,
+        "expert-metadata-unreadable",
+        detail,
+    )
+}
+
 fn qualification_inference_failure(
     error: &(dyn std::error::Error + 'static),
 ) -> crate::qualification::QualificationFailure {
@@ -2544,9 +2564,10 @@ async fn cmd_qualify_hybrid_q4(
 ) -> Result<(), Box<dyn std::error::Error>> {
     use crate::qualification::{
         gpu_io_delta, request_evidence, routed_execution_delta, validate_device,
-        validate_execution_plan, validate_gpu_failure_policy, validate_memory,
-        validate_postconditions, validate_preflight, BuildProvenance, FailureStage,
-        PreflightEvidence, QualificationFailure, QualificationReport, QualificationTiming,
+        validate_execution_plan, validate_gpu_failure_policy, validate_gpu_io,
+        validate_memory, validate_postconditions, validate_preflight, BuildProvenance,
+        FailureStage, PreflightEvidence, QualificationFailure, QualificationReport,
+        QualificationTiming,
     };
 
     // Config/request parse errors retain normal CLI error behavior. Once both
@@ -2576,11 +2597,7 @@ async fn cmd_qualify_hybrid_q4(
     if !artifact_errors.is_empty() {
         return fail_qualification(
             report,
-            QualificationFailure::new(
-                FailureStage::Preflight,
-                "artifact-identity-unavailable",
-                artifact_errors.join("; "),
-            ),
+            qualification_artifact_failure(&artifact_errors),
             args.report_out.as_deref(),
         );
     }
@@ -2589,11 +2606,7 @@ async fn cmd_qualify_hybrid_q4(
         Err(detail) => {
             return fail_qualification(
                 report,
-                QualificationFailure::new(
-                    FailureStage::Preflight,
-                    "q4-layout-not-standard",
-                    detail,
-                ),
+                qualification_metadata_failure(detail),
                 args.report_out.as_deref(),
             );
         }
@@ -2811,6 +2824,9 @@ async fn cmd_qualify_hybrid_q4(
     };
     report.routed_experts = Some(routed_delta);
     report.gpu_io = Some(io_delta);
+    if let Err(failure) = validate_gpu_io(io_delta, &mut report.qualification_checks) {
+        return fail_qualification(report, failure, args.report_out.as_deref());
+    }
     for snapshot in [memory_before, memory_after] {
         if let Err(failure) = validate_memory(snapshot) {
             return fail_qualification(report, failure, args.report_out.as_deref());
@@ -3819,6 +3835,32 @@ enum RealCliRuntimeMode {
     StrictHybridQualification,
 }
 
+fn strict_hybrid_gpu_geometry(
+    cfg: &crate::config::Config,
+    resolved_advanced: &crate::model::AdvancedConfig,
+) -> crate::backend::GpuBackendGeometry {
+    let rt = &cfg.real_transformer;
+    let head_dim = if rt.head_dim == 0 {
+        cfg.model.d_model / rt.num_heads
+    } else {
+        rt.head_dim
+    };
+    crate::backend::GpuBackendGeometry {
+        num_layers: cfg.model.num_layers,
+        max_seq_len: if rt.window_size == 0 {
+            4096
+        } else {
+            rt.window_size
+        },
+        num_heads: rt.num_heads,
+        num_kv_heads: rt.num_kv_heads,
+        head_dim,
+        // Zero preserves GpuBackendGeometry's symmetric fallback to head_dim.
+        v_head_dim: resolved_advanced.v_head_dim.unwrap_or(0),
+        q4_truncation_tolerance: 0,
+    }
+}
+
 async fn build_bench_real_runtime(
     config_path: &Path,
 ) -> Result<BenchRealRuntime, Box<dyn std::error::Error>> {
@@ -3873,28 +3915,10 @@ async fn build_real_cli_runtime(
                 cfg.gpu_cache.vram_anchor_ratio,
                 cfg.gpu_cache.promote_after_hits,
             ));
-            let rt = &cfg.real_transformer;
-            let head_dim = if rt.head_dim == 0 {
-                cfg.model.d_model / rt.num_heads
-            } else {
-                rt.head_dim
-            };
             let context = crate::backend::resolve_execution_context(
                 cfg.real_transformer.compute_offload,
                 true,
-                crate::backend::GpuBackendGeometry {
-                    num_layers: cfg.model.num_layers,
-                    max_seq_len: if rt.window_size == 0 {
-                        4096
-                    } else {
-                        rt.window_size
-                    },
-                    num_heads: rt.num_heads,
-                    num_kv_heads: rt.num_kv_heads,
-                    head_dim,
-                    v_head_dim: 0,
-                    q4_truncation_tolerance: 0,
-                },
+                strict_hybrid_gpu_geometry(&cfg, &resolved_advanced),
                 crate::backend::RoutedExpertGpuSpec {
                     dtype: cfg.model.dtype,
                     d_model: cfg.model.d_model,
@@ -8384,6 +8408,46 @@ mod tests {
         }
     }
 
+    #[test]
+    fn qualification_metadata_read_failure_has_distinct_typed_code() {
+        let failure = qualification_metadata_failure("malformed metadata JSON");
+        assert_eq!(
+            failure.stage,
+            crate::qualification::FailureStage::Preflight
+        );
+        assert_eq!(failure.code, "expert-metadata-unreadable");
+        assert_eq!(failure.detail, "malformed metadata JSON");
+    }
+
+    #[test]
+    fn configured_missing_artifact_produces_typed_identity_failure() {
+        let dir = tempdir_unique("qualification-missing-artifact");
+        std::fs::create_dir_all(&dir).unwrap();
+        let config_path = dir.join("config.toml");
+        std::fs::write(&config_path, b"# qualification fixture\n").unwrap();
+        std::fs::write(dir.join("metadata.json"), b"{}").unwrap();
+
+        let missing_tokenizer = dir.join("missing-tokenizer.json");
+        let mut cfg = minimal_bench_cfg();
+        cfg.model.data_dir = dir.clone();
+        cfg.tokenizer.path = Some(missing_tokenizer.clone());
+        let (artifacts, errors) = qualification_artifacts(&config_path, &cfg);
+
+        assert!(artifacts.tokenizer.is_none());
+        assert_eq!(errors.len(), 1);
+        let missing_tokenizer = missing_tokenizer.display().to_string();
+        assert!(errors[0].contains(&missing_tokenizer));
+        let failure = qualification_artifact_failure(&errors);
+        assert_eq!(
+            failure.stage,
+            crate::qualification::FailureStage::Preflight
+        );
+        assert_eq!(failure.code, "artifact-identity-unavailable");
+        assert!(failure.detail.contains("missing-tokenizer.json"));
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
     /// A distinctive tiny Qwen3-MoE `config.json` (checkpoint dims differ from
     /// [`minimal_bench_cfg`]) with `norm_topk_prob = true`.
     fn write_qwen3_moe_config_json(dir: &Path) {
@@ -8529,6 +8593,25 @@ mod tests {
             &advanced,
         )
         .expect("asymmetric V geometry must be accepted");
+    }
+
+    #[test]
+    fn strict_hybrid_geometry_uses_resolved_asymmetric_v_head_dim() {
+        let mut cfg = minimal_bench_cfg();
+        cfg.real_transformer.num_heads = 4;
+        cfg.real_transformer.num_kv_heads = 2;
+        cfg.real_transformer.head_dim = 24;
+        let advanced = crate::model::AdvancedConfig {
+            v_head_dim: Some(16),
+            ..Default::default()
+        };
+
+        let geometry = strict_hybrid_gpu_geometry(&cfg, &advanced);
+        assert_eq!(geometry.head_dim, 24);
+        assert_eq!(geometry.v_head_dim, 16);
+
+        let symmetric = crate::model::AdvancedConfig::default();
+        assert_eq!(strict_hybrid_gpu_geometry(&cfg, &symmetric).v_head_dim, 0);
     }
 
     #[test]

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -159,6 +159,7 @@ mod packed_storage;
 mod parallel;
 mod prefetch_governor;
 mod pregate;
+mod qualification;
 mod rayon_autotune;
 mod residency;
 mod router;
@@ -850,6 +851,32 @@ enum Cmd {
         format: BenchRealOutputFormat,
     },
 
+    /// Qualify strict real-checkpoint inference with CPU dense/attention/KV/
+    /// router/head planes and native-Q4_0 routed experts on a hardware GPU.
+    QualifyHybridQ4 {
+        /// Path to the TOML config file.
+        #[arg(long)]
+        config: PathBuf,
+        /// Prompt text to encode and qualify.
+        #[arg(long, conflicts_with = "request_json")]
+        prompt: Option<String>,
+        /// OpenAI-style request JSON containing `prompt` or chat `messages`.
+        #[arg(long, conflicts_with = "prompt")]
+        request_json: Option<PathBuf>,
+        /// Completion-token count; overrides request JSON `max_tokens`.
+        #[arg(long)]
+        output_tokens: Option<usize>,
+        /// Strict greedy warmups before the single measured request.
+        #[arg(long, default_value_t = 0)]
+        warmup_runs: usize,
+        /// Write the typed JSON report here instead of stdout.
+        #[arg(long)]
+        report_out: Option<PathBuf>,
+        /// Opaque reference to separately collected external GPU-memory evidence.
+        #[arg(long)]
+        external_gpu_memory_artifact: Option<String>,
+    },
+
     /// Benchmark dense matvec backends on the target Qwen3-Coder CPU shapes.
     ///
     /// This is intentionally separate from `bench-real`: it isolates Q/K/V/O,
@@ -1493,9 +1520,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // handlers still own their normal config reconciliation and runtime
     // construction below.
     let startup_config = match &cli.cmd {
-        Cmd::Serve { config } | Cmd::BenchReal { config, .. } => {
-            Some(crate::config::Config::from_file(config)?)
-        }
+        Cmd::Serve { config }
+        | Cmd::BenchReal { config, .. }
+        | Cmd::QualifyHybridQ4 { config, .. } => Some(crate::config::Config::from_file(config)?),
         _ => None,
     };
 
@@ -1596,9 +1623,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Logged on the same boot line so ops can see both the low-level
     // CPU-feature dispatch and the high-level backend in one place.
     //
-    // For the `serve` subcommand we **defer** the default install
-    // until `cmd_serve` has loaded the TOML config — the hybrid
-    // compute offload (`[real_transformer].compute_offload`, gist
+    // For the `serve` and `qualify-hybrid-q4` subcommands we **defer** the
+    // default install until their handlers have loaded the TOML config — the
+    // hybrid compute offload (`[real_transformer].compute_offload`, gist
     // Part 2 fix #5) is resolved there, and it must run
     // *before* `install_default` claims the OnceLock. Other
     // subcommands keep the immediate install so their math path is
@@ -1611,7 +1638,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // fatal; legacy deterministic dtype/geometry bypass remains visible in
     // the resolved component plan.
     let run_gpu_requested = matches!(cli.cmd, Cmd::Run { gpu: true, .. });
-    if !matches!(cli.cmd, Cmd::Serve { .. }) && !run_gpu_requested {
+    if !matches!(cli.cmd, Cmd::Serve { .. } | Cmd::QualifyHybridQ4 { .. }) && !run_gpu_requested {
         crate::backend::install_default();
         let b = crate::backend::current();
         info!(
@@ -1842,6 +1869,29 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 progress_watchdog,
             }))
         }
+        Cmd::QualifyHybridQ4 {
+            config,
+            prompt,
+            request_json,
+            output_tokens,
+            warmup_runs,
+            report_out,
+            external_gpu_memory_artifact,
+        } => {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()?;
+            rt.block_on(cmd_qualify_hybrid_q4(QualifyHybridQ4Args {
+                config,
+                prompt,
+                request_json,
+                output_tokens,
+                warmup_runs,
+                report_out,
+                external_gpu_memory_artifact,
+                progress_watchdog,
+            }))
+        }
         Cmd::MatvecMicrobench {
             backend,
             warmup_runs,
@@ -2049,6 +2099,17 @@ struct BenchRealArgs {
     cache_reset: BenchRealCacheReset,
     greedy: bool,
     format: BenchRealOutputFormat,
+    progress_watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+}
+
+struct QualifyHybridQ4Args {
+    config: PathBuf,
+    prompt: Option<String>,
+    request_json: Option<PathBuf>,
+    output_tokens: Option<usize>,
+    warmup_runs: usize,
+    report_out: Option<PathBuf>,
+    external_gpu_memory_artifact: Option<String>,
     progress_watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
 }
 
@@ -2297,6 +2358,483 @@ async fn cmd_bench_real(args: BenchRealArgs) -> Result<(), Box<dyn std::error::E
         emit_bench_real_report(&args, input, runs)?;
     }
     Ok(())
+}
+
+struct RealCliRequestInput {
+    prompt: String,
+    output_tokens: usize,
+    input_kind: &'static str,
+}
+
+fn load_real_cli_request_input(
+    command: &'static str,
+    prompt_arg: Option<&String>,
+    request_json: Option<&Path>,
+    output_tokens_arg: Option<usize>,
+) -> Result<RealCliRequestInput, Box<dyn std::error::Error>> {
+    let mut json_max_tokens = None;
+    let (prompt, input_kind) = if let Some(prompt) = prompt_arg {
+        (prompt.clone(), "prompt")
+    } else if let Some(path) = request_json {
+        let body = std::fs::read_to_string(path)?;
+        let value: serde_json::Value = serde_json::from_str(&body)?;
+        json_max_tokens = value
+            .get("max_tokens")
+            .and_then(|value| value.as_u64())
+            .map(|value| value as usize);
+        let prompt = if let Some(prompt) = value.get("prompt").and_then(|value| value.as_str()) {
+            prompt.to_string()
+        } else if let Some(messages) = value.get("messages").and_then(|value| value.as_array()) {
+            flatten_bench_messages(messages)
+        } else {
+            return Err(
+                "--request-json must contain a string `prompt` or chat `messages` array".into(),
+            );
+        };
+        (prompt, "request-json")
+    } else {
+        return Err(format!("{command} requires either --prompt or --request-json").into());
+    };
+    if prompt.is_empty() {
+        return Err(format!("{command} prompt must be non-empty").into());
+    }
+    let output_tokens = output_tokens_arg.or(json_max_tokens).unwrap_or(16);
+    if output_tokens == 0 {
+        return Err(format!("{command} requires output token count > 0").into());
+    }
+    Ok(RealCliRequestInput {
+        prompt,
+        output_tokens,
+        input_kind,
+    })
+}
+
+fn load_qualification_input(
+    args: &QualifyHybridQ4Args,
+) -> Result<RealCliRequestInput, Box<dyn std::error::Error>> {
+    load_real_cli_request_input(
+        "qualify-hybrid-q4",
+        args.prompt.as_ref(),
+        args.request_json.as_deref(),
+        args.output_tokens,
+    )
+}
+
+fn qualification_artifacts(
+    config_path: &Path,
+    cfg: &crate::config::Config,
+) -> (crate::qualification::QualificationArtifacts, Vec<String>) {
+    use crate::qualification::{hash_optional_small_file, hash_small_file};
+
+    let mut errors = Vec::new();
+    let config_digest = match hash_small_file(config_path) {
+        Ok(digest) => Some(digest),
+        Err(error) => {
+            errors.push(format!(
+                "failed to hash qualification config {}: {error}",
+                config_path.display()
+            ));
+            None
+        }
+    };
+    let mut hash_optional = |path: Option<&Path>, label: &str| match hash_optional_small_file(path)
+    {
+        Ok(digest) => digest,
+        Err(error) => {
+            let display = path
+                .map(|path| path.display().to_string())
+                .unwrap_or_else(|| "<none>".to_string());
+            errors.push(format!(
+                "failed to hash optional {label} {display}: {error}"
+            ));
+            None
+        }
+    };
+
+    let metadata_path = cfg.model.data_dir.join("metadata.json");
+    let weights_config = cfg
+        .real_transformer
+        .weights_dir
+        .as_ref()
+        .map(|dir| dir.join("config.json"));
+    let artifacts = crate::qualification::QualificationArtifacts {
+        config: config_digest,
+        tokenizer: hash_optional(cfg.tokenizer.path.as_deref(), "tokenizer"),
+        expert_metadata: hash_optional(Some(&metadata_path), "expert metadata"),
+        packed_manifest: hash_optional(
+            cfg.storage.packed_manifest.as_deref(),
+            "packed expert manifest",
+        ),
+        weights_config: hash_optional(weights_config.as_deref(), "weights config"),
+        dense_weights_directory: cfg
+            .real_transformer
+            .weights_dir
+            .as_deref()
+            .map(crate::qualification::canonical_or_configured),
+        expert_data_directory: crate::qualification::canonical_or_configured(&cfg.model.data_dir),
+        packed_expert_blob: cfg
+            .storage
+            .packed_blob
+            .as_deref()
+            .map(crate::qualification::canonical_or_configured),
+        large_artifacts_recursively_hashed: false,
+    };
+    (artifacts, errors)
+}
+
+fn emit_qualification_report(
+    report: &crate::qualification::QualificationReport,
+    report_out: Option<&Path>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut json = serde_json::to_vec_pretty(report)?;
+    json.push(b'\n');
+    if let Some(path) = report_out {
+        std::fs::write(path, json)?;
+        eprintln!("qualification report written to {}", path.display());
+    } else {
+        use std::io::Write as _;
+        std::io::stdout().write_all(&json)?;
+    }
+    Ok(())
+}
+
+fn fail_qualification(
+    mut report: crate::qualification::QualificationReport,
+    failure: crate::qualification::QualificationFailure,
+    report_out: Option<&Path>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let summary = format!("{}: {}", failure.code, failure.detail);
+    report.fail(failure);
+    emit_qualification_report(&report, report_out)?;
+    Err(summary.into())
+}
+
+fn qualification_inference_failure(
+    error: &(dyn std::error::Error + 'static),
+) -> crate::qualification::QualificationFailure {
+    use crate::engine::MoeStepError;
+    use crate::model::RealInferenceError;
+    use crate::qualification::{FailureStage, GpuFailureEvidence, QualificationFailure};
+
+    if let Some(RealInferenceError::MoeStep(MoeStepError::GpuExpertDispatch { source })) =
+        error.downcast_ref::<RealInferenceError>()
+    {
+        let mut failure = QualificationFailure::new(
+            FailureStage::Inference,
+            "routed-gpu-dispatch-failed",
+            source.to_string(),
+        );
+        failure.gpu_dispatch = Some(GpuFailureEvidence {
+            layer: source.layer,
+            expert_id: source.expert_id,
+            kind: source.kind.to_string(),
+        });
+        failure
+    } else {
+        QualificationFailure::new(
+            FailureStage::Inference,
+            "inference-failed",
+            error.to_string(),
+        )
+    }
+}
+
+async fn cmd_qualify_hybrid_q4(
+    args: QualifyHybridQ4Args,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use crate::qualification::{
+        gpu_io_delta, request_evidence, routed_execution_delta, validate_device,
+        validate_execution_plan, validate_gpu_failure_policy, validate_memory,
+        validate_postconditions, validate_preflight, BuildProvenance, FailureStage,
+        PreflightEvidence, QualificationFailure, QualificationReport, QualificationTiming,
+    };
+
+    // Config/request parse errors retain normal CLI error behavior. Once both
+    // are parsed, every expected qualification failure below emits the typed
+    // report before returning a non-zero status.
+    let cfg = crate::config::Config::from_file(&args.config)?;
+    let input = load_qualification_input(&args)?;
+    let provenance = BuildProvenance::embedded();
+    let (artifacts, artifact_errors) = qualification_artifacts(&args.config, &cfg);
+    let metadata_path = cfg.model.data_dir.join("metadata.json");
+    let metadata_result = crate::qualification::read_expert_metadata(&metadata_path);
+    let metadata = metadata_result.clone().ok();
+    let request = request_evidence(
+        input.input_kind,
+        &input.prompt,
+        input.output_tokens,
+        args.warmup_runs,
+    );
+    let mut report = QualificationReport::new(
+        provenance.clone(),
+        artifacts,
+        metadata.clone(),
+        request,
+        args.external_gpu_memory_artifact.clone(),
+    );
+
+    if !artifact_errors.is_empty() {
+        return fail_qualification(
+            report,
+            QualificationFailure::new(
+                FailureStage::Preflight,
+                "artifact-identity-unavailable",
+                artifact_errors.join("; "),
+            ),
+            args.report_out.as_deref(),
+        );
+    }
+    let metadata = match metadata_result {
+        Ok(metadata) => metadata,
+        Err(detail) => {
+            return fail_qualification(
+                report,
+                QualificationFailure::new(
+                    FailureStage::Preflight,
+                    "q4-layout-not-standard",
+                    detail,
+                ),
+                args.report_out.as_deref(),
+            );
+        }
+    };
+    let weight_policy = cfg.real_transformer.resolve_weight_policy();
+    if !matches!(
+        weight_policy,
+        Ok(crate::config::RealWeightPolicy::StrictReal)
+    ) {
+        return fail_qualification(
+            report,
+            QualificationFailure::new(
+                FailureStage::Preflight,
+                "non-strict-weight-policy",
+                weight_policy
+                    .err()
+                    .unwrap_or_else(|| "resolved weight policy is SeededDev".to_string()),
+            ),
+            args.report_out.as_deref(),
+        );
+    }
+    let capacity_bytes = cfg
+        .gpu_cache
+        .vram_capacity_mb
+        .checked_mul(1024 * 1024)
+        .and_then(|bytes| u64::try_from(bytes).ok())
+        .unwrap_or(0);
+    let preflight = PreflightEvidence {
+        provenance,
+        real_transformer_enabled: cfg.real_transformer.enabled,
+        weights_dir_configured: cfg.real_transformer.weights_dir.is_some(),
+        strict_weights: cfg.real_transformer.strict_weights,
+        allow_seeded_fallback: cfg.real_transformer.allow_seeded_fallback,
+        allow_degraded_experts: cfg.real_transformer.allow_degraded_experts,
+        allow_attention_fallback: cfg.real_transformer.allow_nonfinite_attention_fallback,
+        allow_truncated_expert_payloads: cfg.real_transformer.allow_truncated_expert_payloads,
+        distributed_enabled: cfg.distributed.enabled,
+        gpu_cache_enabled: cfg.gpu_cache.enabled,
+        gpu_expert_capacity_bytes: capacity_bytes,
+        requested_mode: cfg.real_transformer.compute_offload,
+        routed_expert_dtype: cfg.model.dtype,
+        metadata,
+    };
+    if let Err(failure) = validate_preflight(&preflight, &mut report.qualification_checks) {
+        return fail_qualification(report, failure, args.report_out.as_deref());
+    }
+
+    let runtime =
+        match build_real_cli_runtime(&args.config, RealCliRuntimeMode::StrictHybridQualification)
+            .await
+        {
+            Ok(runtime) => runtime,
+            Err(error) => {
+                return fail_qualification(
+                    report,
+                    QualificationFailure::new(
+                        FailureStage::Startup,
+                        "startup-failed",
+                        error.to_string(),
+                    ),
+                    args.report_out.as_deref(),
+                );
+            }
+        };
+    if !runtime.model.load_status.strict
+        || runtime.model.load_status.seeded_fallback_remained
+        || runtime.model.load_status.loaded_tensors != runtime.model.load_status.required_tensors
+    {
+        return fail_qualification(
+            report,
+            QualificationFailure::new(
+                FailureStage::Startup,
+                "seeded-model-loaded",
+                format!(
+                    "strict={} loaded={}/{} seeded_fallback_remained={}",
+                    runtime.model.load_status.strict,
+                    runtime.model.load_status.loaded_tensors,
+                    runtime.model.load_status.required_tensors,
+                    runtime.model.load_status.seeded_fallback_remained
+                ),
+            ),
+            args.report_out.as_deref(),
+        );
+    }
+
+    let context = runtime.engine.execution_context();
+    report.execution_plan = Some(context.plan().into());
+    report.device = runtime.engine.gpu_device_identity();
+    if let Err(failure) = validate_execution_plan(context.plan(), &mut report.qualification_checks)
+    {
+        return fail_qualification(report, failure, args.report_out.as_deref());
+    }
+    if let Err(failure) = validate_device(report.device.as_ref(), &mut report.qualification_checks)
+    {
+        return fail_qualification(report, failure, args.report_out.as_deref());
+    }
+    if let Err(failure) = validate_gpu_failure_policy(
+        runtime.engine.routed_expert_gpu_failure_policy(),
+        &mut report.qualification_checks,
+    ) {
+        return fail_qualification(report, failure, args.report_out.as_deref());
+    }
+
+    let greedy = crate::sampling::SamplingParams::greedy();
+    for index in 0..args.warmup_runs {
+        if let Err(error) = with_progress_timeout(
+            format!("qualify-hybrid-q4 warmup run {index}"),
+            args.progress_watchdog,
+            run_bench_real_once(&runtime, &input.prompt, input.output_tokens, greedy, index),
+        )
+        .await
+        {
+            return fail_qualification(
+                report,
+                qualification_inference_failure(error.as_ref()),
+                args.report_out.as_deref(),
+            );
+        }
+    }
+
+    let routed_before = runtime.engine.routed_expert_execution_snapshot();
+    let io_before = match runtime.engine.gpu_expert_io_snapshot() {
+        Some(snapshot) => snapshot,
+        None => {
+            return fail_qualification(
+                report,
+                QualificationFailure::new(
+                    FailureStage::Startup,
+                    "gpu-device-unavailable",
+                    "authoritative GPU backend has no routed-expert I/O snapshot",
+                ),
+                args.report_out.as_deref(),
+            );
+        }
+    };
+    let memory_before = match runtime.engine.gpu_expert_memory_snapshot() {
+        Some(snapshot) => snapshot,
+        None => {
+            return fail_qualification(
+                report,
+                QualificationFailure::new(
+                    FailureStage::Startup,
+                    "gpu-device-unavailable",
+                    "authoritative GPU backend has no PR4 memory snapshot",
+                ),
+                args.report_out.as_deref(),
+            );
+        }
+    };
+    report.gpu_memory_before = Some(memory_before);
+
+    let measured = with_progress_timeout(
+        "qualify-hybrid-q4 measured request".to_string(),
+        args.progress_watchdog,
+        run_bench_real_once(&runtime, &input.prompt, input.output_tokens, greedy, 0),
+    )
+    .await;
+
+    let routed_after = runtime.engine.routed_expert_execution_snapshot();
+    let io_after = runtime.engine.gpu_expert_io_snapshot();
+    let memory_after = runtime.engine.gpu_expert_memory_snapshot();
+    report.gpu_memory_after = memory_after;
+    report.routed_experts = routed_execution_delta(routed_before, routed_after).ok();
+    report.gpu_io = io_after.and_then(|after| gpu_io_delta(io_before, after).ok());
+
+    let measured = match measured {
+        Ok(measured) => measured,
+        Err(error) => {
+            return fail_qualification(
+                report,
+                qualification_inference_failure(error.as_ref()),
+                args.report_out.as_deref(),
+            );
+        }
+    };
+    let routed_delta = match routed_execution_delta(routed_before, routed_after) {
+        Ok(delta) => delta,
+        Err(failure) => {
+            return fail_qualification(report, failure, args.report_out.as_deref());
+        }
+    };
+    let io_after = match io_after {
+        Some(snapshot) => snapshot,
+        None => {
+            return fail_qualification(
+                report,
+                QualificationFailure::new(
+                    FailureStage::Postcondition,
+                    "gpu-device-unavailable",
+                    "authoritative GPU I/O snapshot disappeared during measurement",
+                ),
+                args.report_out.as_deref(),
+            );
+        }
+    };
+    let memory_after = match memory_after {
+        Some(snapshot) => snapshot,
+        None => {
+            return fail_qualification(
+                report,
+                QualificationFailure::new(
+                    FailureStage::Postcondition,
+                    "gpu-device-unavailable",
+                    "authoritative PR4 memory snapshot disappeared during measurement",
+                ),
+                args.report_out.as_deref(),
+            );
+        }
+    };
+    let io_delta = match gpu_io_delta(io_before, io_after) {
+        Ok(delta) => delta,
+        Err(failure) => {
+            return fail_qualification(report, failure, args.report_out.as_deref());
+        }
+    };
+    report.routed_experts = Some(routed_delta);
+    report.gpu_io = Some(io_delta);
+    for snapshot in [memory_before, memory_after] {
+        if let Err(failure) = validate_memory(snapshot) {
+            return fail_qualification(report, failure, args.report_out.as_deref());
+        }
+    }
+    report.timing = Some(QualificationTiming::from_measurement(
+        measured.prompt_tokens,
+        input.output_tokens,
+        measured.completion_tokens,
+        measured.prompt_seconds,
+        measured.decode_seconds,
+        measured.total_seconds,
+    ));
+    if let Err(failure) = validate_postconditions(
+        measured.completion_tokens,
+        routed_delta,
+        &mut report.qualification_checks,
+    ) {
+        return fail_qualification(report, failure, args.report_out.as_deref());
+    }
+    if let Err(failure) = report.finish() {
+        return fail_qualification(report, failure, args.report_out.as_deref());
+    }
+    emit_qualification_report(&report, args.report_out.as_deref())
 }
 
 async fn with_progress_timeout<T, F>(
@@ -3165,38 +3703,15 @@ fn print_matvec_microbench_human(report: &MatvecMicrobenchReport) {
 fn load_bench_real_input(
     args: &BenchRealArgs,
 ) -> Result<BenchRealInput, Box<dyn std::error::Error>> {
-    let mut json_max_tokens = None;
-    let prompt = if let Some(prompt) = args.prompt.as_ref() {
-        prompt.clone()
-    } else if let Some(path) = args.request_json.as_ref() {
-        let body = std::fs::read_to_string(path)?;
-        let value: serde_json::Value = serde_json::from_str(&body)?;
-        json_max_tokens = value
-            .get("max_tokens")
-            .and_then(|v| v.as_u64())
-            .map(|v| v as usize);
-        if let Some(prompt) = value.get("prompt").and_then(|v| v.as_str()) {
-            prompt.to_string()
-        } else if let Some(messages) = value.get("messages").and_then(|v| v.as_array()) {
-            flatten_bench_messages(messages)
-        } else {
-            return Err(
-                "--request-json must contain a string `prompt` or chat `messages` array".into(),
-            );
-        }
-    } else {
-        return Err("bench-real requires either --prompt or --request-json".into());
-    };
-    if prompt.is_empty() {
-        return Err("bench-real prompt must be non-empty".into());
-    }
-    let output_tokens = args.output_tokens.or(json_max_tokens).unwrap_or(16);
-    if output_tokens == 0 {
-        return Err("bench-real requires output token count > 0".into());
-    }
+    let input = load_real_cli_request_input(
+        "bench-real",
+        args.prompt.as_ref(),
+        args.request_json.as_deref(),
+        args.output_tokens,
+    )?;
     Ok(BenchRealInput {
-        prompt,
-        output_tokens,
+        prompt: input.prompt,
+        output_tokens: input.output_tokens,
     })
 }
 
@@ -3298,8 +3813,21 @@ fn validate_bench_real_policies(cfg: &crate::config::Config) -> Result<(), Strin
     Ok(())
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RealCliRuntimeMode {
+    BenchReal,
+    StrictHybridQualification,
+}
+
 async fn build_bench_real_runtime(
     config_path: &Path,
+) -> Result<BenchRealRuntime, Box<dyn std::error::Error>> {
+    build_real_cli_runtime(config_path, RealCliRuntimeMode::BenchReal).await
+}
+
+async fn build_real_cli_runtime(
+    config_path: &Path,
+    mode: RealCliRuntimeMode,
 ) -> Result<BenchRealRuntime, Box<dyn std::error::Error>> {
     use crate::config::Config;
     use crate::metrics::Metrics;
@@ -3307,7 +3835,9 @@ async fn build_bench_real_runtime(
 
     let mut cfg = Config::from_file(config_path)?;
     crate::parallel::set_dense_matvec_backend(cfg.real_transformer.dense_matvec_backend);
-    validate_bench_real_policies(&cfg)?;
+    if mode == RealCliRuntimeMode::BenchReal {
+        validate_bench_real_policies(&cfg)?;
+    }
 
     let (resolved_architecture, resolved_first_k_dense_replace, resolved_advanced) =
         reconcile_real_model_config(&mut cfg)?;
@@ -3320,15 +3850,63 @@ async fn build_bench_real_runtime(
         &resolved_advanced,
     )?;
 
-    crate::backend::install_default();
-    {
-        let b = crate::backend::current();
-        info!(
-            backend = b.device_name(),
-            compute_plane = b.compute_plane(),
-            "bench-real math backend installed"
-        );
-    }
+    let execution_context = match mode {
+        RealCliRuntimeMode::BenchReal => {
+            crate::backend::install_default();
+            let context = crate::backend::current_execution_context();
+            let b = crate::backend::current();
+            info!(
+                backend = b.device_name(),
+                compute_plane = b.compute_plane(),
+                "bench-real math backend installed"
+            );
+            context
+        }
+        RealCliRuntimeMode::StrictHybridQualification => {
+            let capacity_bytes = cfg
+                .gpu_cache
+                .vram_capacity_mb
+                .checked_mul(1024 * 1024)
+                .ok_or("gpu_cache.vram_capacity_mb overflows usize")?;
+            let gpu_cache = Arc::new(crate::expert_cache::GpuExpertCache::new(
+                capacity_bytes,
+                cfg.gpu_cache.vram_anchor_ratio,
+                cfg.gpu_cache.promote_after_hits,
+            ));
+            let rt = &cfg.real_transformer;
+            let head_dim = if rt.head_dim == 0 {
+                cfg.model.d_model / rt.num_heads
+            } else {
+                rt.head_dim
+            };
+            let context = crate::backend::resolve_execution_context(
+                cfg.real_transformer.compute_offload,
+                true,
+                crate::backend::GpuBackendGeometry {
+                    num_layers: cfg.model.num_layers,
+                    max_seq_len: if rt.window_size == 0 {
+                        4096
+                    } else {
+                        rt.window_size
+                    },
+                    num_heads: rt.num_heads,
+                    num_kv_heads: rt.num_kv_heads,
+                    head_dim,
+                    v_head_dim: 0,
+                    q4_truncation_tolerance: 0,
+                },
+                crate::backend::RoutedExpertGpuSpec {
+                    dtype: cfg.model.dtype,
+                    d_model: cfg.model.d_model,
+                    d_ff: cfg.model.d_ff,
+                },
+                gpu_cache,
+            )?;
+            crate::backend::set_execution_context(context.clone())
+                .map_err(|e| format!("failed to install qualification execution context: {e}"))?;
+            context
+        }
+    };
 
     if !cfg.model.data_dir.is_dir() {
         return Err(format!(
@@ -3503,7 +4081,7 @@ async fn build_bench_real_runtime(
             collect_route_profile: false,
             policy: cfg.real_transformer.inference_policy(),
         },
-        crate::backend::current_execution_context(),
+        execution_context,
     );
     engine_builder = engine_builder.with_pipeline_depth(cfg.storage.pipeline_depth);
     if cfg.predictive.locality_enabled {
@@ -3560,22 +4138,36 @@ async fn build_bench_real_runtime(
         ));
         engine_builder = engine_builder.with_pregate(pregate);
     }
+    if mode == RealCliRuntimeMode::StrictHybridQualification {
+        engine_builder.install_gpu_cache();
+        engine_builder = engine_builder.with_routed_expert_gpu_failure_policy(
+            crate::engine::RoutedExpertGpuFailurePolicy::StrictFailClosed,
+        );
+    }
     let engine = Arc::new(engine_builder.with_metrics(metrics));
 
     let tokenizer = match cfg.tokenizer.path.as_ref() {
         Some(p) => match Tokenizer::from_file(p) {
             Ok(t) => Arc::new(t),
             Err(e) => {
-                return Err(
-                    format!("bench-real failed to load tokenizer {}: {e}", p.display()).into(),
-                );
+                let detail = match mode {
+                    RealCliRuntimeMode::BenchReal => {
+                        format!("bench-real failed to load tokenizer {}: {e}", p.display())
+                    }
+                    RealCliRuntimeMode::StrictHybridQualification => format!(
+                        "qualify-hybrid-q4 failed to load tokenizer {}: {e}",
+                        p.display()
+                    ),
+                };
+                return Err(detail.into());
             }
         },
         None => {
-            return Err(
-                "bench-real requires tokenizer.path; byte tokenizer fallback is not a production benchmark"
-                    .into(),
-            );
+            let detail = match mode {
+                RealCliRuntimeMode::BenchReal => "bench-real requires tokenizer.path; byte tokenizer fallback is not a production benchmark",
+                RealCliRuntimeMode::StrictHybridQualification => "qualify-hybrid-q4 requires tokenizer.path; byte tokenizer fallback is not permitted",
+            };
+            return Err(detail.into());
         }
     };
     // The tokenizer must be addressable by the reconciled model vocabulary
@@ -3583,7 +4175,15 @@ async fn build_bench_real_runtime(
     tokenizer
         .validate_vocab_compat(model.config.vocab_size)
         .map_err(|e| -> Box<dyn std::error::Error> {
-            format!("bench-real tokenizer is incompatible with the model: {e}").into()
+            match mode {
+                RealCliRuntimeMode::BenchReal => {
+                    format!("bench-real tokenizer is incompatible with the model: {e}").into()
+                }
+                RealCliRuntimeMode::StrictHybridQualification => {
+                    format!("qualify-hybrid-q4 tokenizer is incompatible with the model: {e}")
+                        .into()
+                }
+            }
         })?;
 
     Ok(BenchRealRuntime {
@@ -7616,6 +8216,115 @@ mod tests {
         let input = load_bench_real_input(&args).unwrap();
         assert_eq!(input.prompt, "hello");
         assert_eq!(input.output_tokens, 3);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn bench_real_cli_defaults_remain_unchanged() {
+        let cli = <Cli as clap::Parser>::try_parse_from([
+            "micro-expert-router",
+            "bench-real",
+            "--config",
+            "config.toml",
+            "--prompt",
+            "hello",
+        ])
+        .unwrap();
+        let Cmd::BenchReal {
+            warmup_runs,
+            measured_runs,
+            cache_reset,
+            greedy,
+            format,
+            ..
+        } = cli.cmd
+        else {
+            panic!("expected bench-real command");
+        };
+        assert_eq!(warmup_runs, 1);
+        assert_eq!(measured_runs, 1);
+        assert_eq!(cache_reset, BenchRealCacheReset::Keep);
+        assert!(!greedy);
+        assert_eq!(format, BenchRealOutputFormat::Human);
+    }
+
+    #[test]
+    fn qualification_cli_has_strict_defaults_and_external_evidence_slot() {
+        let cli = <Cli as clap::Parser>::try_parse_from([
+            "micro-expert-router",
+            "qualify-hybrid-q4",
+            "--config",
+            "config.toml",
+            "--prompt",
+            "hello",
+            "--external-gpu-memory-artifact",
+            "pr6://sample",
+        ])
+        .unwrap();
+        let Cmd::QualifyHybridQ4 {
+            warmup_runs,
+            output_tokens,
+            report_out,
+            external_gpu_memory_artifact,
+            ..
+        } = cli.cmd
+        else {
+            panic!("expected qualify-hybrid-q4 command");
+        };
+        assert_eq!(warmup_runs, 0);
+        assert_eq!(output_tokens, None);
+        assert_eq!(report_out, None);
+        assert_eq!(
+            external_gpu_memory_artifact.as_deref(),
+            Some("pr6://sample")
+        );
+    }
+
+    #[test]
+    fn qualification_cli_rejects_both_request_inputs() {
+        let error = <Cli as clap::Parser>::try_parse_from([
+            "micro-expert-router",
+            "qualify-hybrid-q4",
+            "--config",
+            "config.toml",
+            "--prompt",
+            "hello",
+            "--request-json",
+            "request.json",
+        ])
+        .unwrap_err();
+        assert!(error.to_string().contains("cannot be used with"));
+    }
+
+    #[test]
+    fn qualification_request_json_uses_bench_semantics_and_cli_override() {
+        let path = tempdir_unique("qualification-request.json");
+        std::fs::write(
+            &path,
+            r#"{ "prompt": "hello", "max_tokens": 7, "temperature": 0.9 }"#,
+        )
+        .unwrap();
+        let args = QualifyHybridQ4Args {
+            config: PathBuf::from("config.toml"),
+            prompt: None,
+            request_json: Some(path.clone()),
+            output_tokens: Some(3),
+            warmup_runs: 0,
+            report_out: None,
+            external_gpu_memory_artifact: None,
+            progress_watchdog: crate::rayon_autotune::ProgressWatchdogConfig::disabled(),
+        };
+        let input = load_qualification_input(&args).unwrap();
+        assert_eq!(input.prompt, "hello");
+        assert_eq!(input.output_tokens, 3);
+        assert_eq!(input.input_kind, "request-json");
+        assert!(crate::qualification::request_evidence(
+            input.input_kind,
+            &input.prompt,
+            input.output_tokens,
+            0
+        )
+        .greedy);
         let _ = std::fs::remove_file(path);
     }
 

--- a/rust-engine/src/metrics.rs
+++ b/rust-engine/src/metrics.rs
@@ -88,10 +88,10 @@ struct MetricsInner {
     /// relying on the `/v1/admin/health/experts` admin endpoint.
     /// Stays at `0` when the GPU cache is disabled. Phase 1.
     pub vram_capacity_bytes: IntGauge,
-    /// Total RAM → logical GPU-admission promotions performed since startup. Each
-    /// promotion is the result of an `ExpertResident` crossing
-    /// `gpu_cache.promote_after_hits` and being copied into the
-    /// Anchor Core (or the LRU Edge as a fallback). Phase 1.
+    /// Total successful logical GPU-promotion transitions since startup: a new
+    /// Anchor/LRU admission or an existing LRU admission graduating to Anchor.
+    /// No-op/already-resident outcomes are excluded. Mirrors
+    /// [`GpuExpertCache::promotions`](crate::expert_cache::GpuExpertCache::promotions).
     pub promotions_total: Counter,
     /// Speculative prefetches dropped because no pool buffer could be
     /// acquired (shadow half starved even after recycling, or legacy
@@ -287,7 +287,7 @@ impl Metrics {
         .expect("metric registration: mer_vram_capacity_bytes");
         let promotions_total = register_counter_with_registry!(
             "mer_promotions_total",
-            "Total RAM-to-logical-GPU-admission promotions performed since startup.",
+            "Total successful logical GPU promotion transitions (new admission or LRU-to-Anchor graduation) since startup.",
             registry
         )
         .expect("metric registration: mer_promotions_total");
@@ -560,7 +560,7 @@ impl Metrics {
         }
     }
 
-    /// Record `n` RAM → logical GPU-admission promotions.
+    /// Record `n` successful logical GPU-promotion transitions.
     pub fn record_promotions(&self, n: u64) {
         if n > 0 {
             self.inner.promotions_total.inc_by(n as f64);

--- a/rust-engine/src/qualification.rs
+++ b/rust-engine/src/qualification.rs
@@ -1,0 +1,1490 @@
+//! Strict Hybrid native-Q4_0 execution-integrity qualification.
+//!
+//! This module intentionally separates hardware-independent validation from
+//! command orchestration. Internal memory evidence is limited to MER-owned
+//! routed-expert buffers and workspaces; it is not total driver/device memory.
+
+use crate::backend::{
+    ComputeOffload, GpuDeviceIdentity, GpuExpertIoSnapshot, GpuExpertMemorySnapshot,
+    ResolvedBackend, ResolvedExecutionPlan,
+};
+use crate::engine::{RoutedExpertExecutionSnapshot, RoutedExpertGpuFailurePolicy};
+use crate::inference::{WeightDtype, Q4_0_LAYOUT_STANDARD_V1};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::fs::File;
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
+
+pub const SCHEMA_VERSION: &str = "mer.strict-hybrid-q4.v1";
+pub const MODE: &str = "strict-hybrid-q4";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum QualificationStatus {
+    Pass,
+    Fail,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FailureStage {
+    Preflight,
+    Startup,
+    Inference,
+    Postcondition,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct GpuFailureEvidence {
+    pub layer: u32,
+    pub expert_id: u32,
+    pub kind: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct QualificationFailure {
+    pub stage: FailureStage,
+    pub code: String,
+    pub detail: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gpu_dispatch: Option<GpuFailureEvidence>,
+}
+
+impl QualificationFailure {
+    pub fn new(stage: FailureStage, code: &'static str, detail: impl Into<String>) -> Self {
+        Self {
+            stage,
+            code: code.to_string(),
+            detail: detail.into(),
+            gpu_dispatch: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct BuildProvenance {
+    pub git_sha: Option<String>,
+    pub dirty: Option<bool>,
+    pub package_version: String,
+}
+
+impl BuildProvenance {
+    pub fn embedded() -> Self {
+        let sha = option_env!("MER_BUILD_GIT_SHA")
+            .filter(|value| *value != "unavailable")
+            .map(str::to_string);
+        let dirty = match option_env!("MER_BUILD_GIT_DIRTY") {
+            Some("true") => Some(true),
+            Some("false") => Some(false),
+            _ => None,
+        };
+        Self {
+            git_sha: sha,
+            dirty,
+            package_version: env!("CARGO_PKG_VERSION").to_string(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ArtifactDigest {
+    pub configured_path: String,
+    pub canonical_path: String,
+    pub byte_length: u64,
+    pub sha256: String,
+}
+
+pub fn hash_small_file(path: &Path) -> io::Result<ArtifactDigest> {
+    let mut file = File::open(path)?;
+    let byte_length = file.metadata()?.len();
+    let mut hasher = Sha256::new();
+    let mut buffer = [0u8; 64 * 1024];
+    loop {
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(ArtifactDigest {
+        configured_path: path.display().to_string(),
+        canonical_path: std::fs::canonicalize(path)?.display().to_string(),
+        byte_length,
+        sha256: format!("{:x}", hasher.finalize()),
+    })
+}
+
+pub fn hash_optional_small_file(path: Option<&Path>) -> io::Result<Option<ArtifactDigest>> {
+    path.filter(|path| path.is_file())
+        .map(hash_small_file)
+        .transpose()
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
+pub struct QualificationArtifacts {
+    pub config: Option<ArtifactDigest>,
+    pub tokenizer: Option<ArtifactDigest>,
+    pub expert_metadata: Option<ArtifactDigest>,
+    pub packed_manifest: Option<ArtifactDigest>,
+    pub weights_config: Option<ArtifactDigest>,
+    pub dense_weights_directory: Option<String>,
+    pub expert_data_directory: String,
+    pub packed_expert_blob: Option<String>,
+    /// Metadata hashes identify metadata only, never the large expert blobs.
+    pub large_artifacts_recursively_hashed: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ExpertMetadataEvidence {
+    pub dtype: Option<String>,
+    pub q4_0_layout: Option<String>,
+    pub conversion_mode: Option<String>,
+    pub source: Option<String>,
+    pub explicitly_synthetic: bool,
+}
+
+#[derive(Deserialize)]
+struct RawExpertMetadata {
+    #[serde(default)]
+    dtype: Option<String>,
+    #[serde(default)]
+    q4_0_layout: Option<String>,
+    #[serde(default)]
+    conversion_mode: Option<String>,
+    #[serde(default)]
+    source: Option<String>,
+}
+
+pub fn read_expert_metadata(path: &Path) -> Result<ExpertMetadataEvidence, String> {
+    let body = std::fs::read_to_string(path)
+        .map_err(|e| format!("failed to read expert metadata {}: {e}", path.display()))?;
+    let raw: RawExpertMetadata = serde_json::from_str(&body)
+        .map_err(|e| format!("expert metadata {} is invalid JSON: {e}", path.display()))?;
+    let explicitly_synthetic = raw
+        .conversion_mode
+        .as_deref()
+        .is_some_and(|value| value.to_ascii_lowercase().contains("synthetic"))
+        || raw
+            .source
+            .as_deref()
+            .is_some_and(|value| value.to_ascii_lowercase().contains("synthetic"));
+    Ok(ExpertMetadataEvidence {
+        dtype: raw.dtype,
+        q4_0_layout: raw.q4_0_layout,
+        conversion_mode: raw.conversion_mode,
+        source: raw.source,
+        explicitly_synthetic,
+    })
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ExecutionPlanEvidence {
+    pub context_id: String,
+    pub requested: String,
+    pub resolved: String,
+    pub embeddings: String,
+    pub lm_head: String,
+    pub dense_projections: String,
+    pub attention: String,
+    pub kv: String,
+    pub router: String,
+    pub routed_experts: String,
+    pub routed_expert_dtype: String,
+    pub fallback_occurred: bool,
+    pub reason: Option<String>,
+}
+
+fn requested_name(mode: ComputeOffload) -> &'static str {
+    match mode {
+        ComputeOffload::Cpu => "cpu",
+        ComputeOffload::Gpu => "gpu",
+        ComputeOffload::Auto => "auto",
+        ComputeOffload::Hybrid => "hybrid",
+    }
+}
+
+fn resolved_name(mode: ResolvedBackend) -> &'static str {
+    match mode {
+        ResolvedBackend::Cpu => "cpu",
+        ResolvedBackend::Gpu => "gpu",
+        ResolvedBackend::HybridCpuAttentionGpuExperts => "hybrid-cpu-attention-gpu-experts",
+    }
+}
+
+impl From<&ResolvedExecutionPlan> for ExecutionPlanEvidence {
+    fn from(plan: &ResolvedExecutionPlan) -> Self {
+        Self {
+            context_id: plan.context_id().to_string(),
+            requested: requested_name(plan.requested()).to_string(),
+            resolved: resolved_name(plan.resolved()).to_string(),
+            embeddings: plan.embeddings().as_str().to_string(),
+            lm_head: plan.lm_head().as_str().to_string(),
+            dense_projections: plan.dense_projections().as_str().to_string(),
+            attention: plan.attention().as_str().to_string(),
+            kv: plan.kv().as_str().to_string(),
+            router: plan.router().as_str().to_string(),
+            routed_experts: plan.routed_experts().as_str().to_string(),
+            routed_expert_dtype: plan.routed_expert_gpu_spec().dtype.as_str().to_string(),
+            fallback_occurred: plan.fallback_occurred(),
+            reason: plan.reason().map(str::to_string),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct RequestEvidence {
+    pub input_kind: String,
+    pub prompt_sha256: String,
+    pub prompt_bytes: usize,
+    pub requested_output_tokens: usize,
+    pub warmup_runs: usize,
+    pub greedy: bool,
+}
+
+pub fn request_evidence(
+    input_kind: &str,
+    prompt: &str,
+    requested_output_tokens: usize,
+    warmup_runs: usize,
+) -> RequestEvidence {
+    RequestEvidence {
+        input_kind: input_kind.to_string(),
+        prompt_sha256: format!("{:x}", Sha256::digest(prompt.as_bytes())),
+        prompt_bytes: prompt.len(),
+        requested_output_tokens,
+        warmup_runs,
+        greedy: true,
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct QualificationTiming {
+    pub prompt_tokens: usize,
+    pub requested_output_tokens: usize,
+    pub generated_tokens: usize,
+    pub prompt_seconds: f64,
+    pub decode_seconds: f64,
+    pub total_seconds: f64,
+    /// Actual generated completion tokens after the first token produced at TTFT.
+    pub decode_generated_tokens: usize,
+    /// Steady autoregressive decode throughput, matching `bench-real` semantics.
+    pub decode_tps: f64,
+    /// Alias for `decode_tps`, retained as the qualification throughput field.
+    pub real_generated_tps: f64,
+    /// Actual generated completion tokens divided by total request wall time.
+    pub end_to_end_generated_tps: f64,
+}
+
+impl QualificationTiming {
+    pub fn from_measurement(
+        prompt_tokens: usize,
+        requested_output_tokens: usize,
+        generated_tokens: usize,
+        prompt_seconds: f64,
+        decode_seconds: f64,
+        total_seconds: f64,
+    ) -> Self {
+        let decode_generated_tokens = generated_tokens.saturating_sub(1);
+        let decode_tps = crate::rate_per_second(decode_generated_tokens, decode_seconds);
+        Self {
+            prompt_tokens,
+            requested_output_tokens,
+            generated_tokens,
+            prompt_seconds,
+            decode_seconds,
+            total_seconds,
+            decode_generated_tokens,
+            decode_tps,
+            real_generated_tps: decode_tps,
+            end_to_end_generated_tps: crate::rate_per_second(generated_tokens, total_seconds),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
+pub struct QualificationChecks {
+    pub clean_build: bool,
+    pub strict_real_checkpoint: bool,
+    pub requested_hybrid: bool,
+    pub resolved_planes_match_contract: bool,
+    pub native_q4_0_routed_experts: bool,
+    pub canonical_q4_layout: bool,
+    pub hardware_gpu_adapter: bool,
+    pub strict_gpu_failure_policy: bool,
+    pub generated_tokens: bool,
+    pub observed_routed_experts: bool,
+    pub all_selected_experts_attempted_on_gpu: bool,
+    pub all_gpu_attempts_succeeded: bool,
+    pub zero_cpu_routed_expert_execution: bool,
+    pub zero_gpu_cpu_fallbacks: bool,
+    pub zero_degraded_expert_substitutions: bool,
+}
+
+impl QualificationChecks {
+    pub fn passes(&self) -> bool {
+        self.clean_build
+            && self.strict_real_checkpoint
+            && self.requested_hybrid
+            && self.resolved_planes_match_contract
+            && self.native_q4_0_routed_experts
+            && self.canonical_q4_layout
+            && self.hardware_gpu_adapter
+            && self.strict_gpu_failure_policy
+            && self.generated_tokens
+            && self.observed_routed_experts
+            && self.all_selected_experts_attempted_on_gpu
+            && self.all_gpu_attempts_succeeded
+            && self.zero_cpu_routed_expert_execution
+            && self.zero_gpu_cpu_fallbacks
+            && self.zero_degraded_expert_substitutions
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PreflightEvidence {
+    pub provenance: BuildProvenance,
+    pub real_transformer_enabled: bool,
+    pub weights_dir_configured: bool,
+    pub strict_weights: bool,
+    pub allow_seeded_fallback: bool,
+    pub allow_degraded_experts: bool,
+    pub allow_attention_fallback: bool,
+    pub allow_truncated_expert_payloads: bool,
+    pub distributed_enabled: bool,
+    pub gpu_cache_enabled: bool,
+    pub gpu_expert_capacity_bytes: u64,
+    pub requested_mode: ComputeOffload,
+    pub routed_expert_dtype: WeightDtype,
+    pub metadata: ExpertMetadataEvidence,
+}
+
+pub fn validate_preflight(
+    evidence: &PreflightEvidence,
+    checks: &mut QualificationChecks,
+) -> Result<(), QualificationFailure> {
+    let sha_available = evidence
+        .provenance
+        .git_sha
+        .as_deref()
+        .is_some_and(|sha| sha.len() == 40 && sha.bytes().all(|byte| byte.is_ascii_hexdigit()));
+    if !sha_available || evidence.provenance.dirty.is_none() {
+        return Err(QualificationFailure::new(
+            FailureStage::Preflight,
+            "build-provenance-unavailable",
+            "build-time full Git SHA or tracked-source dirty state is unavailable",
+        ));
+    }
+    if evidence.provenance.dirty == Some(true) {
+        return Err(QualificationFailure::new(
+            FailureStage::Preflight,
+            "dirty-build",
+            "strict qualification requires a clean tracked-source build",
+        ));
+    }
+    checks.clean_build = true;
+
+    if !evidence.real_transformer_enabled {
+        return Err(QualificationFailure::new(
+            FailureStage::Preflight,
+            "not-real-transformer",
+            "real_transformer.enabled must be true",
+        ));
+    }
+    if !evidence.weights_dir_configured || !evidence.strict_weights {
+        return Err(QualificationFailure::new(
+            FailureStage::Preflight,
+            "non-strict-weight-policy",
+            "a configured weights_dir and strict_weights=true are required",
+        ));
+    }
+    if evidence.allow_seeded_fallback {
+        return Err(QualificationFailure::new(
+            FailureStage::Preflight,
+            "seeded-fallback-enabled",
+            "allow_seeded_fallback must be false",
+        ));
+    }
+    if evidence.allow_degraded_experts {
+        return Err(QualificationFailure::new(
+            FailureStage::Preflight,
+            "degraded-experts-enabled",
+            "allow_degraded_experts must be false",
+        ));
+    }
+    if evidence.allow_attention_fallback {
+        return Err(QualificationFailure::new(
+            FailureStage::Preflight,
+            "attention-fallback-enabled",
+            "allow_nonfinite_attention_fallback must be false",
+        ));
+    }
+    if evidence.allow_truncated_expert_payloads {
+        return Err(QualificationFailure::new(
+            FailureStage::Preflight,
+            "truncated-expert-payloads-enabled",
+            "allow_truncated_expert_payloads must be false",
+        ));
+    }
+    if evidence.distributed_enabled {
+        return Err(QualificationFailure::new(
+            FailureStage::Preflight,
+            "distributed-execution-enabled",
+            "strict qualification requires the local authoritative expert backend",
+        ));
+    }
+    checks.strict_real_checkpoint = true;
+
+    if evidence.requested_mode != ComputeOffload::Hybrid {
+        return Err(QualificationFailure::new(
+            FailureStage::Preflight,
+            "not-hybrid",
+            format!(
+                "requested compute mode is {}, expected hybrid",
+                requested_name(evidence.requested_mode)
+            ),
+        ));
+    }
+    checks.requested_hybrid = true;
+    if !evidence.gpu_cache_enabled {
+        return Err(QualificationFailure::new(
+            FailureStage::Preflight,
+            "gpu-cache-disabled",
+            "gpu_cache.enabled must be true",
+        ));
+    }
+    if evidence.gpu_expert_capacity_bytes == 0 {
+        return Err(QualificationFailure::new(
+            FailureStage::Preflight,
+            "zero-gpu-expert-capacity",
+            "GPU expert capacity must be non-zero",
+        ));
+    }
+    if evidence.routed_expert_dtype != WeightDtype::Q4_0 {
+        return Err(QualificationFailure::new(
+            FailureStage::Preflight,
+            "routed-expert-not-q4-0",
+            format!(
+                "actual routed-expert runtime dtype is {}, expected q4_0",
+                evidence.routed_expert_dtype.as_str()
+            ),
+        ));
+    }
+    checks.native_q4_0_routed_experts = true;
+    if evidence.metadata.explicitly_synthetic {
+        return Err(QualificationFailure::new(
+            FailureStage::Preflight,
+            "synthetic-artifact",
+            "expert metadata explicitly identifies a synthetic dataset",
+        ));
+    }
+    if evidence.metadata.q4_0_layout.as_deref() != Some(Q4_0_LAYOUT_STANDARD_V1) {
+        return Err(QualificationFailure::new(
+            FailureStage::Preflight,
+            "q4-layout-not-standard",
+            format!(
+                "q4_0_layout is {:?}, expected {:?}",
+                evidence.metadata.q4_0_layout, Q4_0_LAYOUT_STANDARD_V1
+            ),
+        ));
+    }
+    checks.canonical_q4_layout = true;
+    Ok(())
+}
+
+pub fn validate_execution_plan(
+    plan: &ResolvedExecutionPlan,
+    checks: &mut QualificationChecks,
+) -> Result<ExecutionPlanEvidence, QualificationFailure> {
+    let evidence: ExecutionPlanEvidence = plan.into();
+    validate_execution_plan_evidence(&evidence, checks)?;
+    Ok(evidence)
+}
+
+/// Hardware-independent form of the exact authoritative-plan check. Runtime
+/// code always constructs this evidence from `ExecutionContext::plan()`.
+pub fn validate_execution_plan_evidence(
+    plan: &ExecutionPlanEvidence,
+    checks: &mut QualificationChecks,
+) -> Result<(), QualificationFailure> {
+    if plan.requested != "hybrid" {
+        return Err(QualificationFailure::new(
+            FailureStage::Startup,
+            "not-hybrid",
+            "authoritative execution context was not requested as Hybrid",
+        ));
+    }
+    checks.requested_hybrid = true;
+    let exact = plan.resolved == "hybrid-cpu-attention-gpu-experts"
+        && plan.embeddings == "cpu"
+        && plan.lm_head == "cpu"
+        && plan.dense_projections == "cpu"
+        && plan.attention == "cpu"
+        && plan.kv == "cpu"
+        && plan.router == "cpu"
+        && plan.routed_experts == "gpu"
+        && !plan.fallback_occurred;
+    if !exact {
+        return Err(QualificationFailure::new(
+            FailureStage::Startup,
+            "invalid-execution-plan",
+            format!("resolved component planes do not match strict Hybrid contract: {plan:?}"),
+        ));
+    }
+    checks.resolved_planes_match_contract = true;
+    if plan.routed_expert_dtype != "q4_0" {
+        return Err(QualificationFailure::new(
+            FailureStage::Startup,
+            "routed-expert-not-q4-0",
+            "authoritative routed-expert GPU spec is not q4_0",
+        ));
+    }
+    checks.native_q4_0_routed_experts = true;
+    Ok(())
+}
+
+pub fn validate_device(
+    device: Option<&GpuDeviceIdentity>,
+    checks: &mut QualificationChecks,
+) -> Result<(), QualificationFailure> {
+    let Some(device) = device else {
+        return Err(QualificationFailure::new(
+            FailureStage::Startup,
+            "gpu-device-unavailable",
+            "authoritative execution context has no production GPU identity",
+        ));
+    };
+    if device.software_adapter || device.device_type.eq_ignore_ascii_case("cpu") {
+        return Err(QualificationFailure::new(
+            FailureStage::Startup,
+            "software-adapter",
+            format!(
+                "selected adapter {:?} is a software/CPU adapter",
+                device.name
+            ),
+        ));
+    }
+    checks.hardware_gpu_adapter = true;
+    Ok(())
+}
+
+pub fn validate_gpu_failure_policy(
+    policy: RoutedExpertGpuFailurePolicy,
+    checks: &mut QualificationChecks,
+) -> Result<(), QualificationFailure> {
+    if policy != RoutedExpertGpuFailurePolicy::StrictFailClosed {
+        return Err(QualificationFailure::new(
+            FailureStage::Startup,
+            "gpu-failure-policy-not-strict",
+            "qualification engine must use StrictFailClosed",
+        ));
+    }
+    checks.strict_gpu_failure_policy = true;
+    Ok(())
+}
+
+fn delta_field(after: u64, before: u64, name: &str) -> Result<u64, QualificationFailure> {
+    after.checked_sub(before).ok_or_else(|| {
+        QualificationFailure::new(
+            FailureStage::Postcondition,
+            "counter-invariant-failed",
+            format!("monotonic counter {name} decreased from {before} to {after}"),
+        )
+    })
+}
+
+pub fn routed_execution_delta(
+    before: RoutedExpertExecutionSnapshot,
+    after: RoutedExpertExecutionSnapshot,
+) -> Result<RoutedExpertExecutionSnapshot, QualificationFailure> {
+    Ok(RoutedExpertExecutionSnapshot {
+        selected_routed_experts: delta_field(
+            after.selected_routed_experts,
+            before.selected_routed_experts,
+            "selected_routed_experts",
+        )?,
+        gpu_dispatch_attempts: delta_field(
+            after.gpu_dispatch_attempts,
+            before.gpu_dispatch_attempts,
+            "gpu_dispatch_attempts",
+        )?,
+        gpu_dispatch_successes: delta_field(
+            after.gpu_dispatch_successes,
+            before.gpu_dispatch_successes,
+            "gpu_dispatch_successes",
+        )?,
+        gpu_dispatch_failures: delta_field(
+            after.gpu_dispatch_failures,
+            before.gpu_dispatch_failures,
+            "gpu_dispatch_failures",
+        )?,
+        cpu_routed_expert_dispatches: delta_field(
+            after.cpu_routed_expert_dispatches,
+            before.cpu_routed_expert_dispatches,
+            "cpu_routed_expert_dispatches",
+        )?,
+        gpu_cpu_fallbacks: delta_field(
+            after.gpu_cpu_fallbacks,
+            before.gpu_cpu_fallbacks,
+            "gpu_cpu_fallbacks",
+        )?,
+        degraded_expert_substitutions: delta_field(
+            after.degraded_expert_substitutions,
+            before.degraded_expert_substitutions,
+            "degraded_expert_substitutions",
+        )?,
+    })
+}
+
+pub fn gpu_io_delta(
+    before: GpuExpertIoSnapshot,
+    after: GpuExpertIoSnapshot,
+) -> Result<GpuExpertIoSnapshot, QualificationFailure> {
+    Ok(GpuExpertIoSnapshot {
+        expert_weight_uploads: delta_field(
+            after.expert_weight_uploads,
+            before.expert_weight_uploads,
+            "expert_weight_uploads",
+        )?,
+        expert_weight_upload_bytes: delta_field(
+            after.expert_weight_upload_bytes,
+            before.expert_weight_upload_bytes,
+            "expert_weight_upload_bytes",
+        )?,
+        hidden_state_uploads: delta_field(
+            after.hidden_state_uploads,
+            before.hidden_state_uploads,
+            "hidden_state_uploads",
+        )?,
+        hidden_state_upload_bytes: delta_field(
+            after.hidden_state_upload_bytes,
+            before.hidden_state_upload_bytes,
+            "hidden_state_upload_bytes",
+        )?,
+        queue_submissions: delta_field(
+            after.queue_submissions,
+            before.queue_submissions,
+            "queue_submissions",
+        )?,
+        map_requests: delta_field(after.map_requests, before.map_requests, "map_requests")?,
+        readback_completions: delta_field(
+            after.readback_completions,
+            before.readback_completions,
+            "readback_completions",
+        )?,
+        readback_bytes: delta_field(
+            after.readback_bytes,
+            before.readback_bytes,
+            "readback_bytes",
+        )?,
+    })
+}
+
+pub fn validate_memory(snapshot: GpuExpertMemorySnapshot) -> Result<(), QualificationFailure> {
+    if snapshot
+        .expert_live_bytes
+        .checked_add(snapshot.workspace_bytes)
+        != Some(snapshot.total_tracked_bytes)
+        || snapshot.expert_registry_bytes > snapshot.expert_live_bytes
+        || snapshot.expert_registry_bytes > snapshot.expert_capacity_bytes
+    {
+        return Err(QualificationFailure::new(
+            FailureStage::Postcondition,
+            "gpu-memory-invariant-failed",
+            format!("invalid PR4 physical memory snapshot: {snapshot:?}"),
+        ));
+    }
+    Ok(())
+}
+
+pub fn validate_postconditions(
+    generated_tokens: usize,
+    routed: RoutedExpertExecutionSnapshot,
+    checks: &mut QualificationChecks,
+) -> Result<(), QualificationFailure> {
+    if generated_tokens == 0 {
+        return Err(QualificationFailure::new(
+            FailureStage::Postcondition,
+            "no-generated-tokens",
+            "measured request generated no completion tokens",
+        ));
+    }
+    checks.generated_tokens = true;
+    if routed.selected_routed_experts == 0 {
+        return Err(QualificationFailure::new(
+            FailureStage::Postcondition,
+            "no-routed-experts-observed",
+            "measured request selected no routed experts",
+        ));
+    }
+    checks.observed_routed_experts = true;
+    if routed.cpu_routed_expert_dispatches != 0 {
+        return Err(QualificationFailure::new(
+            FailureStage::Postcondition,
+            "routed-cpu-execution-observed",
+            format!(
+                "{} selected routed experts executed on CPU",
+                routed.cpu_routed_expert_dispatches
+            ),
+        ));
+    }
+    checks.zero_cpu_routed_expert_execution = true;
+    if routed.gpu_cpu_fallbacks != 0 {
+        return Err(QualificationFailure::new(
+            FailureStage::Postcondition,
+            "gpu-cpu-fallback-observed",
+            format!("{} GPU-to-CPU fallbacks observed", routed.gpu_cpu_fallbacks),
+        ));
+    }
+    checks.zero_gpu_cpu_fallbacks = true;
+    if routed.degraded_expert_substitutions != 0 {
+        return Err(QualificationFailure::new(
+            FailureStage::Postcondition,
+            "degraded-substitution-observed",
+            format!(
+                "{} degraded expert substitutions observed",
+                routed.degraded_expert_substitutions
+            ),
+        ));
+    }
+    checks.zero_degraded_expert_substitutions = true;
+    if routed.gpu_dispatch_failures != 0 {
+        return Err(QualificationFailure::new(
+            FailureStage::Postcondition,
+            "routed-gpu-dispatch-failed",
+            format!(
+                "{} routed GPU dispatch failures observed",
+                routed.gpu_dispatch_failures
+            ),
+        ));
+    }
+    if routed.gpu_dispatch_attempts != routed.selected_routed_experts {
+        return Err(QualificationFailure::new(
+            FailureStage::Postcondition,
+            "counter-invariant-failed",
+            format!(
+                "GPU attempts {} != selected routed experts {}",
+                routed.gpu_dispatch_attempts, routed.selected_routed_experts
+            ),
+        ));
+    }
+    checks.all_selected_experts_attempted_on_gpu = true;
+    if routed.gpu_dispatch_successes != routed.gpu_dispatch_attempts {
+        return Err(QualificationFailure::new(
+            FailureStage::Postcondition,
+            "counter-invariant-failed",
+            format!(
+                "GPU successes {} != attempts {}",
+                routed.gpu_dispatch_successes, routed.gpu_dispatch_attempts
+            ),
+        ));
+    }
+    checks.all_gpu_attempts_succeeded = true;
+    Ok(())
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct QualificationReport {
+    pub schema_version: &'static str,
+    pub mode: &'static str,
+    pub status: QualificationStatus,
+    pub failure: Option<QualificationFailure>,
+    pub provenance: BuildProvenance,
+    pub artifacts: QualificationArtifacts,
+    pub expert_metadata: Option<ExpertMetadataEvidence>,
+    pub execution_plan: Option<ExecutionPlanEvidence>,
+    pub device: Option<GpuDeviceIdentity>,
+    pub request: RequestEvidence,
+    pub timing: Option<QualificationTiming>,
+    pub routed_experts: Option<RoutedExpertExecutionSnapshot>,
+    pub gpu_io: Option<GpuExpertIoSnapshot>,
+    pub gpu_memory_before: Option<GpuExpertMemorySnapshot>,
+    pub gpu_memory_after: Option<GpuExpertMemorySnapshot>,
+    pub external_gpu_memory_artifact: Option<String>,
+    pub qualification_checks: QualificationChecks,
+}
+
+impl QualificationReport {
+    pub fn new(
+        provenance: BuildProvenance,
+        artifacts: QualificationArtifacts,
+        expert_metadata: Option<ExpertMetadataEvidence>,
+        request: RequestEvidence,
+        external_gpu_memory_artifact: Option<String>,
+    ) -> Self {
+        Self {
+            schema_version: SCHEMA_VERSION,
+            mode: MODE,
+            status: QualificationStatus::Fail,
+            failure: None,
+            provenance,
+            artifacts,
+            expert_metadata,
+            execution_plan: None,
+            device: None,
+            request,
+            timing: None,
+            routed_experts: None,
+            gpu_io: None,
+            gpu_memory_before: None,
+            gpu_memory_after: None,
+            external_gpu_memory_artifact,
+            qualification_checks: QualificationChecks::default(),
+        }
+    }
+
+    pub fn fail(&mut self, failure: QualificationFailure) {
+        self.status = QualificationStatus::Fail;
+        self.failure = Some(failure);
+    }
+
+    pub fn finish(&mut self) -> Result<(), QualificationFailure> {
+        if !self.qualification_checks.passes() {
+            return Err(QualificationFailure::new(
+                FailureStage::Postcondition,
+                "qualification-check-failed",
+                "one or more required qualification checks are false",
+            ));
+        }
+        if self.artifacts.config.is_none()
+            || self.artifacts.tokenizer.is_none()
+            || self.artifacts.expert_metadata.is_none()
+            || self.expert_metadata.is_none()
+            || self.execution_plan.is_none()
+            || self.device.is_none()
+            || self.timing.is_none()
+            || self.routed_experts.is_none()
+            || self.gpu_io.is_none()
+            || self.gpu_memory_before.is_none()
+            || self.gpu_memory_after.is_none()
+        {
+            return Err(QualificationFailure::new(
+                FailureStage::Postcondition,
+                "qualification-evidence-incomplete",
+                "one or more mandatory qualification evidence sections are absent",
+            ));
+        }
+        self.status = QualificationStatus::Pass;
+        self.failure = None;
+        Ok(())
+    }
+}
+
+pub fn canonical_or_configured(path: &Path) -> String {
+    std::fs::canonicalize(path)
+        .unwrap_or_else(|_| PathBuf::from(path))
+        .display()
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn clean_provenance() -> BuildProvenance {
+        BuildProvenance {
+            git_sha: Some("0123456789abcdef0123456789abcdef01234567".to_string()),
+            dirty: Some(false),
+            package_version: "test".to_string(),
+        }
+    }
+
+    fn metadata() -> ExpertMetadataEvidence {
+        ExpertMetadataEvidence {
+            dtype: Some("q4_0".to_string()),
+            q4_0_layout: Some(Q4_0_LAYOUT_STANDARD_V1.to_string()),
+            conversion_mode: Some("full".to_string()),
+            source: None,
+            explicitly_synthetic: false,
+        }
+    }
+
+    fn preflight() -> PreflightEvidence {
+        PreflightEvidence {
+            provenance: clean_provenance(),
+            real_transformer_enabled: true,
+            weights_dir_configured: true,
+            strict_weights: true,
+            allow_seeded_fallback: false,
+            allow_degraded_experts: false,
+            allow_attention_fallback: false,
+            allow_truncated_expert_payloads: false,
+            distributed_enabled: false,
+            gpu_cache_enabled: true,
+            gpu_expert_capacity_bytes: 1,
+            requested_mode: ComputeOffload::Hybrid,
+            routed_expert_dtype: WeightDtype::Q4_0,
+            metadata: metadata(),
+        }
+    }
+
+    fn routed_success() -> RoutedExpertExecutionSnapshot {
+        RoutedExpertExecutionSnapshot {
+            selected_routed_experts: 8,
+            gpu_dispatch_attempts: 8,
+            gpu_dispatch_successes: 8,
+            ..Default::default()
+        }
+    }
+
+    fn exact_plan() -> ExecutionPlanEvidence {
+        ExecutionPlanEvidence {
+            context_id: "17".to_string(),
+            requested: "hybrid".to_string(),
+            resolved: "hybrid-cpu-attention-gpu-experts".to_string(),
+            embeddings: "cpu".to_string(),
+            lm_head: "cpu".to_string(),
+            dense_projections: "cpu".to_string(),
+            attention: "cpu".to_string(),
+            kv: "cpu".to_string(),
+            router: "cpu".to_string(),
+            routed_experts: "gpu".to_string(),
+            routed_expert_dtype: "q4_0".to_string(),
+            fallback_occurred: false,
+            reason: None,
+        }
+    }
+
+    #[test]
+    fn strict_preflight_accepts_exact_contract() {
+        let mut checks = QualificationChecks::default();
+        validate_preflight(&preflight(), &mut checks).unwrap();
+        assert!(checks.clean_build);
+        assert!(checks.strict_real_checkpoint);
+        assert!(checks.requested_hybrid);
+        assert!(checks.native_q4_0_routed_experts);
+        assert!(checks.canonical_q4_layout);
+    }
+
+    #[test]
+    fn exact_hybrid_plan_passes_and_preserves_context_identity() {
+        let plan = exact_plan();
+        let mut checks = QualificationChecks::default();
+        validate_execution_plan_evidence(&plan, &mut checks).unwrap();
+        assert_eq!(plan.context_id, "17");
+        assert!(checks.requested_hybrid);
+        assert!(checks.resolved_planes_match_contract);
+        assert!(checks.native_q4_0_routed_experts);
+    }
+
+    #[test]
+    fn wrong_expert_attention_and_dense_planes_fail() {
+        for field in ["experts", "attention", "dense"] {
+            let mut plan = exact_plan();
+            match field {
+                "experts" => plan.routed_experts = "cpu".to_string(),
+                "attention" => plan.attention = "gpu".to_string(),
+                "dense" => plan.dense_projections = "gpu".to_string(),
+                _ => unreachable!(),
+            }
+            assert_eq!(
+                validate_execution_plan_evidence(&plan, &mut QualificationChecks::default())
+                    .unwrap_err()
+                    .code,
+                "invalid-execution-plan"
+            );
+        }
+    }
+
+    #[test]
+    fn cpu_plan_remains_valid_evidence_but_cannot_qualify() {
+        let mut plan = exact_plan();
+        plan.requested = "cpu".to_string();
+        plan.resolved = "cpu".to_string();
+        plan.routed_experts = "cpu".to_string();
+        assert_eq!(
+            validate_execution_plan_evidence(&plan, &mut QualificationChecks::default())
+                .unwrap_err()
+                .code,
+            "not-hybrid"
+        );
+    }
+
+    #[test]
+    fn requested_mode_rejects_cpu_auto_and_gpu() {
+        for mode in [
+            ComputeOffload::Cpu,
+            ComputeOffload::Auto,
+            ComputeOffload::Gpu,
+        ] {
+            let mut evidence = preflight();
+            evidence.requested_mode = mode;
+            assert_eq!(
+                validate_preflight(&evidence, &mut QualificationChecks::default())
+                    .unwrap_err()
+                    .code,
+                "not-hybrid"
+            );
+        }
+    }
+
+    #[test]
+    fn each_fail_open_checkpoint_policy_is_rejected() {
+        let cases = [
+            ("seeded-fallback-enabled", 0),
+            ("non-strict-weight-policy", 1),
+            ("degraded-experts-enabled", 2),
+            ("attention-fallback-enabled", 3),
+            ("truncated-expert-payloads-enabled", 4),
+        ];
+        for (code, which) in cases {
+            let mut evidence = preflight();
+            match which {
+                0 => evidence.allow_seeded_fallback = true,
+                1 => evidence.strict_weights = false,
+                2 => evidence.allow_degraded_experts = true,
+                3 => evidence.allow_attention_fallback = true,
+                4 => evidence.allow_truncated_expert_payloads = true,
+                _ => unreachable!(),
+            }
+            assert_eq!(
+                validate_preflight(&evidence, &mut QualificationChecks::default())
+                    .unwrap_err()
+                    .code,
+                code
+            );
+        }
+    }
+
+    #[test]
+    fn actual_expert_dtype_allows_only_q4_0() {
+        for dtype in [WeightDtype::F32, WeightDtype::Q8_0, WeightDtype::Q4K] {
+            let mut evidence = preflight();
+            evidence.routed_expert_dtype = dtype;
+            assert_eq!(
+                validate_preflight(&evidence, &mut QualificationChecks::default())
+                    .unwrap_err()
+                    .code,
+                "routed-expert-not-q4-0"
+            );
+        }
+    }
+
+    #[test]
+    fn q4_layout_requires_canonical_marker() {
+        for marker in [None, Some("legacy-adjacent-nibbles".to_string())] {
+            let mut evidence = preflight();
+            evidence.metadata.q4_0_layout = marker;
+            assert_eq!(
+                validate_preflight(&evidence, &mut QualificationChecks::default())
+                    .unwrap_err()
+                    .code,
+                "q4-layout-not-standard"
+            );
+        }
+    }
+
+    #[test]
+    fn explicitly_synthetic_metadata_is_rejected() {
+        let mut evidence = preflight();
+        evidence.metadata.explicitly_synthetic = true;
+        assert_eq!(
+            validate_preflight(&evidence, &mut QualificationChecks::default())
+                .unwrap_err()
+                .code,
+            "synthetic-artifact"
+        );
+    }
+
+    #[test]
+    fn metadata_parser_marks_explicit_synthetic_sources() {
+        let path = std::env::temp_dir().join(format!(
+            "mer-pr5-synthetic-metadata-{}-{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("test")
+        ));
+        std::fs::write(
+            &path,
+            r#"{"dtype":"q4_0","q4_0_layout":"ggml-standard-v1","source":"synthetic generator"}"#,
+        )
+        .unwrap();
+        assert!(read_expert_metadata(&path).unwrap().explicitly_synthetic);
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn device_identity_rejects_absent_software_and_cpu() {
+        let mut checks = QualificationChecks::default();
+        assert_eq!(
+            validate_device(None, &mut checks).unwrap_err().code,
+            "gpu-device-unavailable"
+        );
+        for (name, device_type, software) in [
+            ("llvmpipe", "Cpu", true),
+            ("SwiftShader", "IntegratedGpu", true),
+            ("cpu", "Cpu", false),
+        ] {
+            let identity = GpuDeviceIdentity {
+                name: name.to_string(),
+                vendor_id: 1,
+                device_id: 2,
+                device_type: device_type.to_string(),
+                wgpu_backend: "vulkan".to_string(),
+                driver: "test".to_string(),
+                driver_info: String::new(),
+                compute_plane: "wgpu-vulkan".to_string(),
+                software_adapter: software,
+            };
+            assert_eq!(
+                validate_device(Some(&identity), &mut QualificationChecks::default())
+                    .unwrap_err()
+                    .code,
+                "software-adapter"
+            );
+        }
+    }
+
+    #[test]
+    fn hardware_device_and_strict_failure_policy_pass() {
+        let mut checks = QualificationChecks::default();
+        for device_type in ["DiscreteGpu", "IntegratedGpu"] {
+            let identity = GpuDeviceIdentity {
+                name: "hardware".to_string(),
+                vendor_id: 1,
+                device_id: 2,
+                device_type: device_type.to_string(),
+                wgpu_backend: "vulkan".to_string(),
+                driver: "driver".to_string(),
+                driver_info: "info".to_string(),
+                compute_plane: "wgpu-vulkan".to_string(),
+                software_adapter: false,
+            };
+            validate_device(Some(&identity), &mut checks).unwrap();
+        }
+        validate_gpu_failure_policy(RoutedExpertGpuFailurePolicy::StrictFailClosed, &mut checks)
+            .unwrap();
+        assert!(checks.hardware_gpu_adapter && checks.strict_gpu_failure_policy);
+        assert_eq!(
+            validate_gpu_failure_policy(
+                RoutedExpertGpuFailurePolicy::ServingCpuFallback,
+                &mut QualificationChecks::default()
+            )
+            .unwrap_err()
+            .code,
+            "gpu-failure-policy-not-strict"
+        );
+    }
+
+    #[test]
+    fn routed_counter_success_contract_passes() {
+        let mut checks = QualificationChecks::default();
+        validate_postconditions(1, routed_success(), &mut checks).unwrap();
+        assert!(checks.observed_routed_experts);
+        assert!(checks.all_selected_experts_attempted_on_gpu);
+        assert!(checks.all_gpu_attempts_succeeded);
+    }
+
+    #[test]
+    fn routed_counter_failures_are_typed() {
+        let mut cases = Vec::new();
+        let mut cpu = routed_success();
+        cpu.cpu_routed_expert_dispatches = 1;
+        cases.push((cpu, "routed-cpu-execution-observed"));
+        let mut fallback = routed_success();
+        fallback.gpu_cpu_fallbacks = 1;
+        cases.push((fallback, "gpu-cpu-fallback-observed"));
+        let mut failed = routed_success();
+        failed.gpu_dispatch_failures = 1;
+        cases.push((failed, "routed-gpu-dispatch-failed"));
+        let mut mismatch = routed_success();
+        mismatch.gpu_dispatch_attempts = 7;
+        cases.push((mismatch, "counter-invariant-failed"));
+        let mut no_routes = routed_success();
+        no_routes.selected_routed_experts = 0;
+        no_routes.gpu_dispatch_attempts = 0;
+        no_routes.gpu_dispatch_successes = 0;
+        cases.push((no_routes, "no-routed-experts-observed"));
+        let mut degraded = routed_success();
+        degraded.degraded_expert_substitutions = 1;
+        cases.push((degraded, "degraded-substitution-observed"));
+        for (snapshot, code) in cases {
+            assert_eq!(
+                validate_postconditions(1, snapshot, &mut QualificationChecks::default())
+                    .unwrap_err()
+                    .code,
+                code
+            );
+        }
+        assert_eq!(
+            validate_postconditions(0, routed_success(), &mut QualificationChecks::default())
+                .unwrap_err()
+                .code,
+            "no-generated-tokens"
+        );
+    }
+
+    #[test]
+    fn monotonic_counter_deltas_are_checked() {
+        let before = GpuExpertIoSnapshot {
+            expert_weight_uploads: 2,
+            expert_weight_upload_bytes: 20,
+            hidden_state_uploads: 3,
+            hidden_state_upload_bytes: 30,
+            queue_submissions: 3,
+            map_requests: 3,
+            readback_completions: 3,
+            readback_bytes: 30,
+        };
+        let after = GpuExpertIoSnapshot {
+            expert_weight_uploads: 3,
+            expert_weight_upload_bytes: 24,
+            hidden_state_uploads: 5,
+            hidden_state_upload_bytes: 38,
+            queue_submissions: 5,
+            map_requests: 5,
+            readback_completions: 5,
+            readback_bytes: 38,
+        };
+        let delta = gpu_io_delta(before, after).unwrap();
+        assert_eq!(
+            delta,
+            GpuExpertIoSnapshot {
+                expert_weight_uploads: 1,
+                expert_weight_upload_bytes: 4,
+                hidden_state_uploads: 2,
+                hidden_state_upload_bytes: 8,
+                queue_submissions: 2,
+                map_requests: 2,
+                readback_completions: 2,
+                readback_bytes: 8,
+            }
+        );
+        assert!(gpu_io_delta(after, before).is_err());
+        assert_eq!(
+            routed_execution_delta(RoutedExpertExecutionSnapshot::default(), routed_success())
+                .unwrap(),
+            routed_success()
+        );
+        assert!(
+            routed_execution_delta(routed_success(), RoutedExpertExecutionSnapshot::default())
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn pr4_memory_snapshot_invariants_and_serialization() {
+        let snapshot = GpuExpertMemorySnapshot {
+            logical_admitted_bytes: 7,
+            expert_live_bytes: 10,
+            expert_registry_bytes: 8,
+            workspace_bytes: 5,
+            total_tracked_bytes: 15,
+            expert_capacity_bytes: 20,
+            physical_entries: 1,
+            physical_installs: 2,
+            physical_evictions: 3,
+            stale_retirements: 4,
+        };
+        validate_memory(snapshot).unwrap();
+        let value = serde_json::to_value(snapshot).unwrap();
+        for (field, expected) in [
+            ("logical_admitted_bytes", 7),
+            ("expert_live_bytes", 10),
+            ("expert_registry_bytes", 8),
+            ("workspace_bytes", 5),
+            ("total_tracked_bytes", 15),
+            ("expert_capacity_bytes", 20),
+            ("physical_entries", 1),
+            ("physical_installs", 2),
+            ("physical_evictions", 3),
+            ("stale_retirements", 4),
+        ] {
+            assert_eq!(value[field], expected, "{field}");
+        }
+        let mut bad = snapshot;
+        bad.total_tracked_bytes += 1;
+        assert!(validate_memory(bad).is_err());
+        bad = snapshot;
+        bad.expert_registry_bytes = 11;
+        assert!(validate_memory(bad).is_err());
+        bad = snapshot;
+        bad.expert_capacity_bytes = 7;
+        assert!(validate_memory(bad).is_err());
+    }
+
+    #[test]
+    fn small_artifact_sha256_and_optional_absence_are_exact() {
+        let path = std::env::temp_dir().join(format!(
+            "mer-pr5-sha-{}-{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("test")
+        ));
+        std::fs::write(&path, b"abc").unwrap();
+        let digest = hash_small_file(&path).unwrap();
+        assert_eq!(digest.byte_length, 3);
+        assert_eq!(
+            digest.sha256,
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+        std::fs::remove_file(&path).unwrap();
+        assert_eq!(hash_optional_small_file(Some(&path)).unwrap(), None);
+    }
+
+    #[test]
+    fn qualification_timing_matches_bench_real_decode_semantics() {
+        let timing = QualificationTiming::from_measurement(100, 100, 10, 3.0, 2.0, 5.0);
+        assert_eq!(timing.generated_tokens, 10);
+        assert_eq!(timing.decode_generated_tokens, 9);
+        assert_eq!(timing.decode_tps, 4.5);
+        assert_eq!(timing.real_generated_tps, 4.5);
+        assert_eq!(timing.end_to_end_generated_tps, 2.0);
+    }
+
+    #[test]
+    fn qualification_decode_rate_ignores_prompt_and_total_time() {
+        let short_prompt = QualificationTiming::from_measurement(10, 10, 10, 1.0, 2.0, 3.0);
+        let long_prompt = QualificationTiming::from_measurement(10, 10, 10, 9.0, 2.0, 11.0);
+        assert_eq!(short_prompt.decode_tps, long_prompt.decode_tps);
+        assert_eq!(
+            short_prompt.real_generated_tps,
+            long_prompt.real_generated_tps
+        );
+        assert_ne!(
+            short_prompt.end_to_end_generated_tps,
+            long_prompt.end_to_end_generated_tps
+        );
+    }
+
+    #[test]
+    fn qualification_decode_rate_is_zero_for_no_timed_decode_work() {
+        let one_token = QualificationTiming::from_measurement(10, 10, 1, 1.0, 2.0, 3.0);
+        assert_eq!(one_token.decode_generated_tokens, 0);
+        assert_eq!(one_token.decode_tps, 0.0);
+        assert_eq!(one_token.real_generated_tps, 0.0);
+
+        let zero_duration = QualificationTiming::from_measurement(10, 10, 10, 1.0, 0.0, 1.0);
+        assert_eq!(zero_duration.decode_tps, 0.0);
+        assert_eq!(zero_duration.real_generated_tps, 0.0);
+        assert!(zero_duration.decode_tps.is_finite());
+        assert!(zero_duration.real_generated_tps.is_finite());
+    }
+
+    #[test]
+    fn build_provenance_rejects_dirty_and_unavailable() {
+        let mut evidence = preflight();
+        evidence.provenance.dirty = Some(true);
+        assert_eq!(
+            validate_preflight(&evidence, &mut QualificationChecks::default())
+                .unwrap_err()
+                .code,
+            "dirty-build"
+        );
+        evidence = preflight();
+        evidence.provenance.git_sha = None;
+        assert_eq!(
+            validate_preflight(&evidence, &mut QualificationChecks::default())
+                .unwrap_err()
+                .code,
+            "build-provenance-unavailable"
+        );
+    }
+
+    fn report_with_all_checks() -> QualificationReport {
+        let artifact = ArtifactDigest {
+            configured_path: "artifact".to_string(),
+            canonical_path: "/artifact".to_string(),
+            byte_length: 1,
+            sha256: "00".repeat(32),
+        };
+        let mut report = QualificationReport::new(
+            clean_provenance(),
+            QualificationArtifacts {
+                config: Some(artifact.clone()),
+                tokenizer: Some(artifact.clone()),
+                expert_metadata: Some(artifact),
+                expert_data_directory: "/data".to_string(),
+                ..Default::default()
+            },
+            Some(metadata()),
+            request_evidence("prompt", "hello", 1, 0),
+            None,
+        );
+        report.execution_plan = Some(exact_plan());
+        report.device = Some(GpuDeviceIdentity {
+            name: "hardware".to_string(),
+            vendor_id: 1,
+            device_id: 2,
+            device_type: "DiscreteGpu".to_string(),
+            wgpu_backend: "vulkan".to_string(),
+            driver: "driver".to_string(),
+            driver_info: "info".to_string(),
+            compute_plane: "wgpu-vulkan".to_string(),
+            software_adapter: false,
+        });
+        report.timing = Some(QualificationTiming::from_measurement(
+            1, 1, 1, 1.0, 0.0, 1.0,
+        ));
+        report.routed_experts = Some(routed_success());
+        report.gpu_io = Some(GpuExpertIoSnapshot::default());
+        let memory = GpuExpertMemorySnapshot {
+            expert_capacity_bytes: 1,
+            ..Default::default()
+        };
+        report.gpu_memory_before = Some(memory);
+        report.gpu_memory_after = Some(memory);
+        report.qualification_checks = QualificationChecks {
+            clean_build: true,
+            strict_real_checkpoint: true,
+            requested_hybrid: true,
+            resolved_planes_match_contract: true,
+            native_q4_0_routed_experts: true,
+            canonical_q4_layout: true,
+            hardware_gpu_adapter: true,
+            strict_gpu_failure_policy: true,
+            generated_tokens: true,
+            observed_routed_experts: true,
+            all_selected_experts_attempted_on_gpu: true,
+            all_gpu_attempts_succeeded: true,
+            zero_cpu_routed_expert_execution: true,
+            zero_gpu_cpu_fallbacks: true,
+            zero_degraded_expert_substitutions: true,
+        };
+        report
+    }
+
+    #[test]
+    fn pass_and_failure_reports_have_stable_schema() {
+        let mut pass = report_with_all_checks();
+        pass.finish().unwrap();
+        let value = serde_json::to_value(&pass).unwrap();
+        assert_eq!(value["schema_version"], SCHEMA_VERSION);
+        assert_eq!(value["mode"], MODE);
+        assert_eq!(value["status"], "pass");
+        for section in [
+            "provenance",
+            "artifacts",
+            "expert_metadata",
+            "execution_plan",
+            "device",
+            "request",
+            "timing",
+            "routed_experts",
+            "gpu_io",
+            "qualification_checks",
+            "gpu_memory_before",
+            "gpu_memory_after",
+            "external_gpu_memory_artifact",
+        ] {
+            assert!(value.get(section).is_some(), "missing section {section}");
+        }
+
+        let mut incomplete = report_with_all_checks();
+        incomplete.gpu_io = None;
+        assert_eq!(
+            incomplete.finish().unwrap_err().code,
+            "qualification-evidence-incomplete"
+        );
+
+        let mut fail = report_with_all_checks();
+        fail.fail(QualificationFailure::new(
+            FailureStage::Startup,
+            "gpu-device-unavailable",
+            "missing",
+        ));
+        let value = serde_json::to_value(&fail).unwrap();
+        assert_eq!(value["status"], "fail");
+        assert_eq!(value["failure"]["stage"], "startup");
+        assert_eq!(value["failure"]["code"], "gpu-device-unavailable");
+        assert_eq!(value["failure"]["detail"], "missing");
+    }
+}

--- a/rust-engine/src/qualification.rs
+++ b/rust-engine/src/qualification.rs
@@ -97,7 +97,7 @@ pub struct ArtifactDigest {
 
 pub fn hash_small_file(path: &Path) -> io::Result<ArtifactDigest> {
     let mut file = File::open(path)?;
-    let byte_length = file.metadata()?.len();
+    let mut byte_length = 0u64;
     let mut hasher = Sha256::new();
     let mut buffer = [0u8; 64 * 1024];
     loop {
@@ -105,6 +105,18 @@ pub fn hash_small_file(path: &Path) -> io::Result<ArtifactDigest> {
         if read == 0 {
             break;
         }
+        let read_u64 = u64::try_from(read).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "artifact read length cannot be represented as u64",
+            )
+        })?;
+        byte_length = byte_length.checked_add(read_u64).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "artifact byte length overflowed u64",
+            )
+        })?;
         hasher.update(&buffer[..read]);
     }
     Ok(ArtifactDigest {
@@ -116,9 +128,7 @@ pub fn hash_small_file(path: &Path) -> io::Result<ArtifactDigest> {
 }
 
 pub fn hash_optional_small_file(path: Option<&Path>) -> io::Result<Option<ArtifactDigest>> {
-    path.filter(|path| path.is_file())
-        .map(hash_small_file)
-        .transpose()
+    path.map(hash_small_file).transpose()
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
@@ -312,6 +322,7 @@ pub struct QualificationChecks {
     pub canonical_q4_layout: bool,
     pub hardware_gpu_adapter: bool,
     pub strict_gpu_failure_policy: bool,
+    pub observed_routed_gpu_io: bool,
     pub generated_tokens: bool,
     pub observed_routed_experts: bool,
     pub all_selected_experts_attempted_on_gpu: bool,
@@ -331,6 +342,7 @@ impl QualificationChecks {
             && self.canonical_q4_layout
             && self.hardware_gpu_adapter
             && self.strict_gpu_failure_policy
+            && self.observed_routed_gpu_io
             && self.generated_tokens
             && self.observed_routed_experts
             && self.all_selected_experts_attempted_on_gpu
@@ -694,6 +706,26 @@ pub fn validate_memory(snapshot: GpuExpertMemorySnapshot) -> Result<(), Qualific
             format!("invalid PR4 physical memory snapshot: {snapshot:?}"),
         ));
     }
+    Ok(())
+}
+
+pub fn validate_gpu_io(
+    io: GpuExpertIoSnapshot,
+    checks: &mut QualificationChecks,
+) -> Result<(), QualificationFailure> {
+    if io.hidden_state_uploads == 0
+        || io.queue_submissions == 0
+        || io.map_requests == 0
+        || io.readback_completions == 0
+        || io.readback_bytes == 0
+    {
+        return Err(QualificationFailure::new(
+            FailureStage::Postcondition,
+            "no-routed-gpu-io-observed",
+            format!("measured request did not complete routed GPU I/O: {io:?}"),
+        ));
+    }
+    checks.observed_routed_gpu_io = true;
     Ok(())
 }
 
@@ -1262,6 +1294,59 @@ mod tests {
     }
 
     #[test]
+    fn routed_gpu_io_requires_completed_dispatch_evidence() {
+        let io = GpuExpertIoSnapshot {
+            // A warmed physical resident need not upload its weights again.
+            expert_weight_uploads: 0,
+            expert_weight_upload_bytes: 0,
+            hidden_state_uploads: 1,
+            hidden_state_upload_bytes: 8,
+            queue_submissions: 1,
+            map_requests: 1,
+            readback_completions: 1,
+            readback_bytes: 8,
+        };
+        let mut checks = QualificationChecks::default();
+        validate_gpu_io(io, &mut checks).unwrap();
+        assert!(checks.observed_routed_gpu_io);
+    }
+
+    #[test]
+    fn missing_routed_gpu_io_is_a_typed_postcondition_failure() {
+        let complete = GpuExpertIoSnapshot {
+            expert_weight_uploads: 0,
+            expert_weight_upload_bytes: 0,
+            hidden_state_uploads: 1,
+            hidden_state_upload_bytes: 8,
+            queue_submissions: 1,
+            map_requests: 1,
+            readback_completions: 1,
+            readback_bytes: 8,
+        };
+        for missing in [
+            "hidden_state_uploads",
+            "queue_submissions",
+            "map_requests",
+            "readback_completions",
+            "readback_bytes",
+        ] {
+            let mut io = complete;
+            match missing {
+                "hidden_state_uploads" => io.hidden_state_uploads = 0,
+                "queue_submissions" => io.queue_submissions = 0,
+                "map_requests" => io.map_requests = 0,
+                "readback_completions" => io.readback_completions = 0,
+                "readback_bytes" => io.readback_bytes = 0,
+                _ => unreachable!(),
+            }
+            let failure =
+                validate_gpu_io(io, &mut QualificationChecks::default()).unwrap_err();
+            assert_eq!(failure.stage, FailureStage::Postcondition, "{missing}");
+            assert_eq!(failure.code, "no-routed-gpu-io-observed", "{missing}");
+        }
+    }
+
+    #[test]
     fn pr4_memory_snapshot_invariants_and_serialization() {
         let snapshot = GpuExpertMemorySnapshot {
             logical_admitted_bytes: 7,
@@ -1317,7 +1402,8 @@ mod tests {
             "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
         );
         std::fs::remove_file(&path).unwrap();
-        assert_eq!(hash_optional_small_file(Some(&path)).unwrap(), None);
+        assert!(hash_optional_small_file(Some(&path)).is_err());
+        assert_eq!(hash_optional_small_file(None).unwrap(), None);
     }
 
     #[test]
@@ -1415,7 +1501,15 @@ mod tests {
             1, 1, 1, 1.0, 0.0, 1.0,
         ));
         report.routed_experts = Some(routed_success());
-        report.gpu_io = Some(GpuExpertIoSnapshot::default());
+        report.gpu_io = Some(GpuExpertIoSnapshot {
+            hidden_state_uploads: 1,
+            hidden_state_upload_bytes: 1,
+            queue_submissions: 1,
+            map_requests: 1,
+            readback_completions: 1,
+            readback_bytes: 1,
+            ..Default::default()
+        });
         let memory = GpuExpertMemorySnapshot {
             expert_capacity_bytes: 1,
             ..Default::default()
@@ -1431,6 +1525,7 @@ mod tests {
             canonical_q4_layout: true,
             hardware_gpu_adapter: true,
             strict_gpu_failure_policy: true,
+            observed_routed_gpu_io: true,
             generated_tokens: true,
             observed_routed_experts: true,
             all_selected_experts_attempted_on_gpu: true,


### PR DESCRIPTION
## Summary

Adds PR5 of the MER Hybrid Q4 critical path: a separate strict
real-autoregressive qualification command that proves execution integrity
without changing the existing CPU `bench-real` contract.

New command:

`qualify-hybrid-q4`

Qualification schema:

`mer.strict-hybrid-q4.v1`

This PR does not optimize performance. It establishes auditable evidence for
later PR6 target-hardware qualification.

## Qualification contract

A PASS requires:

- known clean full Git build provenance
- strict complete real checkpoint
- no seeded/degraded/non-finite/truncated-payload fail-open policy
- explicitly requested Hybrid mode
- CPU embeddings / LM head
- CPU dense projections
- CPU attention
- CPU KV
- CPU router
- GPU routed experts
- native Q4_0 routed-expert runtime dtype
- canonical `ggml-standard-v1` Q4_0 layout
- non-software authoritative GPU adapter
- `StrictFailClosed` routed-expert GPU policy
- at least one real routed expert observed
- every selected routed expert attempted on GPU
- every GPU attempt successful
- zero CPU routed-expert execution
- zero GPU→CPU fallback
- zero degraded expert substitution
- at least one generated completion token
- complete required qualification evidence

Any violation produces a typed FAIL report and non-zero process result.

## Existing bench-real compatibility

`bench-real` remains the existing CPU real-transformer benchmark.

Its CLI, CPU-only validation, defaults, output schema, timing semantics,
cache-reset behavior, greedy behavior, and startup semantics are unchanged.

Strict Hybrid qualification is a separate command.

## Execution evidence

Adds production monotonic routed-expert counters for the real `moe_step` path:

- selected routed experts
- GPU dispatch attempts
- GPU dispatch successes
- GPU dispatch failures
- CPU routed-expert dispatches
- existing GPU→CPU fallbacks
- existing degraded expert substitutions

Synthetic `Engine::generate` traffic is excluded.

## Logical GPU demand and hot promotion

- Real GPU-routed foreground demand may synchronously enter the logical LRU
  Edge before physical GPU dispatch.
- Demand admission never consumes Anchor Core; dynamic LRU entries may be
  evicted to make room for foreground demand.
- Threshold-hot LRU entries can subsequently graduate atomically to Anchor
  Core.
- LRU→Anchor graduation preserves the exact `GpuAdmission` generation and
  `Arc<GpuResident>`.
- Tier movement is logical only and causes no physical GPU upload or
  allocation.
- Demand/background races preserve the current generation and do not
  double-count promotion telemetry.
- `ServingCpuFallback` and `StrictFailClosed` retain their separate GPU-failure
  policies.

## Authoritative device evidence

Reports identity from the GPU backend already owned by the authoritative
`ExecutionContext`:

- adapter name
- vendor ID
- device ID
- device type
- wgpu backend
- driver
- driver info
- compute plane
- software-adapter classification

No second adapter is discovered for reporting.

## GPU I/O evidence

Adds routed-expert GPU counters for actual operations:

- physical expert-weight uploads / bytes
- hidden-state uploads / bytes
- queue submissions
- map requests
- completed readbacks / bytes

These counters describe actual backend actions and do not claim synchronous
wgpu validation semantics.

## GPU memory evidence

Reuses PR4's existing `GpuExpertMemorySnapshot` as the sole internal physical
memory ledger.

The report captures snapshots immediately before and after the measured
request.

Internal bytes cover MER-owned routed-expert buffers and fixed routed-expert
workspaces only; they are not total device/driver VRAM.

External GPU-memory evidence remains an opaque optional reference for PR6.
No NVML or `nvidia-smi` integration is included.

## Provenance and artifacts

Adds build-time:

- full Git SHA
- tracked-source dirty state
- package version

Adds SHA-256 identity for small available artifacts:

- qualification config
- tokenizer
- expert metadata
- packed manifest when configured
- checkpoint config.json when present

Large dense/expert directories and packed expert blobs are identified by path
but are intentionally not recursively hashed.

Synthetic expert metadata is rejected.

## Throughput semantics

`decode_tps` and `real_generated_tps` use the existing bench-real steady decode
definition:

`generated_tokens.saturating_sub(1) / decode_seconds`

The first generated token is excluded because it precedes the decode timer.

`end_to_end_generated_tps` is reported separately as:

`generated_tokens / total_seconds`

PASS does not require 10 TPS. PR5 qualifies execution integrity, not product
performance.

## Validation

- promotion / pending / rearm focused tests: 7 passed
- demand-admission focused tests: 20 passed
- strict GPU regressions: 7 passed
- serving exact-once fallback regression: 1 passed
- PR4 physical-registry focused tests: 4 passed
- generation regressions: 11 passed
- capacity regressions: 5 passed
- strict qualification tests: 28 passed
- bench-real regressions: 12 passed
- full cargo test: passed, 0 failed, 2 ignored
- cargo clippy --all-targets: passed with existing repository warnings
- git diff --check: passed
- worktree clean

No live GPU/L4 qualification has yet been claimed. No performance claim has
been made.

## Review status

- initial CodeRabbit review: 4 actionable findings, all addressed in `099c41b`
- independent review found and fixed the foreground-demand cold-residency gap
- independent cache-policy audit found and fixed the LRU→Anchor graduation /
  promotion-accounting interaction
- final head: `b107a8db6a1017584a7a1ac44b009cfe3e5dc7fd`
- CodeRabbit final incremental review: no actionable findings
- 2 nonblocking CodeRabbit nitpicks remain:
  - possible future extraction of duplicated LRU eviction helper
  - optional extra unit coverage for hot-promotion `NoCapacity` and
    `GenerationExhausted` outcomes
- neither nitpick changes the merge decision

## Out of scope

No:

- live GPU/L4 qualification
- NVML/nvidia-smi collection
- Vulkan provisioning
- kernel math
- top-k/layer batching
- PR7 device API
- CUDA redesign
- dense/attention/KV GPU migration
- physical GPU residency-policy redesign beyond the existing PR4 registry
- asynchronous demand-upload scheduler redesign
- predictor/prefetch redesign
- new quantization formats
- 10 TPS qualification threshold
- performance claim

PR6 remains responsible for live target-hardware diagnostic qualification.
PR7 remains responsible for layer/top-k batching and subsequent profiling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `qualify-hybrid-q4` command for strict, fail-closed hybrid GPU qualification using real model checkpoints.
  * Qualification now validates hardware, execution behavior, memory usage, GPU activity, generated output, and required postconditions.
  * Added structured JSON pass/fail reports with artifact hashes, timing, build provenance, and failure evidence.
  * Added telemetry for GPU identity, routed-expert execution, transfers, submissions, and readbacks.
  * Improved GPU expert admission, caching, promotion, and fallback behavior.
  * Unified request and prompt handling across benchmarking and qualification commands.

* **Documentation**
  * Documented qualification usage, supported options, measurements, throughput, memory accounting, and evidence artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
