### PR TITLE
feat: add strict Q4 numerical parity qualification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1985,7 +1985,9 @@ checkpoint expert and compares MER's authoritative CPU Q4_0 forward result with
 the existing production routed-expert GPU path. `--expert-id` is a required
 global expert ID in `0..num_layers*num_experts_per_layer`; the report also
 records its derived layer and layer-local ID. It is never wrapped or
-reinterpreted.
+reinterpreted. The current raw matrix contains eight cases, including a direct
+two-row dispatch with distinct row blocks and a nonzero, byte-unaligned Q4_0
+block offset.
 
 ```bash
 ./target/release/micro-expert-router qualify-hybrid-q4-parity \
@@ -2001,6 +2003,13 @@ tolerances and compares `f16(CPU f32)` against the returned GPU f16 value. Both
 apply `abs_error <= absolute + relative * abs(reference)`; any nonfinite result
 fails immediately. The report preserves the original CPU f32, rounded CPU f16,
 GPU f16, per-element errors, allowed errors, and worst index.
+
+In schema `mer.strict-hybrid-q4-parity.v1`, a relative error whose reference is
+zero and absolute error is nonzero is encoded as finite `f32::MAX`; it means
+“relative error undefined because reference is zero.” PASS does not compare
+that sentinel to the relative threshold. It continues to use the documented
+combined allowance, which reduces to the absolute tolerance at a zero
+reference.
 
 PASS additionally requires a clean-provenance release build, strict Hybrid
 component planes, canonical metadata, exact checkpoint payload size, an exact
@@ -2019,6 +2028,14 @@ the slot to have exactly the converter-defined aligned size and every alignment
 byte to be zero. It reports hashes and lengths for both forms; physical
 residency and upload evidence uses the kernel's separately checked 4-byte-padded
 VRAM length.
+
+This strict command also requires a positive
+`performance.progress_timeout_secs` (or `--progress-timeout-secs`). That value
+bounds raw qualification readback with nonblocking WGPU polling and a deadline.
+The complete-expert half intentionally calls the unchanged production
+routed-expert path; its synchronous production readback is not made
+preemptible by this qualification-only deadline. A separately scoped serving
+change would be required to bound that shared production wait safely.
 
 Increase log verbosity:
 

--- a/README.md
+++ b/README.md
@@ -1989,6 +1989,15 @@ reinterpreted. The current raw matrix contains eight cases, including a direct
 two-row dispatch with distinct row blocks and a nonzero, byte-unaligned Q4_0
 block offset.
 
+The authoritative hardened NVIDIA L4 run at commit
+`08c05ff1079b7676623642d354d13c15994af1ea` passed all eight raw cases, all
+three complete-expert vectors, and all 18 fail-closed checks. Its typed report
+is `pr6-q4-parity-08c05ff.json`, SHA-256
+`f50e0915288de6eb0847ea77a0f3685e91966aa54d178c8d8d6ebb63b9326beb`.
+See the [PR6 Q4_0 numerical-parity evidence](docs/benchmarks/qwen3-coder-30b-a3b-pr6-q4-parity-2026-08-11.md)
+for the exact device, execution-plan, residency, and validation record. This is
+numerical-correctness evidence, not a model-quality or performance claim.
+
 ```bash
 ./target/release/micro-expert-router qualify-hybrid-q4-parity \
   --config ./path/to/strict-hybrid-q4.toml \

--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ historical baseline.
 
 | Document | What it contains |
 |---|---|
+| [`docs/benchmarks/qwen3-coder-30b-a3b-pr6-q4-parity-2026-08-11.md`](docs/benchmarks/qwen3-coder-30b-a3b-pr6-q4-parity-2026-08-11.md) | NVIDIA L4 numerical qualification for canonical raw Q4_0 WGSL cases, one complete checkpoint expert, and physical-residency reuse; not a model-quality or TPS claim. |
 | [`docs/benchmarks/qwen3-coder-30b-a3b-q8-cpu-2026-07-11.md`](docs/benchmarks/qwen3-coder-30b-a3b-q8-cpu-2026-07-11.md) | Strict CPU-only `bench-real` validation for one Qwen3-Coder 30B-A3B Q8_0 checkpoint, with generated tokens/s and cache-capacity caveats. |
 | [`docs/benchmarks/mixtral-8x7b-rayon-autotune-2026-07.md`](docs/benchmarks/mixtral-8x7b-rayon-autotune-2026-07.md) | July 2026 observed VM validation for Rayon/autotune, including fast/slow compute-regime caveats. |
 | [`docs/benchmarks/mixtral-8x7b-cpu-cache-scaling-2026-06-27.md`](docs/benchmarks/mixtral-8x7b-cpu-cache-scaling-2026-06-27.md) | Historical full cache-scaling suite for Mixtral Q4_0 on GCP local NVMe. |

--- a/README.md
+++ b/README.md
@@ -1975,6 +1975,50 @@ device memory. `--external-gpu-memory-artifact <STRING>` stores an opaque
 reference to separately collected PR6 evidence; this command does not invoke
 NVML or `nvidia-smi`.
 
+#### Strict Hybrid Q4_0 numerical parity
+
+`qualify-hybrid-q4-parity` is a separate fail-closed numerical qualification.
+It first compares deterministic, literal `ggml-standard-v1` Q4_0 blocks against
+the existing `matmul_q4_0.wgsl` pipeline, then fetches one complete converted
+checkpoint expert and compares MER's authoritative CPU Q4_0 forward result with
+the existing production routed-expert GPU path. `--expert-id` is a required
+global expert ID in `0..num_layers*num_experts_per_layer`; the report also
+records its derived layer and layer-local ID. It is never wrapped or
+reinterpreted.
+
+```bash
+./target/release/micro-expert-router qualify-hybrid-q4-parity \
+  --config ./path/to/strict-hybrid-q4.toml \
+  --expert-id 257 \
+  --expected-adapter-name "NVIDIA L4" \
+  --report-out q4-parity.json
+```
+
+The raw comparison uses fixed absolute `1e-5` and relative `1e-4` tolerances.
+The complete-expert comparison uses fixed absolute `2e-3` and relative `5e-3`
+tolerances and compares `f16(CPU f32)` against the returned GPU f16 value. Both
+apply `abs_error <= absolute + relative * abs(reference)`; any nonfinite result
+fails immediately. The report preserves the original CPU f32, rounded CPU f16,
+GPU f16, per-element errors, allowed errors, and worst index.
+
+PASS additionally requires a clean-provenance release build, strict Hybrid
+component planes, canonical metadata, exact checkpoint payload size, an exact
+hardware adapter-name match, and strict fail-closed GPU policy. Per-vector
+before/after evidence must show one initial physical install, stable generation
+and physical reuse thereafter, no repeated expert-weight upload, complete GPU
+I/O/readback, a valid PR4 capacity ledger, and no eviction, stale retirement,
+CPU execution, fallback, degraded substitution, or dispatch failure. Raw WGSL
+buffers are ephemeral and must leave production expert residency and I/O state
+unchanged. This is numerical correctness evidence, not a batching or throughput
+claim.
+
+The complete-expert section distinguishes canonical, unpadded Q4_0 weight bytes
+from the header-stripped, block-aligned checkpoint payload slot. PASS requires
+the slot to have exactly the converter-defined aligned size and every alignment
+byte to be zero. It reports hashes and lengths for both forms; physical
+residency and upload evidence uses the kernel's separately checked 4-byte-padded
+VRAM length.
+
 Increase log verbosity:
 
 ```bash
@@ -2377,6 +2421,13 @@ micro-expert-router qualify-hybrid-q4
   --report-out <PATH>        Write typed JSON there (default: stdout).
   --external-gpu-memory-artifact <STRING>
                               Opaque reference to separate external evidence.
+
+micro-expert-router qualify-hybrid-q4-parity
+  --config <PATH>            Strict Hybrid native-Q4_0 TOML config.
+  --expert-id <ID>           Required global expert ID (never layer-local).
+  --expected-adapter-name <NAME>
+                              Required exact authoritative wgpu adapter name.
+  --report-out <PATH>        Write typed JSON there (default: stdout).
 
 micro-expert-router monitor          # requires `--features tui` (on by default)
   --url <URL>                Base URL of a running `serve` instance

--- a/docs/benchmarks/qwen3-coder-30b-a3b-pr6-q4-parity-2026-08-11.md
+++ b/docs/benchmarks/qwen3-coder-30b-a3b-pr6-q4-parity-2026-08-11.md
@@ -1,0 +1,322 @@
+# Qwen3-Coder 30B-A3B PR6 Q4_0 numerical parity, 2026-08-11
+
+## 1. Result and scope
+
+MER's strict Hybrid Q4_0 numerical qualification passed on a hardware NVIDIA
+L4 through WGPU/Vulkan. The authoritative report used schema
+`mer.strict-hybrid-q4-parity.v1`, returned `status=pass` with `failure=null`,
+and exited with code 0. All 18 required PASS checks were true.
+
+This is three distinct kinds of evidence:
+
+1. **Raw WGSL block parity:** seven deterministic canonical
+   `ggml-standard-v1` Q4_0 fixtures compared MER's authoritative CPU decoder
+   with the existing WGSL Q4_0 matmul pipeline.
+2. **Complete checkpoint-expert parity:** three deterministic hidden vectors
+   ran through global expert 0 using the authoritative CPU Q4_0 expert forward
+   and the production GPU routed-expert path.
+3. **Execution and residency evidence:** per-vector snapshots proved one
+   physical install, stable generation reuse, complete GPU I/O, and no CPU
+   execution, fallback, degraded substitution, eviction, or stale retirement.
+
+The result qualifies numerical correctness for this command, commit, adapter,
+expert, and checkpoint artifact. It is not a model-quality evaluation, does
+not validate generated-token quality, and makes no throughput or production
+TPS claim. PR7 batching has not started.
+
+## 2. Provenance and environment
+
+| Field | Qualified value |
+|---|---|
+| MER commit | `dac1d213cf641ba79a48e74c24f80bc2eca66548` |
+| Git worktree | clean (`dirty=false`) |
+| Report schema | `mer.strict-hybrid-q4-parity.v1` |
+| Report status | `pass` |
+| Failure | `null` |
+| Cloud VM | GCP `g2-standard-32` |
+| Adapter | `NVIDIA L4` |
+| Vendor/device | `0x10de` / `0x27b8` |
+| Device type | discrete GPU |
+| NVIDIA driver | `580.173.02` |
+| WGPU backend | Vulkan |
+| Compute plane | `wgpu-vulkan` |
+| Software adapter | `false` |
+
+The exact adapter-name gate required `NVIDIA L4`; a missing GPU, software
+adapter, different adapter name, incompatible layout, malformed geometry,
+dispatch failure, nonfinite result, or tolerance failure would have produced a
+failed report and nonzero command exit.
+
+## 3. Execution contract
+
+| Component | Requested/resolved placement |
+|---|---|
+| Requested plan | `hybrid` |
+| Resolved plan | `hybrid-cpu-attention-gpu-experts` |
+| Embeddings | CPU |
+| LM head | CPU |
+| Dense projections | CPU |
+| Attention | CPU |
+| KV | CPU |
+| Router | CPU |
+| Routed experts | GPU |
+| Routed-expert dtype | `q4_0` |
+| Fallback occurred | `false` |
+| GPU failure policy | strict fail-closed |
+
+The selected global expert ID was 0. For the checkpoint's 48 layers and 128
+experts per layer, the global namespace is `48 * 128 = 6144` experts and the
+identity mapping was:
+
+| Identity | Value |
+|---|---:|
+| Global expert ID | 0 |
+| Layer index (`global / 128`) | 0 |
+| Layer-local expert ID (`global % 128`) | 0 |
+
+The expert geometry was `d_model=2048` and `d_ff=768`. The canonical Q4_0
+payload, aligned checkpoint slot, and physical device allocation were each
+2,654,208 bytes; this particular expert required zero alignment padding. The
+payload SHA-256 was
+`705583308419366429619a8840cf5997e2b1523f97b59405d32771ceacdd4948`.
+
+## 4. Fixed comparison contract
+
+The tolerances are schema constants, not values fitted to this run:
+
+| Comparison | Absolute | Relative | Reference | Formula |
+|---|---:|---:|---|---|
+| Raw Q4_0 shader | `1e-5` | `1e-4` | authoritative CPU f32 | `abs_error <= absolute + relative * abs(cpu_reference)` |
+| Complete expert | `2e-3` | `5e-3` | authoritative CPU f32 rounded to f16 | `abs_error <= absolute + relative * abs(cpu_f16_reference)` |
+
+At the complete-expert production boundary, the primary comparison is the
+authoritative CPU result rounded to f16 versus the GPU-returned f16. The typed
+report also retains the original CPU f32 output, rounded CPU f16 output, GPU
+f16 output, per-element absolute and relative errors, allowed error, and the
+worst comparison index. Any nonfinite CPU or GPU value fails before tolerance
+evaluation.
+
+## 5. Raw WGSL block parity
+
+All seven canonical cases passed with exactly zero observed absolute error and
+zero observed relative error:
+
+| Case | Projection | Columns | `w_block_off` | Byte offset | Unaligned 18-byte start | Max abs | Max rel | Result |
+|---|---|---:|---:|---:|---|---:|---:|---|
+| `zero-scale-extrema` | standalone | 32 | 0 | 0 | no | 0 | 0 | PASS |
+| `positive-scale-extrema` | standalone | 32 | 0 | 0 | no | 0 | 0 | PASS |
+| `negative-scale-sign` | standalone | 32 | 0 | 0 | no | 0 | 0 | PASS |
+| `multiple-blocks-nontrivial-hidden` | standalone | 64 | 0 | 0 | no | 0 | 0 | PASS |
+| `gate-projection-offset-zero` | gate | 32 | 0 | 0 | no | 0 | 0 | PASS |
+| `up-projection-offset-one-unaligned` | up | 32 | 1 | 18 | yes | 0 | 0 | PASS |
+| `down-projection-offset-two` | down | 32 | 2 | 36 | no | 0 | 0 | PASS |
+
+The fixtures cover zero scale, positive and negative scale/sign behavior,
+extremal nibbles, multiple blocks, nontrivial hidden vectors, all three expert
+projection offsets, nonzero block offsets, and the unaligned 18-byte Q4_0
+boundary. The raw dispatch used ephemeral qualification buffers. Before and
+after raw dispatch, production expert residency and all production GPU-I/O
+counters remained zero, so the raw phase could not pre-populate the complete
+expert.
+
+## 6. Complete checkpoint-expert parity
+
+Three deterministic vectors passed against the extracted complete checkpoint
+expert:
+
+| Vector | Max absolute error | Max relative error | Expert upload | Hidden upload | Submit | Map | Completed readback |
+|---:|---:|---:|---:|---:|---:|---:|---:|
+| 0 | `7.6293945e-06` | `0.0009451796` | 1 / 2,654,208 B | 1 / 8,192 B | 1 | 1 | 1 / 8,192 B |
+| 1 | `9.536743e-07` | `0.0010615712` | 0 / 0 B | 1 / 8,192 B | 1 | 1 | 1 / 8,192 B |
+| 2 | `0` | `0` | 0 / 0 B | 1 / 8,192 B | 1 | 1 | 1 / 8,192 B |
+
+The worst absolute error across all vectors was `7.6293945e-06`; the worst
+reported relative error was `0.0010615712`. Both are observations, not changed
+tolerances. Every vector recorded one GPU dispatch attempt and success, with
+zero dispatch failures, CPU routed-expert dispatches, GPU-to-CPU fallbacks, and
+degraded substitutions.
+
+## 7. Physical residency and capacity evidence
+
+The first vector began with no logical admission and no physical registry
+entry. It installed expert 0 exactly once at generation 1 and uploaded exactly
+2,654,208 expert-weight bytes. Vectors 1 and 2 began and ended with the same
+generation-1 logical admission and the same physical entry, and each added
+zero expert-weight uploads and zero expert-weight upload bytes.
+
+After installation, the capacity ledger remained stable:
+
+| Ledger/counter | Observed value |
+|---|---:|
+| Logical admitted bytes | 2,654,208 |
+| Physical live bytes | 2,654,208 |
+| Physical registry bytes | 2,654,208 |
+| Routed-expert workspace bytes | 1,310,720 |
+| Total tracked bytes | 3,964,928 |
+| Expert capacity bytes | 12,884,901,888 |
+| Physical entries | 1 |
+| Physical installs | 1 |
+| Physical evictions | 0 |
+| Stale retirements | 0 |
+
+Every vector also recorded one 8,192-byte hidden-state upload, one queue
+submission, one map request, and one completed 8,192-byte readback. The
+per-vector snapshots were continuous: each vector's `before` snapshot equaled
+the preceding vector's `after` snapshot.
+
+## 8. PASS contract
+
+All 18 independently derived checks were true:
+
+| Required check | Observed |
+|---|---|
+| `clean_build` | true |
+| `strict_hybrid_preflight` | true |
+| `canonical_q4_0_layout` | true |
+| `exact_execution_plan` | true |
+| `hardware_gpu_adapter` | true |
+| `expected_adapter_exact_match` | true |
+| `strict_gpu_failure_policy` | true |
+| `global_expert_identity_valid` | true |
+| `exact_expert_payload_size` | true |
+| `raw_shader_cases_passed` | true |
+| `raw_dispatch_isolated_from_expert_registry` | true |
+| `initial_physical_install_exactly_once` | true |
+| `subsequent_dispatches_reused_generation` | true |
+| `subsequent_dispatches_uploaded_zero_weight_bytes` | true |
+| `every_dispatch_completed_gpu_io` | true |
+| `zero_evictions_or_stale_retirements` | true |
+| `zero_cpu_fallback_or_degraded_execution` | true |
+| `complete_expert_vectors_passed` | true |
+
+The successful process exit and a separate typed `jq -e` validation both
+confirmed the fail-closed PASS contract.
+
+## 9. Qualified artifact and checksums
+
+The exact qualification artifact is published at
+[Amalgafy/Qwen3-Coder-30B-A3B-Instruct-MER-Q4-0](https://huggingface.co/Amalgafy/Qwen3-Coder-30B-A3B-Instruct-MER-Q4-0).
+
+| Artifact | SHA-256 |
+|---|---|
+| MER archive `qwen3-coder-30b-a3b-mer-q4_0-v1.tar.zst` | `659b8d31d0a83292c632aa109c8edb5301f4041b1a60ef43c6f23ec0404061fe` |
+| Pure Q4_0 GGUF `Qwen3-Coder-30B-A3B-Instruct-pure-Q4_0.gguf` | `8ddf61cadd354a5095905cc5ce535c44b777d0313ac241abcd2ceafa3362551b` |
+| Typed report `pr6-q4-parity.json` | `1d579a9e7ebc93191544ff162027e840dfbbd55ae7cc85e81021bb6e85784c60` |
+
+This is the current PR6 qualification artifact. Its pure Q4_0 GGUF was
+requantized from an already quantized GGUF using llama.cpp
+`--allow-requantize --pure`, so quantization error may compound. This
+numerical parity run proves MER CPU/GPU agreement on those canonical Q4_0
+bytes; it does not evaluate the artifact's model quality. A future
+release-grade Amalgafy artifact derived directly from BF16/FP16 source weights
+must be identified and qualified separately rather than treated as equivalent
+to this requantized artifact.
+
+## 10. Software validation
+
+The qualified implementation had the following pre-publication validation:
+
+| Command | Result |
+|---|---|
+| `cargo test q4_parity` | 14 passed |
+| `cargo test q4_0_shader_logic_tests` | 4 passed |
+| `cargo test qualification` | 28 passed |
+| `cargo test strict` | 40 passed |
+| `cargo test` | 925 passed, 0 failed, 2 ignored |
+| `cargo clippy --all-targets` | passed with existing warnings |
+| `git diff --check` | passed |
+| Linux release build with `avx512,blas,tokenizer,io_uring` | passed |
+
+The first commit on the branch is a separate test-only fix that gives server
+tests unique atomic temporary-directory sequences. It changes no production
+server behavior. The second commit adds the strict parity command and its
+qualification-only seams while preserving the existing `qualify-hybrid-q4`
+command and serving fallback behavior.
+
+## 11. Reproduction
+
+Start from the exact qualified commit and require a clean checkout:
+
+```bash
+git fetch origin feat/pr6-q4-numerical-correctness
+git switch --detach dac1d213cf641ba79a48e74c24f80bc2eca66548
+test "$(git rev-parse HEAD)" = \
+  dac1d213cf641ba79a48e74c24f80bc2eca66548
+test -z "$(git status --porcelain)"
+
+cd rust-engine
+cargo build --release \
+  --features "avx512,blas,tokenizer,io_uring"
+
+./target/release/micro-expert-router qualify-hybrid-q4-parity \
+  --config "$HOME/mer-pr6/qwen3-coder-strict-hybrid-q4.toml" \
+  --expert-id 0 \
+  --expected-adapter-name "NVIDIA L4" \
+  --report-out "$HOME/mer-pr6/pr6-q4-parity.json"
+```
+
+The config must select strict Hybrid execution and the canonical converted
+checkpoint represented by the checksums above. The command intentionally
+requires the global expert ID and exact adapter name; it does not silently
+select or wrap either value.
+
+Validate the typed report:
+
+```bash
+REPORT="$HOME/mer-pr6/pr6-q4-parity.json"
+
+jq -e '
+  .schema_version == "mer.strict-hybrid-q4-parity.v1" and
+  .status == "pass" and
+  .failure == null and
+  .provenance.git_sha ==
+    "dac1d213cf641ba79a48e74c24f80bc2eca66548" and
+  (.provenance.dirty | not) and
+  .device.name == "NVIDIA L4" and
+  .device.vendor_id == 4318 and
+  .device.device_id == 10168 and
+  .device.wgpu_backend == "vulkan" and
+  (.device.software_adapter | not) and
+  .execution_plan.requested == "hybrid" and
+  .execution_plan.resolved ==
+    "hybrid-cpu-attention-gpu-experts" and
+  (.execution_plan.fallback_occurred | not) and
+  (.raw_cases | length == 7) and
+  (all(.raw_cases[];
+    .passed and .max_absolute_error == 0 and
+    .max_relative_error == 0)) and
+  (.complete_expert.vectors | length == 3) and
+  (all(.complete_expert.vectors[]; .passed)) and
+  (.checks | to_entries | length == 18 and
+    all(.value == true))
+' "$REPORT"
+```
+
+To verify the published evidence independently without copying any VM-local
+paths into documentation:
+
+```bash
+curl -L \
+  https://huggingface.co/Amalgafy/Qwen3-Coder-30B-A3B-Instruct-MER-Q4-0/resolve/main/evidence/pr6-q4-parity.json \
+  -o pr6-q4-parity.json
+
+printf '%s  %s\n' \
+  1d579a9e7ebc93191544ff162027e840dfbbd55ae7cc85e81021bb6e85784c60 \
+  pr6-q4-parity.json | sha256sum --check
+```
+
+## 12. Remaining PR6 diagnostics and exclusions
+
+Raw-block shader parity and extracted full-expert parity are completed by this
+qualification. The remaining PR6 diagnostic work is separate:
+
+- fixed-corpus CPU/Hybrid greedy token parity;
+- physical-capacity and eviction qualification;
+- injected GPU-dispatch-failure qualification; and
+- repeated-run stability qualification.
+
+Those items are not implicitly passed by this report. Likewise, this report
+does not redesign CUDA, KV, attention, dense execution, scheduling, or model
+quantization; does not qualify model quality; and does not make a production
+TPS or 10-TPS claim. Layer/top-k batching and profile-led performance work
+remain PR7 scope, and PR7 has not started.

--- a/docs/benchmarks/qwen3-coder-30b-a3b-pr6-q4-parity-2026-08-11.md
+++ b/docs/benchmarks/qwen3-coder-30b-a3b-pr6-q4-parity-2026-08-11.md
@@ -304,7 +304,7 @@ jq -e '
   .failure == null and
   .provenance.git_sha ==
     "08c05ff1079b7676623642d354d13c15994af1ea" and
-  (.provenance.dirty | not) and
+  .provenance.dirty == false and
   .provenance.package_version == "0.1.0" and
   .device.name == "NVIDIA L4" and
   .device.vendor_id == 4318 and

--- a/docs/benchmarks/qwen3-coder-30b-a3b-pr6-q4-parity-2026-08-11.md
+++ b/docs/benchmarks/qwen3-coder-30b-a3b-pr6-q4-parity-2026-08-11.md
@@ -24,6 +24,13 @@ expert, and checkpoint artifact. It is not a model-quality evaluation, does
 not validate generated-token quality, and makes no throughput or production
 TPS claim. PR7 batching has not started.
 
+> **Post-report hardening status:** this immutable live result covers the seven
+> raw cases and exact commit recorded below. The current PR head adds an eighth,
+> direct multi-row/offset case plus qualification-evidence hardening. Those
+> changes require a fresh clean NVIDIA L4 run before they can replace or extend
+> this historical seven-case result; this document does not claim that rerun
+> has happened.
+
 ## 2. Provenance and environment
 
 | Field | Qualified value |
@@ -95,6 +102,11 @@ report also retains the original CPU f32 output, rounded CPU f16 output, GPU
 f16 output, per-element absolute and relative errors, allowed error, and the
 worst comparison index. Any nonfinite CPU or GPU value fails before tolerance
 evaluation.
+
+Schema v1 serializes `f32::MAX` as the finite sentinel for an undefined relative
+error when the reference is zero and absolute error is nonzero. PASS remains
+controlled by the combined absolute-plus-relative allowance, which uses only
+the absolute component at a zero reference.
 
 ## 5. Raw WGSL block parity
 

--- a/docs/benchmarks/qwen3-coder-30b-a3b-pr6-q4-parity-2026-08-11.md
+++ b/docs/benchmarks/qwen3-coder-30b-a3b-pr6-q4-parity-2026-08-11.md
@@ -9,9 +9,11 @@ and exited with code 0. All 18 required PASS checks were true.
 
 This is three distinct kinds of evidence:
 
-1. **Raw WGSL block parity:** seven deterministic canonical
+1. **Raw WGSL block parity:** eight deterministic canonical
    `ggml-standard-v1` Q4_0 fixtures compared MER's authoritative CPU decoder
-   with the existing WGSL Q4_0 matmul pipeline.
+   with the existing WGSL Q4_0 matmul pipeline. The eighth fixture directly
+   exercised multi-row output indexing and row stride at a nonzero Q4 block
+   offset.
 2. **Complete checkpoint-expert parity:** three deterministic hidden vectors
    ran through global expert 0 using the authoritative CPU Q4_0 expert forward
    and the production GPU routed-expert path.
@@ -24,30 +26,35 @@ expert, and checkpoint artifact. It is not a model-quality evaluation, does
 not validate generated-token quality, and makes no throughput or production
 TPS claim. PR7 batching has not started.
 
-> **Post-report hardening status:** this immutable live result covers the seven
-> raw cases and exact commit recorded below. The current PR head adds an eighth,
-> direct multi-row/offset case plus qualification-evidence hardening. Those
-> changes require a fresh clean NVIDIA L4 run before they can replace or extend
-> this historical seven-case result; this document does not claim that rerun
-> has happened.
+The authoritative hardened run was performed from a clean detached checkout of
+`08c05ff1079b7676623642d354d13c15994af1ea`, after the multi-row fixture and
+review hardening were present. The earlier seven-case run at `dac1d213...` is
+superseded historical evidence and does not qualify the hardened implementation.
 
 ## 2. Provenance and environment
 
 | Field | Qualified value |
 |---|---|
-| MER commit | `dac1d213cf641ba79a48e74c24f80bc2eca66548` |
+| MER commit | `08c05ff1079b7676623642d354d13c15994af1ea` |
 | Git worktree | clean (`dirty=false`) |
+| Package version | `0.1.0` |
 | Report schema | `mer.strict-hybrid-q4-parity.v1` |
+| Qualification mode | `strict-hybrid-q4-parity` |
 | Report status | `pass` |
 | Failure | `null` |
+| Process exit code | `0` |
+| Report filename | `pr6-q4-parity-08c05ff.json` |
+| Report SHA-256 | `f50e0915288de6eb0847ea77a0f3685e91966aa54d178c8d8d6ebb63b9326beb` |
+| Progress watchdog | 300 seconds |
 | Cloud VM | GCP `g2-standard-32` |
 | Adapter | `NVIDIA L4` |
-| Vendor/device | `0x10de` / `0x27b8` |
-| Device type | discrete GPU |
-| NVIDIA driver | `580.173.02` |
-| WGPU backend | Vulkan |
+| Vendor/device | `4318` (`0x10de`) / `10168` (`0x27b8`) |
+| Device type | `DiscreteGpu` |
+| NVIDIA driver/version | `NVIDIA` / `580.173.02` |
+| WGPU backend | `vulkan` |
 | Compute plane | `wgpu-vulkan` |
 | Software adapter | `false` |
+| Linux release build | `cargo build --release --features "avx512,blas,tokenizer,io_uring"` passed |
 
 The exact adapter-name gate required `NVIDIA L4`; a missing GPU, software
 adapter, different adapter name, incompatible layout, malformed geometry,
@@ -110,43 +117,53 @@ the absolute component at a zero reference.
 
 ## 5. Raw WGSL block parity
 
-All seven canonical cases passed with exactly zero observed absolute error and
-zero observed relative error:
+All eight canonical cases passed with exactly zero observed absolute error,
+zero observed relative error, and worst index 0:
 
-| Case | Projection | Columns | `w_block_off` | Byte offset | Unaligned 18-byte start | Max abs | Max rel | Result |
-|---|---|---:|---:|---:|---|---:|---:|---|
-| `zero-scale-extrema` | standalone | 32 | 0 | 0 | no | 0 | 0 | PASS |
-| `positive-scale-extrema` | standalone | 32 | 0 | 0 | no | 0 | 0 | PASS |
-| `negative-scale-sign` | standalone | 32 | 0 | 0 | no | 0 | 0 | PASS |
-| `multiple-blocks-nontrivial-hidden` | standalone | 64 | 0 | 0 | no | 0 | 0 | PASS |
-| `gate-projection-offset-zero` | gate | 32 | 0 | 0 | no | 0 | 0 | PASS |
-| `up-projection-offset-one-unaligned` | up | 32 | 1 | 18 | yes | 0 | 0 | PASS |
-| `down-projection-offset-two` | down | 32 | 2 | 36 | no | 0 | 0 | PASS |
+| Case | Projection | Rows | Columns | `w_block_off` | Byte offset | Unaligned 18-byte start | Max abs | Max rel | Worst index | Result |
+|---|---|---:|---:|---:|---:|---|---:|---:|---:|---|
+| `zero-scale-extrema` | standalone | 1 | 32 | 0 | 0 | no | 0 | 0 | 0 | PASS |
+| `positive-scale-extrema` | standalone | 1 | 32 | 0 | 0 | no | 0 | 0 | 0 | PASS |
+| `negative-scale-sign` | standalone | 1 | 32 | 0 | 0 | no | 0 | 0 | 0 | PASS |
+| `multiple-blocks-nontrivial-hidden` | standalone | 1 | 64 | 0 | 0 | no | 0 | 0 | 0 | PASS |
+| `gate-projection-offset-zero` | gate | 1 | 32 | 0 | 0 | no | 0 | 0 | 0 | PASS |
+| `up-projection-offset-one-unaligned` | up | 1 | 32 | 1 | 18 | yes | 0 | 0 | 0 | PASS |
+| `down-projection-offset-two` | down | 1 | 32 | 2 | 36 | no | 0 | 0 | 0 | PASS |
+| `multi-row-offset-row-stride` | standalone | 2 | 32 | 1 | 18 | yes | 0 | 0 | 0 | PASS |
 
 The fixtures cover zero scale, positive and negative scale/sign behavior,
 extremal nibbles, multiple blocks, nontrivial hidden vectors, all three expert
 projection offsets, nonzero block offsets, and the unaligned 18-byte Q4_0
-boundary. The raw dispatch used ephemeral qualification buffers. Before and
-after raw dispatch, production expert residency and all production GPU-I/O
-counters remained zero, so the raw phase could not pre-populate the complete
-expert.
+boundary. The eighth case directly qualifies two-row output indexing and row
+stride using distinct row blocks at nonzero `w_block_off=1`. The raw dispatch
+used ephemeral qualification buffers. Before and after raw dispatch,
+production expert residency and all production GPU-I/O counters remained zero,
+so the raw phase could not pre-populate the complete expert.
 
 ## 6. Complete checkpoint-expert parity
 
 Three deterministic vectors passed against the extracted complete checkpoint
 expert:
 
-| Vector | Max absolute error | Max relative error | Expert upload | Hidden upload | Submit | Map | Completed readback |
-|---:|---:|---:|---:|---:|---:|---:|---:|
-| 0 | `7.6293945e-06` | `0.0009451796` | 1 / 2,654,208 B | 1 / 8,192 B | 1 | 1 | 1 / 8,192 B |
-| 1 | `9.536743e-07` | `0.0010615712` | 0 / 0 B | 1 / 8,192 B | 1 | 1 | 1 / 8,192 B |
-| 2 | `0` | `0` | 0 / 0 B | 1 / 8,192 B | 1 | 1 | 1 / 8,192 B |
+| Vector | Max absolute error | Max relative error | Worst index | Expert upload | Hidden upload | Submit | Map | Completed readback |
+|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 0 | `7.6293945e-06` | `0.0009451796` | 1831 | 1 / 2,654,208 B | 1 / 8,192 B | 1 | 1 | 1 / 8,192 B |
+| 1 | `9.536743e-07` | `0.0010615712` | 1500 | 0 / 0 B | 1 / 8,192 B | 1 | 1 | 1 / 8,192 B |
+| 2 | `0` | `0` | 0 | 0 / 0 B | 1 / 8,192 B | 1 | 1 | 1 / 8,192 B |
 
 The worst absolute error across all vectors was `7.6293945e-06`; the worst
 reported relative error was `0.0010615712`. Both are observations, not changed
 tolerances. Every vector recorded one GPU dispatch attempt and success, with
 zero dispatch failures, CPU routed-expert dispatches, GPU-to-CPU fallbacks, and
 degraded substitutions.
+
+Each vector's `routed_delta.selected_routed_experts` is zero by design. This
+qualification explicitly selects global expert 0 and invokes the existing
+production `forward_moe_resident` boundary; it does not run the model router and
+therefore must not increment the router-selection counter. This does not weaken
+dispatch evidence: every vector recorded GPU attempts/successes/failures of
+`1/1/0`, while CPU expert executions, GPU-to-CPU fallbacks, and degraded
+substitutions all remained zero.
 
 ## 7. Physical residency and capacity evidence
 
@@ -204,16 +221,16 @@ All 18 independently derived checks were true:
 The successful process exit and a separate typed `jq -e` validation both
 confirmed the fail-closed PASS contract.
 
-## 9. Qualified artifact and checksums
+## 9. Qualified checkpoint and report checksum
 
-The exact qualification artifact is published at
+The checkpoint artifact exercised by the qualification is published at
 [Amalgafy/Qwen3-Coder-30B-A3B-Instruct-MER-Q4-0](https://huggingface.co/Amalgafy/Qwen3-Coder-30B-A3B-Instruct-MER-Q4-0).
 
 | Artifact | SHA-256 |
 |---|---|
 | MER archive `qwen3-coder-30b-a3b-mer-q4_0-v1.tar.zst` | `659b8d31d0a83292c632aa109c8edb5301f4041b1a60ef43c6f23ec0404061fe` |
 | Pure Q4_0 GGUF `Qwen3-Coder-30B-A3B-Instruct-pure-Q4_0.gguf` | `8ddf61cadd354a5095905cc5ce535c44b777d0313ac241abcd2ceafa3362551b` |
-| Typed report `pr6-q4-parity.json` | `1d579a9e7ebc93191544ff162027e840dfbbd55ae7cc85e81021bb6e85784c60` |
+| Hardened typed report `pr6-q4-parity-08c05ff.json` | `f50e0915288de6eb0847ea77a0f3685e91966aa54d178c8d8d6ebb63b9326beb` |
 
 This is the current PR6 qualification artifact. Its pure Q4_0 GGUF was
 requantized from an already quantized GGUF using llama.cpp
@@ -230,13 +247,14 @@ The qualified implementation had the following pre-publication validation:
 
 | Command | Result |
 |---|---|
-| `cargo test q4_parity` | 14 passed |
+| `cargo test q4_parity` | 19 passed |
 | `cargo test q4_0_shader_logic_tests` | 4 passed |
 | `cargo test qualification` | 28 passed |
 | `cargo test strict` | 40 passed |
-| `cargo test` | 925 passed, 0 failed, 2 ignored |
+| `cargo test` | 932 passed, 0 failed, 2 ignored |
 | `cargo clippy --all-targets` | passed with existing warnings |
 | `git diff --check` | passed |
+| Local macOS `cargo build --release` | passed with existing warnings |
 | Linux release build with `avx512,blas,tokenizer,io_uring` | passed |
 
 The first commit on the branch is a separate test-only fix that gives server
@@ -251,20 +269,22 @@ Start from the exact qualified commit and require a clean checkout:
 
 ```bash
 git fetch origin feat/pr6-q4-numerical-correctness
-git switch --detach dac1d213cf641ba79a48e74c24f80bc2eca66548
+git switch --detach 08c05ff1079b7676623642d354d13c15994af1ea
 test "$(git rev-parse HEAD)" = \
-  dac1d213cf641ba79a48e74c24f80bc2eca66548
+  08c05ff1079b7676623642d354d13c15994af1ea
 test -z "$(git status --porcelain)"
 
 cd rust-engine
 cargo build --release \
   --features "avx512,blas,tokenizer,io_uring"
 
-./target/release/micro-expert-router qualify-hybrid-q4-parity \
+./target/release/micro-expert-router \
+  --progress-timeout-secs 300 \
+  qualify-hybrid-q4-parity \
   --config "$HOME/mer-pr6/qwen3-coder-strict-hybrid-q4.toml" \
   --expert-id 0 \
   --expected-adapter-name "NVIDIA L4" \
-  --report-out "$HOME/mer-pr6/pr6-q4-parity.json"
+  --report-out "$HOME/mer-pr6/pr6-q4-parity-08c05ff.json"
 ```
 
 The config must select strict Hybrid execution and the canonical converted
@@ -275,15 +295,17 @@ select or wrap either value.
 Validate the typed report:
 
 ```bash
-REPORT="$HOME/mer-pr6/pr6-q4-parity.json"
+REPORT="$HOME/mer-pr6/pr6-q4-parity-08c05ff.json"
 
 jq -e '
   .schema_version == "mer.strict-hybrid-q4-parity.v1" and
+  .mode == "strict-hybrid-q4-parity" and
   .status == "pass" and
   .failure == null and
   .provenance.git_sha ==
-    "dac1d213cf641ba79a48e74c24f80bc2eca66548" and
+    "08c05ff1079b7676623642d354d13c15994af1ea" and
   (.provenance.dirty | not) and
+  .provenance.package_version == "0.1.0" and
   .device.name == "NVIDIA L4" and
   .device.vendor_id == 4318 and
   .device.device_id == 10168 and
@@ -292,29 +314,43 @@ jq -e '
   .execution_plan.requested == "hybrid" and
   .execution_plan.resolved ==
     "hybrid-cpu-attention-gpu-experts" and
+  .execution_plan.embeddings == "cpu" and
+  .execution_plan.lm_head == "cpu" and
+  .execution_plan.dense_projections == "cpu" and
+  .execution_plan.attention == "cpu" and
+  .execution_plan.kv == "cpu" and
+  .execution_plan.router == "cpu" and
+  .execution_plan.routed_experts == "gpu" and
+  .execution_plan.routed_expert_dtype == "q4_0" and
   (.execution_plan.fallback_occurred | not) and
-  (.raw_cases | length == 7) and
+  (.raw_cases | length == 8) and
   (all(.raw_cases[];
     .passed and .max_absolute_error == 0 and
-    .max_relative_error == 0)) and
+    .max_relative_error == 0 and .worst_index == 0)) and
+  (any(.raw_cases[];
+    .name == "multi-row-offset-row-stride" and
+    .rows == 2 and .columns == 32 and
+    .w_block_off == 1)) and
+  .complete_expert.identity.global_expert_id == 0 and
+  .complete_expert.identity.layer_index == 0 and
+  .complete_expert.identity.layer_local_expert_id == 0 and
   (.complete_expert.vectors | length == 3) and
-  (all(.complete_expert.vectors[]; .passed)) and
+  (all(.complete_expert.vectors[];
+    .passed and
+    .routed_delta.selected_routed_experts == 0 and
+    .routed_delta.gpu_dispatch_attempts == 1 and
+    .routed_delta.gpu_dispatch_successes == 1 and
+    .routed_delta.gpu_dispatch_failures == 0 and
+    .routed_delta.cpu_routed_expert_dispatches == 0 and
+    .routed_delta.gpu_cpu_fallbacks == 0 and
+    .routed_delta.degraded_expert_substitutions == 0)) and
   (.checks | to_entries | length == 18 and
     all(.value == true))
 ' "$REPORT"
-```
-
-To verify the published evidence independently without copying any VM-local
-paths into documentation:
-
-```bash
-curl -L \
-  https://huggingface.co/Amalgafy/Qwen3-Coder-30B-A3B-Instruct-MER-Q4-0/resolve/main/evidence/pr6-q4-parity.json \
-  -o pr6-q4-parity.json
 
 printf '%s  %s\n' \
-  1d579a9e7ebc93191544ff162027e840dfbbd55ae7cc85e81021bb6e85784c60 \
-  pr6-q4-parity.json | sha256sum --check
+  f50e0915288de6eb0847ea77a0f3685e91966aa54d178c8d8d6ebb63b9326beb \
+  "$REPORT" | sha256sum --check
 ```
 
 ## 12. Remaining PR6 diagnostics and exclusions

--- a/rust-engine/src/backend/mod.rs
+++ b/rust-engine/src/backend/mod.rs
@@ -433,6 +433,16 @@ pub struct GpuExpertMemorySnapshot {
     pub stale_retirements: u64,
 }
 
+/// Non-mutating identity evidence for one physically resident expert. This is
+/// exposed only through the crate-private numerical-qualification seam; it
+/// neither touches physical LRU recency nor participates in serving dispatch.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+pub(crate) struct GpuPhysicalExpertResidency {
+    pub(crate) expert_id: u32,
+    pub(crate) generation: u64,
+    pub(crate) device_bytes: u64,
+}
+
 /// Monotonic counters for only the routed-expert GPU path. Dense and
 /// attention operations are deliberately excluded.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize)]
@@ -838,6 +848,18 @@ impl<T: PhysicalRegistryEntry> PhysicalGpuExpertRegistry<T> {
             physical_evictions: inner.evictions,
             stale_retirements: inner.stale_retirements,
         }
+    }
+
+    fn residency_evidence(&self, expert_id: u32) -> Option<GpuPhysicalExpertResidency> {
+        let inner = self.inner.lock();
+        inner.entries.peek(&expert_id).map(|entry| {
+            let key = entry.physical_key();
+            GpuPhysicalExpertResidency {
+                expert_id: key.expert_id,
+                generation: key.generation,
+                device_bytes: entry.device_bytes(),
+            }
+        })
     }
 
     #[cfg(test)]
@@ -3113,6 +3135,202 @@ impl Backend for GpuBackend {
 }
 
 impl GpuBackend {
+    /// Execute the already-constructed production Q4_0 WGSL pipeline over a
+    /// small canonical block stream and return its f32 result. This seam is
+    /// crate-private and is called only by `qualify-hybrid-q4-parity`: it owns
+    /// ephemeral buffers, does not consult or mutate logical admission, does
+    /// not touch the physical expert registry, and does not increment routed
+    /// expert I/O counters.
+    fn qualification_q4_0_matvec(
+        &self,
+        weights: &[u8],
+        input: &[f32],
+        rows: usize,
+        columns: usize,
+        w_block_off: usize,
+    ) -> std::result::Result<Vec<f32>, String> {
+        use crate::inference::{Q4_0_BLOCK_BYTES, Q4_0_BLOCK_ELEMS};
+
+        if let Some(detail) = self.device_loss.detail() {
+            return Err(format!("GPU device is lost before raw Q4_0 dispatch: {detail}"));
+        }
+        if rows == 0 || columns == 0 || !columns.is_multiple_of(Q4_0_BLOCK_ELEMS) {
+            return Err(format!(
+                "invalid raw Q4_0 geometry rows={rows} columns={columns}; columns must be a non-zero multiple of {Q4_0_BLOCK_ELEMS}"
+            ));
+        }
+        if input.len() != columns || input.iter().any(|value| !value.is_finite()) {
+            return Err(format!(
+                "raw Q4_0 input has {} values for {columns} columns or contains a nonfinite value",
+                input.len()
+            ));
+        }
+        let blocks_per_row = columns / Q4_0_BLOCK_ELEMS;
+        let accessed_blocks = rows
+            .checked_mul(blocks_per_row)
+            .and_then(|count| w_block_off.checked_add(count))
+            .ok_or_else(|| "raw Q4_0 block geometry overflow".to_string())?;
+        let required_weight_bytes = accessed_blocks
+            .checked_mul(Q4_0_BLOCK_BYTES)
+            .ok_or_else(|| "raw Q4_0 byte length overflow".to_string())?;
+        if weights.len() < required_weight_bytes
+            || !weights.len().is_multiple_of(Q4_0_BLOCK_BYTES)
+        {
+            return Err(format!(
+                "raw Q4_0 weights have {} bytes, require at least {required_weight_bytes} bytes in complete {Q4_0_BLOCK_BYTES}-byte blocks",
+                weights.len()
+            ));
+        }
+        let rows_u32 = u32::try_from(rows)
+            .map_err(|_| format!("raw Q4_0 rows {rows} exceed u32"))?;
+        let columns_u32 = u32::try_from(columns)
+            .map_err(|_| format!("raw Q4_0 columns {columns} exceed u32"))?;
+        let block_off_u32 = u32::try_from(w_block_off)
+            .map_err(|_| format!("raw Q4_0 w_block_off {w_block_off} exceeds u32"))?;
+        let weight_size = weights
+            .len()
+            .checked_add(3)
+            .ok_or_else(|| "raw Q4_0 padded weight size overflow".to_string())?
+            / 4
+            * 4;
+        let input_size = columns
+            .checked_mul(std::mem::size_of::<f32>())
+            .ok_or_else(|| "raw Q4_0 input byte size overflow".to_string())?;
+        let output_size = rows
+            .checked_mul(std::mem::size_of::<f32>())
+            .ok_or_else(|| "raw Q4_0 output byte size overflow".to_string())?;
+        let weight_size_u64 = u64::try_from(weight_size)
+            .map_err(|_| "raw Q4_0 weight size does not fit u64".to_string())?;
+        let input_size_u64 = u64::try_from(input_size)
+            .map_err(|_| "raw Q4_0 input size does not fit u64".to_string())?;
+        let output_size_u64 = u64::try_from(output_size)
+            .map_err(|_| "raw Q4_0 output size does not fit u64".to_string())?;
+        let pipeline = self.matmul_q4_0_pipeline.as_ref().ok_or_else(|| {
+            format!(
+                "Q4_0 pipeline is unavailable in {:?} backend mode",
+                self.component_resources.plan().mode()
+            )
+        })?;
+
+        // Capture qualification-created validation/OOM errors rather than
+        // letting wgpu route them through the process-wide uncaptured handler.
+        self.device
+            .push_error_scope(wgpu::ErrorFilter::OutOfMemory);
+        self.device.push_error_scope(wgpu::ErrorFilter::Validation);
+        let result = (|| -> std::result::Result<Vec<f32>, String> {
+            let weight_buf = create_startup_buffer(
+                &self.device,
+                "q4_parity_weights",
+                weight_size_u64,
+                wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+            )
+            .map_err(|error| error.to_string())?;
+            let input_buf = create_startup_buffer(
+                &self.device,
+                "q4_parity_input",
+                input_size_u64,
+                wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+            )
+            .map_err(|error| error.to_string())?;
+            let output_buf = create_startup_buffer(
+                &self.device,
+                "q4_parity_output",
+                output_size_u64,
+                wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+            )
+            .map_err(|error| error.to_string())?;
+            let staging = create_startup_buffer(
+                &self.device,
+                "q4_parity_staging",
+                output_size_u64,
+                wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+            )
+            .map_err(|error| error.to_string())?;
+
+            if weights.len() == weight_size {
+                self.queue.write_buffer(&weight_buf, 0, weights);
+            } else {
+                let mut padded = Vec::with_capacity(weight_size);
+                padded.extend_from_slice(weights);
+                padded.resize(weight_size, 0);
+                self.queue.write_buffer(&weight_buf, 0, &padded);
+            }
+            self.queue
+                .write_buffer(&input_buf, 0, bytemuck::cast_slice(input));
+
+            let bind_group = self.device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("q4_parity_bind_group"),
+                layout: &pipeline.get_bind_group_layout(0),
+                entries: &[
+                    wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: weight_buf.as_entire_binding(),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: input_buf.as_entire_binding(),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 2,
+                        resource: output_buf.as_entire_binding(),
+                    },
+                ],
+            });
+            let mut encoder = self
+                .device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                    label: Some("q4_parity_encoder"),
+                });
+            {
+                let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                    label: Some("q4_parity_pass"),
+                    timestamp_writes: None,
+                });
+                pass.set_pipeline(pipeline);
+                pass.set_bind_group(0, &bind_group, &[]);
+                pass.set_push_constants(
+                    0,
+                    bytemuck::bytes_of(&MatmulPushConstants {
+                        m: rows_u32,
+                        n: 1,
+                        k: columns_u32,
+                        w_block_off: block_off_u32,
+                    }),
+                );
+                pass.dispatch_workgroups((rows_u32 + 63) / 64, 1, 1);
+            }
+            encoder.copy_buffer_to_buffer(&output_buf, 0, &staging, 0, output_size_u64);
+            let submission = self.queue.submit(Some(encoder.finish()));
+            let slice = staging.slice(..output_size_u64);
+            let (tx, rx) = std::sync::mpsc::channel();
+            slice.map_async(wgpu::MapMode::Read, move |mapped| {
+                let _ = tx.send(mapped);
+            });
+            self.device.poll(wgpu::Maintain::wait_for(submission));
+            if let Some(detail) = self.device_loss.detail() {
+                return Err(format!("GPU device was lost during raw Q4_0 dispatch: {detail}"));
+            }
+            rx.recv()
+                .map_err(|error| format!("raw Q4_0 readback callback channel failed: {error}"))?
+                .map_err(|error| format!("raw Q4_0 staging map failed: {error:?}"))?;
+            let output = {
+                let view = slice.get_mapped_range();
+                bytemuck::cast_slice::<u8, f32>(&view).to_vec()
+            };
+            staging.unmap();
+            if output.iter().any(|value| !value.is_finite()) {
+                return Err("raw Q4_0 GPU output contains a nonfinite value".to_string());
+            }
+            Ok(output)
+        })();
+        let validation_error = pollster::block_on(self.device.pop_error_scope());
+        let oom_error = pollster::block_on(self.device.pop_error_scope());
+        if let Some(error) = validation_error.or(oom_error) {
+            return Err(format!("wgpu raw Q4_0 qualification error: {error}"));
+        }
+        result
+    }
+
     fn routed_expert_matmul(
         &self,
         layer: u32,
@@ -3292,6 +3510,14 @@ impl GpuBackend {
 
     fn gpu_expert_io_snapshot(&self) -> GpuExpertIoSnapshot {
         self.expert_io.snapshot()
+    }
+
+    fn gpu_physical_expert_residency(
+        &self,
+        expert_id: u32,
+    ) -> Option<GpuPhysicalExpertResidency> {
+        self.physical_expert_registry
+            .residency_evidence(expert_id)
     }
 }
 
@@ -3551,6 +3777,43 @@ impl BackendBox {
             Self::Cpu(_) => None,
             #[cfg(test)]
             Self::TestGpu(_) => None,
+        }
+    }
+
+    pub(crate) fn gpu_physical_expert_residency(
+        &self,
+        expert_id: u32,
+    ) -> Option<GpuPhysicalExpertResidency> {
+        match self {
+            Self::Gpu(gpu) => gpu.gpu_physical_expert_residency(expert_id),
+            Self::Cpu(_) => None,
+            #[cfg(test)]
+            Self::TestGpu(_) => None,
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn qualification_q4_0_matvec(
+        &self,
+        weights: &[u8],
+        input: &[f32],
+        rows: usize,
+        columns: usize,
+        w_block_off: usize,
+    ) -> std::result::Result<Vec<f32>, String> {
+        match self {
+            Self::Gpu(gpu) => {
+                gpu.qualification_q4_0_matvec(weights, input, rows, columns, w_block_off)
+            }
+            Self::Cpu(_) => Err(
+                "raw Q4_0 qualification requires the authoritative production GPU backend"
+                    .to_string(),
+            ),
+            #[cfg(test)]
+            Self::TestGpu(_) => Err(
+                "raw Q4_0 qualification cannot run against the hardware-independent test backend"
+                    .to_string(),
+            ),
         }
     }
 

--- a/rust-engine/src/backend/mod.rs
+++ b/rust-engine/src/backend/mod.rs
@@ -8,6 +8,7 @@ use std::fmt;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::sync::OnceLock;
+use std::time::{Duration, Instant};
 
 /// Maximum routed-expert workspace dimension supported for both `d_model` and
 /// `d_ff`. Sized for Mixtral-8x7B (`d_ff = 14336`).
@@ -356,6 +357,46 @@ pub enum GpuExpertDispatchErrorKind {
     DeviceLost,
     RuntimeInvariant,
 }
+
+/// Fail-closed error category for the crate-private raw Q4_0 qualification
+/// dispatch. These errors are deliberately separate from serving dispatch
+/// errors because this seam neither admits nor executes a routed expert.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum Q4ParityGpuErrorKind {
+    InvalidRequest,
+    ResourceUnavailable,
+    ResourceCreation,
+    Validation,
+    ReadbackTimeout,
+    ReadbackChannel,
+    ReadbackMap,
+    DeviceLost,
+    NonfiniteOutput,
+}
+
+/// Typed raw-Q4 qualification failure returned only within this crate.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct Q4ParityGpuError {
+    pub kind: Q4ParityGpuErrorKind,
+    pub detail: String,
+}
+
+impl Q4ParityGpuError {
+    fn new(kind: Q4ParityGpuErrorKind, detail: impl Into<String>) -> Self {
+        Self {
+            kind,
+            detail: detail.into(),
+        }
+    }
+}
+
+impl fmt::Display for Q4ParityGpuError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}: {}", self.kind, self.detail)
+    }
+}
+
+impl std::error::Error for Q4ParityGpuError {}
 
 impl fmt::Display for GpuExpertDispatchErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -1335,6 +1376,90 @@ impl DeviceLossState {
         } else {
             None
         }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+enum BoundedCallbackError<E> {
+    DeadlineOverflow,
+    Timeout,
+    ChannelDisconnected,
+    Callback(E),
+    DeviceLost(String),
+}
+
+/// Drive a callback-based WGPU operation with nonblocking polls until it
+/// completes or its deadline expires. The callback channel is inspected both
+/// before and after every poll so an already-completed operation never loses
+/// to a zero-duration test deadline.
+fn wait_for_bounded_callback<T, E>(
+    receiver: &std::sync::mpsc::Receiver<std::result::Result<T, E>>,
+    timeout: Duration,
+    mut poll: impl FnMut(),
+    mut device_loss: impl FnMut() -> Option<String>,
+) -> std::result::Result<T, BoundedCallbackError<E>> {
+    let deadline = Instant::now()
+        .checked_add(timeout)
+        .ok_or(BoundedCallbackError::DeadlineOverflow)?;
+    loop {
+        match receiver.try_recv() {
+            Ok(result) => return result.map_err(BoundedCallbackError::Callback),
+            Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                return Err(BoundedCallbackError::ChannelDisconnected);
+            }
+            Err(std::sync::mpsc::TryRecvError::Empty) => {}
+        }
+        if let Some(detail) = device_loss() {
+            return Err(BoundedCallbackError::DeviceLost(detail));
+        }
+
+        poll();
+
+        match receiver.try_recv() {
+            Ok(result) => return result.map_err(BoundedCallbackError::Callback),
+            Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                return Err(BoundedCallbackError::ChannelDisconnected);
+            }
+            Err(std::sync::mpsc::TryRecvError::Empty) => {}
+        }
+        if let Some(detail) = device_loss() {
+            return Err(BoundedCallbackError::DeviceLost(detail));
+        }
+        if Instant::now() >= deadline {
+            return Err(BoundedCallbackError::Timeout);
+        }
+        std::thread::sleep(Duration::from_millis(1));
+    }
+}
+
+fn q4_parity_readback_error<E: fmt::Debug>(
+    error: BoundedCallbackError<E>,
+    timeout: Duration,
+) -> Q4ParityGpuError {
+    match error {
+        BoundedCallbackError::DeadlineOverflow => Q4ParityGpuError::new(
+            Q4ParityGpuErrorKind::InvalidRequest,
+            "raw Q4_0 readback deadline overflowed",
+        ),
+        BoundedCallbackError::Timeout => Q4ParityGpuError::new(
+            Q4ParityGpuErrorKind::ReadbackTimeout,
+            format!(
+                "raw Q4_0 readback did not complete within {} seconds",
+                timeout.as_secs_f64()
+            ),
+        ),
+        BoundedCallbackError::ChannelDisconnected => Q4ParityGpuError::new(
+            Q4ParityGpuErrorKind::ReadbackChannel,
+            "raw Q4_0 readback callback channel disconnected",
+        ),
+        BoundedCallbackError::Callback(error) => Q4ParityGpuError::new(
+            Q4ParityGpuErrorKind::ReadbackMap,
+            format!("raw Q4_0 staging map failed: {error:?}"),
+        ),
+        BoundedCallbackError::DeviceLost(detail) => Q4ParityGpuError::new(
+            Q4ParityGpuErrorKind::DeviceLost,
+            format!("GPU device was lost during raw Q4_0 dispatch: {detail}"),
+        ),
     }
 }
 
@@ -3148,67 +3273,97 @@ impl GpuBackend {
         rows: usize,
         columns: usize,
         w_block_off: usize,
-    ) -> std::result::Result<Vec<f32>, String> {
+        readback_timeout: Duration,
+    ) -> std::result::Result<Vec<f32>, Q4ParityGpuError> {
         use crate::inference::{Q4_0_BLOCK_BYTES, Q4_0_BLOCK_ELEMS};
 
         if let Some(detail) = self.device_loss.detail() {
-            return Err(format!("GPU device is lost before raw Q4_0 dispatch: {detail}"));
+            return Err(Q4ParityGpuError::new(
+                Q4ParityGpuErrorKind::DeviceLost,
+                format!("GPU device is lost before raw Q4_0 dispatch: {detail}"),
+            ));
         }
         if rows == 0 || columns == 0 || !columns.is_multiple_of(Q4_0_BLOCK_ELEMS) {
-            return Err(format!(
-                "invalid raw Q4_0 geometry rows={rows} columns={columns}; columns must be a non-zero multiple of {Q4_0_BLOCK_ELEMS}"
+            return Err(Q4ParityGpuError::new(
+                Q4ParityGpuErrorKind::InvalidRequest,
+                format!(
+                    "invalid raw Q4_0 geometry rows={rows} columns={columns}; columns must be a non-zero multiple of {Q4_0_BLOCK_ELEMS}"
+                ),
             ));
         }
         if input.len() != columns || input.iter().any(|value| !value.is_finite()) {
-            return Err(format!(
-                "raw Q4_0 input has {} values for {columns} columns or contains a nonfinite value",
-                input.len()
+            return Err(Q4ParityGpuError::new(
+                Q4ParityGpuErrorKind::InvalidRequest,
+                format!(
+                    "raw Q4_0 input has {} values for {columns} columns or contains a nonfinite value",
+                    input.len()
+                ),
             ));
         }
         let blocks_per_row = columns / Q4_0_BLOCK_ELEMS;
         let accessed_blocks = rows
             .checked_mul(blocks_per_row)
             .and_then(|count| w_block_off.checked_add(count))
-            .ok_or_else(|| "raw Q4_0 block geometry overflow".to_string())?;
+            .ok_or_else(|| {
+                Q4ParityGpuError::new(
+                    Q4ParityGpuErrorKind::InvalidRequest,
+                    "raw Q4_0 block geometry overflow",
+                )
+            })?;
         let required_weight_bytes = accessed_blocks
             .checked_mul(Q4_0_BLOCK_BYTES)
-            .ok_or_else(|| "raw Q4_0 byte length overflow".to_string())?;
+            .ok_or_else(|| {
+                Q4ParityGpuError::new(
+                    Q4ParityGpuErrorKind::InvalidRequest,
+                    "raw Q4_0 byte length overflow",
+                )
+            })?;
         if weights.len() < required_weight_bytes
             || !weights.len().is_multiple_of(Q4_0_BLOCK_BYTES)
         {
-            return Err(format!(
-                "raw Q4_0 weights have {} bytes, require at least {required_weight_bytes} bytes in complete {Q4_0_BLOCK_BYTES}-byte blocks",
-                weights.len()
+            return Err(Q4ParityGpuError::new(
+                Q4ParityGpuErrorKind::InvalidRequest,
+                format!(
+                    "raw Q4_0 weights have {} bytes, require at least {required_weight_bytes} bytes in complete {Q4_0_BLOCK_BYTES}-byte blocks",
+                    weights.len()
+                ),
             ));
         }
+        let invalid_request = |detail| {
+            Q4ParityGpuError::new(Q4ParityGpuErrorKind::InvalidRequest, detail)
+        };
         let rows_u32 = u32::try_from(rows)
-            .map_err(|_| format!("raw Q4_0 rows {rows} exceed u32"))?;
+            .map_err(|_| invalid_request(format!("raw Q4_0 rows {rows} exceed u32")))?;
         let columns_u32 = u32::try_from(columns)
-            .map_err(|_| format!("raw Q4_0 columns {columns} exceed u32"))?;
-        let block_off_u32 = u32::try_from(w_block_off)
-            .map_err(|_| format!("raw Q4_0 w_block_off {w_block_off} exceeds u32"))?;
+            .map_err(|_| invalid_request(format!("raw Q4_0 columns {columns} exceed u32")))?;
+        let block_off_u32 = u32::try_from(w_block_off).map_err(|_| {
+            invalid_request(format!("raw Q4_0 w_block_off {w_block_off} exceeds u32"))
+        })?;
         let weight_size = weights
             .len()
             .checked_add(3)
-            .ok_or_else(|| "raw Q4_0 padded weight size overflow".to_string())?
+            .ok_or_else(|| invalid_request("raw Q4_0 padded weight size overflow".to_string()))?
             / 4
             * 4;
         let input_size = columns
             .checked_mul(std::mem::size_of::<f32>())
-            .ok_or_else(|| "raw Q4_0 input byte size overflow".to_string())?;
+            .ok_or_else(|| invalid_request("raw Q4_0 input byte size overflow".to_string()))?;
         let output_size = rows
             .checked_mul(std::mem::size_of::<f32>())
-            .ok_or_else(|| "raw Q4_0 output byte size overflow".to_string())?;
+            .ok_or_else(|| invalid_request("raw Q4_0 output byte size overflow".to_string()))?;
         let weight_size_u64 = u64::try_from(weight_size)
-            .map_err(|_| "raw Q4_0 weight size does not fit u64".to_string())?;
+            .map_err(|_| invalid_request("raw Q4_0 weight size does not fit u64".to_string()))?;
         let input_size_u64 = u64::try_from(input_size)
-            .map_err(|_| "raw Q4_0 input size does not fit u64".to_string())?;
+            .map_err(|_| invalid_request("raw Q4_0 input size does not fit u64".to_string()))?;
         let output_size_u64 = u64::try_from(output_size)
-            .map_err(|_| "raw Q4_0 output size does not fit u64".to_string())?;
+            .map_err(|_| invalid_request("raw Q4_0 output size does not fit u64".to_string()))?;
         let pipeline = self.matmul_q4_0_pipeline.as_ref().ok_or_else(|| {
-            format!(
-                "Q4_0 pipeline is unavailable in {:?} backend mode",
-                self.component_resources.plan().mode()
+            Q4ParityGpuError::new(
+                Q4ParityGpuErrorKind::ResourceUnavailable,
+                format!(
+                    "Q4_0 pipeline is unavailable in {:?} backend mode",
+                    self.component_resources.plan().mode()
+                ),
             )
         })?;
 
@@ -3217,35 +3372,43 @@ impl GpuBackend {
         self.device
             .push_error_scope(wgpu::ErrorFilter::OutOfMemory);
         self.device.push_error_scope(wgpu::ErrorFilter::Validation);
-        let result = (|| -> std::result::Result<Vec<f32>, String> {
+        let result = (|| -> std::result::Result<Vec<f32>, Q4ParityGpuError> {
             let weight_buf = create_startup_buffer(
                 &self.device,
                 "q4_parity_weights",
                 weight_size_u64,
                 wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
             )
-            .map_err(|error| error.to_string())?;
+            .map_err(|error| {
+                Q4ParityGpuError::new(Q4ParityGpuErrorKind::ResourceCreation, error.to_string())
+            })?;
             let input_buf = create_startup_buffer(
                 &self.device,
                 "q4_parity_input",
                 input_size_u64,
                 wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
             )
-            .map_err(|error| error.to_string())?;
+            .map_err(|error| {
+                Q4ParityGpuError::new(Q4ParityGpuErrorKind::ResourceCreation, error.to_string())
+            })?;
             let output_buf = create_startup_buffer(
                 &self.device,
                 "q4_parity_output",
                 output_size_u64,
                 wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
             )
-            .map_err(|error| error.to_string())?;
+            .map_err(|error| {
+                Q4ParityGpuError::new(Q4ParityGpuErrorKind::ResourceCreation, error.to_string())
+            })?;
             let staging = create_startup_buffer(
                 &self.device,
                 "q4_parity_staging",
                 output_size_u64,
                 wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
             )
-            .map_err(|error| error.to_string())?;
+            .map_err(|error| {
+                Q4ParityGpuError::new(Q4ParityGpuErrorKind::ResourceCreation, error.to_string())
+            })?;
 
             if weights.len() == weight_size {
                 self.queue.write_buffer(&weight_buf, 0, weights);
@@ -3300,33 +3463,43 @@ impl GpuBackend {
                 pass.dispatch_workgroups((rows_u32 + 63) / 64, 1, 1);
             }
             encoder.copy_buffer_to_buffer(&output_buf, 0, &staging, 0, output_size_u64);
-            let submission = self.queue.submit(Some(encoder.finish()));
+            let _submission = self.queue.submit(Some(encoder.finish()));
             let slice = staging.slice(..output_size_u64);
             let (tx, rx) = std::sync::mpsc::channel();
             slice.map_async(wgpu::MapMode::Read, move |mapped| {
                 let _ = tx.send(mapped);
             });
-            self.device.poll(wgpu::Maintain::wait_for(submission));
-            if let Some(detail) = self.device_loss.detail() {
-                return Err(format!("GPU device was lost during raw Q4_0 dispatch: {detail}"));
-            }
-            rx.recv()
-                .map_err(|error| format!("raw Q4_0 readback callback channel failed: {error}"))?
-                .map_err(|error| format!("raw Q4_0 staging map failed: {error:?}"))?;
+            wait_for_bounded_callback(
+                &rx,
+                readback_timeout,
+                || {
+                    self.device.poll(wgpu::Maintain::Poll);
+                },
+                || self.device_loss.detail(),
+            )
+            .map_err(|error| q4_parity_readback_error(error, readback_timeout))?;
             let output = {
                 let view = slice.get_mapped_range();
                 bytemuck::cast_slice::<u8, f32>(&view).to_vec()
             };
             staging.unmap();
             if output.iter().any(|value| !value.is_finite()) {
-                return Err("raw Q4_0 GPU output contains a nonfinite value".to_string());
+                return Err(Q4ParityGpuError::new(
+                    Q4ParityGpuErrorKind::NonfiniteOutput,
+                    "raw Q4_0 GPU output contains a nonfinite value",
+                ));
             }
             Ok(output)
         })();
         let validation_error = pollster::block_on(self.device.pop_error_scope());
         let oom_error = pollster::block_on(self.device.pop_error_scope());
-        if let Some(error) = validation_error.or(oom_error) {
-            return Err(format!("wgpu raw Q4_0 qualification error: {error}"));
+        if result.is_ok() {
+            if let Some(error) = validation_error.or(oom_error) {
+                return Err(Q4ParityGpuError::new(
+                    Q4ParityGpuErrorKind::Validation,
+                    format!("wgpu raw Q4_0 qualification error: {error}"),
+                ));
+            }
         }
         result
     }
@@ -3800,20 +3973,26 @@ impl BackendBox {
         rows: usize,
         columns: usize,
         w_block_off: usize,
-    ) -> std::result::Result<Vec<f32>, String> {
+        readback_timeout: Duration,
+    ) -> std::result::Result<Vec<f32>, Q4ParityGpuError> {
         match self {
-            Self::Gpu(gpu) => {
-                gpu.qualification_q4_0_matvec(weights, input, rows, columns, w_block_off)
-            }
-            Self::Cpu(_) => Err(
-                "raw Q4_0 qualification requires the authoritative production GPU backend"
-                    .to_string(),
+            Self::Gpu(gpu) => gpu.qualification_q4_0_matvec(
+                weights,
+                input,
+                rows,
+                columns,
+                w_block_off,
+                readback_timeout,
             ),
+            Self::Cpu(_) => Err(Q4ParityGpuError::new(
+                Q4ParityGpuErrorKind::ResourceUnavailable,
+                "raw Q4_0 qualification requires the authoritative production GPU backend",
+            )),
             #[cfg(test)]
-            Self::TestGpu(_) => Err(
-                "raw Q4_0 qualification cannot run against the hardware-independent test backend"
-                    .to_string(),
-            ),
+            Self::TestGpu(_) => Err(Q4ParityGpuError::new(
+                Q4ParityGpuErrorKind::ResourceUnavailable,
+                "raw Q4_0 qualification cannot run against the hardware-independent test backend",
+            )),
         }
     }
 
@@ -5169,6 +5348,86 @@ pub fn current() -> Arc<BackendBox> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn bounded_callback_reports_timeout_without_a_blocking_wait() {
+        let (_tx, rx) = std::sync::mpsc::channel::<std::result::Result<(), &'static str>>();
+        let mut polls = 0usize;
+        let error = wait_for_bounded_callback(
+            &rx,
+            Duration::ZERO,
+            || polls += 1,
+            || None,
+        )
+        .unwrap_err();
+        assert_eq!(error, BoundedCallbackError::Timeout);
+        assert_eq!(polls, 1);
+    }
+
+    #[test]
+    fn bounded_callback_distinguishes_channel_map_and_device_loss() {
+        let (tx, rx) = std::sync::mpsc::channel::<std::result::Result<(), &'static str>>();
+        drop(tx);
+        assert_eq!(
+            wait_for_bounded_callback(&rx, Duration::from_secs(1), || {}, || None)
+                .unwrap_err(),
+            BoundedCallbackError::ChannelDisconnected
+        );
+
+        let (tx, rx) =
+            std::sync::mpsc::channel::<std::result::Result<(), &'static str>>();
+        tx.send(Err("map failed")).unwrap();
+        assert_eq!(
+            wait_for_bounded_callback(&rx, Duration::from_secs(1), || {}, || None)
+                .unwrap_err(),
+            BoundedCallbackError::Callback("map failed")
+        );
+
+        let (_tx, rx) = std::sync::mpsc::channel::<std::result::Result<(), &'static str>>();
+        assert_eq!(
+            wait_for_bounded_callback(
+                &rx,
+                Duration::from_secs(1),
+                || {},
+                || Some("adapter reset".to_string()),
+            )
+            .unwrap_err(),
+            BoundedCallbackError::DeviceLost("adapter reset".to_string())
+        );
+
+        assert_eq!(
+            q4_parity_readback_error::<&str>(
+                BoundedCallbackError::Timeout,
+                Duration::from_secs(3),
+            )
+            .kind,
+            Q4ParityGpuErrorKind::ReadbackTimeout
+        );
+        assert_eq!(
+            q4_parity_readback_error::<&str>(
+                BoundedCallbackError::ChannelDisconnected,
+                Duration::from_secs(3),
+            )
+            .kind,
+            Q4ParityGpuErrorKind::ReadbackChannel
+        );
+        assert_eq!(
+            q4_parity_readback_error(
+                BoundedCallbackError::Callback("map failed"),
+                Duration::from_secs(3),
+            )
+            .kind,
+            Q4ParityGpuErrorKind::ReadbackMap
+        );
+        assert_eq!(
+            q4_parity_readback_error::<&str>(
+                BoundedCallbackError::DeviceLost("adapter reset".to_string()),
+                Duration::from_secs(3),
+            )
+            .kind,
+            Q4ParityGpuErrorKind::DeviceLost
+        );
+    }
 
     #[test]
     fn routed_expert_io_snapshot_reads_each_monotonic_counter() {

--- a/rust-engine/src/engine.rs
+++ b/rust-engine/src/engine.rs
@@ -1962,6 +1962,9 @@ impl Engine {
             ));
         }
 
+        let block_align = self.core.storage.config().block_align;
+        crate::q4_parity::validate_checkpoint_block_align(block_align)?;
+
         self.core
             .storage
             .validate_expert_file_layout(std::iter::once(global_expert_id))
@@ -1971,22 +1974,17 @@ impl Engine {
                 )
             })?;
 
-        let resident = self
-            .fetch_with_retry(global_expert_id)
-            .await
-            .map_err(|error| format!("failed to fetch global expert {global_expert_id}: {error}"))?;
         let expected_payload = crate::inference::expert_weight_bytes_for(
             self.core.shape.d_model,
             self.core.shape.d_ff,
             WeightDtype::Q4_0,
         );
-        let block_align = self.core.storage.config().block_align;
-        let checkpoint_payload_bytes = expected_payload
-            .checked_add(block_align.checked_sub(1).ok_or_else(|| {
-                "complete-expert parity requires non-zero storage block alignment".to_string()
-            })?)
-            .map(|bytes| bytes / block_align * block_align)
-            .ok_or_else(|| "aligned checkpoint payload size overflowed usize".to_string())?;
+        let checkpoint_payload_bytes =
+            crate::q4_parity::aligned_checkpoint_payload_bytes(expected_payload, block_align)?;
+        let resident = self
+            .fetch_with_retry(global_expert_id)
+            .await
+            .map_err(|error| format!("failed to fetch global expert {global_expert_id}: {error}"))?;
         if resident.data().len() != checkpoint_payload_bytes {
             return Err(format!(
                 "global expert {global_expert_id} checkpoint payload has {} bytes, expected exactly {checkpoint_payload_bytes} ({expected_payload} canonical Q4_0 bytes plus alignment padding)",
@@ -2032,13 +2030,14 @@ impl Engine {
                 .gpu_expert_cache()
                 .get(global_expert_id);
             let before = self.q4_parity_dispatch_snapshot(global_expert_id)?;
-            let gpu_f16 = self
-                .forward_moe_resident(0, layer_index, resident.as_ref(), &input, None)
-                .map_err(|error| {
-                    format!(
-                        "global expert {global_expert_id} layer {layer_index} GPU dispatch failed: {error}"
-                    )
-                })?;
+            let gpu_f16 = run_compute_donated(|| {
+                self.forward_moe_resident(0, layer_index, resident.as_ref(), &input, None)
+            })
+            .map_err(|error| {
+                format!(
+                    "global expert {global_expert_id} layer {layer_index} GPU dispatch failed: {error}"
+                )
+            })?;
             let after = self.q4_parity_dispatch_snapshot(global_expert_id)?;
             dispatches.push(crate::q4_parity::CompleteDispatchExecution {
                 input,

--- a/rust-engine/src/engine.rs
+++ b/rust-engine/src/engine.rs
@@ -1892,6 +1892,176 @@ impl Engine {
         self.core.execution_context.gpu_expert_io_snapshot()
     }
 
+    fn q4_parity_dispatch_snapshot(
+        &self,
+        expert_id: u32,
+    ) -> Result<crate::q4_parity::CompleteDispatchSnapshot, String> {
+        let backend = self.routed_expert_backend();
+        let logical_generation = self
+            .execution_context()
+            .gpu_expert_cache()
+            .current_admission(expert_id)
+            .map(|admission| admission.generation());
+        let memory = self
+            .gpu_expert_memory_snapshot()
+            .ok_or_else(|| "authoritative GPU backend has no physical-memory snapshot".to_string())?;
+        let gpu_io = self
+            .gpu_expert_io_snapshot()
+            .ok_or_else(|| "authoritative GPU backend has no routed-expert I/O snapshot".to_string())?;
+        Ok(crate::q4_parity::CompleteDispatchSnapshot {
+            logical_generation,
+            physical: backend.gpu_physical_expert_residency(expert_id),
+            memory,
+            gpu_io,
+            routed: self.routed_expert_execution_snapshot(),
+        })
+    }
+
+    /// Qualification-only complete Q4_0 expert execution. It fetches the
+    /// selected global expert through production storage, computes the
+    /// fail-loud authoritative CPU reference from that exact stripped payload,
+    /// and sends each vector through the normal strict routed-expert boundary.
+    /// Normal serving never calls this method.
+    pub(crate) async fn qualify_q4_0_complete_expert(
+        self: &Arc<Self>,
+        global_expert_id: u32,
+        layer_index: u32,
+        inputs: &[Vec<f32>],
+    ) -> Result<crate::q4_parity::CompleteExpertExecution, String> {
+        use sha2::{Digest, Sha256};
+
+        if self.core.options.dtype != WeightDtype::Q4_0 {
+            return Err(format!(
+                "complete-expert parity requires Q4_0, got {}",
+                self.core.options.dtype.as_str()
+            ));
+        }
+        if self.execution_context().plan().routed_experts()
+            != crate::backend::ExecutionPlane::Gpu
+            || self.routed_expert_gpu_failure_policy()
+                != RoutedExpertGpuFailurePolicy::StrictFailClosed
+            || self.core.options.policy != crate::inference::RealInferencePolicy::STRICT
+        {
+            return Err(
+                "complete-expert parity requires a strict fail-closed GPU routed-expert plan"
+                    .to_string(),
+            );
+        }
+        if inputs.len() < 2 {
+            return Err("complete-expert parity requires at least two input vectors".to_string());
+        }
+        if inputs.iter().any(|input| {
+            input.len() != self.core.shape.d_model
+                || input.iter().any(|value| {
+                    !value.is_finite() || half::f16::from_f32(*value).to_f32() != *value
+                })
+        }) {
+            return Err(format!(
+                "complete-expert inputs must contain exactly {} finite f16-exact values",
+                self.core.shape.d_model
+            ));
+        }
+
+        self.core
+            .storage
+            .validate_expert_file_layout(std::iter::once(global_expert_id))
+            .map_err(|error| {
+                format!(
+                    "global expert {global_expert_id} does not have the exact configured checkpoint file size: {error}"
+                )
+            })?;
+
+        let resident = self
+            .fetch_with_retry(global_expert_id)
+            .await
+            .map_err(|error| format!("failed to fetch global expert {global_expert_id}: {error}"))?;
+        let expected_payload = crate::inference::expert_weight_bytes_for(
+            self.core.shape.d_model,
+            self.core.shape.d_ff,
+            WeightDtype::Q4_0,
+        );
+        let block_align = self.core.storage.config().block_align;
+        let checkpoint_payload_bytes = expected_payload
+            .checked_add(block_align.checked_sub(1).ok_or_else(|| {
+                "complete-expert parity requires non-zero storage block alignment".to_string()
+            })?)
+            .map(|bytes| bytes / block_align * block_align)
+            .ok_or_else(|| "aligned checkpoint payload size overflowed usize".to_string())?;
+        if resident.data().len() != checkpoint_payload_bytes {
+            return Err(format!(
+                "global expert {global_expert_id} checkpoint payload has {} bytes, expected exactly {checkpoint_payload_bytes} ({expected_payload} canonical Q4_0 bytes plus alignment padding)",
+                resident.data().len(),
+            ));
+        }
+        let (canonical_payload, alignment_padding) = resident.data().split_at(expected_payload);
+        let alignment_padding_bytes = alignment_padding.len();
+        if alignment_padding.iter().any(|byte| *byte != 0) {
+            return Err(format!(
+                "global expert {global_expert_id} has non-zero bytes in its {}-byte checkpoint alignment pad",
+                alignment_padding.len()
+            ));
+        }
+        let payload_sha256 = format!("{:x}", Sha256::digest(canonical_payload));
+        let checkpoint_payload_sha256 = format!("{:x}", Sha256::digest(resident.data()));
+
+        // Compute every CPU oracle before the first GPU snapshot. This keeps
+        // each recorded before/after pair immediately adjacent to exactly one
+        // production GPU dispatch.
+        let cpu_outputs: Result<Vec<Vec<f32>>, String> = inputs
+            .iter()
+            .enumerate()
+            .map(|(index, input)| {
+                crate::inference::q4_0_cpu_reference_forward(
+                    canonical_payload,
+                    input,
+                    self.core.shape.d_model,
+                    self.core.shape.d_ff,
+                )
+                .map_err(|error| format!("CPU reference vector {index} failed: {error}"))
+            })
+            .collect();
+        let cpu_outputs = cpu_outputs?;
+
+        let mut dispatches = Vec::with_capacity(inputs.len());
+        for (input, cpu_f32) in inputs.iter().cloned().zip(cpu_outputs) {
+            // Mirror the authoritative production routing probe exactly once.
+            // This owns logical admission hit/miss telemetry and LRU recency;
+            // the backend remains non-mutating with respect to logical LRU.
+            let _ = self
+                .execution_context()
+                .gpu_expert_cache()
+                .get(global_expert_id);
+            let before = self.q4_parity_dispatch_snapshot(global_expert_id)?;
+            let gpu_f16 = self
+                .forward_moe_resident(0, layer_index, resident.as_ref(), &input, None)
+                .map_err(|error| {
+                    format!(
+                        "global expert {global_expert_id} layer {layer_index} GPU dispatch failed: {error}"
+                    )
+                })?;
+            let after = self.q4_parity_dispatch_snapshot(global_expert_id)?;
+            dispatches.push(crate::q4_parity::CompleteDispatchExecution {
+                input,
+                cpu_f32,
+                gpu_f16,
+                before,
+                after,
+            });
+        }
+
+        Ok(crate::q4_parity::CompleteExpertExecution {
+            d_model: self.core.shape.d_model,
+            d_ff: self.core.shape.d_ff,
+            checkpoint_block_align: block_align,
+            payload_bytes: expected_payload,
+            checkpoint_payload_bytes,
+            alignment_padding_bytes,
+            payload_sha256,
+            checkpoint_payload_sha256,
+            dispatches,
+        })
+    }
+
     /// Snapshot the qualification-only real routed-expert execution counters.
     pub fn routed_expert_execution_snapshot(&self) -> RoutedExpertExecutionSnapshot {
         RoutedExpertExecutionSnapshot {

--- a/rust-engine/src/inference.rs
+++ b/rust-engine/src/inference.rs
@@ -3283,6 +3283,28 @@ pub fn run_inference_q4_0(
     Ok((out, y))
 }
 
+/// Fail-loud authoritative CPU reference for strict Q4_0 numerical
+/// qualification. Unlike [`run_inference_q4_0`], this never routes a Candle
+/// error through `ExpertWeights::forward`'s legacy zero-output compatibility
+/// behavior. The decoder, matrix layout, SwiGLU clamp, and CPU math are the
+/// same production implementations.
+pub(crate) fn q4_0_cpu_reference_forward(
+    bytes: &[u8],
+    x: &[f32],
+    d_model: usize,
+    d_ff: usize,
+) -> Result<HiddenState, ExpertWeightsError> {
+    let owned = OwnedExpertWeights::from_bytes_q4_0(bytes, d_model, d_ff)?;
+    ExpertWeights {
+        d_model: owned.d_model,
+        d_ff: owned.d_ff,
+        gate: &owned.gate,
+        up: &owned.up,
+        down: &owned.down,
+    }
+    .forward_candle(x)
+}
+
 /// Legacy Q8_0 dequantisation reference: materialises the resident
 /// bytes (a stream of GGUF Q8_0 34-byte blocks, each holding an `f16`
 /// scale and 32 signed `i8` weights) into an owned `Vec<f32>` (via

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -160,6 +160,7 @@ mod parallel;
 mod prefetch_governor;
 mod pregate;
 mod qualification;
+mod q4_parity;
 mod rayon_autotune;
 mod residency;
 mod router;
@@ -877,6 +878,23 @@ enum Cmd {
         external_gpu_memory_artifact: Option<String>,
     },
 
+    /// Qualify canonical Q4_0 WGSL math and one complete extracted routed
+    /// expert against MER's authoritative CPU implementation.
+    QualifyHybridQ4Parity {
+        /// Path to the strict Hybrid native-Q4_0 TOML config.
+        #[arg(long)]
+        config: PathBuf,
+        /// Global expert id: layer * num_experts_per_layer + layer-local id.
+        #[arg(long)]
+        expert_id: u32,
+        /// Exact wgpu adapter name required for this qualification run.
+        #[arg(long)]
+        expected_adapter_name: String,
+        /// Write the typed JSON report here instead of stdout.
+        #[arg(long)]
+        report_out: Option<PathBuf>,
+    },
+
     /// Benchmark dense matvec backends on the target Qwen3-Coder CPU shapes.
     ///
     /// This is intentionally separate from `bench-real`: it isolates Q/K/V/O,
@@ -1522,7 +1540,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let startup_config = match &cli.cmd {
         Cmd::Serve { config }
         | Cmd::BenchReal { config, .. }
-        | Cmd::QualifyHybridQ4 { config, .. } => Some(crate::config::Config::from_file(config)?),
+        | Cmd::QualifyHybridQ4 { config, .. }
+        | Cmd::QualifyHybridQ4Parity { config, .. } => {
+            Some(crate::config::Config::from_file(config)?)
+        }
         _ => None,
     };
 
@@ -1638,7 +1659,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // fatal; legacy deterministic dtype/geometry bypass remains visible in
     // the resolved component plan.
     let run_gpu_requested = matches!(cli.cmd, Cmd::Run { gpu: true, .. });
-    if !matches!(cli.cmd, Cmd::Serve { .. } | Cmd::QualifyHybridQ4 { .. }) && !run_gpu_requested {
+    if !matches!(
+        cli.cmd,
+        Cmd::Serve { .. }
+            | Cmd::QualifyHybridQ4 { .. }
+            | Cmd::QualifyHybridQ4Parity { .. }
+    ) && !run_gpu_requested
+    {
         crate::backend::install_default();
         let b = crate::backend::current();
         info!(
@@ -1892,6 +1919,24 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 progress_watchdog,
             }))
         }
+        Cmd::QualifyHybridQ4Parity {
+            config,
+            expert_id,
+            expected_adapter_name,
+            report_out,
+        } => {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()?;
+            rt.block_on(cmd_qualify_hybrid_q4_parity(
+                QualifyHybridQ4ParityArgs {
+                    config,
+                    expert_id,
+                    expected_adapter_name,
+                    report_out,
+                },
+            ))
+        }
         Cmd::MatvecMicrobench {
             backend,
             warmup_runs,
@@ -2111,6 +2156,13 @@ struct QualifyHybridQ4Args {
     report_out: Option<PathBuf>,
     external_gpu_memory_artifact: Option<String>,
     progress_watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+}
+
+struct QualifyHybridQ4ParityArgs {
+    config: PathBuf,
+    expert_id: u32,
+    expected_adapter_name: String,
+    report_out: Option<PathBuf>,
 }
 
 struct MatvecMicrobenchArgs {
@@ -2509,6 +2561,33 @@ fn fail_qualification(
     Err(summary.into())
 }
 
+fn emit_q4_parity_report(
+    report: &crate::q4_parity::Q4ParityReport,
+    report_out: Option<&Path>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut json = serde_json::to_vec_pretty(report)?;
+    json.push(b'\n');
+    if let Some(path) = report_out {
+        std::fs::write(path, json)?;
+        eprintln!("Q4_0 parity report written to {}", path.display());
+    } else {
+        use std::io::Write as _;
+        std::io::stdout().write_all(&json)?;
+    }
+    Ok(())
+}
+
+fn fail_q4_parity(
+    mut report: crate::q4_parity::Q4ParityReport,
+    failure: crate::qualification::QualificationFailure,
+    report_out: Option<&Path>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let summary = format!("{}: {}", failure.code, failure.detail);
+    report.fail(failure);
+    emit_q4_parity_report(&report, report_out)?;
+    Err(summary.into())
+}
+
 fn qualification_artifact_failure(
     errors: &[String],
 ) -> crate::qualification::QualificationFailure {
@@ -2851,6 +2930,368 @@ async fn cmd_qualify_hybrid_q4(
         return fail_qualification(report, failure, args.report_out.as_deref());
     }
     emit_qualification_report(&report, args.report_out.as_deref())
+}
+
+async fn cmd_qualify_hybrid_q4_parity(
+    args: QualifyHybridQ4ParityArgs,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use crate::qualification::{
+        validate_device, validate_execution_plan, validate_gpu_failure_policy,
+        validate_memory, validate_preflight, BuildProvenance, FailureStage, PreflightEvidence,
+        QualificationChecks, QualificationFailure,
+    };
+
+    let cfg = crate::config::Config::from_file(&args.config)?;
+    let provenance = BuildProvenance::embedded();
+    let (artifacts, artifact_errors) = qualification_artifacts(&args.config, &cfg);
+    let metadata_path = cfg.model.data_dir.join("metadata.json");
+    let metadata_result = crate::qualification::read_expert_metadata(&metadata_path);
+    let metadata = metadata_result.clone().ok();
+    let mut report = crate::q4_parity::Q4ParityReport::new(
+        provenance.clone(),
+        artifacts,
+        metadata.clone(),
+        args.expected_adapter_name.clone(),
+    );
+
+    if !artifact_errors.is_empty() {
+        return fail_q4_parity(
+            report,
+            qualification_artifact_failure(&artifact_errors),
+            args.report_out.as_deref(),
+        );
+    }
+    let metadata = match metadata_result {
+        Ok(metadata) => metadata,
+        Err(detail) => {
+            return fail_q4_parity(
+                report,
+                qualification_metadata_failure(detail),
+                args.report_out.as_deref(),
+            );
+        }
+    };
+    let weight_policy = cfg.real_transformer.resolve_weight_policy();
+    if !matches!(weight_policy, Ok(crate::config::RealWeightPolicy::StrictReal)) {
+        return fail_q4_parity(
+            report,
+            QualificationFailure::new(
+                FailureStage::Preflight,
+                "non-strict-weight-policy",
+                weight_policy
+                    .err()
+                    .unwrap_or_else(|| "resolved weight policy is SeededDev".to_string()),
+            ),
+            args.report_out.as_deref(),
+        );
+    }
+    let capacity_bytes = cfg
+        .gpu_cache
+        .vram_capacity_mb
+        .checked_mul(1024 * 1024)
+        .and_then(|bytes| u64::try_from(bytes).ok())
+        .unwrap_or(0);
+    let preflight = PreflightEvidence {
+        provenance,
+        real_transformer_enabled: cfg.real_transformer.enabled,
+        weights_dir_configured: cfg.real_transformer.weights_dir.is_some(),
+        strict_weights: cfg.real_transformer.strict_weights,
+        allow_seeded_fallback: cfg.real_transformer.allow_seeded_fallback,
+        allow_degraded_experts: cfg.real_transformer.allow_degraded_experts,
+        allow_attention_fallback: cfg.real_transformer.allow_nonfinite_attention_fallback,
+        allow_truncated_expert_payloads: cfg.real_transformer.allow_truncated_expert_payloads,
+        distributed_enabled: cfg.distributed.enabled,
+        gpu_cache_enabled: cfg.gpu_cache.enabled,
+        gpu_expert_capacity_bytes: capacity_bytes,
+        requested_mode: cfg.real_transformer.compute_offload,
+        routed_expert_dtype: cfg.model.dtype,
+        metadata,
+    };
+    let mut base_checks = QualificationChecks::default();
+    if let Err(failure) = validate_preflight(&preflight, &mut base_checks) {
+        return fail_q4_parity(report, failure, args.report_out.as_deref());
+    }
+    report.checks.clean_build = base_checks.clean_build;
+    report.checks.strict_hybrid_preflight = base_checks.strict_real_checkpoint
+        && base_checks.requested_hybrid
+        && base_checks.native_q4_0_routed_experts;
+    report.checks.canonical_q4_0_layout = base_checks.canonical_q4_layout;
+
+    let runtime = match build_real_cli_runtime(
+        &args.config,
+        RealCliRuntimeMode::StrictHybridQualification,
+    )
+    .await
+    {
+        Ok(runtime) => runtime,
+        Err(error) => {
+            return fail_q4_parity(
+                report,
+                QualificationFailure::new(
+                    FailureStage::Startup,
+                    "startup-failed",
+                    error.to_string(),
+                ),
+                args.report_out.as_deref(),
+            );
+        }
+    };
+    if !runtime.model.load_status.strict
+        || runtime.model.load_status.seeded_fallback_remained
+        || runtime.model.load_status.loaded_tensors != runtime.model.load_status.required_tensors
+    {
+        return fail_q4_parity(
+            report,
+            QualificationFailure::new(
+                FailureStage::Startup,
+                "seeded-model-loaded",
+                format!(
+                    "strict={} loaded={}/{} seeded_fallback_remained={}",
+                    runtime.model.load_status.strict,
+                    runtime.model.load_status.loaded_tensors,
+                    runtime.model.load_status.required_tensors,
+                    runtime.model.load_status.seeded_fallback_remained
+                ),
+            ),
+            args.report_out.as_deref(),
+        );
+    }
+
+    let context = runtime.engine.execution_context();
+    report.execution_plan = Some(context.plan().into());
+    if let Err(failure) = validate_execution_plan(context.plan(), &mut base_checks) {
+        return fail_q4_parity(report, failure, args.report_out.as_deref());
+    }
+    report.checks.exact_execution_plan = base_checks.resolved_planes_match_contract;
+
+    let device = runtime.engine.gpu_device_identity();
+    report.device = device.clone();
+    if let Err(failure) = validate_device(device.as_ref(), &mut base_checks) {
+        return fail_q4_parity(report, failure, args.report_out.as_deref());
+    }
+    report.checks.hardware_gpu_adapter = base_checks.hardware_gpu_adapter;
+    let Some(device) = device else {
+        return fail_q4_parity(
+            report,
+            QualificationFailure::new(
+                FailureStage::Startup,
+                "gpu-device-unavailable",
+                "validated authoritative GPU identity unexpectedly disappeared",
+            ),
+            args.report_out.as_deref(),
+        );
+    };
+    if device.name != args.expected_adapter_name {
+        return fail_q4_parity(
+            report,
+            QualificationFailure::new(
+                FailureStage::Startup,
+                "unexpected-gpu-adapter",
+                format!(
+                    "selected adapter {:?}, expected exact name {:?}",
+                    device.name, args.expected_adapter_name
+                ),
+            ),
+            args.report_out.as_deref(),
+        );
+    }
+    report.checks.expected_adapter_exact_match = true;
+    if let Err(failure) = validate_gpu_failure_policy(
+        runtime.engine.routed_expert_gpu_failure_policy(),
+        &mut base_checks,
+    ) {
+        return fail_q4_parity(report, failure, args.report_out.as_deref());
+    }
+    report.checks.strict_gpu_failure_policy = base_checks.strict_gpu_failure_policy;
+
+    let identity = match crate::q4_parity::expert_identity(
+        args.expert_id,
+        runtime.cfg.model.num_layers,
+        runtime.cfg.model.num_experts,
+    ) {
+        Ok(identity) => identity,
+        Err(failure) => {
+            return fail_q4_parity(report, failure, args.report_out.as_deref());
+        }
+    };
+    report.checks.global_expert_identity_valid = true;
+
+    // Raw canonical blocks use only ephemeral qualification buffers. Prove
+    // they leave logical/physical expert state and production I/O counters
+    // unchanged before beginning the complete-expert evidence window.
+    let backend = context.routed_expert_backend();
+    let raw_memory_before = runtime.engine.gpu_expert_memory_snapshot();
+    let raw_io_before = runtime.engine.gpu_expert_io_snapshot();
+    let raw_physical_before = backend.gpu_physical_expert_residency(args.expert_id);
+    let Some(raw_memory_before) = raw_memory_before else {
+        return fail_q4_parity(
+            report,
+            QualificationFailure::new(
+                FailureStage::Startup,
+                "gpu-device-unavailable",
+                "raw Q4_0 qualification has no physical-memory snapshot",
+            ),
+            args.report_out.as_deref(),
+        );
+    };
+    let Some(raw_io_before) = raw_io_before else {
+        return fail_q4_parity(
+            report,
+            QualificationFailure::new(
+                FailureStage::Startup,
+                "gpu-device-unavailable",
+                "raw Q4_0 qualification has no routed-expert I/O snapshot",
+            ),
+            args.report_out.as_deref(),
+        );
+    };
+    if let Err(failure) = validate_memory(raw_memory_before) {
+        return fail_q4_parity(report, failure, args.report_out.as_deref());
+    }
+    if raw_memory_before.logical_admitted_bytes != 0
+        || raw_memory_before.expert_live_bytes != 0
+        || raw_memory_before.expert_registry_bytes != 0
+        || raw_memory_before.physical_entries != 0
+        || raw_memory_before.physical_installs != 0
+        || raw_memory_before.physical_evictions != 0
+        || raw_memory_before.stale_retirements != 0
+        || raw_io_before != crate::backend::GpuExpertIoSnapshot::default()
+        || raw_physical_before.is_some()
+    {
+        return fail_q4_parity(
+            report,
+            QualificationFailure::new(
+                FailureStage::Startup,
+                "physical-registry-not-cold",
+                "complete-expert parity requires a fresh logical/physical expert registry and zero routed GPU-I/O counters",
+            ),
+            args.report_out.as_deref(),
+        );
+    }
+    let raw_cases = match crate::q4_parity::run_raw_shader_cases(backend) {
+        Ok(cases) => cases,
+        Err(failure) => {
+            return fail_q4_parity(report, failure, args.report_out.as_deref());
+        }
+    };
+    report.raw_cases = raw_cases;
+    report.checks.raw_shader_cases_passed = true;
+    let raw_memory_after = runtime.engine.gpu_expert_memory_snapshot();
+    let raw_io_after = runtime.engine.gpu_expert_io_snapshot();
+    let raw_physical_after = backend.gpu_physical_expert_residency(args.expert_id);
+    let Some(raw_memory_after) = raw_memory_after else {
+        return fail_q4_parity(
+            report,
+            QualificationFailure::new(
+                FailureStage::Postcondition,
+                "gpu-device-unavailable",
+                "raw Q4_0 qualification lost its physical-memory snapshot",
+            ),
+            args.report_out.as_deref(),
+        );
+    };
+    let Some(raw_io_after) = raw_io_after else {
+        return fail_q4_parity(
+            report,
+            QualificationFailure::new(
+                FailureStage::Postcondition,
+                "gpu-device-unavailable",
+                "raw Q4_0 qualification lost its routed-expert I/O snapshot",
+            ),
+            args.report_out.as_deref(),
+        );
+    };
+    report.raw_isolation = Some(crate::q4_parity::RawIsolationEvidence {
+        memory_before: raw_memory_before,
+        memory_after: raw_memory_after,
+        gpu_io_before: raw_io_before,
+        gpu_io_after: raw_io_after,
+        selected_physical_before: raw_physical_before,
+        selected_physical_after: raw_physical_after,
+    });
+    if let Err(failure) = validate_memory(raw_memory_after) {
+        return fail_q4_parity(report, failure, args.report_out.as_deref());
+    }
+    if raw_memory_after != raw_memory_before
+        || raw_io_after != raw_io_before
+        || raw_physical_after != raw_physical_before
+    {
+        return fail_q4_parity(
+            report,
+            QualificationFailure::new(
+                FailureStage::Postcondition,
+                "raw-q4-contaminated-expert-residency",
+                "raw Q4_0 dispatch changed production expert residency, memory, or I/O evidence",
+            ),
+            args.report_out.as_deref(),
+        );
+    }
+    report.checks.raw_dispatch_isolated_from_expert_registry = true;
+
+    let inputs = crate::q4_parity::deterministic_complete_inputs(runtime.cfg.model.d_model);
+    let execution = match runtime
+        .engine
+        .qualify_q4_0_complete_expert(args.expert_id, identity.layer_index, &inputs)
+        .await
+    {
+        Ok(execution) => execution,
+        Err(detail) => {
+            return fail_q4_parity(
+                report,
+                QualificationFailure::new(
+                    FailureStage::Inference,
+                    "complete-expert-dispatch-failed",
+                    detail,
+                ),
+                args.report_out.as_deref(),
+            );
+        }
+    };
+    let expected_payload = crate::inference::expert_weight_bytes_for(
+        runtime.cfg.model.d_model,
+        runtime.cfg.model.d_ff,
+        crate::inference::WeightDtype::Q4_0,
+    );
+    if execution.payload_bytes != expected_payload {
+        return fail_q4_parity(
+            report,
+            QualificationFailure::new(
+                FailureStage::Postcondition,
+                "expert-payload-size-mismatch",
+                format!(
+                    "complete expert has {} logical bytes, expected exactly {expected_payload}",
+                    execution.payload_bytes
+                ),
+            ),
+            args.report_out.as_deref(),
+        );
+    }
+    report.checks.exact_expert_payload_size = true;
+    let complete_validation = match crate::q4_parity::validate_complete_expert(
+        identity,
+        execution,
+        runtime.cfg.model.d_model,
+    ) {
+        Ok(complete) => complete,
+        Err(failure) => {
+            return fail_q4_parity(report, failure, args.report_out.as_deref());
+        }
+    };
+    report.complete_expert = Some(complete_validation.report);
+    if let Some(failure) = complete_validation.tolerance_failure {
+        return fail_q4_parity(report, failure, args.report_out.as_deref());
+    }
+    report.checks.initial_physical_install_exactly_once = true;
+    report.checks.subsequent_dispatches_reused_generation = true;
+    report.checks.subsequent_dispatches_uploaded_zero_weight_bytes = true;
+    report.checks.every_dispatch_completed_gpu_io = true;
+    report.checks.zero_evictions_or_stale_retirements = true;
+    report.checks.zero_cpu_fallback_or_degraded_execution = true;
+    report.checks.complete_expert_vectors_passed = true;
+    if let Err(failure) = report.finish() {
+        return fail_q4_parity(report, failure, args.report_out.as_deref());
+    }
+    emit_q4_parity_report(&report, args.report_out.as_deref())
 }
 
 async fn with_progress_timeout<T, F>(
@@ -8318,6 +8759,53 @@ mod tests {
         ])
         .unwrap_err();
         assert!(error.to_string().contains("cannot be used with"));
+    }
+
+    #[test]
+    fn q4_parity_cli_requires_and_preserves_global_expert_and_adapter() {
+        let cli = <Cli as clap::Parser>::try_parse_from([
+            "micro-expert-router",
+            "qualify-hybrid-q4-parity",
+            "--config",
+            "config.toml",
+            "--expert-id",
+            "257",
+            "--expected-adapter-name",
+            "NVIDIA L4",
+        ])
+        .unwrap();
+        let Cmd::QualifyHybridQ4Parity {
+            expert_id,
+            expected_adapter_name,
+            report_out,
+            ..
+        } = cli.cmd
+        else {
+            panic!("expected qualify-hybrid-q4-parity command");
+        };
+        assert_eq!(expert_id, 257);
+        assert_eq!(expected_adapter_name, "NVIDIA L4");
+        assert_eq!(report_out, None);
+    }
+
+    #[test]
+    fn q4_parity_cli_rejects_missing_explicit_identity_inputs() {
+        for missing in ["--expert-id", "--expected-adapter-name"] {
+            let mut args = vec![
+                "micro-expert-router",
+                "qualify-hybrid-q4-parity",
+                "--config",
+                "config.toml",
+                "--expert-id",
+                "257",
+                "--expected-adapter-name",
+                "NVIDIA L4",
+            ];
+            let index = args.iter().position(|value| *value == missing).unwrap();
+            args.drain(index..=index + 1);
+            let error = <Cli as clap::Parser>::try_parse_from(args).unwrap_err();
+            assert!(error.to_string().contains(missing), "{error}");
+        }
     }
 
     #[test]

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -1934,6 +1934,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     expert_id,
                     expected_adapter_name,
                     report_out,
+                    progress_watchdog,
                 },
             ))
         }
@@ -2163,6 +2164,7 @@ struct QualifyHybridQ4ParityArgs {
     expert_id: u32,
     expected_adapter_name: String,
     report_out: Option<PathBuf>,
+    progress_watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
 }
 
 struct MatvecMicrobenchArgs {
@@ -2584,8 +2586,25 @@ fn fail_q4_parity(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let summary = format!("{}: {}", failure.code, failure.detail);
     report.fail(failure);
-    emit_q4_parity_report(&report, report_out)?;
-    Err(summary.into())
+    match emit_q4_parity_report(&report, report_out) {
+        Ok(()) => Err(summary.into()),
+        Err(emit_error) => Err(format!(
+            "{summary}; additionally failed to emit Q4_0 parity report: {emit_error}"
+        )
+        .into()),
+    }
+}
+
+fn q4_parity_readback_timeout(
+    args: &QualifyHybridQ4ParityArgs,
+) -> Result<std::time::Duration, crate::qualification::QualificationFailure> {
+    args.progress_watchdog.timeout.ok_or_else(|| {
+        crate::qualification::QualificationFailure::new(
+            crate::qualification::FailureStage::Preflight,
+            "progress-watchdog-required",
+            "strict Q4_0 parity requires a positive performance.progress_timeout_secs or --progress-timeout-secs so raw GPU readback is bounded",
+        )
+    })
 }
 
 fn qualification_artifact_failure(
@@ -2953,6 +2972,12 @@ async fn cmd_qualify_hybrid_q4_parity(
         metadata.clone(),
         args.expected_adapter_name.clone(),
     );
+    let raw_readback_timeout = match q4_parity_readback_timeout(&args) {
+        Ok(timeout) => timeout,
+        Err(failure) => {
+            return fail_q4_parity(report, failure, args.report_out.as_deref());
+        }
+    };
 
     if !artifact_errors.is_empty() {
         return fail_q4_parity(
@@ -3168,36 +3193,42 @@ async fn cmd_qualify_hybrid_q4_parity(
             args.report_out.as_deref(),
         );
     }
-    let raw_cases = match crate::q4_parity::run_raw_shader_cases(backend) {
-        Ok(cases) => cases,
+    let raw_validation = match crate::q4_parity::run_raw_shader_cases(
+        backend,
+        raw_readback_timeout,
+    ) {
+        Ok(validation) => validation,
         Err(failure) => {
             return fail_q4_parity(report, failure, args.report_out.as_deref());
         }
     };
-    report.raw_cases = raw_cases;
-    report.checks.raw_shader_cases_passed = true;
+    report.checks.raw_shader_cases_passed = raw_validation.all_cases_passed();
+    let mut raw_failure = raw_validation.tolerance_failure;
+    report.raw_cases = raw_validation.reports;
     let raw_memory_after = runtime.engine.gpu_expert_memory_snapshot();
     let raw_io_after = runtime.engine.gpu_expert_io_snapshot();
     let raw_physical_after = backend.gpu_physical_expert_residency(args.expert_id);
     let Some(raw_memory_after) = raw_memory_after else {
+        let missing = QualificationFailure::new(
+            FailureStage::Postcondition,
+            "gpu-device-unavailable",
+            "raw Q4_0 qualification lost its physical-memory snapshot",
+        );
         return fail_q4_parity(
             report,
-            QualificationFailure::new(
-                FailureStage::Postcondition,
-                "gpu-device-unavailable",
-                "raw Q4_0 qualification lost its physical-memory snapshot",
-            ),
+            raw_failure.unwrap_or(missing),
             args.report_out.as_deref(),
         );
     };
     let Some(raw_io_after) = raw_io_after else {
+        let missing = QualificationFailure::new(
+            FailureStage::Postcondition,
+            "gpu-device-unavailable",
+            "raw Q4_0 qualification lost its routed-expert I/O snapshot",
+        );
         return fail_q4_parity(
             report,
-            QualificationFailure::new(
-                FailureStage::Postcondition,
-                "gpu-device-unavailable",
-                "raw Q4_0 qualification lost its routed-expert I/O snapshot",
-            ),
+            raw_failure.unwrap_or(missing),
             args.report_out.as_deref(),
         );
     };
@@ -3209,24 +3240,28 @@ async fn cmd_qualify_hybrid_q4_parity(
         selected_physical_before: raw_physical_before,
         selected_physical_after: raw_physical_after,
     });
-    if let Err(failure) = validate_memory(raw_memory_after) {
+    let memory_after_valid = match validate_memory(raw_memory_after) {
+        Ok(()) => true,
+        Err(failure) => {
+            raw_failure.get_or_insert(failure);
+            false
+        }
+    };
+    let raw_state_unchanged = raw_memory_after == raw_memory_before
+        && raw_io_after == raw_io_before
+        && raw_physical_after == raw_physical_before;
+    if !raw_state_unchanged {
+        raw_failure.get_or_insert_with(|| QualificationFailure::new(
+            FailureStage::Postcondition,
+            "raw-q4-contaminated-expert-residency",
+            "raw Q4_0 dispatch changed production expert residency, memory, or I/O evidence",
+        ));
+    }
+    report.checks.raw_dispatch_isolated_from_expert_registry =
+        memory_after_valid && raw_state_unchanged;
+    if let Some(failure) = raw_failure {
         return fail_q4_parity(report, failure, args.report_out.as_deref());
     }
-    if raw_memory_after != raw_memory_before
-        || raw_io_after != raw_io_before
-        || raw_physical_after != raw_physical_before
-    {
-        return fail_q4_parity(
-            report,
-            QualificationFailure::new(
-                FailureStage::Postcondition,
-                "raw-q4-contaminated-expert-residency",
-                "raw Q4_0 dispatch changed production expert residency, memory, or I/O evidence",
-            ),
-            args.report_out.as_deref(),
-        );
-    }
-    report.checks.raw_dispatch_isolated_from_expert_registry = true;
 
     let inputs = crate::q4_parity::deterministic_complete_inputs(runtime.cfg.model.d_model);
     let execution = match runtime
@@ -3277,17 +3312,27 @@ async fn cmd_qualify_hybrid_q4_parity(
             return fail_q4_parity(report, failure, args.report_out.as_deref());
         }
     };
-    report.complete_expert = Some(complete_validation.report);
-    if let Some(failure) = complete_validation.tolerance_failure {
+    let crate::q4_parity::CompleteExpertValidation {
+        report: complete_report,
+        invariants: outcomes,
+        tolerance_failure,
+    } = complete_validation;
+    report.complete_expert = Some(complete_report);
+    report.checks.initial_physical_install_exactly_once =
+        outcomes.initial_physical_install_exactly_once;
+    report.checks.subsequent_dispatches_reused_generation =
+        outcomes.subsequent_dispatches_reused_generation;
+    report.checks.subsequent_dispatches_uploaded_zero_weight_bytes =
+        outcomes.subsequent_dispatches_uploaded_zero_weight_bytes;
+    report.checks.every_dispatch_completed_gpu_io = outcomes.every_dispatch_completed_gpu_io;
+    report.checks.zero_evictions_or_stale_retirements =
+        outcomes.zero_evictions_or_stale_retirements;
+    report.checks.zero_cpu_fallback_or_degraded_execution =
+        outcomes.zero_cpu_fallback_or_degraded_execution;
+    report.checks.complete_expert_vectors_passed = outcomes.complete_expert_vectors_passed;
+    if let Some(failure) = tolerance_failure {
         return fail_q4_parity(report, failure, args.report_out.as_deref());
     }
-    report.checks.initial_physical_install_exactly_once = true;
-    report.checks.subsequent_dispatches_reused_generation = true;
-    report.checks.subsequent_dispatches_uploaded_zero_weight_bytes = true;
-    report.checks.every_dispatch_completed_gpu_io = true;
-    report.checks.zero_evictions_or_stale_retirements = true;
-    report.checks.zero_cpu_fallback_or_degraded_execution = true;
-    report.checks.complete_expert_vectors_passed = true;
     if let Err(failure) = report.finish() {
         return fail_q4_parity(report, failure, args.report_out.as_deref());
     }
@@ -8806,6 +8851,58 @@ mod tests {
             let error = <Cli as clap::Parser>::try_parse_from(args).unwrap_err();
             assert!(error.to_string().contains(missing), "{error}");
         }
+    }
+
+    #[test]
+    fn q4_parity_command_receives_configured_progress_watchdog() {
+        let args = QualifyHybridQ4ParityArgs {
+            config: PathBuf::from("config.toml"),
+            expert_id: 0,
+            expected_adapter_name: "NVIDIA L4".to_string(),
+            report_out: None,
+            progress_watchdog: crate::rayon_autotune::ProgressWatchdogConfig {
+                timeout: Some(std::time::Duration::from_secs(17)),
+            },
+        };
+        assert_eq!(
+            q4_parity_readback_timeout(&args).unwrap(),
+            std::time::Duration::from_secs(17)
+        );
+
+        let disabled = QualifyHybridQ4ParityArgs {
+            progress_watchdog: crate::rayon_autotune::ProgressWatchdogConfig::disabled(),
+            ..args
+        };
+        assert_eq!(
+            q4_parity_readback_timeout(&disabled).unwrap_err().code,
+            "progress-watchdog-required"
+        );
+    }
+
+    #[test]
+    fn q4_parity_report_emission_error_preserves_primary_failure_first() {
+        let report = crate::q4_parity::Q4ParityReport::new(
+            crate::qualification::BuildProvenance::embedded(),
+            crate::qualification::QualificationArtifacts::default(),
+            None,
+            "NVIDIA L4".to_string(),
+        );
+        let failure = crate::qualification::QualificationFailure::new(
+            crate::qualification::FailureStage::Postcondition,
+            "primary-q4-failure",
+            "primary detail",
+        );
+        let directory = tempdir_unique("q4-parity-report-is-directory");
+        std::fs::create_dir_all(&directory).unwrap();
+        let error = fail_q4_parity(report, failure, Some(&directory))
+            .unwrap_err()
+            .to_string();
+        assert!(error.starts_with("primary-q4-failure: primary detail;"), "{error}");
+        assert!(
+            error.contains("additionally failed to emit Q4_0 parity report"),
+            "{error}"
+        );
+        let _ = std::fs::remove_dir_all(directory);
     }
 
     #[test]

--- a/rust-engine/src/q4_parity.rs
+++ b/rust-engine/src/q4_parity.rs
@@ -16,9 +16,11 @@ use crate::qualification::{
 };
 use serde::Serialize;
 use sha2::{Digest, Sha256};
+use std::time::Duration;
 
 pub const SCHEMA_VERSION: &str = "mer.strict-hybrid-q4-parity.v1";
 pub const MODE: &str = "strict-hybrid-q4-parity";
+pub const RAW_CASE_COUNT: usize = 8;
 
 /// Raw shader output remains f32, but its block-local operation order differs
 /// slightly from materialising every scaled CPU weight before the dot product.
@@ -76,12 +78,64 @@ pub struct RawQ4CaseReport {
     pub cpu_f32: Vec<f32>,
     pub gpu_f32: Vec<f32>,
     pub absolute_errors: Vec<f32>,
+    /// `f32::MAX` means relative error is undefined because the CPU
+    /// reference is zero while absolute error is nonzero. PASS still uses the
+    /// finite combined absolute-plus-relative allowance.
     pub relative_errors: Vec<f32>,
     pub allowed_errors: Vec<f32>,
     pub worst_index: usize,
+    pub worst_cpu_f32: f32,
+    pub worst_gpu_f32: f32,
+    pub worst_absolute_error: f32,
+    pub worst_relative_error: f32,
     pub max_absolute_error: f32,
     pub max_relative_error: f32,
     pub passed: bool,
+}
+
+/// Raw shader evidence plus the first observed tolerance failure. A tolerance
+/// miss is data, not a control-flow error: all safe deterministic cases keep
+/// running and every completed report is retained.
+#[derive(Debug)]
+pub struct RawShaderValidation {
+    pub reports: Vec<RawQ4CaseReport>,
+    pub tolerance_failure: Option<QualificationFailure>,
+}
+
+impl RawShaderValidation {
+    fn new() -> Self {
+        Self {
+            reports: Vec::with_capacity(RAW_CASE_COUNT),
+            tolerance_failure: None,
+        }
+    }
+
+    fn record(&mut self, report: RawQ4CaseReport) {
+        if !report.passed {
+            self.tolerance_failure.get_or_insert_with(|| {
+                QualificationFailure::new(
+                    FailureStage::Postcondition,
+                    "raw-q4-tolerance-failed",
+                    format!(
+                        "{} failed at output {}: cpu={} gpu={} abs_error={} allowed={}",
+                        report.name,
+                        report.worst_index,
+                        report.worst_cpu_f32,
+                        report.worst_gpu_f32,
+                        report.worst_absolute_error,
+                        report.allowed_errors[report.worst_index]
+                    ),
+                )
+            });
+        }
+        self.reports.push(report);
+    }
+
+    pub fn all_cases_passed(&self) -> bool {
+        self.tolerance_failure.is_none()
+            && self.reports.len() == RAW_CASE_COUNT
+            && self.reports.iter().all(|report| report.passed)
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
@@ -187,6 +241,8 @@ pub struct CompleteExpertVectorReport {
     pub cpu_f16: Vec<f32>,
     pub gpu_f16: Vec<f32>,
     pub absolute_errors: Vec<f32>,
+    /// Uses the same finite `f32::MAX` sentinel as raw reports when the rounded
+    /// CPU f16 reference is zero and absolute error is nonzero.
     pub relative_errors: Vec<f32>,
     pub allowed_errors: Vec<f32>,
     pub worst_index: usize,
@@ -224,7 +280,21 @@ pub struct CompleteExpertReport {
 #[derive(Debug)]
 pub struct CompleteExpertValidation {
     pub report: CompleteExpertReport,
+    pub invariants: CompleteExpertInvariantOutcomes,
     pub tolerance_failure: Option<QualificationFailure>,
+}
+
+/// Observed completion invariants used verbatim to populate the top-level PASS
+/// checks. Every value is calculated from dispatch snapshots and counters.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CompleteExpertInvariantOutcomes {
+    pub initial_physical_install_exactly_once: bool,
+    pub subsequent_dispatches_reused_generation: bool,
+    pub subsequent_dispatches_uploaded_zero_weight_bytes: bool,
+    pub every_dispatch_completed_gpu_io: bool,
+    pub zero_evictions_or_stale_retirements: bool,
+    pub zero_cpu_fallback_or_degraded_execution: bool,
+    pub complete_expert_vectors_passed: bool,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize)]
@@ -337,7 +407,7 @@ impl Q4ParityReport {
             || self.expert_metadata.is_none()
             || self.execution_plan.is_none()
             || self.device.is_none()
-            || self.raw_cases.is_empty()
+            || self.raw_cases.len() != RAW_CASE_COUNT
             || self.raw_isolation.is_none()
             || self.complete_expert.is_none()
         {
@@ -351,6 +421,31 @@ impl Q4ParityReport {
         self.failure = None;
         Ok(())
     }
+}
+
+/// Validate the checkpoint storage alignment before any aligned payload-size
+/// arithmetic. The qualification path deliberately fails instead of relying
+/// on a lower-level aligned-buffer assertion.
+pub(crate) fn validate_checkpoint_block_align(block_align: usize) -> Result<(), String> {
+    if block_align == 0 || !block_align.is_power_of_two() {
+        return Err(format!(
+            "storage block_align {block_align} must be a positive power of two for complete-expert parity"
+        ));
+    }
+    Ok(())
+}
+
+/// Round canonical expert bytes to the exact header-stripped checkpoint slot
+/// size with checked arithmetic.
+pub(crate) fn aligned_checkpoint_payload_bytes(
+    payload_bytes: usize,
+    block_align: usize,
+) -> Result<usize, String> {
+    validate_checkpoint_block_align(block_align)?;
+    payload_bytes
+        .checked_add(block_align - 1)
+        .map(|bytes| bytes / block_align * block_align)
+        .ok_or_else(|| "aligned checkpoint payload size overflowed usize".to_string())
 }
 
 fn canonical_block(scale: f32, nibbles: [u8; 16]) -> Vec<u8> {
@@ -387,6 +482,16 @@ pub fn canonical_raw_cases() -> Vec<RawQ4Case> {
     let multiple_blocks = [
         canonical_block(0.125, alternating),
         canonical_block(-0.25, ramp),
+    ]
+    .concat();
+
+    // Block zero is an unused prefix. Blocks one and two are deliberately
+    // distinct so rows=2 validates both row stride and output indexing from a
+    // nonzero, byte-unaligned Q4_0 block offset.
+    let multi_row_stream = [
+        canonical_block(0.0, alternating),
+        canonical_block(0.125, ramp),
+        canonical_block(-0.25, inverse_ramp),
     ]
     .concat();
 
@@ -453,6 +558,15 @@ pub fn canonical_raw_cases() -> Vec<RawQ4Case> {
             rows: 1,
             columns: 32,
             w_block_off: 2,
+        },
+        RawQ4Case {
+            name: "multi-row-offset-row-stride",
+            projection: "standalone",
+            weights: multi_row_stream,
+            input: deterministic_input(32, 8),
+            rows: 2,
+            columns: 32,
+            w_block_off: 1,
         },
     ]
 }
@@ -542,6 +656,10 @@ fn validate_raw_case(case: &RawQ4Case) -> Result<(), String> {
     Ok(())
 }
 
+/// Schema-v1 relative-error encoding. A zero reference with nonzero absolute
+/// error has no finite mathematical relative error, so the already-published
+/// schema retains `f32::MAX` as a finite JSON-safe sentinel. Tolerance PASS is
+/// determined independently from the combined absolute allowance.
 fn relative_error(reference: f32, absolute_error: f32) -> f32 {
     if reference == 0.0 {
         if absolute_error == 0.0 {
@@ -618,83 +736,85 @@ fn compare_vectors(
     ))
 }
 
+fn build_raw_case_report(
+    case: &RawQ4Case,
+    cpu: Vec<f32>,
+    gpu: Vec<f32>,
+) -> Result<RawQ4CaseReport, QualificationFailure> {
+    let (
+        absolute_errors,
+        relative_errors,
+        allowed_errors,
+        worst_index,
+        max_absolute_error,
+        max_relative_error,
+        passed,
+    ) = compare_vectors(&cpu, &gpu, RAW_TOLERANCE).map_err(|detail| {
+        QualificationFailure::new(
+            FailureStage::Postcondition,
+            "raw-q4-comparison-invalid",
+            format!("{}: {detail}", case.name),
+        )
+    })?;
+    let byte_offset = case.w_block_off * Q4_0_BLOCK_BYTES;
+    Ok(RawQ4CaseReport {
+        name: case.name.to_string(),
+        projection: case.projection.to_string(),
+        rows: case.rows,
+        columns: case.columns,
+        w_block_off: case.w_block_off,
+        byte_offset,
+        starts_on_unaligned_18_byte_boundary: !byte_offset.is_multiple_of(4),
+        weight_bytes: case.weights.len(),
+        weights_sha256: format!("{:x}", Sha256::digest(&case.weights)),
+        input_sha256: hash_f32(&case.input),
+        worst_cpu_f32: cpu[worst_index],
+        worst_gpu_f32: gpu[worst_index],
+        worst_absolute_error: absolute_errors[worst_index],
+        worst_relative_error: relative_errors[worst_index],
+        cpu_f32: cpu,
+        gpu_f32: gpu,
+        absolute_errors,
+        relative_errors,
+        allowed_errors,
+        worst_index,
+        max_absolute_error,
+        max_relative_error,
+        passed,
+    })
+}
+
+/// Execute all deterministic raw fixtures through the existing production
+/// Q4_0 pipeline. Structural/dispatch errors stop immediately; tolerance
+/// failures retain their reports and do not prevent later safe cases running.
 pub fn run_raw_shader_cases(
     backend: &BackendBox,
-) -> Result<Vec<RawQ4CaseReport>, QualificationFailure> {
-    canonical_raw_cases()
-        .into_iter()
-        .map(|case| {
-            let cpu = cpu_q4_matvec(&case).map_err(|detail| {
-                QualificationFailure::new(FailureStage::Preflight, "raw-q4-case-invalid", detail)
-            })?;
-            let gpu = backend
-                .qualification_q4_0_matvec(
-                    &case.weights,
-                    &case.input,
-                    case.rows,
-                    case.columns,
-                    case.w_block_off,
-                )
-                .map_err(|detail| {
-                    QualificationFailure::new(
-                        FailureStage::Inference,
-                        "raw-q4-gpu-dispatch-failed",
-                        format!("{}: {detail}", case.name),
-                    )
-                })?;
-            let (
-                absolute_errors,
-                relative_errors,
-                allowed_errors,
-                worst_index,
-                max_absolute_error,
-                max_relative_error,
-                passed,
-            ) = compare_vectors(&cpu, &gpu, RAW_TOLERANCE).map_err(|detail| {
+    readback_timeout: Duration,
+) -> Result<RawShaderValidation, QualificationFailure> {
+    let mut validation = RawShaderValidation::new();
+    for case in canonical_raw_cases() {
+        let cpu = cpu_q4_matvec(&case).map_err(|detail| {
+            QualificationFailure::new(FailureStage::Preflight, "raw-q4-case-invalid", detail)
+        })?;
+        let gpu = backend
+            .qualification_q4_0_matvec(
+                &case.weights,
+                &case.input,
+                case.rows,
+                case.columns,
+                case.w_block_off,
+                readback_timeout,
+            )
+            .map_err(|error| {
                 QualificationFailure::new(
-                    FailureStage::Postcondition,
-                    "raw-q4-comparison-invalid",
-                    format!("{}: {detail}", case.name),
+                    FailureStage::Inference,
+                    "raw-q4-gpu-dispatch-failed",
+                    format!("{}: {error}", case.name),
                 )
             })?;
-            if !passed {
-                return Err(QualificationFailure::new(
-                    FailureStage::Postcondition,
-                    "raw-q4-tolerance-failed",
-                    format!(
-                        "{} failed at output {worst_index}: cpu={} gpu={} abs_error={} allowed={}",
-                        case.name,
-                        cpu[worst_index],
-                        gpu[worst_index],
-                        absolute_errors[worst_index],
-                        allowed_errors[worst_index]
-                    ),
-                ));
-            }
-            let byte_offset = case.w_block_off * Q4_0_BLOCK_BYTES;
-            Ok(RawQ4CaseReport {
-                name: case.name.to_string(),
-                projection: case.projection.to_string(),
-                rows: case.rows,
-                columns: case.columns,
-                w_block_off: case.w_block_off,
-                byte_offset,
-                starts_on_unaligned_18_byte_boundary: !byte_offset.is_multiple_of(4),
-                weight_bytes: case.weights.len(),
-                weights_sha256: format!("{:x}", Sha256::digest(&case.weights)),
-                input_sha256: hash_f32(&case.input),
-                cpu_f32: cpu,
-                gpu_f32: gpu,
-                absolute_errors,
-                relative_errors,
-                allowed_errors,
-                worst_index,
-                max_absolute_error,
-                max_relative_error,
-                passed,
-            })
-        })
-        .collect()
+        validation.record(build_raw_case_report(&case, cpu, gpu)?);
+    }
+    Ok(validation)
 }
 
 fn subtract_io(
@@ -846,11 +966,18 @@ pub fn validate_complete_expert(
                 "d_model * sizeof(f32) overflowed u64",
             )
         })?;
-    let mut reports = Vec::with_capacity(execution.dispatches.len());
+    let dispatch_count = execution.dispatches.len();
+    let mut reports = Vec::with_capacity(dispatch_count);
     let mut stable_generation = None;
     let mut stable_physical = None;
     let mut previous_after = None;
     let mut tolerance_failure = None;
+    let mut initial_physical_install_exactly_once = false;
+    let mut subsequent_dispatches_reused_generation = true;
+    let mut subsequent_dispatches_uploaded_zero_weight_bytes = true;
+    let mut every_dispatch_completed_gpu_io = true;
+    let mut zero_evictions_or_stale_retirements = true;
+    let mut zero_cpu_fallback_or_degraded_execution = true;
 
     for (vector_index, dispatch) in execution.dispatches.into_iter().enumerate() {
         for snapshot in [dispatch.before.memory, dispatch.after.memory] {
@@ -997,33 +1124,37 @@ pub fn validate_complete_expert(
             .memory
             .stale_retirements
             .checked_sub(dispatch.before.memory.stale_retirements);
-        if eviction_delta != Some(0) || stale_delta != Some(0) {
+        let no_registry_churn = eviction_delta == Some(0) && stale_delta == Some(0);
+        zero_evictions_or_stale_retirements &= no_registry_churn;
+        if !no_registry_churn {
             return Err(QualificationFailure::new(
                 FailureStage::Postcondition,
                 "physical-registry-churn",
                 format!("vector {vector_index} evicted or retired a physical entry"),
             ));
         }
-        if io_delta.hidden_state_uploads != 1
-            || io_delta.hidden_state_upload_bytes != output_bytes
-            || io_delta.queue_submissions != 1
-            || io_delta.map_requests != 1
-            || io_delta.readback_completions != 1
-            || io_delta.readback_bytes != output_bytes
-        {
+        let gpu_io_completed = io_delta.hidden_state_uploads == 1
+            && io_delta.hidden_state_upload_bytes == output_bytes
+            && io_delta.queue_submissions == 1
+            && io_delta.map_requests == 1
+            && io_delta.readback_completions == 1
+            && io_delta.readback_bytes == output_bytes;
+        every_dispatch_completed_gpu_io &= gpu_io_completed;
+        if !gpu_io_completed {
             return Err(QualificationFailure::new(
                 FailureStage::Postcondition,
                 "incomplete-per-vector-gpu-io",
                 format!("vector {vector_index} GPU I/O delta is {io_delta:?}"),
             ));
         }
-        if routed_delta.gpu_dispatch_attempts != 1
-            || routed_delta.gpu_dispatch_successes != 1
-            || routed_delta.gpu_dispatch_failures != 0
-            || routed_delta.cpu_routed_expert_dispatches != 0
-            || routed_delta.gpu_cpu_fallbacks != 0
-            || routed_delta.degraded_expert_substitutions != 0
-        {
+        let gpu_dispatch_succeeded = routed_delta.gpu_dispatch_attempts == 1
+            && routed_delta.gpu_dispatch_successes == 1
+            && routed_delta.gpu_dispatch_failures == 0;
+        let no_cpu_or_degraded_execution = routed_delta.cpu_routed_expert_dispatches == 0
+            && routed_delta.gpu_cpu_fallbacks == 0
+            && routed_delta.degraded_expert_substitutions == 0;
+        zero_cpu_fallback_or_degraded_execution &= no_cpu_or_degraded_execution;
+        if !gpu_dispatch_succeeded || !no_cpu_or_degraded_execution {
             return Err(QualificationFailure::new(
                 FailureStage::Postcondition,
                 "invalid-per-vector-routed-execution",
@@ -1032,21 +1163,21 @@ pub fn validate_complete_expert(
         }
 
         if vector_index == 0 {
-            if dispatch.before.physical.is_some()
-                || dispatch.before.logical_generation.is_some()
-                || dispatch.before.memory.logical_admitted_bytes != 0
-                || dispatch.before.memory.expert_live_bytes != 0
-                || dispatch.before.memory.physical_entries != 0
-                || dispatch.before.memory.expert_registry_bytes != 0
-                || dispatch.before.memory.physical_installs != 0
-                || dispatch.before.memory.physical_evictions != 0
-                || dispatch.before.memory.stale_retirements != 0
-                || dispatch.before.gpu_io != GpuExpertIoSnapshot::default()
-                || dispatch.before.routed != RoutedExpertExecutionSnapshot::default()
-                || memory_install_delta != Some(1)
-                || io_delta.expert_weight_uploads != 1
-                || io_delta.expert_weight_upload_bytes != after_physical.device_bytes
-            {
+            initial_physical_install_exactly_once = dispatch.before.physical.is_none()
+                && dispatch.before.logical_generation.is_none()
+                && dispatch.before.memory.logical_admitted_bytes == 0
+                && dispatch.before.memory.expert_live_bytes == 0
+                && dispatch.before.memory.physical_entries == 0
+                && dispatch.before.memory.expert_registry_bytes == 0
+                && dispatch.before.memory.physical_installs == 0
+                && dispatch.before.memory.physical_evictions == 0
+                && dispatch.before.memory.stale_retirements == 0
+                && dispatch.before.gpu_io == GpuExpertIoSnapshot::default()
+                && dispatch.before.routed == RoutedExpertExecutionSnapshot::default()
+                && memory_install_delta == Some(1)
+                && io_delta.expert_weight_uploads == 1
+                && io_delta.expert_weight_upload_bytes == after_physical.device_bytes;
+            if !initial_physical_install_exactly_once {
                 return Err(QualificationFailure::new(
                     FailureStage::Postcondition,
                     "initial-physical-install-not-exactly-once",
@@ -1058,23 +1189,27 @@ pub fn validate_complete_expert(
             }
             stable_generation = Some(after_generation);
             stable_physical = Some(after_physical);
-        } else if dispatch.before.logical_generation != stable_generation
-            || dispatch.before.physical != stable_physical
-            || dispatch.after.logical_generation != stable_generation
-            || dispatch.after.physical != stable_physical
-            || dispatch.before.memory.physical_entries != 1
-            || dispatch.before.memory.expert_registry_bytes != physical_device_bytes
-            || memory_install_delta != Some(0)
-            || io_delta.expert_weight_uploads != 0
-            || io_delta.expert_weight_upload_bytes != 0
-        {
-            return Err(QualificationFailure::new(
-                FailureStage::Postcondition,
-                "physical-expert-not-reused",
-                format!(
-                    "vector {vector_index} changed generation/residency or re-uploaded weights"
-                ),
-            ));
+        } else {
+            let reused_generation = dispatch.before.logical_generation == stable_generation
+                && dispatch.before.physical == stable_physical
+                && dispatch.after.logical_generation == stable_generation
+                && dispatch.after.physical == stable_physical
+                && dispatch.before.memory.physical_entries == 1
+                && dispatch.before.memory.expert_registry_bytes == physical_device_bytes
+                && memory_install_delta == Some(0);
+            let uploaded_zero_weight_bytes = io_delta.expert_weight_uploads == 0
+                && io_delta.expert_weight_upload_bytes == 0;
+            subsequent_dispatches_reused_generation &= reused_generation;
+            subsequent_dispatches_uploaded_zero_weight_bytes &= uploaded_zero_weight_bytes;
+            if !reused_generation || !uploaded_zero_weight_bytes {
+                return Err(QualificationFailure::new(
+                    FailureStage::Postcondition,
+                    "physical-expert-not-reused",
+                    format!(
+                        "vector {vector_index} changed generation/residency or re-uploaded weights"
+                    ),
+                ));
+            }
         }
 
         reports.push(CompleteExpertVectorReport {
@@ -1103,6 +1238,9 @@ pub fn validate_complete_expert(
         previous_after = Some(dispatch.after);
     }
 
+    let complete_expert_vectors_passed = tolerance_failure.is_none()
+        && reports.len() == dispatch_count
+        && reports.iter().all(|report| report.passed);
     Ok(CompleteExpertValidation {
         report: CompleteExpertReport {
             identity,
@@ -1116,6 +1254,15 @@ pub fn validate_complete_expert(
             payload_sha256: execution.payload_sha256,
             checkpoint_payload_sha256: execution.checkpoint_payload_sha256,
             vectors: reports,
+        },
+        invariants: CompleteExpertInvariantOutcomes {
+            initial_physical_install_exactly_once,
+            subsequent_dispatches_reused_generation,
+            subsequent_dispatches_uploaded_zero_weight_bytes,
+            every_dispatch_completed_gpu_io,
+            zero_evictions_or_stale_retirements,
+            zero_cpu_fallback_or_degraded_execution,
+            complete_expert_vectors_passed,
         },
         tolerance_failure,
     })
@@ -1252,6 +1399,7 @@ mod tests {
     #[test]
     fn canonical_cases_cover_required_scale_offsets_and_projections() {
         let cases = canonical_raw_cases();
+        assert_eq!(cases.len(), RAW_CASE_COUNT);
         assert!(cases.iter().any(|case| case.name.contains("zero-scale")));
         assert!(cases
             .iter()
@@ -1268,6 +1416,13 @@ mod tests {
             .find(|case| case.name.contains("unaligned"))
             .unwrap();
         assert_ne!((unaligned.w_block_off * Q4_0_BLOCK_BYTES) % 4, 0);
+
+        let multi_row = cases.iter().find(|case| case.rows >= 2).unwrap();
+        assert!(multi_row.w_block_off > 0);
+        assert_ne!((multi_row.w_block_off * Q4_0_BLOCK_BYTES) % 4, 0);
+        let output = cpu_q4_matvec(multi_row).unwrap();
+        assert_eq!(output.len(), multi_row.rows);
+        assert_ne!(output[0], output[1]);
     }
 
     #[test]
@@ -1326,6 +1481,78 @@ mod tests {
                 .unwrap()
                 .6
         );
+    }
+
+    #[test]
+    fn zero_reference_uses_finite_relative_sentinel_but_absolute_rule_decides_pass() {
+        let within = compare_vectors(
+            &[0.0],
+            &[RAW_ABSOLUTE_TOLERANCE * 0.5],
+            RAW_TOLERANCE,
+        )
+        .unwrap();
+        assert_eq!(within.1, vec![f32::MAX]);
+        assert!(within.6);
+
+        let outside = compare_vectors(
+            &[0.0],
+            &[RAW_ABSOLUTE_TOLERANCE * 2.0],
+            RAW_TOLERANCE,
+        )
+        .unwrap();
+        assert_eq!(outside.1, vec![f32::MAX]);
+        assert!(!outside.6);
+    }
+
+    #[test]
+    fn failed_raw_case_retains_diagnostics_and_first_failure_while_later_cases_run() {
+        let cases = canonical_raw_cases();
+        let mut validation = RawShaderValidation::new();
+
+        let first_cpu = cpu_q4_matvec(&cases[0]).unwrap();
+        validation.record(
+            build_raw_case_report(&cases[0], first_cpu.clone(), first_cpu).unwrap(),
+        );
+
+        let second_cpu = cpu_q4_matvec(&cases[1]).unwrap();
+        let mut second_gpu = second_cpu.clone();
+        second_gpu[0] += 0.25;
+        validation.record(
+            build_raw_case_report(&cases[1], second_cpu.clone(), second_gpu).unwrap(),
+        );
+
+        let third_cpu = cpu_q4_matvec(&cases[2]).unwrap();
+        let mut third_gpu = third_cpu.clone();
+        third_gpu[0] -= 0.5;
+        validation.record(build_raw_case_report(&cases[2], third_cpu, third_gpu).unwrap());
+
+        assert_eq!(validation.reports.len(), 3);
+        assert!(validation.reports[0].passed);
+        let failed = &validation.reports[1];
+        assert!(!failed.passed);
+        assert_eq!(failed.cpu_f32.len(), 1);
+        assert_eq!(failed.gpu_f32.len(), 1);
+        assert_eq!(failed.absolute_errors.len(), 1);
+        assert_eq!(failed.relative_errors.len(), 1);
+        assert_eq!(failed.allowed_errors.len(), 1);
+        assert_eq!(failed.worst_index, 0);
+        assert_eq!(failed.worst_cpu_f32, failed.cpu_f32[0]);
+        assert_eq!(failed.worst_gpu_f32, failed.gpu_f32[0]);
+        assert!(validation.reports[2].name.contains("negative-scale"));
+        let first_failure = validation.tolerance_failure.unwrap();
+        assert!(first_failure.detail.contains("positive-scale-extrema"));
+        assert!(!first_failure.detail.contains("negative-scale-sign"));
+    }
+
+    #[test]
+    fn checkpoint_payload_alignment_rejects_invalid_values_before_arithmetic() {
+        assert!(aligned_checkpoint_payload_bytes(54, 0)
+            .unwrap_err()
+            .contains("storage block_align 0"));
+        assert!(aligned_checkpoint_payload_bytes(54, 48)
+            .unwrap_err()
+            .contains("positive power of two"));
+        assert_eq!(aligned_checkpoint_payload_bytes(54, 64).unwrap(), 64);
     }
 
     #[test]
@@ -1397,6 +1624,18 @@ mod tests {
         let (identity, execution) = valid_complete_execution();
         let validation = validate_complete_expert(identity, execution, 2).unwrap();
         assert!(validation.tolerance_failure.is_none());
+        assert_eq!(
+            validation.invariants,
+            CompleteExpertInvariantOutcomes {
+                initial_physical_install_exactly_once: true,
+                subsequent_dispatches_reused_generation: true,
+                subsequent_dispatches_uploaded_zero_weight_bytes: true,
+                every_dispatch_completed_gpu_io: true,
+                zero_evictions_or_stale_retirements: true,
+                zero_cpu_fallback_or_degraded_execution: true,
+                complete_expert_vectors_passed: true,
+            }
+        );
         let report = validation.report;
         assert_eq!(report.vectors.len(), 3);
         assert_eq!(report.vectors[0].gpu_io_delta.expert_weight_uploads, 1);
@@ -1477,6 +1716,17 @@ mod tests {
             validation.tolerance_failure.unwrap().code,
             "complete-expert-tolerance-failed"
         );
+        assert!(validation.invariants.initial_physical_install_exactly_once);
+        assert!(validation.invariants.subsequent_dispatches_reused_generation);
+        assert!(validation
+            .invariants
+            .subsequent_dispatches_uploaded_zero_weight_bytes);
+        assert!(validation.invariants.every_dispatch_completed_gpu_io);
+        assert!(validation.invariants.zero_evictions_or_stale_retirements);
+        assert!(validation
+            .invariants
+            .zero_cpu_fallback_or_degraded_execution);
+        assert!(!validation.invariants.complete_expert_vectors_passed);
         assert!(!validation.report.vectors[0].passed);
         assert_eq!(validation.report.vectors[0].cpu_f32[0], 1.0001);
         assert_eq!(validation.report.vectors[0].cpu_f16[0], 1.0);

--- a/rust-engine/src/q4_parity.rs
+++ b/rust-engine/src/q4_parity.rs
@@ -1,0 +1,1486 @@
+//! Fail-closed numerical qualification for MER's canonical Q4_0 GPU path.
+//!
+//! The pure fixture/comparison code in this module is hardware-independent.
+//! Live dispatch is deliberately delegated to narrow methods on the already
+//! selected production [`crate::backend::BackendBox`] and [`crate::engine::Engine`].
+
+use crate::backend::{
+    BackendBox, GpuDeviceIdentity, GpuExpertIoSnapshot, GpuExpertMemorySnapshot,
+    GpuPhysicalExpertResidency,
+};
+use crate::engine::RoutedExpertExecutionSnapshot;
+use crate::inference::{dequantize_q4_0_block, Q4_0_BLOCK_BYTES, Q4_0_BLOCK_ELEMS};
+use crate::qualification::{
+    BuildProvenance, ExecutionPlanEvidence, ExpertMetadataEvidence, FailureStage,
+    QualificationArtifacts, QualificationFailure, QualificationStatus,
+};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+pub const SCHEMA_VERSION: &str = "mer.strict-hybrid-q4-parity.v1";
+pub const MODE: &str = "strict-hybrid-q4-parity";
+
+/// Raw shader output remains f32, but its block-local operation order differs
+/// slightly from materialising every scaled CPU weight before the dot product.
+pub const RAW_ABSOLUTE_TOLERANCE: f32 = 1.0e-5;
+pub const RAW_RELATIVE_TOLERANCE: f32 = 1.0e-4;
+
+/// The production routed-expert boundary accepts and returns f16. The primary
+/// complete-expert oracle is therefore the authoritative CPU f32 result rounded
+/// to f16, compared with the returned GPU f16 value.
+pub const COMPLETE_ABSOLUTE_TOLERANCE: f32 = 2.0e-3;
+pub const COMPLETE_RELATIVE_TOLERANCE: f32 = 5.0e-3;
+
+#[derive(Clone, Copy, Debug, PartialEq, Serialize)]
+pub struct ErrorTolerance {
+    pub absolute: f32,
+    pub relative: f32,
+    pub formula: &'static str,
+}
+
+pub const RAW_TOLERANCE: ErrorTolerance = ErrorTolerance {
+    absolute: RAW_ABSOLUTE_TOLERANCE,
+    relative: RAW_RELATIVE_TOLERANCE,
+    formula: "abs_error <= absolute + relative * abs(cpu_reference)",
+};
+
+pub const COMPLETE_TOLERANCE: ErrorTolerance = ErrorTolerance {
+    absolute: COMPLETE_ABSOLUTE_TOLERANCE,
+    relative: COMPLETE_RELATIVE_TOLERANCE,
+    formula: "abs_error <= absolute + relative * abs(cpu_f16_reference)",
+};
+
+#[derive(Clone, Debug)]
+pub struct RawQ4Case {
+    pub name: &'static str,
+    pub projection: &'static str,
+    pub weights: Vec<u8>,
+    pub input: Vec<f32>,
+    pub rows: usize,
+    pub columns: usize,
+    pub w_block_off: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct RawQ4CaseReport {
+    pub name: String,
+    pub projection: String,
+    pub rows: usize,
+    pub columns: usize,
+    pub w_block_off: usize,
+    pub byte_offset: usize,
+    pub starts_on_unaligned_18_byte_boundary: bool,
+    pub weight_bytes: usize,
+    pub weights_sha256: String,
+    pub input_sha256: String,
+    pub cpu_f32: Vec<f32>,
+    pub gpu_f32: Vec<f32>,
+    pub absolute_errors: Vec<f32>,
+    pub relative_errors: Vec<f32>,
+    pub allowed_errors: Vec<f32>,
+    pub worst_index: usize,
+    pub max_absolute_error: f32,
+    pub max_relative_error: f32,
+    pub passed: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+pub struct RawIsolationEvidence {
+    pub memory_before: GpuExpertMemorySnapshot,
+    pub memory_after: GpuExpertMemorySnapshot,
+    pub gpu_io_before: GpuExpertIoSnapshot,
+    pub gpu_io_after: GpuExpertIoSnapshot,
+    pub selected_physical_before: Option<GpuPhysicalExpertResidency>,
+    pub selected_physical_after: Option<GpuPhysicalExpertResidency>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct ExpertIdentityEvidence {
+    pub global_expert_id: u32,
+    pub layer_index: u32,
+    pub layer_local_expert_id: u32,
+    pub num_layers: usize,
+    pub num_experts_per_layer: u32,
+    pub total_global_experts: u32,
+}
+
+pub fn expert_identity(
+    global_expert_id: u32,
+    num_layers: usize,
+    num_experts_per_layer: u32,
+) -> Result<ExpertIdentityEvidence, QualificationFailure> {
+    let layers = u32::try_from(num_layers).map_err(|_| {
+        QualificationFailure::new(
+            FailureStage::Preflight,
+            "expert-namespace-overflow",
+            format!("num_layers {num_layers} exceeds u32"),
+        )
+    })?;
+    let total = layers.checked_mul(num_experts_per_layer).ok_or_else(|| {
+        QualificationFailure::new(
+            FailureStage::Preflight,
+            "expert-namespace-overflow",
+            format!(
+                "num_layers {num_layers} * num_experts_per_layer {num_experts_per_layer} overflows u32"
+            ),
+        )
+    })?;
+    if global_expert_id >= total {
+        return Err(QualificationFailure::new(
+            FailureStage::Preflight,
+            "global-expert-id-out-of-range",
+            format!(
+                "global expert id {global_expert_id} is outside 0..{total} for {num_layers} layers * {num_experts_per_layer} experts/layer"
+            ),
+        ));
+    }
+    Ok(ExpertIdentityEvidence {
+        global_expert_id,
+        layer_index: global_expert_id / num_experts_per_layer,
+        layer_local_expert_id: global_expert_id % num_experts_per_layer,
+        num_layers,
+        num_experts_per_layer,
+        total_global_experts: total,
+    })
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+pub struct CompleteDispatchSnapshot {
+    pub logical_generation: Option<u64>,
+    pub physical: Option<GpuPhysicalExpertResidency>,
+    pub memory: GpuExpertMemorySnapshot,
+    pub gpu_io: GpuExpertIoSnapshot,
+    pub routed: RoutedExpertExecutionSnapshot,
+}
+
+#[derive(Clone, Debug)]
+pub struct CompleteDispatchExecution {
+    pub input: Vec<f32>,
+    pub cpu_f32: Vec<f32>,
+    /// Values returned through the production f16 boundary, represented as
+    /// f32 solely for comparison and JSON serialization.
+    pub gpu_f16: Vec<f32>,
+    pub before: CompleteDispatchSnapshot,
+    pub after: CompleteDispatchSnapshot,
+}
+
+#[derive(Clone, Debug)]
+pub struct CompleteExpertExecution {
+    pub d_model: usize,
+    pub d_ff: usize,
+    pub checkpoint_block_align: usize,
+    /// Canonical unpadded Q4_0 weights consumed by both kernels.
+    pub payload_bytes: usize,
+    /// Header-stripped checkpoint slot, including zero alignment padding.
+    pub checkpoint_payload_bytes: usize,
+    pub alignment_padding_bytes: usize,
+    pub payload_sha256: String,
+    pub checkpoint_payload_sha256: String,
+    pub dispatches: Vec<CompleteDispatchExecution>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct CompleteExpertVectorReport {
+    pub vector_index: usize,
+    pub input_sha256: String,
+    pub cpu_f32: Vec<f32>,
+    pub cpu_f16: Vec<f32>,
+    pub gpu_f16: Vec<f32>,
+    pub absolute_errors: Vec<f32>,
+    pub relative_errors: Vec<f32>,
+    pub allowed_errors: Vec<f32>,
+    pub worst_index: usize,
+    pub worst_cpu_f32: f32,
+    pub worst_cpu_f16: f32,
+    pub worst_gpu_f16: f32,
+    pub worst_absolute_error: f32,
+    pub worst_relative_error: f32,
+    pub max_absolute_error: f32,
+    pub max_relative_error: f32,
+    pub before: CompleteDispatchSnapshot,
+    pub after: CompleteDispatchSnapshot,
+    pub gpu_io_delta: GpuExpertIoSnapshot,
+    pub routed_delta: RoutedExpertExecutionSnapshot,
+    pub passed: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct CompleteExpertReport {
+    pub identity: ExpertIdentityEvidence,
+    pub d_model: usize,
+    pub d_ff: usize,
+    pub checkpoint_block_align: usize,
+    pub physical_device_bytes: u64,
+    /// Canonical unpadded Q4_0 weights consumed by both kernels.
+    pub payload_bytes: usize,
+    /// Header-stripped checkpoint slot, including zero alignment padding.
+    pub checkpoint_payload_bytes: usize,
+    pub alignment_padding_bytes: usize,
+    pub payload_sha256: String,
+    pub checkpoint_payload_sha256: String,
+    pub vectors: Vec<CompleteExpertVectorReport>,
+}
+
+#[derive(Debug)]
+pub struct CompleteExpertValidation {
+    pub report: CompleteExpertReport,
+    pub tolerance_failure: Option<QualificationFailure>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize)]
+pub struct Q4ParityChecks {
+    pub clean_build: bool,
+    pub strict_hybrid_preflight: bool,
+    pub canonical_q4_0_layout: bool,
+    pub exact_execution_plan: bool,
+    pub hardware_gpu_adapter: bool,
+    pub expected_adapter_exact_match: bool,
+    pub strict_gpu_failure_policy: bool,
+    pub global_expert_identity_valid: bool,
+    pub exact_expert_payload_size: bool,
+    pub raw_shader_cases_passed: bool,
+    pub raw_dispatch_isolated_from_expert_registry: bool,
+    pub initial_physical_install_exactly_once: bool,
+    pub subsequent_dispatches_reused_generation: bool,
+    pub subsequent_dispatches_uploaded_zero_weight_bytes: bool,
+    pub every_dispatch_completed_gpu_io: bool,
+    pub zero_evictions_or_stale_retirements: bool,
+    pub zero_cpu_fallback_or_degraded_execution: bool,
+    pub complete_expert_vectors_passed: bool,
+}
+
+impl Q4ParityChecks {
+    fn passes(&self) -> bool {
+        self.clean_build
+            && self.strict_hybrid_preflight
+            && self.canonical_q4_0_layout
+            && self.exact_execution_plan
+            && self.hardware_gpu_adapter
+            && self.expected_adapter_exact_match
+            && self.strict_gpu_failure_policy
+            && self.global_expert_identity_valid
+            && self.exact_expert_payload_size
+            && self.raw_shader_cases_passed
+            && self.raw_dispatch_isolated_from_expert_registry
+            && self.initial_physical_install_exactly_once
+            && self.subsequent_dispatches_reused_generation
+            && self.subsequent_dispatches_uploaded_zero_weight_bytes
+            && self.every_dispatch_completed_gpu_io
+            && self.zero_evictions_or_stale_retirements
+            && self.zero_cpu_fallback_or_degraded_execution
+            && self.complete_expert_vectors_passed
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct Q4ParityReport {
+    pub schema_version: &'static str,
+    pub mode: &'static str,
+    pub status: QualificationStatus,
+    pub failure: Option<QualificationFailure>,
+    pub provenance: BuildProvenance,
+    pub artifacts: QualificationArtifacts,
+    pub expert_metadata: Option<ExpertMetadataEvidence>,
+    pub execution_plan: Option<ExecutionPlanEvidence>,
+    pub device: Option<GpuDeviceIdentity>,
+    pub expected_adapter_name: String,
+    pub raw_tolerance: ErrorTolerance,
+    pub complete_tolerance: ErrorTolerance,
+    pub raw_cases: Vec<RawQ4CaseReport>,
+    pub raw_isolation: Option<RawIsolationEvidence>,
+    pub complete_expert: Option<CompleteExpertReport>,
+    pub checks: Q4ParityChecks,
+}
+
+impl Q4ParityReport {
+    pub fn new(
+        provenance: BuildProvenance,
+        artifacts: QualificationArtifacts,
+        expert_metadata: Option<ExpertMetadataEvidence>,
+        expected_adapter_name: String,
+    ) -> Self {
+        Self {
+            schema_version: SCHEMA_VERSION,
+            mode: MODE,
+            status: QualificationStatus::Fail,
+            failure: None,
+            provenance,
+            artifacts,
+            expert_metadata,
+            execution_plan: None,
+            device: None,
+            expected_adapter_name,
+            raw_tolerance: RAW_TOLERANCE,
+            complete_tolerance: COMPLETE_TOLERANCE,
+            raw_cases: Vec::new(),
+            raw_isolation: None,
+            complete_expert: None,
+            checks: Q4ParityChecks::default(),
+        }
+    }
+
+    pub fn fail(&mut self, failure: QualificationFailure) {
+        self.status = QualificationStatus::Fail;
+        self.failure = Some(failure);
+    }
+
+    pub fn finish(&mut self) -> Result<(), QualificationFailure> {
+        if !self.checks.passes() {
+            return Err(QualificationFailure::new(
+                FailureStage::Postcondition,
+                "q4-parity-check-failed",
+                "one or more required Q4_0 parity checks are false",
+            ));
+        }
+        if self.artifacts.config.is_none()
+            || self.artifacts.expert_metadata.is_none()
+            || self.expert_metadata.is_none()
+            || self.execution_plan.is_none()
+            || self.device.is_none()
+            || self.raw_cases.is_empty()
+            || self.raw_isolation.is_none()
+            || self.complete_expert.is_none()
+        {
+            return Err(QualificationFailure::new(
+                FailureStage::Postcondition,
+                "q4-parity-evidence-incomplete",
+                "one or more mandatory Q4_0 parity evidence sections are absent",
+            ));
+        }
+        self.status = QualificationStatus::Pass;
+        self.failure = None;
+        Ok(())
+    }
+}
+
+fn canonical_block(scale: f32, nibbles: [u8; 16]) -> Vec<u8> {
+    let mut block = Vec::with_capacity(Q4_0_BLOCK_BYTES);
+    block.extend_from_slice(&half::f16::from_f32(scale).to_bits().to_le_bytes());
+    block.extend_from_slice(&nibbles);
+    block
+}
+
+fn deterministic_input(len: usize, seed: usize) -> Vec<f32> {
+    (0..len)
+        .map(|index| {
+            let signed = ((index * (seed * 2 + 3) + seed) % 31) as i32 - 15;
+            // Multiples of 1/32 are exactly representable as f16 and f32.
+            half::f16::from_f32(signed as f32 / 32.0).to_f32()
+        })
+        .collect()
+}
+
+/// Literal canonical byte fixtures. They intentionally do not call MER's Q4_0
+/// quantizer, so a shared encoder/decoder bug cannot make them self-consistent.
+pub fn canonical_raw_cases() -> Vec<RawQ4Case> {
+    let alternating = std::array::from_fn(|index| if index % 2 == 0 { 0xf0 } else { 0x0f });
+    let ramp = std::array::from_fn(|index| index as u8 | ((15 - index as u8) << 4));
+    let inverse_ramp = std::array::from_fn(|index| (15 - index as u8) | ((index as u8) << 4));
+
+    let projection_stream = [
+        canonical_block(0.25, ramp),
+        canonical_block(-0.5, inverse_ramp),
+        canonical_block(0.0, alternating),
+    ]
+    .concat();
+
+    let multiple_blocks = [
+        canonical_block(0.125, alternating),
+        canonical_block(-0.25, ramp),
+    ]
+    .concat();
+
+    vec![
+        RawQ4Case {
+            name: "zero-scale-extrema",
+            projection: "standalone",
+            weights: canonical_block(0.0, alternating),
+            input: deterministic_input(32, 1),
+            rows: 1,
+            columns: 32,
+            w_block_off: 0,
+        },
+        RawQ4Case {
+            name: "positive-scale-extrema",
+            projection: "standalone",
+            weights: canonical_block(0.25, alternating),
+            input: deterministic_input(32, 2),
+            rows: 1,
+            columns: 32,
+            w_block_off: 0,
+        },
+        RawQ4Case {
+            name: "negative-scale-sign",
+            projection: "standalone",
+            weights: canonical_block(-0.5, ramp),
+            input: deterministic_input(32, 3),
+            rows: 1,
+            columns: 32,
+            w_block_off: 0,
+        },
+        RawQ4Case {
+            name: "multiple-blocks-nontrivial-hidden",
+            projection: "standalone",
+            weights: multiple_blocks,
+            input: deterministic_input(64, 4),
+            rows: 1,
+            columns: 64,
+            w_block_off: 0,
+        },
+        RawQ4Case {
+            name: "gate-projection-offset-zero",
+            projection: "gate",
+            weights: projection_stream.clone(),
+            input: deterministic_input(32, 5),
+            rows: 1,
+            columns: 32,
+            w_block_off: 0,
+        },
+        RawQ4Case {
+            name: "up-projection-offset-one-unaligned",
+            projection: "up",
+            weights: projection_stream.clone(),
+            input: deterministic_input(32, 6),
+            rows: 1,
+            columns: 32,
+            w_block_off: 1,
+        },
+        RawQ4Case {
+            name: "down-projection-offset-two",
+            projection: "down",
+            weights: projection_stream,
+            input: deterministic_input(32, 7),
+            rows: 1,
+            columns: 32,
+            w_block_off: 2,
+        },
+    ]
+}
+
+pub fn deterministic_complete_inputs(d_model: usize) -> Vec<Vec<f32>> {
+    vec![
+        deterministic_input(d_model, 11),
+        deterministic_input(d_model, 19),
+        (0..d_model)
+            .map(|index| {
+                let numerator = match index % 7 {
+                    0 => 0,
+                    1 | 2 => (index % 13 + 1) as i32,
+                    _ => -((index % 11 + 1) as i32),
+                };
+                half::f16::from_f32(numerator as f32 / 64.0).to_f32()
+            })
+            .collect(),
+    ]
+}
+
+pub fn cpu_q4_matvec(case: &RawQ4Case) -> Result<Vec<f32>, String> {
+    validate_raw_case(case)?;
+    let blocks_per_row = case.columns / Q4_0_BLOCK_ELEMS;
+    let mut output = Vec::with_capacity(case.rows);
+    for row in 0..case.rows {
+        let mut sum = 0.0f32;
+        for block_in_row in 0..blocks_per_row {
+            let block_index = case
+                .w_block_off
+                .checked_add(
+                    row.checked_mul(blocks_per_row)
+                        .ok_or("row block overflow")?,
+                )
+                .and_then(|value| value.checked_add(block_in_row))
+                .ok_or("Q4_0 block index overflow")?;
+            let start = block_index
+                .checked_mul(Q4_0_BLOCK_BYTES)
+                .ok_or("Q4_0 byte offset overflow")?;
+            let mut decoded = [0.0f32; Q4_0_BLOCK_ELEMS];
+            dequantize_q4_0_block(&case.weights[start..start + Q4_0_BLOCK_BYTES], &mut decoded);
+            let x_base = block_in_row * Q4_0_BLOCK_ELEMS;
+            for (column, weight) in decoded.iter().enumerate() {
+                sum += weight * case.input[x_base + column];
+            }
+        }
+        output.push(sum);
+    }
+    Ok(output)
+}
+
+fn validate_raw_case(case: &RawQ4Case) -> Result<(), String> {
+    if case.rows == 0 || case.columns == 0 {
+        return Err("Q4_0 raw dispatch requires non-zero rows and columns".to_string());
+    }
+    if !case.columns.is_multiple_of(Q4_0_BLOCK_ELEMS) {
+        return Err(format!(
+            "Q4_0 raw dispatch columns {} are not a multiple of {}",
+            case.columns, Q4_0_BLOCK_ELEMS
+        ));
+    }
+    if case.input.len() != case.columns {
+        return Err(format!(
+            "Q4_0 raw input has {} values, expected {}",
+            case.input.len(),
+            case.columns
+        ));
+    }
+    let blocks_per_row = case.columns / Q4_0_BLOCK_ELEMS;
+    let accessed_blocks = case
+        .rows
+        .checked_mul(blocks_per_row)
+        .and_then(|count| case.w_block_off.checked_add(count))
+        .ok_or("Q4_0 raw geometry overflow")?;
+    let required = accessed_blocks
+        .checked_mul(Q4_0_BLOCK_BYTES)
+        .ok_or("Q4_0 raw byte length overflow")?;
+    if case.weights.len() < required || !case.weights.len().is_multiple_of(Q4_0_BLOCK_BYTES) {
+        return Err(format!(
+            "Q4_0 raw weights have {} bytes, require at least {required} complete 18-byte blocks",
+            case.weights.len()
+        ));
+    }
+    if case.input.iter().any(|value| !value.is_finite()) {
+        return Err("Q4_0 raw input contains a nonfinite value".to_string());
+    }
+    Ok(())
+}
+
+fn relative_error(reference: f32, absolute_error: f32) -> f32 {
+    if reference == 0.0 {
+        if absolute_error == 0.0 {
+            0.0
+        } else {
+            f32::MAX
+        }
+    } else {
+        absolute_error / reference.abs()
+    }
+}
+
+type ComparisonResult = (Vec<f32>, Vec<f32>, Vec<f32>, usize, f32, f32, bool);
+
+fn compare_vectors(
+    reference: &[f32],
+    actual: &[f32],
+    tolerance: ErrorTolerance,
+) -> Result<ComparisonResult, String> {
+    if reference.len() != actual.len() || reference.is_empty() {
+        return Err(format!(
+            "comparison length mismatch or empty output: cpu={} gpu={}",
+            reference.len(),
+            actual.len()
+        ));
+    }
+    if reference
+        .iter()
+        .chain(actual)
+        .any(|value| !value.is_finite())
+    {
+        return Err("CPU or GPU output contains a nonfinite value".to_string());
+    }
+    let mut absolute_errors = Vec::with_capacity(reference.len());
+    let mut relative_errors = Vec::with_capacity(reference.len());
+    let mut allowed_errors = Vec::with_capacity(reference.len());
+    let mut worst_index = 0usize;
+    let mut worst_ratio = -1.0f32;
+    let mut max_absolute = 0.0f32;
+    let mut max_relative = 0.0f32;
+    let mut passed = true;
+    for (index, (&cpu, &gpu)) in reference.iter().zip(actual).enumerate() {
+        let absolute = (gpu - cpu).abs();
+        let relative = relative_error(cpu, absolute);
+        let allowed = tolerance.absolute + tolerance.relative * cpu.abs();
+        let ratio = if allowed == 0.0 {
+            if absolute == 0.0 {
+                0.0
+            } else {
+                f32::MAX
+            }
+        } else {
+            absolute / allowed
+        };
+        if ratio > worst_ratio {
+            worst_ratio = ratio;
+            worst_index = index;
+        }
+        max_absolute = max_absolute.max(absolute);
+        max_relative = max_relative.max(relative);
+        passed &= absolute <= allowed;
+        absolute_errors.push(absolute);
+        relative_errors.push(relative);
+        allowed_errors.push(allowed);
+    }
+    Ok((
+        absolute_errors,
+        relative_errors,
+        allowed_errors,
+        worst_index,
+        max_absolute,
+        max_relative,
+        passed,
+    ))
+}
+
+pub fn run_raw_shader_cases(
+    backend: &BackendBox,
+) -> Result<Vec<RawQ4CaseReport>, QualificationFailure> {
+    canonical_raw_cases()
+        .into_iter()
+        .map(|case| {
+            let cpu = cpu_q4_matvec(&case).map_err(|detail| {
+                QualificationFailure::new(FailureStage::Preflight, "raw-q4-case-invalid", detail)
+            })?;
+            let gpu = backend
+                .qualification_q4_0_matvec(
+                    &case.weights,
+                    &case.input,
+                    case.rows,
+                    case.columns,
+                    case.w_block_off,
+                )
+                .map_err(|detail| {
+                    QualificationFailure::new(
+                        FailureStage::Inference,
+                        "raw-q4-gpu-dispatch-failed",
+                        format!("{}: {detail}", case.name),
+                    )
+                })?;
+            let (
+                absolute_errors,
+                relative_errors,
+                allowed_errors,
+                worst_index,
+                max_absolute_error,
+                max_relative_error,
+                passed,
+            ) = compare_vectors(&cpu, &gpu, RAW_TOLERANCE).map_err(|detail| {
+                QualificationFailure::new(
+                    FailureStage::Postcondition,
+                    "raw-q4-comparison-invalid",
+                    format!("{}: {detail}", case.name),
+                )
+            })?;
+            if !passed {
+                return Err(QualificationFailure::new(
+                    FailureStage::Postcondition,
+                    "raw-q4-tolerance-failed",
+                    format!(
+                        "{} failed at output {worst_index}: cpu={} gpu={} abs_error={} allowed={}",
+                        case.name,
+                        cpu[worst_index],
+                        gpu[worst_index],
+                        absolute_errors[worst_index],
+                        allowed_errors[worst_index]
+                    ),
+                ));
+            }
+            let byte_offset = case.w_block_off * Q4_0_BLOCK_BYTES;
+            Ok(RawQ4CaseReport {
+                name: case.name.to_string(),
+                projection: case.projection.to_string(),
+                rows: case.rows,
+                columns: case.columns,
+                w_block_off: case.w_block_off,
+                byte_offset,
+                starts_on_unaligned_18_byte_boundary: !byte_offset.is_multiple_of(4),
+                weight_bytes: case.weights.len(),
+                weights_sha256: format!("{:x}", Sha256::digest(&case.weights)),
+                input_sha256: hash_f32(&case.input),
+                cpu_f32: cpu,
+                gpu_f32: gpu,
+                absolute_errors,
+                relative_errors,
+                allowed_errors,
+                worst_index,
+                max_absolute_error,
+                max_relative_error,
+                passed,
+            })
+        })
+        .collect()
+}
+
+fn subtract_io(
+    before: GpuExpertIoSnapshot,
+    after: GpuExpertIoSnapshot,
+) -> Result<GpuExpertIoSnapshot, String> {
+    let sub = |name: &str, before: u64, after: u64| {
+        after
+            .checked_sub(before)
+            .ok_or_else(|| format!("GPU I/O counter {name} decreased"))
+    };
+    Ok(GpuExpertIoSnapshot {
+        expert_weight_uploads: sub(
+            "expert_weight_uploads",
+            before.expert_weight_uploads,
+            after.expert_weight_uploads,
+        )?,
+        expert_weight_upload_bytes: sub(
+            "expert_weight_upload_bytes",
+            before.expert_weight_upload_bytes,
+            after.expert_weight_upload_bytes,
+        )?,
+        hidden_state_uploads: sub(
+            "hidden_state_uploads",
+            before.hidden_state_uploads,
+            after.hidden_state_uploads,
+        )?,
+        hidden_state_upload_bytes: sub(
+            "hidden_state_upload_bytes",
+            before.hidden_state_upload_bytes,
+            after.hidden_state_upload_bytes,
+        )?,
+        queue_submissions: sub(
+            "queue_submissions",
+            before.queue_submissions,
+            after.queue_submissions,
+        )?,
+        map_requests: sub("map_requests", before.map_requests, after.map_requests)?,
+        readback_completions: sub(
+            "readback_completions",
+            before.readback_completions,
+            after.readback_completions,
+        )?,
+        readback_bytes: sub(
+            "readback_bytes",
+            before.readback_bytes,
+            after.readback_bytes,
+        )?,
+    })
+}
+
+fn subtract_routed(
+    before: RoutedExpertExecutionSnapshot,
+    after: RoutedExpertExecutionSnapshot,
+) -> Result<RoutedExpertExecutionSnapshot, String> {
+    crate::qualification::routed_execution_delta(before, after).map_err(|failure| failure.detail)
+}
+
+pub fn validate_complete_expert(
+    identity: ExpertIdentityEvidence,
+    execution: CompleteExpertExecution,
+    d_model: usize,
+) -> Result<CompleteExpertValidation, QualificationFailure> {
+    if execution.d_model != d_model
+        || execution.d_model == 0
+        || execution.d_ff == 0
+        || execution.checkpoint_block_align == 0
+        || !execution.checkpoint_block_align.is_power_of_two()
+    {
+        return Err(QualificationFailure::new(
+            FailureStage::Postcondition,
+            "complete-expert-geometry-invalid",
+            format!(
+                "reported geometry d_model={} d_ff={} block_align={} disagrees with expected d_model={d_model} or is zero",
+                execution.d_model, execution.d_ff, execution.checkpoint_block_align
+            ),
+        ));
+    }
+    if execution.dispatches.len() < 2 {
+        return Err(QualificationFailure::new(
+            FailureStage::Postcondition,
+            "insufficient-complete-expert-vectors",
+            "complete-expert qualification requires at least two vectors to prove physical reuse",
+        ));
+    }
+    let payload_bytes = u64::try_from(execution.payload_bytes).map_err(|_| {
+        QualificationFailure::new(
+            FailureStage::Postcondition,
+            "expert-payload-size-overflow",
+            "complete expert payload does not fit u64",
+        )
+    })?;
+    let checkpoint_payload_bytes =
+        u64::try_from(execution.checkpoint_payload_bytes).map_err(|_| {
+            QualificationFailure::new(
+                FailureStage::Postcondition,
+                "checkpoint-payload-size-overflow",
+                "checkpoint payload does not fit u64",
+            )
+        })?;
+    if execution
+        .payload_bytes
+        .checked_add(execution.alignment_padding_bytes)
+        != Some(execution.checkpoint_payload_bytes)
+        || execution.payload_bytes == 0
+        || execution.alignment_padding_bytes >= execution.checkpoint_block_align
+        || !execution
+            .checkpoint_payload_bytes
+            .is_multiple_of(execution.checkpoint_block_align)
+    {
+        return Err(QualificationFailure::new(
+            FailureStage::Postcondition,
+            "checkpoint-payload-accounting-invalid",
+            "canonical Q4_0 bytes plus alignment padding do not equal checkpoint payload bytes",
+        ));
+    }
+    let expected_payload = crate::inference::expert_weight_bytes_for(
+        execution.d_model,
+        execution.d_ff,
+        crate::inference::WeightDtype::Q4_0,
+    );
+    if execution.payload_bytes != expected_payload {
+        return Err(QualificationFailure::new(
+            FailureStage::Postcondition,
+            "expert-payload-size-mismatch",
+            format!(
+                "complete expert reports {} canonical Q4_0 bytes, expected exactly {expected_payload}",
+                execution.payload_bytes
+            ),
+        ));
+    }
+    let physical_device_bytes = payload_bytes
+        .checked_add(3)
+        .map(|bytes| bytes / 4 * 4)
+        .ok_or_else(|| {
+            QualificationFailure::new(
+                FailureStage::Postcondition,
+                "expert-device-size-overflow",
+                "Q4_0 physical device byte size overflowed u64",
+            )
+        })?;
+    let output_bytes = u64::try_from(d_model)
+        .ok()
+        .and_then(|count| count.checked_mul(4))
+        .ok_or_else(|| {
+            QualificationFailure::new(
+                FailureStage::Postcondition,
+                "expert-output-size-overflow",
+                "d_model * sizeof(f32) overflowed u64",
+            )
+        })?;
+    let mut reports = Vec::with_capacity(execution.dispatches.len());
+    let mut stable_generation = None;
+    let mut stable_physical = None;
+    let mut previous_after = None;
+    let mut tolerance_failure = None;
+
+    for (vector_index, dispatch) in execution.dispatches.into_iter().enumerate() {
+        for snapshot in [dispatch.before.memory, dispatch.after.memory] {
+            crate::qualification::validate_memory(snapshot).map_err(|failure| {
+                QualificationFailure::new(
+                    FailureStage::Postcondition,
+                    "complete-expert-capacity-ledger-invalid",
+                    format!("vector {vector_index}: {}", failure.detail),
+                )
+            })?;
+        }
+        if previous_after.is_some_and(|previous| dispatch.before != previous) {
+            return Err(QualificationFailure::new(
+                FailureStage::Postcondition,
+                "inter-vector-evidence-discontinuity",
+                format!(
+                    "vector {vector_index} before snapshot differs from the prior vector after snapshot"
+                ),
+            ));
+        }
+        if dispatch.input.len() != d_model
+            || dispatch.cpu_f32.len() != d_model
+            || dispatch.gpu_f16.len() != d_model
+        {
+            return Err(QualificationFailure::new(
+                FailureStage::Postcondition,
+                "complete-expert-output-shape-mismatch",
+                format!("vector {vector_index} did not return d_model={d_model} values"),
+            ));
+        }
+        if dispatch
+            .input
+            .iter()
+            .any(|value| !value.is_finite() || half::f16::from_f32(*value).to_f32() != *value)
+            || dispatch.cpu_f32.iter().any(|value| !value.is_finite())
+            || dispatch.gpu_f16.iter().any(|value| !value.is_finite())
+        {
+            return Err(QualificationFailure::new(
+                FailureStage::Postcondition,
+                "complete-expert-nonfinite-output",
+                format!("vector {vector_index} contains nonfinite CPU or GPU output"),
+            ));
+        }
+        let cpu_f16: Vec<f32> = dispatch
+            .cpu_f32
+            .iter()
+            .map(|value| half::f16::from_f32(*value).to_f32())
+            .collect();
+        if cpu_f16.iter().any(|value| !value.is_finite()) {
+            return Err(QualificationFailure::new(
+                FailureStage::Postcondition,
+                "complete-expert-nonfinite-output",
+                format!("vector {vector_index} CPU f32 output overflows f16"),
+            ));
+        }
+        let (
+            absolute_errors,
+            relative_errors,
+            allowed_errors,
+            worst_index,
+            max_absolute_error,
+            max_relative_error,
+            passed,
+        ) = compare_vectors(&cpu_f16, &dispatch.gpu_f16, COMPLETE_TOLERANCE).map_err(|detail| {
+            QualificationFailure::new(
+                FailureStage::Postcondition,
+                "complete-expert-comparison-invalid",
+                format!("vector {vector_index}: {detail}"),
+            )
+        })?;
+        if !passed {
+            tolerance_failure.get_or_insert_with(|| QualificationFailure::new(
+                FailureStage::Postcondition,
+                "complete-expert-tolerance-failed",
+                format!(
+                    "vector {vector_index} failed at output {worst_index}: cpu_f32={} cpu_f16={} gpu_f16={} abs_error={} allowed={}",
+                    dispatch.cpu_f32[worst_index], cpu_f16[worst_index], dispatch.gpu_f16[worst_index], absolute_errors[worst_index], allowed_errors[worst_index]
+                ),
+            ));
+        }
+
+        let io_delta =
+            subtract_io(dispatch.before.gpu_io, dispatch.after.gpu_io).map_err(|detail| {
+                QualificationFailure::new(
+                    FailureStage::Postcondition,
+                    "gpu-io-counter-invariant",
+                    detail,
+                )
+            })?;
+        let routed_delta =
+            subtract_routed(dispatch.before.routed, dispatch.after.routed).map_err(|detail| {
+                QualificationFailure::new(
+                    FailureStage::Postcondition,
+                    "routed-counter-invariant",
+                    detail,
+                )
+            })?;
+        let after_physical = dispatch.after.physical.ok_or_else(|| {
+            QualificationFailure::new(
+                FailureStage::Postcondition,
+                "physical-expert-missing-after-dispatch",
+                format!("vector {vector_index} completed without a physical registry entry"),
+            )
+        })?;
+        let after_generation = dispatch.after.logical_generation.ok_or_else(|| {
+            QualificationFailure::new(
+                FailureStage::Postcondition,
+                "logical-admission-missing-after-dispatch",
+                format!("vector {vector_index} completed without a logical admission"),
+            )
+        })?;
+        if after_physical.expert_id != identity.global_expert_id
+            || after_physical.generation != after_generation
+            || after_physical.device_bytes != physical_device_bytes
+            || dispatch.after.memory.logical_admitted_bytes != checkpoint_payload_bytes
+            || dispatch.after.memory.expert_live_bytes != physical_device_bytes
+            || dispatch.after.memory.expert_registry_bytes != physical_device_bytes
+            || dispatch.after.memory.physical_entries != 1
+            || dispatch.after.memory.physical_installs != 1
+            || dispatch.after.memory.physical_evictions != 0
+            || dispatch.after.memory.stale_retirements != 0
+        {
+            return Err(QualificationFailure::new(
+                FailureStage::Postcondition,
+                "physical-generation-or-ledger-mismatch",
+                format!(
+                    "vector {vector_index} physical/logical identity or capacity ledger disagrees"
+                ),
+            ));
+        }
+
+        let memory_install_delta = dispatch
+            .after
+            .memory
+            .physical_installs
+            .checked_sub(dispatch.before.memory.physical_installs);
+        let eviction_delta = dispatch
+            .after
+            .memory
+            .physical_evictions
+            .checked_sub(dispatch.before.memory.physical_evictions);
+        let stale_delta = dispatch
+            .after
+            .memory
+            .stale_retirements
+            .checked_sub(dispatch.before.memory.stale_retirements);
+        if eviction_delta != Some(0) || stale_delta != Some(0) {
+            return Err(QualificationFailure::new(
+                FailureStage::Postcondition,
+                "physical-registry-churn",
+                format!("vector {vector_index} evicted or retired a physical entry"),
+            ));
+        }
+        if io_delta.hidden_state_uploads != 1
+            || io_delta.hidden_state_upload_bytes != output_bytes
+            || io_delta.queue_submissions != 1
+            || io_delta.map_requests != 1
+            || io_delta.readback_completions != 1
+            || io_delta.readback_bytes != output_bytes
+        {
+            return Err(QualificationFailure::new(
+                FailureStage::Postcondition,
+                "incomplete-per-vector-gpu-io",
+                format!("vector {vector_index} GPU I/O delta is {io_delta:?}"),
+            ));
+        }
+        if routed_delta.gpu_dispatch_attempts != 1
+            || routed_delta.gpu_dispatch_successes != 1
+            || routed_delta.gpu_dispatch_failures != 0
+            || routed_delta.cpu_routed_expert_dispatches != 0
+            || routed_delta.gpu_cpu_fallbacks != 0
+            || routed_delta.degraded_expert_substitutions != 0
+        {
+            return Err(QualificationFailure::new(
+                FailureStage::Postcondition,
+                "invalid-per-vector-routed-execution",
+                format!("vector {vector_index} routed delta is {routed_delta:?}"),
+            ));
+        }
+
+        if vector_index == 0 {
+            if dispatch.before.physical.is_some()
+                || dispatch.before.logical_generation.is_some()
+                || dispatch.before.memory.logical_admitted_bytes != 0
+                || dispatch.before.memory.expert_live_bytes != 0
+                || dispatch.before.memory.physical_entries != 0
+                || dispatch.before.memory.expert_registry_bytes != 0
+                || dispatch.before.memory.physical_installs != 0
+                || dispatch.before.memory.physical_evictions != 0
+                || dispatch.before.memory.stale_retirements != 0
+                || dispatch.before.gpu_io != GpuExpertIoSnapshot::default()
+                || dispatch.before.routed != RoutedExpertExecutionSnapshot::default()
+                || memory_install_delta != Some(1)
+                || io_delta.expert_weight_uploads != 1
+                || io_delta.expert_weight_upload_bytes != after_physical.device_bytes
+            {
+                return Err(QualificationFailure::new(
+                    FailureStage::Postcondition,
+                    "initial-physical-install-not-exactly-once",
+                    format!(
+                        "initial before={:?} after={:?} io={io_delta:?}",
+                        dispatch.before, dispatch.after
+                    ),
+                ));
+            }
+            stable_generation = Some(after_generation);
+            stable_physical = Some(after_physical);
+        } else if dispatch.before.logical_generation != stable_generation
+            || dispatch.before.physical != stable_physical
+            || dispatch.after.logical_generation != stable_generation
+            || dispatch.after.physical != stable_physical
+            || dispatch.before.memory.physical_entries != 1
+            || dispatch.before.memory.expert_registry_bytes != physical_device_bytes
+            || memory_install_delta != Some(0)
+            || io_delta.expert_weight_uploads != 0
+            || io_delta.expert_weight_upload_bytes != 0
+        {
+            return Err(QualificationFailure::new(
+                FailureStage::Postcondition,
+                "physical-expert-not-reused",
+                format!(
+                    "vector {vector_index} changed generation/residency or re-uploaded weights"
+                ),
+            ));
+        }
+
+        reports.push(CompleteExpertVectorReport {
+            vector_index,
+            input_sha256: hash_f32(&dispatch.input),
+            worst_cpu_f32: dispatch.cpu_f32[worst_index],
+            worst_cpu_f16: cpu_f16[worst_index],
+            worst_gpu_f16: dispatch.gpu_f16[worst_index],
+            worst_absolute_error: absolute_errors[worst_index],
+            worst_relative_error: relative_errors[worst_index],
+            cpu_f32: dispatch.cpu_f32,
+            cpu_f16,
+            gpu_f16: dispatch.gpu_f16,
+            absolute_errors,
+            relative_errors,
+            allowed_errors,
+            worst_index,
+            max_absolute_error,
+            max_relative_error,
+            before: dispatch.before,
+            after: dispatch.after,
+            gpu_io_delta: io_delta,
+            routed_delta,
+            passed,
+        });
+        previous_after = Some(dispatch.after);
+    }
+
+    Ok(CompleteExpertValidation {
+        report: CompleteExpertReport {
+            identity,
+            d_model: execution.d_model,
+            d_ff: execution.d_ff,
+            checkpoint_block_align: execution.checkpoint_block_align,
+            physical_device_bytes,
+            payload_bytes: execution.payload_bytes,
+            checkpoint_payload_bytes: execution.checkpoint_payload_bytes,
+            alignment_padding_bytes: execution.alignment_padding_bytes,
+            payload_sha256: execution.payload_sha256,
+            checkpoint_payload_sha256: execution.checkpoint_payload_sha256,
+            vectors: reports,
+        },
+        tolerance_failure,
+    })
+}
+
+fn hash_f32(values: &[f32]) -> String {
+    let mut hasher = Sha256::new();
+    for value in values {
+        hasher.update(value.to_bits().to_le_bytes());
+    }
+    format!("{:x}", hasher.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn memory_snapshot(
+        logical_admitted_bytes: u64,
+        expert_bytes: u64,
+        physical_entries: usize,
+        physical_installs: u64,
+    ) -> GpuExpertMemorySnapshot {
+        let workspace_bytes = 64;
+        GpuExpertMemorySnapshot {
+            logical_admitted_bytes,
+            expert_live_bytes: expert_bytes,
+            expert_registry_bytes: expert_bytes,
+            workspace_bytes,
+            total_tracked_bytes: expert_bytes + workspace_bytes,
+            expert_capacity_bytes: 256,
+            physical_entries,
+            physical_installs,
+            physical_evictions: 0,
+            stale_retirements: 0,
+        }
+    }
+
+    fn io_snapshot(weight_uploads: u64, weight_bytes: u64, dispatches: u64) -> GpuExpertIoSnapshot {
+        GpuExpertIoSnapshot {
+            expert_weight_uploads: weight_uploads,
+            expert_weight_upload_bytes: weight_bytes,
+            hidden_state_uploads: dispatches,
+            hidden_state_upload_bytes: dispatches * 8,
+            queue_submissions: dispatches,
+            map_requests: dispatches,
+            readback_completions: dispatches,
+            readback_bytes: dispatches * 8,
+        }
+    }
+
+    fn routed_snapshot(dispatches: u64) -> RoutedExpertExecutionSnapshot {
+        RoutedExpertExecutionSnapshot {
+            gpu_dispatch_attempts: dispatches,
+            gpu_dispatch_successes: dispatches,
+            ..RoutedExpertExecutionSnapshot::default()
+        }
+    }
+
+    fn dispatch_snapshot(
+        generation: Option<u64>,
+        physical: Option<GpuPhysicalExpertResidency>,
+        memory: GpuExpertMemorySnapshot,
+        io: GpuExpertIoSnapshot,
+        routed: RoutedExpertExecutionSnapshot,
+    ) -> CompleteDispatchSnapshot {
+        CompleteDispatchSnapshot {
+            logical_generation: generation,
+            physical,
+            memory,
+            gpu_io: io,
+            routed,
+        }
+    }
+
+    fn valid_complete_execution() -> (ExpertIdentityEvidence, CompleteExpertExecution) {
+        let identity = expert_identity(9, 2, 8).unwrap();
+        let physical = GpuPhysicalExpertResidency {
+            expert_id: identity.global_expert_id,
+            generation: 7,
+            device_bytes: 56,
+        };
+        let mut dispatches = Vec::new();
+        for vector_index in 0..3u64 {
+            let first = vector_index == 0;
+            let before_dispatches = vector_index;
+            let after_dispatches = vector_index + 1;
+            let before = dispatch_snapshot(
+                (!first).then_some(7),
+                (!first).then_some(physical),
+                if first {
+                    memory_snapshot(0, 0, 0, 0)
+                } else {
+                    memory_snapshot(64, 56, 1, 1)
+                },
+                if first {
+                    io_snapshot(0, 0, before_dispatches)
+                } else {
+                    io_snapshot(1, 56, before_dispatches)
+                },
+                routed_snapshot(before_dispatches),
+            );
+            let after = dispatch_snapshot(
+                Some(7),
+                Some(physical),
+                memory_snapshot(64, 56, 1, 1),
+                io_snapshot(1, 56, after_dispatches),
+                routed_snapshot(after_dispatches),
+            );
+            dispatches.push(CompleteDispatchExecution {
+                input: vec![vector_index as f32, -0.5],
+                cpu_f32: vec![1.0001, -0.5],
+                gpu_f16: vec![1.0, -0.5],
+                before,
+                after,
+            });
+        }
+        (
+            identity,
+            CompleteExpertExecution {
+                d_model: 2,
+                d_ff: 2,
+                checkpoint_block_align: 64,
+                payload_bytes: 54,
+                checkpoint_payload_bytes: 64,
+                alignment_padding_bytes: 10,
+                payload_sha256: "fixture".to_string(),
+                checkpoint_payload_sha256: "checkpoint-fixture".to_string(),
+                dispatches,
+            },
+        )
+    }
+
+    #[test]
+    fn canonical_cases_cover_required_scale_offsets_and_projections() {
+        let cases = canonical_raw_cases();
+        assert!(cases.iter().any(|case| case.name.contains("zero-scale")));
+        assert!(cases
+            .iter()
+            .any(|case| case.name.contains("positive-scale")));
+        assert!(cases
+            .iter()
+            .any(|case| case.name.contains("negative-scale")));
+        assert!(cases.iter().any(|case| case.columns > Q4_0_BLOCK_ELEMS));
+        for projection in ["gate", "up", "down"] {
+            assert!(cases.iter().any(|case| case.projection == projection));
+        }
+        let unaligned = cases
+            .iter()
+            .find(|case| case.name.contains("unaligned"))
+            .unwrap();
+        assert_ne!((unaligned.w_block_off * Q4_0_BLOCK_BYTES) % 4, 0);
+    }
+
+    #[test]
+    fn literal_extrema_and_negative_scale_use_authoritative_decoder() {
+        let positive = canonical_block(0.25, [0xf0; 16]);
+        let mut decoded = [0.0f32; 32];
+        dequantize_q4_0_block(&positive, &mut decoded);
+        assert_eq!(&decoded[..16], &[-2.0; 16]);
+        assert_eq!(&decoded[16..], &[1.75; 16]);
+
+        let negative = canonical_block(-0.5, [0xf0; 16]);
+        dequantize_q4_0_block(&negative, &mut decoded);
+        assert_eq!(&decoded[..16], &[4.0; 16]);
+        assert_eq!(&decoded[16..], &[-3.5; 16]);
+    }
+
+    #[test]
+    fn q4_parity_complete_cpu_oracle_executes_authoritative_q4_0_forward() {
+        let d_model = 32;
+        let d_ff = 32;
+        let block = canonical_block(
+            0.125,
+            std::array::from_fn(|index| index as u8 | ((15 - index as u8) << 4)),
+        );
+        let block_count = crate::inference::expert_weight_bytes_for(
+            d_model,
+            d_ff,
+            crate::inference::WeightDtype::Q4_0,
+        ) / Q4_0_BLOCK_BYTES;
+        let bytes = block.repeat(block_count);
+        let input = deterministic_input(d_model, 23);
+        let output =
+            crate::inference::q4_0_cpu_reference_forward(&bytes, &input, d_model, d_ff).unwrap();
+        assert_eq!(output.len(), d_model);
+        assert!(output.iter().all(|value| value.is_finite()));
+        assert!(output.iter().any(|value| *value != 0.0));
+    }
+
+    #[test]
+    fn zero_scale_is_zero_even_with_extremal_nibbles() {
+        let case = &canonical_raw_cases()[0];
+        assert_eq!(cpu_q4_matvec(case).unwrap(), vec![0.0]);
+    }
+
+    #[test]
+    fn fixed_combined_tolerance_accepts_boundary_and_rejects_excess() {
+        let cpu = [2.0f32];
+        let allowed = RAW_ABSOLUTE_TOLERANCE + RAW_RELATIVE_TOLERANCE * 2.0;
+        assert!(
+            compare_vectors(&cpu, &[2.0 + allowed * 0.9], RAW_TOLERANCE)
+                .unwrap()
+                .6
+        );
+        assert!(
+            !compare_vectors(&cpu, &[2.0 + allowed * 1.1], RAW_TOLERANCE)
+                .unwrap()
+                .6
+        );
+    }
+
+    #[test]
+    fn nonfinite_values_fail_before_tolerance_evaluation() {
+        assert!(compare_vectors(&[f32::NAN], &[0.0], RAW_TOLERANCE).is_err());
+        assert!(compare_vectors(&[0.0], &[f32::INFINITY], COMPLETE_TOLERANCE).is_err());
+    }
+
+    #[test]
+    fn deterministic_complete_inputs_are_nontrivial_finite_and_f16_exact() {
+        for input in deterministic_complete_inputs(64) {
+            assert!(input.iter().any(|value| *value > 0.0));
+            assert!(input.iter().any(|value| *value < 0.0));
+            assert!(input.iter().all(|value| value.is_finite()));
+            assert!(input
+                .iter()
+                .all(|value| half::f16::from_f32(*value).to_f32() == *value));
+        }
+    }
+
+    #[test]
+    fn global_expert_identity_never_wraps_or_reinterprets() {
+        let identity = expert_identity(257, 48, 128).unwrap();
+        assert_eq!(identity.layer_index, 2);
+        assert_eq!(identity.layer_local_expert_id, 1);
+        assert_eq!(identity.total_global_experts, 6144);
+        assert_eq!(
+            expert_identity(6144, 48, 128).unwrap_err().code,
+            "global-expert-id-out-of-range"
+        );
+        assert_eq!(
+            expert_identity(0, usize::MAX, u32::MAX).unwrap_err().code,
+            "expert-namespace-overflow"
+        );
+    }
+
+    #[test]
+    fn malformed_raw_geometry_and_payload_fail_loudly() {
+        let mut case = canonical_raw_cases().remove(0);
+        case.columns = 31;
+        assert!(cpu_q4_matvec(&case).unwrap_err().contains("multiple"));
+        case.columns = 32;
+        case.weights.pop();
+        assert!(cpu_q4_matvec(&case)
+            .unwrap_err()
+            .contains("complete 18-byte blocks"));
+    }
+
+    #[test]
+    fn complete_report_uses_cpu_f16_as_primary_oracle_and_preserves_f32() {
+        let (identity, execution) = valid_complete_execution();
+        let validation = validate_complete_expert(identity, execution, 2).unwrap();
+        assert!(validation.tolerance_failure.is_none());
+        let report = validation.report;
+        assert_eq!(report.payload_bytes, 54);
+        assert_eq!(report.checkpoint_payload_bytes, 64);
+        assert_eq!(report.alignment_padding_bytes, 10);
+        assert_eq!(report.physical_device_bytes, 56);
+        let vector = &report.vectors[0];
+        assert_eq!(vector.cpu_f32, vec![1.0001, -0.5]);
+        assert_eq!(vector.cpu_f16, vec![1.0, -0.5]);
+        assert_eq!(vector.gpu_f16, vec![1.0, -0.5]);
+        assert_eq!(vector.absolute_errors, vec![0.0, 0.0]);
+        assert!(vector.passed);
+    }
+
+    #[test]
+    fn complete_evidence_proves_one_install_then_stable_reuse_and_per_vector_io() {
+        let (identity, execution) = valid_complete_execution();
+        let validation = validate_complete_expert(identity, execution, 2).unwrap();
+        assert!(validation.tolerance_failure.is_none());
+        let report = validation.report;
+        assert_eq!(report.vectors.len(), 3);
+        assert_eq!(report.vectors[0].gpu_io_delta.expert_weight_uploads, 1);
+        assert_eq!(
+            report.vectors[0].gpu_io_delta.expert_weight_upload_bytes,
+            56
+        );
+        for vector in &report.vectors {
+            assert_eq!(vector.gpu_io_delta.hidden_state_uploads, 1);
+            assert_eq!(vector.gpu_io_delta.hidden_state_upload_bytes, 8);
+            assert_eq!(vector.gpu_io_delta.queue_submissions, 1);
+            assert_eq!(vector.gpu_io_delta.map_requests, 1);
+            assert_eq!(vector.gpu_io_delta.readback_completions, 1);
+            assert_eq!(vector.gpu_io_delta.readback_bytes, 8);
+            assert_eq!(vector.routed_delta.gpu_dispatch_attempts, 1);
+            assert_eq!(vector.routed_delta.gpu_dispatch_successes, 1);
+        }
+        for vector in &report.vectors[1..] {
+            assert_eq!(vector.before.logical_generation, Some(7));
+            assert_eq!(vector.after.logical_generation, Some(7));
+            assert_eq!(vector.before.physical, vector.after.physical);
+            assert_eq!(vector.gpu_io_delta.expert_weight_uploads, 0);
+            assert_eq!(vector.gpu_io_delta.expert_weight_upload_bytes, 0);
+        }
+    }
+
+    #[test]
+    fn complete_evidence_fails_on_reupload_generation_change_or_bad_ledger() {
+        let (identity, mut execution) = valid_complete_execution();
+        execution.dispatches[1].after.gpu_io.expert_weight_uploads += 1;
+        assert_eq!(
+            validate_complete_expert(identity.clone(), execution, 2)
+                .unwrap_err()
+                .code,
+            "physical-expert-not-reused"
+        );
+
+        let (identity, mut execution) = valid_complete_execution();
+        execution.dispatches[1].after.logical_generation = Some(8);
+        assert_eq!(
+            validate_complete_expert(identity.clone(), execution, 2)
+                .unwrap_err()
+                .code,
+            "physical-generation-or-ledger-mismatch"
+        );
+
+        let (identity, mut execution) = valid_complete_execution();
+        execution.dispatches[0].after.memory.total_tracked_bytes += 1;
+        assert_eq!(
+            validate_complete_expert(identity, execution, 2)
+                .unwrap_err()
+                .code,
+            "complete-expert-capacity-ledger-invalid"
+        );
+
+        let (identity, mut execution) = valid_complete_execution();
+        execution.alignment_padding_bytes = 9;
+        assert_eq!(
+            validate_complete_expert(identity.clone(), execution, 2)
+                .unwrap_err()
+                .code,
+            "checkpoint-payload-accounting-invalid"
+        );
+
+        let (identity, mut execution) = valid_complete_execution();
+        execution.dispatches[1].before.routed.gpu_dispatch_attempts += 1;
+        assert_eq!(
+            validate_complete_expert(identity.clone(), execution, 2)
+                .unwrap_err()
+                .code,
+            "inter-vector-evidence-discontinuity"
+        );
+
+        let (identity, mut execution) = valid_complete_execution();
+        execution.dispatches[0].gpu_f16[0] = 1.25;
+        let validation = validate_complete_expert(identity, execution, 2).unwrap();
+        assert_eq!(
+            validation.tolerance_failure.unwrap().code,
+            "complete-expert-tolerance-failed"
+        );
+        assert!(!validation.report.vectors[0].passed);
+        assert_eq!(validation.report.vectors[0].cpu_f32[0], 1.0001);
+        assert_eq!(validation.report.vectors[0].cpu_f16[0], 1.0);
+        assert_eq!(validation.report.vectors[0].gpu_f16[0], 1.25);
+        assert_eq!(validation.report.vectors[0].worst_index, 0);
+    }
+}

--- a/rust-engine/src/server.rs
+++ b/rust-engine/src/server.rs
@@ -2232,6 +2232,10 @@ mod tests {
     // test; reuse `std::env::temp_dir()` with a unique subpath.
     mod tempdir {
         use std::path::PathBuf;
+        use std::sync::atomic::{AtomicU64, Ordering};
+
+        static TEMP_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
+
         pub struct TempDir {
             path: PathBuf,
         }
@@ -2242,8 +2246,9 @@ mod tests {
                     .duration_since(std::time::UNIX_EPOCH)
                     .map(|d| d.as_nanos())
                     .unwrap_or(0);
+                let sequence = TEMP_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
                 path.push(format!(
-                    "mer-server-test-{tag}-{}-{nanos}",
+                    "mer-server-test-{tag}-{}-{nanos}-{sequence}",
                     std::process::id()
                 ));
                 std::fs::create_dir_all(&path)?;


### PR DESCRIPTION
## Summary

Adds the fail-closed `qualify-hybrid-q4-parity` command for strict Hybrid Q4_0 numerical qualification.

The command:

- compares eight deterministic canonical `ggml-standard-v1` Q4_0 fixtures through MER's authoritative CPU decoder and existing `matmul_q4_0.wgsl` pipeline;
- includes a direct two-row case with distinct row blocks and a nonzero, byte-unaligned Q4 block offset;
- compares three deterministic vectors through one complete converted checkpoint expert using the authoritative CPU Q4_0 forward and production GPU routed-expert path;
- uses `f16(CPU f32)` versus returned GPU f16 at the production boundary while retaining complete numerical and residency evidence; and
- fails closed on provenance, layout, adapter, dispatch, nonfinite-output, tolerance, residency, or counter violations.

The report schema remains `mer.strict-hybrid-q4-parity.v1`. Shader math, Q4 layout/decoder semantics, and fixed tolerances are unchanged.

## Authoritative hardened NVIDIA L4 qualification

Qualified implementation commit:

`08c05ff1079b7676623642d354d13c15994af1ea`

The later branch-head commit `8e57e3b72bd0da36275c5684727267ad0447dd27` changes documentation only; no Rust source differs from the qualified implementation.

- worktree dirty: `false`;
- package version: `0.1.0`;
- schema/mode: `mer.strict-hybrid-q4-parity.v1` / `strict-hybrid-q4-parity`;
- status/failure/exit: `pass` / `null` / `0`;
- report: `pr6-q4-parity-08c05ff.json`;
- report SHA-256: `f50e0915288de6eb0847ea77a0f3685e91966aa54d178c8d8d6ebb63b9326beb`;
- progress watchdog: 300 seconds; and
- Linux release build with `avx512,blas,tokenizer,io_uring`: passed.

The earlier `dac1d213...` seven-case run is superseded historical evidence and does not qualify the hardened implementation.

## Device and execution plan

- GCP `g2-standard-32`;
- NVIDIA L4, vendor/device `4318 (0x10de) / 10168 (0x27b8)`;
- `DiscreteGpu`, WGPU `vulkan`, compute plane `wgpu-vulkan`;
- NVIDIA driver `580.173.02`;
- software adapter: false;
- requested `hybrid`;
- resolved `hybrid-cpu-attention-gpu-experts`;
- embeddings, LM head, dense projections, attention, KV, and router: CPU;
- routed experts: GPU with `q4_0`; and
- fallback occurred: false.

## Raw Q4_0 parity

All eight cases passed with maximum absolute error 0, maximum relative error 0, and worst index 0:

1. `zero-scale-extrema` — 1 × 32, `w_block_off=0`
2. `positive-scale-extrema` — 1 × 32, `w_block_off=0`
3. `negative-scale-sign` — 1 × 32, `w_block_off=0`
4. `multiple-blocks-nontrivial-hidden` — 1 × 64, `w_block_off=0`
5. `gate-projection-offset-zero` — 1 × 32, `w_block_off=0`
6. `up-projection-offset-one-unaligned` — 1 × 32, `w_block_off=1`
7. `down-projection-offset-two` — 1 × 32, `w_block_off=2`
8. `multi-row-offset-row-stride` — 2 × 32, `w_block_off=1`

The eighth case directly qualifies multi-row output indexing and row stride with distinct row blocks at a nonzero 18-byte Q4 block offset. Raw qualification remained isolated from production expert residency and GPU-I/O evidence.

## Complete checkpoint expert

Global expert 0 mapped exactly to layer 0 / layer-local expert 0 in the 48 × 128 = 6,144 expert namespace. Canonical checkpoint payload and physical allocation were each 2,654,208 bytes with zero alignment padding.

| Vector | Max abs | Max rel | Worst index | Expert upload | Hidden upload | Submit/map/readback |
|---:|---:|---:|---:|---:|---:|---:|
| 0 | `7.6293945e-06` | `0.0009451796` | 1831 | 1 / 2,654,208 B | 1 / 8,192 B | 1 / 1 / 1 (8,192 B) |
| 1 | `9.536743e-07` | `0.0010615712` | 1500 | 0 / 0 B | 1 / 8,192 B | 1 / 1 / 1 (8,192 B) |
| 2 | `0` | `0` | 0 | 0 / 0 B | 1 / 8,192 B | 1 / 1 / 1 (8,192 B) |

The initial dispatch installed physical expert 0 exactly once at generation 1. Later vectors reused the same generation and physical entry with zero expert-weight re-upload. Every vector recorded GPU attempts/successes/failures of `1/1/0`; CPU expert execution, GPU-to-CPU fallback, degraded substitution, eviction, and stale retirement remained zero.

`routed_delta.selected_routed_experts` is zero by design. The command explicitly selects global expert 0 and invokes the existing production `forward_moe_resident` boundary; it does not run the model router, so it must not increment the router-selection counter. The independent dispatch and fallback counters above remain authoritative.

## PASS contract

All 18 independently derived checks passed: clean provenance, strict Hybrid preflight, canonical layout, exact execution plan, hardware/exact adapter identity, strict GPU failure policy, global expert identity, exact payload size, all raw cases, raw-residency isolation, one initial physical install, stable generation reuse, zero later weight uploads, complete per-vector GPU I/O, zero eviction/stale retirement, zero CPU fallback/degraded execution, and all complete-expert vectors.

Fixed tolerances remain:

- raw: absolute `1e-5`, relative `1e-4`, against authoritative CPU f32;
- complete expert: absolute `2e-3`, relative `5e-3`, against CPU f32 rounded to f16; and
- formula: `abs_error <= absolute + relative * abs(reference)`.

## Software validation

- `cargo test q4_parity`: 19 passed;
- `cargo test q4_0_shader_logic_tests`: 4 passed;
- `cargo test qualification`: 28 passed;
- `cargo test strict`: 40 passed;
- full `cargo test`: 932 passed, 0 failed, 2 ignored;
- `cargo clippy --all-targets`: passed with existing warnings;
- `git diff --check`: passed;
- local macOS release build: passed with existing warnings; and
- Linux L4 feature release build: passed.

Detailed evidence and reproduction commands are in `docs/benchmarks/qwen3-coder-30b-a3b-pr6-q4-parity-2026-08-11.md`.

## Scope exclusions and remaining PR6 diagnostics

This PR does not modify Q4 shader math or layout, serving fallback behavior, scheduling, batching, CUDA, KV, attention, dense execution, or quantization. It makes no model-quality, production-TPS, 10-TPS, commercial-performance, or batching claim. PR7 has not started.

Remaining separate PR6 diagnostics are:

- fixed-corpus CPU/Hybrid greedy-token parity;
- physical-capacity and eviction qualification;
- injected GPU-dispatch-failure qualification; and
- repeated-run stability qualification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a strict `qualify-hybrid-q4-parity` command for validating Q4_0 numerical parity across CPU and GPU execution.
  * Added JSON qualification reports covering numerical tolerances, execution placement, residency, GPU I/O, routing, and artifact verification.
  * Added fail-closed handling for invalid configuration, GPU readback failures, device loss, nonfinite output, and report-generation errors.

* **Documentation**
  * Documented command usage, required checks, tolerances, provenance, report semantics, and reproduction steps.
  * Added a historical benchmark report for a passing NVIDIA L4 qualification run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->