### PR TITLE
PR6: add fixed-corpus CPU/Hybrid greedy token parity qualification

### DIFF
--- a/README.md
+++ b/README.md
@@ -2170,6 +2170,9 @@ jq -e '
   .diagnostic_complete == true and
   .failure == null and
   (.runs | length) == 6 and
+  ([.runs[] | select(.plane == "cpu")] | length) == 2 and
+  ([.runs[] | select(.plane == "cpu_boundary_emulation")] | length) == 2 and
+  ([.runs[] | select(.plane == "hybrid")] | length) == 2 and
   .reproducibility.cpu_bitwise_reproducible == true and
   .reproducibility.cpu_boundary_emulation_bitwise_reproducible == true and
   .reproducibility.hybrid_bitwise_reproducible == true and
@@ -2184,8 +2187,9 @@ jq -e '
       (.plane_evidence.cpu_q4_boundary_emulation.enabled == true and
        (.plane_evidence.cpu_q4_boundary_emulation.routed_expert_dispatches ==
         .plane_evidence.routed_execution_delta.cpu_routed_expert_dispatches))
-    else
+    elif .plane == "hybrid" then
       .plane_evidence.cpu_q4_boundary_emulation == {"enabled":false,"routed_expert_dispatches":0}
+    else false
     end) and
   (.first_token_logits.cpu_top_16 | length) == 16 and
   (.first_token_logits.hybrid_top_16 | length) == 16

--- a/README.md
+++ b/README.md
@@ -2116,6 +2116,48 @@ jq -e '
 ' greedy-parity.json
 ```
 
+##### First-token numerical diagnostic
+
+`diagnose-hybrid-q4-greedy-divergence` is a separate Phase-A diagnostic for
+the fixed `json-transformation` case. It leaves the exact-token qualification
+contract unchanged. The parent tokenizes once, then starts two fresh CPU and
+two fresh process-isolated Hybrid workers. Each worker returns the complete
+first-token logit vector as bounded exact f32 bits through a private typed
+protocol; the final JSON contains only hashes and comparison evidence.
+
+```bash
+./target/release/micro-expert-router diagnose-hybrid-q4-greedy-divergence \
+  --config ./path/to/strict-hybrid-q4.toml \
+  --expected-adapter-name "NVIDIA L4" \
+  --report-out ./greedy-logit-diagnostic.json
+```
+
+The report schema is
+`mer.strict-hybrid-q4-greedy-logit-diagnostic.v1`. It records repeated-run
+bitwise reproducibility, chosen tokens, top-16 logits and bits, the union of
+both top-16 sets, complete-vector error metrics, and the CPU/Hybrid change in
+the token-715-versus-token-5212 margin. `qualification_pass` is always false;
+`diagnostic_complete` means only that all identity, process, strict-plane, and
+logit evidence was collected and reconciled.
+
+```bash
+jq -e '
+  .schema_version == "mer.strict-hybrid-q4-greedy-logit-diagnostic.v1" and
+  .qualification_pass == false and
+  .diagnostic_complete == true and
+  .failure == null and
+  (.runs | length) == 4 and
+  .reproducibility.cpu_bitwise_reproducible == true and
+  .reproducibility.hybrid_bitwise_reproducible == true and
+  .reproducibility.all_worker_ids_unique == true and
+  .reproducibility.all_process_ids_unique == true and
+  .reproducibility.every_worker_exited_zero_and_reaped == true and
+  .reproducibility.no_retries == true and
+  (.first_token_logits.cpu_top_16 | length) == 16 and
+  (.first_token_logits.hybrid_top_16 | length) == 16
+' ./greedy-logit-diagnostic.json
+```
+
 Increase log verbosity:
 
 ```bash
@@ -2531,6 +2573,12 @@ micro-expert-router qualify-hybrid-q4-greedy-parity
   --expected-adapter-name <NAME>
                               Required exact authoritative wgpu adapter name.
   --report-out <PATH>        Write typed JSON there (default: stdout).
+
+micro-expert-router diagnose-hybrid-q4-greedy-divergence
+  --config <PATH>            One strict Hybrid native-Q4_0 TOML config.
+  --expected-adapter-name <NAME>
+                              Required exact authoritative wgpu adapter name.
+  --report-out <PATH>        Required typed diagnostic JSON destination.
 
 micro-expert-router monitor          # requires `--features tui` (on by default)
   --url <URL>                Base URL of a running `serve` instance

--- a/README.md
+++ b/README.md
@@ -2086,7 +2086,10 @@ Hybrid-boundary reference must resolve every component to CPU and account
 every selected routed expert as a CPU dispatch with zero GPU counters. The
 boundary reference applies the documented production Hybrid f16 conversion at
 every routed-expert input and output while retaining the original f32 routing
-weights and aggregation semantics. Hybrid must resolve
+weights and aggregation semantics. Typed runtime evidence must show boundary
+emulation disabled with zero emulated dispatches for ordinary CPU and Hybrid,
+and enabled with every CPU routed-expert dispatch observed through the emulation
+path for the boundary reference. Hybrid must resolve
 embeddings, LM head, dense projections, attention, KV, and router to CPU while
 routing native Q4_0 experts to the exact named non-software GPU under
 `StrictFailClosed`. Every selected Hybrid expert must be attempted and succeed
@@ -2122,6 +2125,11 @@ jq -e '
   all($report.cases[];
     .hybrid.device.name == $report.expected_adapter_name and
     .hybrid.device.software_adapter == false and
+    .cpu.cpu_q4_boundary_emulation == {"enabled":false,"routed_expert_dispatches":0} and
+    .boundary_reference.cpu_q4_boundary_emulation.enabled == true and
+    (.boundary_reference.cpu_q4_boundary_emulation.routed_expert_dispatches ==
+      .boundary_reference.routed_execution_delta.cpu_routed_expert_dispatches) and
+    .hybrid.cpu_q4_boundary_emulation == {"enabled":false,"routed_expert_dispatches":0} and
     .boundary_reference_vs_hybrid.exact_token_ids == true and
     .boundary_reference_vs_hybrid.equal_generated_count == true and
     .boundary_reference_vs_hybrid.equal_termination_reason == true and
@@ -2133,10 +2141,12 @@ jq -e '
 
 `diagnose-hybrid-q4-greedy-divergence` is a separate Phase-A diagnostic for
 the fixed `json-transformation` case. It leaves the exact-token qualification
-contract unchanged. The parent tokenizes once, then starts two fresh CPU and
-two fresh process-isolated Hybrid workers. Each worker returns the complete
-first-token logit vector as bounded exact f32 bits through a private typed
-protocol; the final JSON contains only hashes and comparison evidence.
+contract unchanged. The parent tokenizes once, then starts two fresh
+process-isolated ordinary CPU workers, two fresh process-isolated CPU
+Hybrid-boundary-emulation workers, and two fresh process-isolated Hybrid
+workers: six runs total. Each worker returns the complete first-token logit
+vector as bounded exact f32 bits through a private typed protocol; the final
+JSON contains only hashes and comparison evidence.
 
 ```bash
 ./target/release/micro-expert-router diagnose-hybrid-q4-greedy-divergence \
@@ -2159,13 +2169,24 @@ jq -e '
   .qualification_pass == false and
   .diagnostic_complete == true and
   .failure == null and
-  (.runs | length) == 4 and
+  (.runs | length) == 6 and
   .reproducibility.cpu_bitwise_reproducible == true and
+  .reproducibility.cpu_boundary_emulation_bitwise_reproducible == true and
   .reproducibility.hybrid_bitwise_reproducible == true and
   .reproducibility.all_worker_ids_unique == true and
   .reproducibility.all_process_ids_unique == true and
   .reproducibility.every_worker_exited_zero_and_reaped == true and
   .reproducibility.no_retries == true and
+  all(.runs[];
+    if .plane == "cpu" then
+      .plane_evidence.cpu_q4_boundary_emulation == {"enabled":false,"routed_expert_dispatches":0}
+    elif .plane == "cpu_boundary_emulation" then
+      (.plane_evidence.cpu_q4_boundary_emulation.enabled == true and
+       (.plane_evidence.cpu_q4_boundary_emulation.routed_expert_dispatches ==
+        .plane_evidence.routed_execution_delta.cpu_routed_expert_dispatches))
+    else
+      .plane_evidence.cpu_q4_boundary_emulation == {"enabled":false,"routed_expert_dispatches":0}
+    end) and
   (.first_token_logits.cpu_top_16 | length) == 16 and
   (.first_token_logits.hybrid_top_16 | length) == 16
 ' ./greedy-logit-diagnostic.json

--- a/README.md
+++ b/README.md
@@ -2055,8 +2055,12 @@ an all-CPU control and strict Hybrid execution exclusively from that frozen
 specification. A second CPU config is neither accepted nor inferred. Each
 plane and each corpus case receives a fresh engine, KV state, RAM/logical GPU
 cache, physical registry, counters, predictors, background state, and storage
-runtime. Controlled shutdown must release every resource family before the
-next isolated runtime is constructed.
+runtime. CPU controls remain fresh in-process runtimes. Every Hybrid plane runs
+in a separate short-lived child of the same immutable executable; the parent
+passes already-tokenized IDs through a typed stdin protocol, waits for a normal
+zero exit, and reaps the child before starting the next case. Controlled Rust
+shutdown remains reported, while process termination is the authoritative
+NVIDIA client/device teardown boundary.
 
 The versioned corpus `qwen3-coder-30b-a3b-greedy-v1` contains four cases:
 Rust function generation, Rust code correction, compact JSON transformation,
@@ -2084,6 +2088,10 @@ routing native Q4_0 experts to the exact named non-software GPU under
 on GPU; hidden uploads, queue submissions, map requests, completed readbacks,
 and readback bytes must all be nonzero; CPU expert execution, fallback,
 degraded substitution, and GPU failures must remain zero.
+Each Hybrid case must also prove its unique worker identity, matching executable
+and build SHA, case/config/token identities, normal zero exit, successful reap,
+and absence of timeout or signal termination. Missing worker-process evidence
+fails closed. Worker stderr is diagnostic-only and bounded in failure reports.
 
 PASS additionally requires exact generated token-ID equality at every position,
 identical generated count and termination reason, and identical decoded-text

--- a/README.md
+++ b/README.md
@@ -2051,11 +2051,12 @@ change would be required to bound that shared production wait safely.
 `qualify-hybrid-q4-greedy-parity` is a separate fail-closed diagnostic for
 Qwen3-Coder 30B-A3B Q4_0. It parses and reconciles one supplied strict Hybrid
 configuration, freezes that resolved model/runtime specification, then derives
-an all-CPU control and strict Hybrid execution exclusively from that frozen
-specification. A second CPU config is neither accepted nor inferred. Each
-plane and each corpus case receives a fresh engine, KV state, RAM/logical GPU
-cache, physical registry, counters, predictors, background state, and storage
-runtime. CPU controls remain fresh in-process runtimes. Every Hybrid plane runs
+an ordinary all-CPU control, an all-CPU Hybrid-boundary reference, and strict
+Hybrid execution exclusively from that frozen specification. A second CPU
+config is neither accepted nor inferred. Each run and each corpus case receives
+a fresh engine, KV state, RAM/logical GPU cache, physical registry, counters,
+predictors, background state, and storage runtime. Both CPU runs remain fresh
+in-process runtimes. Every Hybrid case runs
 in a separate short-lived child of the same immutable executable; the parent
 passes already-tokenized IDs through a typed stdin protocol, waits for a normal
 zero exit, and reaps the child before starting the next case. Controlled Rust
@@ -2065,7 +2066,7 @@ NVIDIA client/device teardown boundary.
 The versioned corpus `qwen3-coder-30b-a3b-greedy-v1` contains four cases:
 Rust function generation, Rust code correction, compact JSON transformation,
 and a short Spanish instruction. Each prompt is tokenized exactly once, the
-same token-ID slice is passed to both planes, and each plane produces exactly
+same token-ID slice is passed to all three runs, and each run produces exactly
 16 completion tokens with `SamplingParams::greedy()` (`temperature=0`,
 `top_p=1`, `top_k=0`, `seed=0`). This is deliberately small correctness
 coverage, not a throughput benchmark.
@@ -2077,34 +2078,43 @@ coverage, not a throughput benchmark.
   --report-out greedy-parity.json
 ```
 
-Schema `mer.strict-hybrid-q4-greedy-parity.v1` passes only when the clean build,
+Schema `mer.strict-hybrid-q4-greedy-parity.v2` passes only when the clean build,
 real checkpoint, canonical `ggml-standard-v1` metadata, exact Qwen3-Coder
 geometry, fixed corpus, and fixed sampling identity all validate. Per case,
-the CPU plan must resolve every component to CPU and account every selected
-routed expert as a CPU dispatch with zero GPU counters. Hybrid must resolve
+both the ordinary informational CPU plane and the authoritative CPU
+Hybrid-boundary reference must resolve every component to CPU and account
+every selected routed expert as a CPU dispatch with zero GPU counters. The
+boundary reference applies the documented production Hybrid f16 conversion at
+every routed-expert input and output while retaining the original f32 routing
+weights and aggregation semantics. Hybrid must resolve
 embeddings, LM head, dense projections, attention, KV, and router to CPU while
 routing native Q4_0 experts to the exact named non-software GPU under
 `StrictFailClosed`. Every selected Hybrid expert must be attempted and succeed
 on GPU; hidden uploads, queue submissions, map requests, completed readbacks,
 and readback bytes must all be nonzero; CPU expert execution, fallback,
 degraded substitution, and GPU failures must remain zero.
-Each Hybrid case must also prove its unique worker identity, matching executable
-and build SHA, case/config/token identities, normal zero exit, successful reap,
-and absence of timeout or signal termination. Missing worker-process evidence
-fails closed. Worker stderr is diagnostic-only and bounded in failure reports.
+Each Hybrid case must also prove unique worker and process identities, matching
+executable and build SHA, case/config/token identities, normal zero exit,
+successful reap, and absence of timeout or signal termination. Missing
+worker-process evidence fails closed. Worker stderr is diagnostic-only and
+bounded in failure reports.
 
-PASS additionally requires exact generated token-ID equality at every position,
-identical generated count and termination reason, and identical decoded-text
-SHA-256. A failure report preserves the first differing position, nullable CPU
-and Hybrid token IDs for length divergence, both termination reasons, lengths,
-counters, and decoded prefixes bounded to 512 UTF-8 bytes. The report contains
-no timing or TPS fields and does not change EOS, serving, batching, scheduling,
-quantization, shader math, or numerical-parity tolerances.
+PASS additionally requires the CPU Hybrid-boundary reference and Hybrid to have
+exact generated token-ID equality at every position, identical generated count
+and termination reason, and identical decoded-text SHA-256. Ordinary CPU output
+and its comparison with Hybrid remain informational evidence; their divergence
+does not fail the boundary-aware v2 contract. Both comparisons preserve the
+first differing position, nullable reference and Hybrid token IDs for length
+divergence, termination reasons, lengths, counters, and decoded prefixes
+bounded to 512 UTF-8 bytes. The report contains no timing or TPS fields and does
+not change EOS, serving, batching, scheduling, quantization, shader math, or
+numerical-parity tolerances. The earlier v1 schema retains its original raw-CPU
+parity meaning and is not accepted as v2 evidence.
 
 ```bash
 jq -e '
   . as $report |
-  $report.schema_version == "mer.strict-hybrid-q4-greedy-parity.v1" and
+  $report.schema_version == "mer.strict-hybrid-q4-greedy-parity.v2" and
   $report.status == "pass" and
   $report.failure == null and
   ($report.checks | all(.[]; . == true)) and
@@ -2112,7 +2122,10 @@ jq -e '
   all($report.cases[];
     .hybrid.device.name == $report.expected_adapter_name and
     .hybrid.device.software_adapter == false and
-    .comparison.exact_token_ids == true)
+    .boundary_reference_vs_hybrid.exact_token_ids == true and
+    .boundary_reference_vs_hybrid.equal_generated_count == true and
+    .boundary_reference_vs_hybrid.equal_termination_reason == true and
+    .boundary_reference_vs_hybrid.equal_generated_text_hash == true)
 ' greedy-parity.json
 ```
 

--- a/README.md
+++ b/README.md
@@ -2046,6 +2046,68 @@ routed-expert path; its synchronous production readback is not made
 preemptible by this qualification-only deadline. A separately scoped serving
 change would be required to bound that shared production wait safely.
 
+#### Strict Hybrid fixed-corpus greedy-token parity
+
+`qualify-hybrid-q4-greedy-parity` is a separate fail-closed diagnostic for
+Qwen3-Coder 30B-A3B Q4_0. It parses and reconciles one supplied strict Hybrid
+configuration, freezes that resolved model/runtime specification, then derives
+an all-CPU control and strict Hybrid execution exclusively from that frozen
+specification. A second CPU config is neither accepted nor inferred. Each
+plane and each corpus case receives a fresh engine, KV state, RAM/logical GPU
+cache, physical registry, counters, predictors, background state, and storage
+runtime. Controlled shutdown must release every resource family before the
+next isolated runtime is constructed.
+
+The versioned corpus `qwen3-coder-30b-a3b-greedy-v1` contains four cases:
+Rust function generation, Rust code correction, compact JSON transformation,
+and a short Spanish instruction. Each prompt is tokenized exactly once, the
+same token-ID slice is passed to both planes, and each plane produces exactly
+16 completion tokens with `SamplingParams::greedy()` (`temperature=0`,
+`top_p=1`, `top_k=0`, `seed=0`). This is deliberately small correctness
+coverage, not a throughput benchmark.
+
+```bash
+./target/release/micro-expert-router qualify-hybrid-q4-greedy-parity \
+  --config ./path/to/strict-hybrid-q4.toml \
+  --expected-adapter-name "NVIDIA L4" \
+  --report-out greedy-parity.json
+```
+
+Schema `mer.strict-hybrid-q4-greedy-parity.v1` passes only when the clean build,
+real checkpoint, canonical `ggml-standard-v1` metadata, exact Qwen3-Coder
+geometry, fixed corpus, and fixed sampling identity all validate. Per case,
+the CPU plan must resolve every component to CPU and account every selected
+routed expert as a CPU dispatch with zero GPU counters. Hybrid must resolve
+embeddings, LM head, dense projections, attention, KV, and router to CPU while
+routing native Q4_0 experts to the exact named non-software GPU under
+`StrictFailClosed`. Every selected Hybrid expert must be attempted and succeed
+on GPU; hidden uploads, queue submissions, map requests, completed readbacks,
+and readback bytes must all be nonzero; CPU expert execution, fallback,
+degraded substitution, and GPU failures must remain zero.
+
+PASS additionally requires exact generated token-ID equality at every position,
+identical generated count and termination reason, and identical decoded-text
+SHA-256. A failure report preserves the first differing position, nullable CPU
+and Hybrid token IDs for length divergence, both termination reasons, lengths,
+counters, and decoded prefixes bounded to 512 UTF-8 bytes. The report contains
+no timing or TPS fields and does not change EOS, serving, batching, scheduling,
+quantization, shader math, or numerical-parity tolerances.
+
+```bash
+jq -e '
+  . as $report |
+  $report.schema_version == "mer.strict-hybrid-q4-greedy-parity.v1" and
+  $report.status == "pass" and
+  $report.failure == null and
+  ($report.checks | all(.[]; . == true)) and
+  $report.source_preflight.requested_mode == "hybrid" and
+  all($report.cases[];
+    .hybrid.device.name == $report.expected_adapter_name and
+    .hybrid.device.software_adapter == false and
+    .comparison.exact_token_ids == true)
+' greedy-parity.json
+```
+
 Increase log verbosity:
 
 ```bash
@@ -2452,6 +2514,12 @@ micro-expert-router qualify-hybrid-q4
 micro-expert-router qualify-hybrid-q4-parity
   --config <PATH>            Strict Hybrid native-Q4_0 TOML config.
   --expert-id <ID>           Required global expert ID (never layer-local).
+  --expected-adapter-name <NAME>
+                              Required exact authoritative wgpu adapter name.
+  --report-out <PATH>        Write typed JSON there (default: stdout).
+
+micro-expert-router qualify-hybrid-q4-greedy-parity
+  --config <PATH>            One strict Hybrid native-Q4_0 TOML config.
   --expected-adapter-name <NAME>
                               Required exact authoritative wgpu adapter name.
   --report-out <PATH>        Write typed JSON there (default: stdout).

--- a/rust-engine/src/backend/mod.rs
+++ b/rust-engine/src/backend/mod.rs
@@ -2,7 +2,7 @@
 
 use anyhow::{anyhow, Result};
 use parking_lot::Mutex as ParkingMutex;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -140,7 +140,7 @@ struct AdapterMetadata {
 /// Immutable identity of the adapter selected by the authoritative GPU
 /// backend. This is evidence about the backend that executes work; it does not
 /// enumerate or rediscover a second adapter for reporting.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct GpuDeviceIdentity {
     pub name: String,
     pub vendor_id: u32,
@@ -452,7 +452,7 @@ impl std::error::Error for GpuExpertDispatchError {}
 /// deliberately narrower than process/device memory: physical expert weight
 /// buffers plus the fixed routed-expert workspace buffers. Dense, attention,
 /// KV, driver, and allocator overhead remain outside this internal ledger.
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 #[allow(dead_code)] // Public PR5 seam; PR4 validates it through backend-local tests.
 pub struct GpuExpertMemorySnapshot {
     /// Host payload bytes admitted by [`crate::expert_cache::GpuExpertCache`].
@@ -486,7 +486,7 @@ pub(crate) struct GpuPhysicalExpertResidency {
 
 /// Monotonic counters for only the routed-expert GPU path. Dense and
 /// attention operations are deliberately excluded.
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct GpuExpertIoSnapshot {
     /// Actual physical expert-buffer writes; registry hits do not increment it.
     pub expert_weight_uploads: u64,

--- a/rust-engine/src/dense_tensor.rs
+++ b/rust-engine/src/dense_tensor.rs
@@ -484,6 +484,14 @@ impl DenseWeight {
         }
     }
 
+    /// Diagnostic-only full view of the exact per-row logits consumed by
+    /// [`Self::greedy_argmax`]. Calling the general matvec path here would be
+    /// incorrect because its selected backend may accumulate differently.
+    pub(crate) fn diagnostic_greedy_logits(&self, x: &[f32]) -> Vec<f32> {
+        assert_eq!(x.len(), self.cols(), "dense logit input length mismatch");
+        (0..self.rows()).map(|row| self.row_dot(row, x)).collect()
+    }
+
     pub fn top_k_logits(&self, x: &[f32], k: usize) -> Vec<(usize, f32)> {
         assert_eq!(x.len(), self.cols(), "dense top-k input length mismatch");
         if k == 0 || self.rows() == 0 {

--- a/rust-engine/src/engine.rs
+++ b/rust-engine/src/engine.rs
@@ -1523,6 +1523,22 @@ pub struct Engine {
     pub(crate) core: EngineCore,
     pub(crate) speculation: EngineSpeculation,
     pub(crate) metrics: EngineMetrics,
+    diagnostic_route_capture_armed: std::sync::atomic::AtomicBool,
+    diagnostic_route_capture: parking_lot::Mutex<Option<DiagnosticRouteCaptureArm>>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+pub(crate) struct RoutedFfnDiagnosticCapture {
+    pub token_idx: u64,
+    pub layer: u32,
+    pub input_bits: Vec<u32>,
+    pub expert_ids: Vec<u32>,
+    pub routing_weight_bits: Vec<u32>,
+}
+
+struct DiagnosticRouteCaptureArm {
+    target_token_idx: u64,
+    captured: Option<RoutedFfnDiagnosticCapture>,
 }
 
 /// Run a CPU/GPU-blocking expert compute closure while *donating* the
@@ -1831,6 +1847,65 @@ impl Engine {
             ),
             speculation: EngineSpeculation::new(speculator_topk_default),
             metrics: EngineMetrics::new(),
+            diagnostic_route_capture_armed: std::sync::atomic::AtomicBool::new(false),
+            diagnostic_route_capture: parking_lot::Mutex::new(None),
+        }
+    }
+
+    /// Arm a one-shot, diagnostic-only capture at the routed-FFN boundary.
+    /// Normal serving never arms this slot, so its hot path performs only one
+    /// relaxed atomic load and never locks or clones activations.
+    pub(crate) fn arm_layer0_route_capture(&self, target_token_idx: u64) -> Result<(), String> {
+        let mut slot = self.diagnostic_route_capture.lock();
+        if slot.is_some() {
+            return Err("routed-FFN diagnostic capture is already armed".to_string());
+        }
+        *slot = Some(DiagnosticRouteCaptureArm {
+            target_token_idx,
+            captured: None,
+        });
+        self.diagnostic_route_capture_armed
+            .store(true, Ordering::Relaxed);
+        Ok(())
+    }
+
+    pub(crate) fn take_layer0_route_capture(
+        &self,
+    ) -> Option<RoutedFfnDiagnosticCapture> {
+        self.diagnostic_route_capture_armed
+            .store(false, Ordering::Relaxed);
+        self.diagnostic_route_capture
+            .lock()
+            .take()
+            .and_then(|arm| arm.captured)
+    }
+
+    fn capture_layer0_route_if_armed(
+        &self,
+        token_idx: u64,
+        layer: u32,
+        x: &[f32],
+        experts: &[u32],
+        weights: &[f32],
+    ) {
+        if !self
+            .diagnostic_route_capture_armed
+            .load(Ordering::Relaxed)
+        {
+            return;
+        }
+        let mut slot = self.diagnostic_route_capture.lock();
+        let Some(arm) = slot.as_mut() else {
+            return;
+        };
+        if layer == 0 && token_idx == arm.target_token_idx && arm.captured.is_none() {
+            arm.captured = Some(RoutedFfnDiagnosticCapture {
+                token_idx,
+                layer,
+                input_bits: x.iter().copied().map(f32::to_bits).collect(),
+                expert_ids: experts.to_vec(),
+                routing_weight_bits: weights.iter().copied().map(f32::to_bits).collect(),
+            });
         }
     }
 
@@ -4460,6 +4535,7 @@ impl Engine {
             weights.len(),
             "moe_step_weighted_into_with_timing: experts and weights must align"
         );
+        self.capture_layer0_route_if_armed(token_idx, layer, x, experts, weights);
         match self
             .moe_step_inner(
                 token_idx,

--- a/rust-engine/src/engine.rs
+++ b/rust-engine/src/engine.rs
@@ -1523,6 +1523,7 @@ pub struct Engine {
     pub(crate) core: EngineCore,
     pub(crate) speculation: EngineSpeculation,
     pub(crate) metrics: EngineMetrics,
+    diagnostic_cpu_q4_boundary_emulation: std::sync::atomic::AtomicBool,
     diagnostic_route_capture_armed: std::sync::atomic::AtomicBool,
     diagnostic_route_capture: parking_lot::Mutex<Option<DiagnosticRouteCaptureArm>>,
 }
@@ -1847,9 +1848,29 @@ impl Engine {
             ),
             speculation: EngineSpeculation::new(speculator_topk_default),
             metrics: EngineMetrics::new(),
+            diagnostic_cpu_q4_boundary_emulation: std::sync::atomic::AtomicBool::new(false),
             diagnostic_route_capture_armed: std::sync::atomic::AtomicBool::new(false),
             diagnostic_route_capture: parking_lot::Mutex::new(None),
         }
+    }
+
+    /// Enable CPU-only emulation of the production routed-expert f16 input
+    /// and output boundaries. Only isolated numerical-diagnostic workers call
+    /// this; ordinary CPU serving retains its existing Q4 execution path.
+    pub(crate) fn enable_cpu_q4_boundary_emulation(&self) -> Result<(), String> {
+        if self.execution_context().plan().routed_experts()
+            != crate::backend::ExecutionPlane::Cpu
+            || self.core.options.dtype != WeightDtype::Q4_0
+            || self.core.options.policy != crate::inference::RealInferencePolicy::STRICT
+        {
+            return Err(
+                "Q4 boundary emulation requires a strict CPU Q4_0 routed-expert plan"
+                    .to_string(),
+            );
+        }
+        self.diagnostic_cpu_q4_boundary_emulation
+            .store(true, Ordering::Relaxed);
+        Ok(())
     }
 
     /// Arm a one-shot, diagnostic-only capture at the routed-FFN boundary.
@@ -4475,6 +4496,51 @@ impl Engine {
             .counters
             .cpu_expert_forward_calls
             .fetch_add(1, Ordering::Relaxed);
+
+        if self
+            .diagnostic_cpu_q4_boundary_emulation
+            .load(Ordering::Relaxed)
+        {
+            let expected = crate::inference::expert_weight_bytes_for(
+                self.core.shape.d_model,
+                self.core.shape.d_ff,
+                WeightDtype::Q4_0,
+            );
+            if r.data().len() < expected || r.data()[expected..].iter().any(|byte| *byte != 0) {
+                return Err(MoeStepError::ExpertCompute {
+                    layer,
+                    expert: r.id,
+                    source: ExpertWeightsError::InvalidLayout(format!(
+                        "diagnostic Q4 payload has {} bytes; expected {expected} canonical bytes followed only by zero alignment padding",
+                        r.data().len()
+                    )),
+                });
+            }
+            let effective_input = crate::numerical_diagnostics::round_trip_f16_values(x)
+                .map_err(|source| MoeStepError::ExpertCompute {
+                    layer,
+                    expert: r.id,
+                    source,
+                })?;
+            let cpu = crate::inference::q4_0_cpu_reference_forward(
+                &r.data()[..expected],
+                &effective_input,
+                self.core.shape.d_model,
+                self.core.shape.d_ff,
+            )
+            .map_err(|source| MoeStepError::ExpertCompute {
+                layer,
+                expert: r.id,
+                source,
+            })?;
+            return crate::numerical_diagnostics::round_trip_f16_values(&cpu).map_err(|source| {
+                MoeStepError::ExpertCompute {
+                    layer,
+                    expert: r.id,
+                    source,
+                }
+            });
+        }
 
         dispatch_expert_forward(
             self.core.options.dtype,

--- a/rust-engine/src/engine.rs
+++ b/rust-engine/src/engine.rs
@@ -36,7 +36,7 @@ use crate::router::{
 };
 use dashmap::DashMap;
 use hdrhistogram::Histogram;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -871,7 +871,7 @@ pub(crate) struct Counters {
 /// These counters deliberately exclude the synthetic [`Engine::generate`]
 /// path. They are a qualification seam rather than a second Prometheus
 /// telemetry surface.
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct RoutedExpertExecutionSnapshot {
     pub selected_routed_experts: u64,
     pub gpu_dispatch_attempts: u64,

--- a/rust-engine/src/engine.rs
+++ b/rust-engine/src/engine.rs
@@ -1524,8 +1524,16 @@ pub struct Engine {
     pub(crate) speculation: EngineSpeculation,
     pub(crate) metrics: EngineMetrics,
     diagnostic_cpu_q4_boundary_emulation: std::sync::atomic::AtomicBool,
+    diagnostic_cpu_q4_boundary_emulated_dispatches: AtomicU64,
     diagnostic_route_capture_armed: std::sync::atomic::AtomicBool,
     diagnostic_route_capture: parking_lot::Mutex<Option<DiagnosticRouteCaptureArm>>,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CpuQ4BoundaryEmulationSnapshot {
+    pub enabled: bool,
+    pub routed_expert_dispatches: u64,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -1849,6 +1857,7 @@ impl Engine {
             speculation: EngineSpeculation::new(speculator_topk_default),
             metrics: EngineMetrics::new(),
             diagnostic_cpu_q4_boundary_emulation: std::sync::atomic::AtomicBool::new(false),
+            diagnostic_cpu_q4_boundary_emulated_dispatches: AtomicU64::new(0),
             diagnostic_route_capture_armed: std::sync::atomic::AtomicBool::new(false),
             diagnostic_route_capture: parking_lot::Mutex::new(None),
         }
@@ -1869,8 +1878,21 @@ impl Engine {
             );
         }
         self.diagnostic_cpu_q4_boundary_emulation
-            .store(true, Ordering::Relaxed);
+            .store(true, Ordering::Release);
         Ok(())
+    }
+
+    pub(crate) fn cpu_q4_boundary_emulation_snapshot(
+        &self,
+    ) -> CpuQ4BoundaryEmulationSnapshot {
+        CpuQ4BoundaryEmulationSnapshot {
+            enabled: self
+                .diagnostic_cpu_q4_boundary_emulation
+                .load(Ordering::Acquire),
+            routed_expert_dispatches: self
+                .diagnostic_cpu_q4_boundary_emulated_dispatches
+                .load(Ordering::Acquire),
+        }
     }
 
     /// Arm a one-shot, diagnostic-only capture at the routed-FFN boundary.
@@ -4499,7 +4521,7 @@ impl Engine {
 
         if self
             .diagnostic_cpu_q4_boundary_emulation
-            .load(Ordering::Relaxed)
+            .load(Ordering::Acquire)
         {
             let expected = crate::inference::expert_weight_bytes_for(
                 self.core.shape.d_model,
@@ -4533,13 +4555,16 @@ impl Engine {
                 expert: r.id,
                 source,
             })?;
-            return crate::numerical_diagnostics::round_trip_f16_values(&cpu).map_err(|source| {
-                MoeStepError::ExpertCompute {
+            let output = crate::numerical_diagnostics::round_trip_f16_values(&cpu).map_err(
+                |source| MoeStepError::ExpertCompute {
                     layer,
                     expert: r.id,
                     source,
-                }
-            });
+                },
+            )?;
+            self.diagnostic_cpu_q4_boundary_emulated_dispatches
+                .fetch_add(1, Ordering::Release);
+            return Ok(output);
         }
 
         dispatch_expert_forward(

--- a/rust-engine/src/greedy_parity.rs
+++ b/rust-engine/src/greedy_parity.rs
@@ -14,7 +14,9 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::HashSet;
 
-pub const SCHEMA_VERSION: &str = "mer.strict-hybrid-q4-greedy-parity.v1";
+#[cfg(test)]
+pub const LEGACY_SCHEMA_VERSION: &str = "mer.strict-hybrid-q4-greedy-parity.v1";
+pub const SCHEMA_VERSION: &str = "mer.strict-hybrid-q4-greedy-parity.v2";
 pub const MODE: &str = "strict-hybrid-q4-greedy-parity";
 pub const CORPUS_ID: &str = "qwen3-coder-30b-a3b-greedy-v1";
 pub const CORPUS_VERSION: u32 = 1;
@@ -738,6 +740,57 @@ where
     })
 }
 
+fn comparison_matches_generations(
+    reference: &GenerationEvidence,
+    hybrid: &GenerationEvidence,
+    comparison: &CaseComparisonEvidence,
+) -> bool {
+    let exact_token_ids = reference.generated_token_ids == hybrid.generated_token_ids;
+    let equal_generated_count =
+        reference.generated_token_count == hybrid.generated_token_count;
+    let equal_termination_reason =
+        reference.termination_reason == hybrid.termination_reason;
+    let equal_generated_text_hash =
+        reference.generated_text_sha256 == hybrid.generated_text_sha256;
+    if comparison.exact_token_ids != exact_token_ids
+        || comparison.equal_generated_count != equal_generated_count
+        || comparison.equal_termination_reason != equal_termination_reason
+        || comparison.equal_generated_text_hash != equal_generated_text_hash
+    {
+        return false;
+    }
+    let diverged = !exact_token_ids
+        || !equal_generated_count
+        || !equal_termination_reason
+        || !equal_generated_text_hash;
+    match (&comparison.first_divergence, diverged) {
+        (None, false) => true,
+        (Some(divergence), true) => {
+            let common = reference
+                .generated_token_ids
+                .len()
+                .min(hybrid.generated_token_ids.len());
+            let position = (0..common)
+                .find(|&index| {
+                    reference.generated_token_ids[index] != hybrid.generated_token_ids[index]
+                })
+                .unwrap_or(common);
+            divergence.position == position
+                && divergence.cpu_token_id
+                    == reference.generated_token_ids.get(position).copied()
+                && divergence.hybrid_token_id
+                    == hybrid.generated_token_ids.get(position).copied()
+                && divergence.cpu_generated_length == reference.generated_token_ids.len()
+                && divergence.hybrid_generated_length == hybrid.generated_token_ids.len()
+                && divergence.cpu_termination_reason == reference.termination_reason
+                && divergence.hybrid_termination_reason == hybrid.termination_reason
+                && divergence.cpu_decoded_prefix.len() <= MAX_DECODED_PREFIX_BYTES
+                && divergence.hybrid_decoded_prefix.len() <= MAX_DECODED_PREFIX_BYTES
+        }
+        _ => false,
+    }
+}
+
 #[derive(Clone, Debug, Serialize)]
 pub struct CaseReport {
     pub name: &'static str,
@@ -749,8 +802,10 @@ pub struct CaseReport {
     pub tokenization_calls: u32,
     pub output_token_limit: usize,
     pub cpu: Option<PlaneRunEvidence>,
+    pub boundary_reference: Option<PlaneRunEvidence>,
     pub hybrid: Option<PlaneRunEvidence>,
-    pub comparison: Option<CaseComparisonEvidence>,
+    pub ordinary_cpu_vs_hybrid: Option<CaseComparisonEvidence>,
+    pub boundary_reference_vs_hybrid: Option<CaseComparisonEvidence>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub worker_failure: Option<HybridWorkerFailureEvidence>,
     pub failure: Option<QualificationFailure>,
@@ -769,8 +824,10 @@ impl CaseReport {
             tokenization_calls: 1,
             output_token_limit: OUTPUT_TOKEN_LIMIT,
             cpu: None,
+            boundary_reference: None,
             hybrid: None,
-            comparison: None,
+            ordinary_cpu_vs_hybrid: None,
+            boundary_reference_vs_hybrid: None,
             worker_failure: None,
             failure: None,
         }
@@ -849,6 +906,7 @@ pub struct GreedyParityChecks {
     pub controlled_background_shutdown_every_run: bool,
     pub hybrid_worker_processes_exact: bool,
     pub unique_hybrid_worker_identity: bool,
+    pub unique_hybrid_process_identity: bool,
     pub cpu_plans_exact: bool,
     pub cpu_counter_invariants: bool,
     pub cpu_gpu_io_zero: bool,
@@ -860,10 +918,11 @@ pub struct GreedyParityChecks {
     pub hybrid_gpu_io_observed: bool,
     pub hybrid_memory_ledger_valid: bool,
     pub zero_gpu_failures_fallbacks_or_degraded: bool,
-    pub exact_generated_token_ids: bool,
-    pub identical_generated_token_count: bool,
-    pub identical_termination_reason: bool,
-    pub identical_generated_text_hash: bool,
+    pub ordinary_cpu_comparison_recorded: bool,
+    pub boundary_reference_exact_generated_token_ids: bool,
+    pub boundary_reference_identical_generated_token_count: bool,
+    pub boundary_reference_identical_termination_reason: bool,
+    pub boundary_reference_identical_generated_text_hash: bool,
 }
 
 impl GreedyParityChecks {
@@ -881,6 +940,7 @@ impl GreedyParityChecks {
             && self.controlled_background_shutdown_every_run
             && self.hybrid_worker_processes_exact
             && self.unique_hybrid_worker_identity
+            && self.unique_hybrid_process_identity
             && self.cpu_plans_exact
             && self.cpu_counter_invariants
             && self.cpu_gpu_io_zero
@@ -892,10 +952,11 @@ impl GreedyParityChecks {
             && self.hybrid_gpu_io_observed
             && self.hybrid_memory_ledger_valid
             && self.zero_gpu_failures_fallbacks_or_degraded
-            && self.exact_generated_token_ids
-            && self.identical_generated_token_count
-            && self.identical_termination_reason
-            && self.identical_generated_text_hash
+            && self.ordinary_cpu_comparison_recorded
+            && self.boundary_reference_exact_generated_token_ids
+            && self.boundary_reference_identical_generated_token_count
+            && self.boundary_reference_identical_termination_reason
+            && self.boundary_reference_identical_generated_text_hash
     }
 }
 
@@ -962,15 +1023,19 @@ impl GreedyParityReport {
                     && report.worker_failure.is_none()
                     && report.failure.is_none()
                     && report.cpu.is_some()
+                    && report.boundary_reference.is_some()
                     && report.hybrid.is_some()
-                    && report.comparison.is_some()
+                    && report.ordinary_cpu_vs_hybrid.is_some()
+                    && report.boundary_reference_vs_hybrid.is_some()
             });
         let runs = self.cases.iter().filter_map(|case| {
             Some((
                 case,
                 case.cpu.as_ref()?,
+                case.boundary_reference.as_ref()?,
                 case.hybrid.as_ref()?,
-                case.comparison.as_ref()?,
+                case.ordinary_cpu_vs_hybrid.as_ref()?,
+                case.boundary_reference_vs_hybrid.as_ref()?,
             ))
         });
         let collected: Vec<_> = runs.collect();
@@ -982,59 +1047,76 @@ impl GreedyParityReport {
                 .source_preflight
                 .as_ref()
                 .is_some_and(StrictHybridPreflightEvidence::is_exact)
-            && collected.iter().all(|(_, cpu, hybrid, _)| {
-                cpu.model_load.is_strict_complete() && hybrid.model_load.is_strict_complete()
+            && collected.iter().all(|(_, cpu, boundary, hybrid, _, _)| {
+                cpu.model_load.is_strict_complete()
+                    && boundary.model_load.is_strict_complete()
+                    && hybrid.model_load.is_strict_complete()
             });
         let resolved_config_identity = exact_run_count
             && config_hash.is_some_and(is_sha256_hex)
-            && collected.iter().all(|(_, cpu, hybrid, _)| {
+            && collected.iter().all(|(_, cpu, boundary, hybrid, _, _)| {
                 Some(cpu.initial_state.resolved_config_sha256.as_str()) == config_hash
+                    && Some(boundary.initial_state.resolved_config_sha256.as_str()) == config_hash
                     && Some(hybrid.initial_state.resolved_config_sha256.as_str()) == config_hash
             });
         let tokenized_once_and_shared = exact_run_count
-            && collected.iter().all(|(case, cpu, hybrid, _)| {
+            && collected.iter().all(|(case, cpu, boundary, hybrid, _, _)| {
                 !case.prompt_token_ids.is_empty()
                     && case.tokenization_calls == 1
                     && case.prompt_token_ids_sha256 == token_ids_sha256(&case.prompt_token_ids)
                     && cpu.generation.prompt_token_ids_sha256 == case.prompt_token_ids_sha256
+                    && boundary.generation.prompt_token_ids_sha256
+                        == case.prompt_token_ids_sha256
                     && hybrid.generation.prompt_token_ids_sha256 == case.prompt_token_ids_sha256
                     && cpu.generation.generated_token_count == OUTPUT_TOKEN_LIMIT
+                    && boundary.generation.generated_token_count == OUTPUT_TOKEN_LIMIT
                     && hybrid.generation.generated_token_count == OUTPUT_TOKEN_LIMIT
                     && cpu.generation.generated_token_count
                         == cpu.generation.generated_token_ids.len()
+                    && boundary.generation.generated_token_count
+                        == boundary.generation.generated_token_ids.len()
                     && hybrid.generation.generated_token_count
                         == hybrid.generation.generated_token_ids.len()
                     && cpu.generation.generated_token_ids_sha256
                         == token_ids_sha256(&cpu.generation.generated_token_ids)
+                    && boundary.generation.generated_token_ids_sha256
+                        == token_ids_sha256(&boundary.generation.generated_token_ids)
                     && hybrid.generation.generated_token_ids_sha256
                         == token_ids_sha256(&hybrid.generation.generated_token_ids)
                     && is_sha256_hex(&cpu.generation.generated_text_sha256)
+                    && is_sha256_hex(&boundary.generation.generated_text_sha256)
                     && is_sha256_hex(&hybrid.generation.generated_text_sha256)
                     && cpu.generation.termination_reason == TerminationReason::LengthLimit
+                    && boundary.generation.termination_reason == TerminationReason::LengthLimit
                     && hybrid.generation.termination_reason == TerminationReason::LengthLimit
             });
         let fresh_state_every_run = exact_run_count
-            && collected.iter().all(|(_, cpu, hybrid, _)| {
+            && collected.iter().all(|(_, cpu, boundary, hybrid, _, _)| {
                 cpu.initial_state.is_clean()
+                    && boundary.initial_state.is_clean()
                     && hybrid.initial_state.is_clean()
                     && cpu.initial_state.context_id == cpu.execution_plan.context_id
+                    && boundary.initial_state.context_id == boundary.execution_plan.context_id
                     && hybrid.initial_state.context_id == hybrid.execution_plan.context_id
             });
         let context_ids: HashSet<&str> = collected
             .iter()
-            .flat_map(|(_, cpu, hybrid, _)| {
+            .flat_map(|(_, cpu, boundary, hybrid, _, _)| {
                 [
                     cpu.execution_plan.context_id.as_str(),
+                    boundary.execution_plan.context_id.as_str(),
                     hybrid.execution_plan.context_id.as_str(),
                 ]
             })
             .collect();
         let unique_execution_context_every_run =
-            exact_run_count && context_ids.len() == CORPUS_CASE_COUNT * 2;
+            exact_run_count && context_ids.len() == CORPUS_CASE_COUNT * 3;
         let controlled_background_shutdown_every_run = exact_run_count
-            && collected.iter().all(|(_, cpu, hybrid, _)| {
+            && collected.iter().all(|(_, cpu, boundary, hybrid, _, _)| {
                 cpu.background_shutdown.controlled_shutdown_requested
                     && cpu.background_shutdown.all_runtime_resources_released
+                    && boundary.background_shutdown.controlled_shutdown_requested
+                    && boundary.background_shutdown.all_runtime_resources_released
                     && hybrid.background_shutdown.controlled_shutdown_requested
                     && hybrid.background_shutdown.all_runtime_resources_released
             });
@@ -1043,8 +1125,9 @@ impl GreedyParityReport {
                 .orchestrator_executable_sha256
                 .as_deref()
                 .is_some_and(is_sha256_hex)
-            && collected.iter().all(|(_, cpu, hybrid, _)| {
+            && collected.iter().all(|(_, cpu, boundary, hybrid, _, _)| {
                 cpu.worker_process.is_none()
+                    && boundary.worker_process.is_none()
                     && hybrid.worker_process.as_ref().is_some_and(|process| {
                         process.is_exact()
                             && Some(process.executable_sha256.as_str())
@@ -1055,7 +1138,7 @@ impl GreedyParityReport {
             });
         let worker_ids: HashSet<&str> = collected
             .iter()
-            .filter_map(|(_, _, hybrid, _)| {
+            .filter_map(|(_, _, _, hybrid, _, _)| {
                 hybrid
                     .worker_process
                     .as_ref()
@@ -1064,37 +1147,58 @@ impl GreedyParityReport {
             .collect();
         let unique_hybrid_worker_identity =
             hybrid_worker_processes_exact && worker_ids.len() == CORPUS_CASE_COUNT;
+        let process_ids: HashSet<u32> = collected
+            .iter()
+            .filter_map(|(_, _, _, hybrid, _, _)| {
+                hybrid
+                    .worker_process
+                    .as_ref()
+                    .and_then(|process| process.process_id)
+            })
+            .collect();
+        let unique_hybrid_process_identity =
+            hybrid_worker_processes_exact && process_ids.len() == CORPUS_CASE_COUNT;
         let cpu_plans_exact = exact_run_count
-            && collected
-                .iter()
-                .all(|(_, cpu, _, _)| cpu.plane == "cpu" && cpu_plan_exact(&cpu.execution_plan));
+            && collected.iter().all(|(_, cpu, boundary, _, _, _)| {
+                cpu.plane == "cpu"
+                    && boundary.plane == "cpu"
+                    && cpu_plan_exact(&cpu.execution_plan)
+                    && cpu_plan_exact(&boundary.execution_plan)
+            });
         let cpu_counter_invariants = exact_run_count
-            && collected
-                .iter()
-                .all(|(_, cpu, _, _)| cpu_counters_exact(cpu.routed_execution_delta));
+            && collected.iter().all(|(_, cpu, boundary, _, _, _)| {
+                cpu_counters_exact(cpu.routed_execution_delta)
+                    && cpu_counters_exact(boundary.routed_execution_delta)
+            });
         let cpu_gpu_io_zero = exact_run_count
-            && collected.iter().all(|(_, cpu, _, _)| {
+            && collected.iter().all(|(_, cpu, boundary, _, _, _)| {
                 cpu.device.is_none()
                     && !cpu.initial_state.gpu_io_available
                     && cpu.initial_state.gpu_io == GpuExpertIoSnapshot::default()
                     && cpu.gpu_io_delta == GpuExpertIoSnapshot::default()
                     && cpu.gpu_memory_before.is_none()
                     && cpu.gpu_memory_after.is_none()
+                    && boundary.device.is_none()
+                    && !boundary.initial_state.gpu_io_available
+                    && boundary.initial_state.gpu_io == GpuExpertIoSnapshot::default()
+                    && boundary.gpu_io_delta == GpuExpertIoSnapshot::default()
+                    && boundary.gpu_memory_before.is_none()
+                    && boundary.gpu_memory_after.is_none()
             });
         let hybrid_plans_exact = exact_run_count
-            && collected.iter().all(|(_, _, hybrid, _)| {
+            && collected.iter().all(|(_, _, _, hybrid, _, _)| {
                 hybrid.plane == "hybrid" && hybrid_plan_exact(&hybrid.execution_plan)
             });
         let hardware_adapter_exact_match = exact_run_count
             && !self.expected_adapter_name.is_empty()
-            && collected.iter().all(|(_, _, hybrid, _)| {
+            && collected.iter().all(|(_, _, _, hybrid, _, _)| {
                 hybrid.device.as_ref().is_some_and(|device| {
                     device.name == self.expected_adapter_name
                         && !device.device_type.eq_ignore_ascii_case("cpu")
                 })
             });
         let software_adapter_false = exact_run_count
-            && collected.iter().all(|(_, _, hybrid, _)| {
+            && collected.iter().all(|(_, _, _, hybrid, _, _)| {
                 hybrid
                     .device
                     .as_ref()
@@ -1103,13 +1207,13 @@ impl GreedyParityReport {
         let hybrid_counter_invariants = exact_run_count
             && collected
                 .iter()
-                .all(|(_, _, hybrid, _)| hybrid_counters_exact(hybrid.routed_execution_delta));
+                .all(|(_, _, _, hybrid, _, _)| hybrid_counters_exact(hybrid.routed_execution_delta));
         let hybrid_gpu_io_observed = exact_run_count
-            && collected.iter().all(|(_, _, hybrid, _)| {
+            && collected.iter().all(|(_, _, _, hybrid, _, _)| {
                 hybrid.initial_state.gpu_io_available && gpu_io_observed(hybrid.gpu_io_delta)
             });
         let hybrid_memory_ledger_valid = exact_run_count
-            && collected.iter().all(|(_, _, hybrid, _)| {
+            && collected.iter().all(|(_, _, _, hybrid, _, _)| {
                 hybrid
                     .gpu_memory_before
                     .is_some_and(|snapshot| crate::qualification::validate_memory(snapshot).is_ok())
@@ -1118,11 +1222,15 @@ impl GreedyParityReport {
                     })
             });
         let zero_gpu_failures_fallbacks_or_degraded = exact_run_count
-            && collected.iter().all(|(_, cpu, hybrid, _)| {
+            && collected.iter().all(|(_, cpu, boundary, hybrid, _, _)| {
                 cpu.routed_execution_delta.gpu_dispatch_failures == 0
                     && cpu.routed_execution_delta.gpu_cpu_fallbacks == 0
                     && cpu.routed_execution_delta.degraded_expert_substitutions == 0
                     && cpu.attention_softmax_nonfinite_fallbacks == 0
+                    && boundary.routed_execution_delta.gpu_dispatch_failures == 0
+                    && boundary.routed_execution_delta.gpu_cpu_fallbacks == 0
+                    && boundary.routed_execution_delta.degraded_expert_substitutions == 0
+                    && boundary.attention_softmax_nonfinite_fallbacks == 0
                     && hybrid.routed_execution_delta.gpu_dispatch_failures == 0
                     && hybrid.routed_execution_delta.cpu_routed_expert_dispatches == 0
                     && hybrid.routed_execution_delta.gpu_cpu_fallbacks == 0
@@ -1153,6 +1261,7 @@ impl GreedyParityReport {
             controlled_background_shutdown_every_run,
             hybrid_worker_processes_exact,
             unique_hybrid_worker_identity,
+            unique_hybrid_process_identity,
             cpu_plans_exact,
             cpu_counter_invariants,
             cpu_gpu_io_zero,
@@ -1160,35 +1269,49 @@ impl GreedyParityReport {
             hardware_adapter_exact_match,
             software_adapter_false,
             strict_gpu_failure_policy: exact_run_count
-                && collected.iter().all(|(_, _, hybrid, _)| {
+                && collected.iter().all(|(_, _, _, hybrid, _, _)| {
                     hybrid.routed_expert_gpu_failure_policy == "strict-fail-closed"
                 }),
             hybrid_counter_invariants,
             hybrid_gpu_io_observed,
             hybrid_memory_ledger_valid,
             zero_gpu_failures_fallbacks_or_degraded,
-            exact_generated_token_ids: exact_run_count
-                && collected.iter().all(|(_, cpu, hybrid, comparison)| {
+            ordinary_cpu_comparison_recorded: exact_run_count
+                && collected.iter().all(|(_, cpu, _, hybrid, comparison, _)| {
+                    comparison_matches_generations(
+                        &cpu.generation,
+                        &hybrid.generation,
+                        comparison,
+                    )
+                }),
+            boundary_reference_exact_generated_token_ids: exact_run_count
+                && collected.iter().all(|(_, _, boundary, hybrid, _, comparison)| {
                     comparison.exact_token_ids
                         && comparison.first_divergence.is_none()
-                        && cpu.generation.generated_token_ids
+                        && boundary.generation.generated_token_ids
                             == hybrid.generation.generated_token_ids
+                        && comparison_matches_generations(
+                            &boundary.generation,
+                            &hybrid.generation,
+                            comparison,
+                        )
                 }),
-            identical_generated_token_count: exact_run_count
-                && collected.iter().all(|(_, cpu, hybrid, comparison)| {
+            boundary_reference_identical_generated_token_count: exact_run_count
+                && collected.iter().all(|(_, _, boundary, hybrid, _, comparison)| {
                     comparison.equal_generated_count
-                        && cpu.generation.generated_token_count
+                        && boundary.generation.generated_token_count
                             == hybrid.generation.generated_token_count
                 }),
-            identical_termination_reason: exact_run_count
-                && collected.iter().all(|(_, cpu, hybrid, comparison)| {
+            boundary_reference_identical_termination_reason: exact_run_count
+                && collected.iter().all(|(_, _, boundary, hybrid, _, comparison)| {
                     comparison.equal_termination_reason
-                        && cpu.generation.termination_reason == hybrid.generation.termination_reason
+                        && boundary.generation.termination_reason
+                            == hybrid.generation.termination_reason
                 }),
-            identical_generated_text_hash: exact_run_count
-                && collected.iter().all(|(_, cpu, hybrid, comparison)| {
+            boundary_reference_identical_generated_text_hash: exact_run_count
+                && collected.iter().all(|(_, _, boundary, hybrid, _, comparison)| {
                     comparison.equal_generated_text_hash
-                        && cpu.generation.generated_text_sha256
+                        && boundary.generation.generated_text_sha256
                             == hybrid.generation.generated_text_sha256
                 }),
         }
@@ -1409,6 +1532,10 @@ mod tests {
             let mut case = CaseReport::new(fixed, prompt_ids);
             let prompt_hash = case.prompt_token_ids_sha256.clone();
             let mut cpu = plane_evidence(index, false, &ids);
+            let mut boundary = plane_evidence(index, false, &ids);
+            let boundary_context_id = format!("boundary-{index}");
+            boundary.execution_plan.context_id = boundary_context_id.clone();
+            boundary.initial_state.context_id = boundary_context_id;
             let mut hybrid = plane_evidence(index, true, &ids);
             hybrid.worker_process = Some(HybridWorkerProcessEvidence {
                 worker_id: hybrid_worker_id(
@@ -1443,14 +1570,22 @@ mod tests {
                 evidence_emitted: true,
             });
             cpu.generation.prompt_token_ids_sha256 = prompt_hash.clone();
+            boundary.generation.prompt_token_ids_sha256 = prompt_hash.clone();
             hybrid.generation.prompt_token_ids_sha256 = prompt_hash;
-            case.comparison = Some(
+            case.ordinary_cpu_vs_hybrid = Some(
                 compare_generations(&cpu.generation, &hybrid.generation, |_| {
                     Ok("same".to_string())
                 })
                 .unwrap(),
             );
+            case.boundary_reference_vs_hybrid = Some(
+                compare_generations(&boundary.generation, &hybrid.generation, |_| {
+                    Ok("same".to_string())
+                })
+                .unwrap(),
+            );
             case.cpu = Some(cpu);
+            case.boundary_reference = Some(boundary);
             case.hybrid = Some(hybrid);
             report.cases.push(case);
         }
@@ -1470,6 +1605,9 @@ mod tests {
 
     #[test]
     fn greedy_parity_fixed_corpus_contract_is_versioned_and_nontrivial() {
+        assert_eq!(SCHEMA_VERSION, "mer.strict-hybrid-q4-greedy-parity.v2");
+        assert_eq!(LEGACY_SCHEMA_VERSION, "mer.strict-hybrid-q4-greedy-parity.v1");
+        assert_ne!(SCHEMA_VERSION, LEGACY_SCHEMA_VERSION);
         assert_eq!(FIXED_CORPUS.len(), 4);
         assert_eq!(OUTPUT_TOKEN_LIMIT, 16);
         assert_eq!(FIXED_CORPUS[0].name, "rust-generation");
@@ -1768,10 +1906,100 @@ mod tests {
         assert_eq!(report.status, QualificationStatus::Pass);
         assert!(report.checks.passes());
         let json = serde_json::to_value(&report).unwrap();
+        assert_eq!(json["schema_version"], SCHEMA_VERSION);
+        assert_ne!(json["schema_version"], LEGACY_SCHEMA_VERSION);
         assert_eq!(
             json["cases"][0]["hybrid"]["device"]["software_adapter"],
             false
         );
+    }
+
+    #[test]
+    fn greedy_parity_ordinary_cpu_divergence_is_informational() {
+        let mut report = passing_report();
+        let case = &mut report.cases[0];
+        let cpu = case.cpu.as_mut().unwrap();
+        cpu.generation.generated_token_ids[0] ^= 1;
+        cpu.generation.generated_token_ids_sha256 =
+            token_ids_sha256(&cpu.generation.generated_token_ids);
+        cpu.generation.generated_text_sha256 = sha256_hex(b"ordinary-cpu-diverged");
+        case.ordinary_cpu_vs_hybrid = Some(
+            compare_generations(
+                &cpu.generation,
+                &case.hybrid.as_ref().unwrap().generation,
+                |ids| Ok(format!("{ids:?}")),
+            )
+            .unwrap(),
+        );
+
+        report.finish().unwrap();
+        assert_eq!(report.status, QualificationStatus::Pass);
+        assert!(report.checks.ordinary_cpu_comparison_recorded);
+        assert!(!report.cases[0]
+            .ordinary_cpu_vs_hybrid
+            .as_ref()
+            .unwrap()
+            .exact_token_ids);
+        assert!(report.cases[0]
+            .boundary_reference_vs_hybrid
+            .as_ref()
+            .unwrap()
+            .exact_token_ids);
+    }
+
+    #[test]
+    fn greedy_parity_boundary_reference_divergence_fails() {
+        let mut report = passing_report();
+        let case = &mut report.cases[1];
+        let boundary = case.boundary_reference.as_mut().unwrap();
+        boundary.generation.generated_token_ids[3] ^= 1;
+        boundary.generation.generated_token_ids_sha256 =
+            token_ids_sha256(&boundary.generation.generated_token_ids);
+        boundary.generation.generated_text_sha256 = sha256_hex(b"boundary-diverged");
+        case.boundary_reference_vs_hybrid = Some(
+            compare_generations(
+                &boundary.generation,
+                &case.hybrid.as_ref().unwrap().generation,
+                |ids| Ok(format!("{ids:?}")),
+            )
+            .unwrap(),
+        );
+
+        assert!(report.finish().is_err());
+        assert!(!report
+            .checks
+            .boundary_reference_exact_generated_token_ids);
+    }
+
+    #[test]
+    fn greedy_parity_partial_boundary_or_process_evidence_fails() {
+        let mut missing_boundary = passing_report();
+        missing_boundary.cases[0].boundary_reference = None;
+        assert!(missing_boundary.finish().is_err());
+
+        let mut partial_corpus = passing_report();
+        partial_corpus.cases.pop();
+        assert!(partial_corpus.finish().is_err());
+
+        let mut reused_process = passing_report();
+        let process_id = reused_process.cases[0]
+            .hybrid
+            .as_ref()
+            .unwrap()
+            .worker_process
+            .as_ref()
+            .unwrap()
+            .process_id;
+        reused_process.cases[1]
+            .hybrid
+            .as_mut()
+            .unwrap()
+            .worker_process
+            .as_mut()
+            .unwrap()
+            .process_id = process_id;
+        assert!(reused_process.finish().is_err());
+        assert!(!reused_process.checks.unique_hybrid_process_identity);
     }
 
     #[test]
@@ -1915,7 +2143,9 @@ mod tests {
         // Leave the stored comparison flags untouched to simulate copied or
         // stale intended evidence. PASS must still be impossible.
         assert!(report.finish().is_err());
-        assert!(!report.checks.exact_generated_token_ids);
+        assert!(!report
+            .checks
+            .boundary_reference_exact_generated_token_ids);
 
         let mut bad_hash = passing_report();
         bad_hash.cases[0]
@@ -2157,8 +2387,8 @@ mod tests {
         ));
         let json = serde_json::to_value(&report).unwrap();
         assert_eq!(json["cases"].as_array().unwrap().len(), 3);
-        assert!(json["cases"][0]["comparison"].is_object());
-        assert!(json["cases"][1]["comparison"].is_object());
+        assert!(json["cases"][0]["boundary_reference_vs_hybrid"].is_object());
+        assert!(json["cases"][1]["ordinary_cpu_vs_hybrid"].is_object());
         assert_eq!(json["cases"][2]["worker_failure"]["signal"], 15);
     }
 }

--- a/rust-engine/src/greedy_parity.rs
+++ b/rust-engine/src/greedy_parity.rs
@@ -453,7 +453,6 @@ pub(crate) fn cpu_plan_exact(plan: &ExecutionPlanEvidence) -> bool {
         && plan.routed_experts == "cpu"
         && plan.routed_expert_dtype == "q4_0"
         && !plan.fallback_occurred
-        && plan.reason.is_none()
 }
 
 pub(crate) fn hybrid_plan_exact(plan: &ExecutionPlanEvidence) -> bool {
@@ -468,7 +467,6 @@ pub(crate) fn hybrid_plan_exact(plan: &ExecutionPlanEvidence) -> bool {
         && plan.routed_experts == "gpu"
         && plan.routed_expert_dtype == "q4_0"
         && !plan.fallback_occurred
-        && plan.reason.is_none()
 }
 
 fn cpu_counters_exact(routed: RoutedExpertExecutionSnapshot) -> bool {
@@ -1251,14 +1249,44 @@ mod tests {
             reason: None,
         };
         assert!(cpu_plan_exact(&cpu));
+        let mut cpu_with_reason = cpu.clone();
+        cpu_with_reason.reason = Some("CPU control selected for qualification".to_string());
+        assert!(cpu_plan_exact(&cpu_with_reason));
+
         let mut hybrid = cpu.clone();
         hybrid.context_id = "ctx-hybrid".to_string();
         hybrid.requested = "hybrid".to_string();
         hybrid.resolved = "hybrid-cpu-attention-gpu-experts".to_string();
         hybrid.routed_experts = "gpu".to_string();
+        hybrid.reason = Some(
+            "hybrid: attention pinned to the checked CPU path; routed-expert FFN compute offloaded to the GPU"
+                .to_string(),
+        );
         assert!(hybrid_plan_exact(&hybrid));
-        hybrid.attention = "gpu".to_string();
-        assert!(!hybrid_plan_exact(&hybrid));
+
+        let mut hybrid_without_reason = hybrid.clone();
+        hybrid_without_reason.reason = None;
+        assert!(hybrid_plan_exact(&hybrid_without_reason));
+
+        let mut bad_attention = hybrid.clone();
+        bad_attention.attention = "gpu".to_string();
+        assert!(!hybrid_plan_exact(&bad_attention));
+
+        let mut bad_experts = hybrid.clone();
+        bad_experts.routed_experts = "cpu".to_string();
+        assert!(!hybrid_plan_exact(&bad_experts));
+
+        let mut bad_dtype = hybrid.clone();
+        bad_dtype.routed_expert_dtype = "f16".to_string();
+        assert!(!hybrid_plan_exact(&bad_dtype));
+
+        let mut bad_resolution = hybrid.clone();
+        bad_resolution.resolved = "gpu".to_string();
+        assert!(!hybrid_plan_exact(&bad_resolution));
+
+        let mut bad_fallback = hybrid;
+        bad_fallback.fallback_occurred = true;
+        assert!(!hybrid_plan_exact(&bad_fallback));
     }
 
     #[test]

--- a/rust-engine/src/greedy_parity.rs
+++ b/rust-engine/src/greedy_parity.rs
@@ -426,6 +426,7 @@ pub struct PlaneRunEvidence {
     pub model_load: ModelLoadEvidence,
     pub execution_plan: ExecutionPlanEvidence,
     pub routed_expert_gpu_failure_policy: String,
+    pub cpu_q4_boundary_emulation: crate::engine::CpuQ4BoundaryEmulationSnapshot,
     pub device: Option<GpuDeviceIdentity>,
     pub initial_state: InitialStateEvidence,
     pub generation: GenerationEvidence,
@@ -914,6 +915,7 @@ pub struct GreedyParityChecks {
     pub hardware_adapter_exact_match: bool,
     pub software_adapter_false: bool,
     pub strict_gpu_failure_policy: bool,
+    pub q4_boundary_emulation_exact: bool,
     pub hybrid_counter_invariants: bool,
     pub hybrid_gpu_io_observed: bool,
     pub hybrid_memory_ledger_valid: bool,
@@ -948,6 +950,7 @@ impl GreedyParityChecks {
             && self.hardware_adapter_exact_match
             && self.software_adapter_false
             && self.strict_gpu_failure_policy
+            && self.q4_boundary_emulation_exact
             && self.hybrid_counter_invariants
             && self.hybrid_gpu_io_observed
             && self.hybrid_memory_ledger_valid
@@ -1226,6 +1229,20 @@ impl GreedyParityReport {
             && collected
                 .iter()
                 .all(|(_, _, _, hybrid, _, _)| hybrid_counters_exact(hybrid.routed_execution_delta));
+        let q4_boundary_emulation_exact = exact_run_count
+            && collected.iter().all(|(_, cpu, boundary, hybrid, _, _)| {
+                cpu.cpu_q4_boundary_emulation
+                    == crate::engine::CpuQ4BoundaryEmulationSnapshot::default()
+                    && boundary.cpu_q4_boundary_emulation.enabled
+                    && boundary
+                        .cpu_q4_boundary_emulation
+                        .routed_expert_dispatches
+                        == boundary
+                            .routed_execution_delta
+                            .cpu_routed_expert_dispatches
+                    && hybrid.cpu_q4_boundary_emulation
+                        == crate::engine::CpuQ4BoundaryEmulationSnapshot::default()
+            });
         let hybrid_gpu_io_observed = exact_run_count
             && collected.iter().all(|(_, _, _, hybrid, _, _)| {
                 hybrid.initial_state.gpu_io_available && gpu_io_observed(hybrid.gpu_io_delta)
@@ -1290,6 +1307,7 @@ impl GreedyParityReport {
                 && collected.iter().all(|(_, _, _, hybrid, _, _)| {
                     hybrid.routed_expert_gpu_failure_policy == "strict-fail-closed"
                 }),
+            q4_boundary_emulation_exact,
             hybrid_counter_invariants,
             hybrid_gpu_io_observed,
             hybrid_memory_ledger_valid,
@@ -1439,6 +1457,8 @@ mod tests {
                 "serving-cpu-fallback"
             }
             .to_string(),
+            cpu_q4_boundary_emulation:
+                crate::engine::CpuQ4BoundaryEmulationSnapshot::default(),
             device: hybrid.then(|| GpuDeviceIdentity {
                 name: "NVIDIA L4".to_string(),
                 vendor_id: 0x10de,
@@ -1551,6 +1571,11 @@ mod tests {
             let prompt_hash = case.prompt_token_ids_sha256.clone();
             let mut cpu = plane_evidence(index, false, &ids);
             let mut boundary = plane_evidence(index, false, &ids);
+            boundary.cpu_q4_boundary_emulation =
+                crate::engine::CpuQ4BoundaryEmulationSnapshot {
+                    enabled: true,
+                    routed_expert_dispatches: 8,
+                };
             let boundary_context_id = format!("boundary-{index}");
             boundary.execution_plan.context_id = boundary_context_id.clone();
             boundary.initial_state.context_id = boundary_context_id;
@@ -1930,6 +1955,49 @@ mod tests {
             json["cases"][0]["hybrid"]["device"]["software_adapter"],
             false
         );
+    }
+
+    #[test]
+    fn greedy_parity_requires_runtime_observed_boundary_emulation_by_role() {
+        let mut substituted = passing_report();
+        let case = &mut substituted.cases[0];
+        let boundary_context = case
+            .boundary_reference
+            .as_ref()
+            .unwrap()
+            .execution_plan
+            .context_id
+            .clone();
+        let mut ordinary_cpu = case.cpu.as_ref().unwrap().clone();
+        ordinary_cpu.execution_plan.context_id = boundary_context.clone();
+        ordinary_cpu.initial_state.context_id = boundary_context;
+        case.boundary_reference = Some(ordinary_cpu);
+        assert!(substituted.finish().is_err());
+        assert!(!substituted.checks.q4_boundary_emulation_exact);
+
+        let mut mislabeled_cpu = passing_report();
+        mislabeled_cpu.cases[0]
+            .cpu
+            .as_mut()
+            .unwrap()
+            .cpu_q4_boundary_emulation = crate::engine::CpuQ4BoundaryEmulationSnapshot {
+            enabled: true,
+            routed_expert_dispatches: 8,
+        };
+        assert!(mislabeled_cpu.finish().is_err());
+        assert!(!mislabeled_cpu.checks.q4_boundary_emulation_exact);
+
+        let mut mislabeled_hybrid = passing_report();
+        mislabeled_hybrid.cases[0]
+            .hybrid
+            .as_mut()
+            .unwrap()
+            .cpu_q4_boundary_emulation = crate::engine::CpuQ4BoundaryEmulationSnapshot {
+            enabled: true,
+            routed_expert_dispatches: 8,
+        };
+        assert!(mislabeled_hybrid.finish().is_err());
+        assert!(!mislabeled_hybrid.checks.q4_boundary_emulation_exact);
     }
 
     #[test]

--- a/rust-engine/src/greedy_parity.rs
+++ b/rust-engine/src/greedy_parity.rs
@@ -1099,18 +1099,36 @@ impl GreedyParityReport {
                     && boundary.initial_state.context_id == boundary.execution_plan.context_id
                     && hybrid.initial_state.context_id == hybrid.execution_plan.context_id
             });
-        let context_ids: HashSet<&str> = collected
+        // CPU and boundary-reference contexts are created in this parent
+        // process, so their process-local IDs must be unique as bare IDs.
+        let parent_context_ids: HashSet<&str> = collected
             .iter()
-            .flat_map(|(_, cpu, boundary, hybrid, _, _)| {
+            .flat_map(|(_, cpu, boundary, _, _, _)| {
                 [
                     cpu.execution_plan.context_id.as_str(),
                     boundary.execution_plan.context_id.as_str(),
-                    hybrid.execution_plan.context_id.as_str(),
                 ]
             })
             .collect();
-        let unique_execution_context_every_run =
-            exact_run_count && context_ids.len() == CORPUS_CASE_COUNT * 3;
+        // Hybrid context IDs are process-local. Qualify them with the worker
+        // PID so a fresh worker may validly allocate context "1", while reuse
+        // of the same process/context identity remains a collision.
+        let hybrid_process_context_ids: HashSet<(u32, &str)> = collected
+            .iter()
+            .filter_map(|(_, _, _, hybrid, _, _)| {
+                let process_id = hybrid.worker_process.as_ref()?.process_id?;
+                Some((process_id, hybrid.execution_plan.context_id.as_str()))
+            })
+            .collect();
+        let unique_execution_context_every_run = exact_run_count
+            && parent_context_ids.len() == CORPUS_CASE_COUNT * 2
+            && parent_context_ids
+                .iter()
+                .all(|context_id| !context_id.is_empty())
+            && hybrid_process_context_ids.len() == CORPUS_CASE_COUNT
+            && hybrid_process_context_ids
+                .iter()
+                .all(|(_, context_id)| !context_id.is_empty());
         let controlled_background_shutdown_every_run = exact_run_count
             && collected.iter().all(|(_, cpu, boundary, hybrid, _, _)| {
                 cpu.background_shutdown.controlled_shutdown_requested
@@ -2045,6 +2063,73 @@ mod tests {
             .context_id = reused;
         assert!(context_reuse.finish().is_err());
         assert!(!context_reuse.checks.unique_execution_context_every_run);
+    }
+
+    #[test]
+    fn greedy_parity_worker_context_identity_is_process_aware_and_fail_closed() {
+        let mut process_local_ids = passing_report();
+        for case in &mut process_local_ids.cases {
+            let hybrid = case.hybrid.as_mut().unwrap();
+            hybrid.execution_plan.context_id = "1".to_string();
+            hybrid.initial_state.context_id = "1".to_string();
+        }
+        assert!(process_local_ids.finish().is_ok());
+        assert!(process_local_ids.checks.unique_execution_context_every_run);
+        assert!(process_local_ids.checks.unique_hybrid_process_identity);
+
+        let mut reused_process_context = passing_report();
+        for case in &mut reused_process_context.cases {
+            let hybrid = case.hybrid.as_mut().unwrap();
+            hybrid.execution_plan.context_id = "1".to_string();
+            hybrid.initial_state.context_id = "1".to_string();
+        }
+        let reused_process_id = reused_process_context.cases[0]
+            .hybrid
+            .as_ref()
+            .unwrap()
+            .worker_process
+            .as_ref()
+            .unwrap()
+            .process_id;
+        reused_process_context.cases[1]
+            .hybrid
+            .as_mut()
+            .unwrap()
+            .worker_process
+            .as_mut()
+            .unwrap()
+            .process_id = reused_process_id;
+        assert!(reused_process_context.finish().is_err());
+        assert!(!reused_process_context
+            .checks
+            .unique_execution_context_every_run);
+        assert!(!reused_process_context
+            .checks
+            .unique_hybrid_process_identity);
+
+        let mut missing_process = passing_report();
+        missing_process.cases[2]
+            .hybrid
+            .as_mut()
+            .unwrap()
+            .worker_process
+            .as_mut()
+            .unwrap()
+            .process_id = None;
+        assert!(missing_process.finish().is_err());
+        assert!(!missing_process
+            .checks
+            .unique_execution_context_every_run);
+        assert!(!missing_process.checks.hybrid_worker_processes_exact);
+
+        let mut missing_context = passing_report();
+        let hybrid = missing_context.cases[3].hybrid.as_mut().unwrap();
+        hybrid.execution_plan.context_id.clear();
+        hybrid.initial_state.context_id.clear();
+        assert!(missing_context.finish().is_err());
+        assert!(!missing_context
+            .checks
+            .unique_execution_context_every_run);
     }
 
     #[test]

--- a/rust-engine/src/greedy_parity.rs
+++ b/rust-engine/src/greedy_parity.rs
@@ -10,7 +10,7 @@ use crate::qualification::{
     BuildProvenance, ExecutionPlanEvidence, ExpertMetadataEvidence, QualificationArtifacts,
     QualificationFailure, QualificationStatus,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::HashSet;
 
@@ -21,6 +21,9 @@ pub const CORPUS_VERSION: u32 = 1;
 pub const OUTPUT_TOKEN_LIMIT: usize = 16;
 pub const CORPUS_CASE_COUNT: usize = 4;
 pub const MAX_DECODED_PREFIX_BYTES: usize = 512;
+pub const WORKER_PROTOCOL_VERSION: &str = "mer.strict-hybrid-q4-greedy-worker.v1";
+pub const MAX_WORKER_STDOUT_BYTES: usize = 1024 * 1024;
+pub const MAX_WORKER_STDERR_BYTES: usize = 64 * 1024;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct FixedCorpusCase {
@@ -83,6 +86,13 @@ pub fn token_ids_sha256(ids: &[u32]) -> String {
     format!("{:x}", hasher.finalize())
 }
 
+pub fn fixed_case(name: &str) -> Option<FixedCorpusCase> {
+    FIXED_CORPUS
+        .iter()
+        .copied()
+        .find(|candidate| candidate.name == name)
+}
+
 fn is_sha256_hex(value: &str) -> bool {
     value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
@@ -116,13 +126,119 @@ impl CorpusEvidence {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct GreedySamplingEvidence {
     pub temperature: f32,
     pub top_p: f32,
     pub top_k: usize,
     pub seed: u64,
     pub deterministic_greedy: bool,
+}
+
+/// Exact typed stdin contract between the aggregate orchestrator and one
+/// short-lived Hybrid worker. It intentionally contains token IDs, not prompt
+/// text, so the worker has no encoding surface.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HybridWorkerRequest {
+    pub protocol_version: String,
+    pub worker_id: String,
+    pub case_name: String,
+    pub prompt_sha256: String,
+    pub resolved_config_sha256: String,
+    pub expected_adapter_name: String,
+    pub prompt_token_ids: Vec<u32>,
+    pub prompt_token_ids_sha256: String,
+    pub output_token_limit: usize,
+    pub sampling: GreedySamplingEvidence,
+    pub executable_sha256: String,
+    pub build_git_sha: String,
+}
+
+impl HybridWorkerRequest {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        worker_id: String,
+        case: FixedCorpusCase,
+        resolved_config_sha256: String,
+        expected_adapter_name: String,
+        prompt_token_ids: Vec<u32>,
+        executable_sha256: String,
+        build_git_sha: String,
+    ) -> Self {
+        Self {
+            protocol_version: WORKER_PROTOCOL_VERSION.to_string(),
+            worker_id,
+            case_name: case.name.to_string(),
+            prompt_sha256: sha256_hex(case.prompt.as_bytes()),
+            resolved_config_sha256,
+            expected_adapter_name,
+            prompt_token_ids_sha256: token_ids_sha256(&prompt_token_ids),
+            prompt_token_ids,
+            output_token_limit: OUTPUT_TOKEN_LIMIT,
+            sampling: GreedySamplingEvidence::fixed(),
+            executable_sha256,
+            build_git_sha,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HybridWorkerIdentityEvidence {
+    pub protocol_version_verified: bool,
+    pub case_identity_verified: bool,
+    pub config_identity_verified: bool,
+    pub expected_adapter_verified: bool,
+    pub prompt_token_identity_verified: bool,
+    pub output_token_limit_verified: bool,
+    pub greedy_sampling_identity_verified: bool,
+    pub executable_identity_verified: bool,
+    pub build_sha_identity_verified: bool,
+}
+
+impl HybridWorkerIdentityEvidence {
+    pub fn all_verified(&self) -> bool {
+        self.protocol_version_verified
+            && self.case_identity_verified
+            && self.config_identity_verified
+            && self.expected_adapter_verified
+            && self.prompt_token_identity_verified
+            && self.output_token_limit_verified
+            && self.greedy_sampling_identity_verified
+            && self.executable_identity_verified
+            && self.build_sha_identity_verified
+    }
+}
+
+pub fn validate_hybrid_worker_request(
+    request: &HybridWorkerRequest,
+    observed_config_sha256: &str,
+    observed_executable_sha256: &str,
+    observed_build_git_sha: Option<&str>,
+) -> HybridWorkerIdentityEvidence {
+    let fixed = fixed_case(&request.case_name);
+    HybridWorkerIdentityEvidence {
+        protocol_version_verified: request.protocol_version == WORKER_PROTOCOL_VERSION,
+        case_identity_verified: fixed.is_some_and(|case| {
+            request.prompt_sha256 == sha256_hex(case.prompt.as_bytes())
+        }),
+        config_identity_verified: is_sha256_hex(&request.resolved_config_sha256)
+            && request.resolved_config_sha256 == observed_config_sha256,
+        expected_adapter_verified: !request.expected_adapter_name.is_empty(),
+        prompt_token_identity_verified: !request.prompt_token_ids.is_empty()
+            && request.prompt_token_ids_sha256 == token_ids_sha256(&request.prompt_token_ids),
+        output_token_limit_verified: request.output_token_limit == OUTPUT_TOKEN_LIMIT,
+        greedy_sampling_identity_verified: request.sampling.is_exact(),
+        executable_identity_verified: is_sha256_hex(&request.executable_sha256)
+            && request.executable_sha256 == observed_executable_sha256,
+        build_sha_identity_verified: observed_build_git_sha.is_some_and(|sha| {
+            sha.len() == 40
+                && sha.bytes().all(|byte| byte.is_ascii_hexdigit())
+                && request.build_git_sha == sha
+        }),
+    }
 }
 
 impl GreedySamplingEvidence {
@@ -203,7 +319,8 @@ impl StrictHybridPreflightEvidence {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ModelLoadEvidence {
     pub strict: bool,
     pub loader: String,
@@ -224,7 +341,8 @@ impl ModelLoadEvidence {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct RuntimeCacheSnapshot {
     pub ram_entries: usize,
     pub ram_hits: u64,
@@ -244,7 +362,8 @@ pub struct RuntimeCacheSnapshot {
     pub stale_retirements: u64,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct InitialStateEvidence {
     pub context_id: String,
     pub resolved_config_sha256: String,
@@ -269,7 +388,7 @@ impl InitialStateEvidence {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum TerminationReason {
     LengthLimit,
@@ -279,7 +398,8 @@ pub enum TerminationReason {
     EndOfSequence,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct GenerationEvidence {
     pub prompt_token_ids_sha256: String,
     pub generated_token_ids: Vec<u32>,
@@ -289,16 +409,18 @@ pub struct GenerationEvidence {
     pub termination_reason: TerminationReason,
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct BackgroundShutdownEvidence {
     pub controlled_shutdown_requested: bool,
     pub all_runtime_resources_released: bool,
     pub poll_iterations: u32,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PlaneRunEvidence {
-    pub plane: &'static str,
+    pub plane: String,
     pub model_load: ModelLoadEvidence,
     pub execution_plan: ExecutionPlanEvidence,
     pub routed_expert_gpu_failure_policy: String,
@@ -311,6 +433,217 @@ pub struct PlaneRunEvidence {
     pub gpu_memory_before: Option<GpuExpertMemorySnapshot>,
     pub gpu_memory_after: Option<GpuExpertMemorySnapshot>,
     pub background_shutdown: BackgroundShutdownEvidence,
+    /// Populated by the parent only after the worker has exited and been
+    /// reaped. A worker cannot attest to its own process termination.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub worker_process: Option<HybridWorkerProcessEvidence>,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HybridWorkerProcessEvidence {
+    pub worker_id: String,
+    pub child_process_spawned: bool,
+    pub process_id: Option<u32>,
+    pub executable_sha256: String,
+    pub build_git_sha: String,
+    pub executable_identity_verified: bool,
+    pub build_sha_identity_verified: bool,
+    pub case_identity_verified: bool,
+    pub config_identity_verified: bool,
+    pub expected_adapter_identity_verified: bool,
+    pub prompt_token_identity_verified: bool,
+    pub output_token_limit_verified: bool,
+    pub greedy_sampling_identity_verified: bool,
+    pub normal_zero_exit: bool,
+    pub exit_code: Option<i32>,
+    pub signal: Option<i32>,
+    pub process_reaped: bool,
+    pub timed_out: bool,
+    pub evidence_emitted: bool,
+}
+
+impl HybridWorkerProcessEvidence {
+    fn is_exact(&self) -> bool {
+        !self.worker_id.is_empty()
+            && self.child_process_spawned
+            && self.process_id.is_some()
+            && is_sha256_hex(&self.executable_sha256)
+            && self.build_git_sha.len() == 40
+            && self
+                .build_git_sha
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit())
+            && self.executable_identity_verified
+            && self.build_sha_identity_verified
+            && self.case_identity_verified
+            && self.config_identity_verified
+            && self.expected_adapter_identity_verified
+            && self.prompt_token_identity_verified
+            && self.output_token_limit_verified
+            && self.greedy_sampling_identity_verified
+            && self.normal_zero_exit
+            && self.exit_code == Some(0)
+            && self.signal.is_none()
+            && self.process_reaped
+            && !self.timed_out
+            && self.evidence_emitted
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct HybridWorkerFailureEvidence {
+    pub worker_id: String,
+    pub case_name: String,
+    pub child_process_spawned: bool,
+    pub process_id: Option<u32>,
+    pub exit_code: Option<i32>,
+    pub signal: Option<i32>,
+    pub timed_out: bool,
+    pub process_reaped: bool,
+    pub evidence_emitted: bool,
+    pub identity_validation_succeeded: bool,
+    pub identity_validation: Option<HybridWorkerParentValidation>,
+    pub stderr: String,
+    pub stderr_truncated: bool,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HybridWorkerResponse {
+    pub protocol_version: String,
+    pub worker_id: String,
+    pub case_name: String,
+    pub prompt_sha256: String,
+    pub resolved_config_sha256: String,
+    pub expected_adapter_name: String,
+    pub prompt_token_ids_sha256: String,
+    pub output_token_limit: usize,
+    pub sampling: GreedySamplingEvidence,
+    pub executable_sha256: String,
+    pub build_git_sha: String,
+    pub identity: HybridWorkerIdentityEvidence,
+    pub plane: Option<PlaneRunEvidence>,
+    pub failure: Option<String>,
+}
+
+impl HybridWorkerResponse {
+    pub fn from_request(
+        request: &HybridWorkerRequest,
+        observed_config_sha256: &str,
+        observed_executable_sha256: &str,
+        observed_build_git_sha: Option<&str>,
+        identity: HybridWorkerIdentityEvidence,
+        plane: Option<PlaneRunEvidence>,
+        failure: Option<String>,
+    ) -> Self {
+        Self {
+            protocol_version: WORKER_PROTOCOL_VERSION.to_string(),
+            worker_id: request.worker_id.clone(),
+            case_name: request.case_name.clone(),
+            prompt_sha256: request.prompt_sha256.clone(),
+            resolved_config_sha256: observed_config_sha256.to_string(),
+            expected_adapter_name: request.expected_adapter_name.clone(),
+            prompt_token_ids_sha256: request.prompt_token_ids_sha256.clone(),
+            output_token_limit: request.output_token_limit,
+            sampling: request.sampling,
+            executable_sha256: observed_executable_sha256.to_string(),
+            build_git_sha: observed_build_git_sha.unwrap_or_default().to_string(),
+            identity,
+            plane,
+            failure,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize)]
+pub struct HybridWorkerParentValidation {
+    pub executable_identity_verified: bool,
+    pub build_sha_identity_verified: bool,
+    pub case_identity_verified: bool,
+    pub config_identity_verified: bool,
+    pub expected_adapter_identity_verified: bool,
+    pub prompt_token_identity_verified: bool,
+    pub output_token_limit_verified: bool,
+    pub greedy_sampling_identity_verified: bool,
+}
+
+impl HybridWorkerParentValidation {
+    pub fn all_verified(self) -> bool {
+        self.executable_identity_verified
+            && self.build_sha_identity_verified
+            && self.case_identity_verified
+            && self.config_identity_verified
+            && self.expected_adapter_identity_verified
+            && self.prompt_token_identity_verified
+            && self.output_token_limit_verified
+            && self.greedy_sampling_identity_verified
+    }
+}
+
+pub fn validate_hybrid_worker_response(
+    request: &HybridWorkerRequest,
+    response: &HybridWorkerResponse,
+) -> HybridWorkerParentValidation {
+    HybridWorkerParentValidation {
+        executable_identity_verified: response.identity.executable_identity_verified
+            && response.executable_sha256 == request.executable_sha256,
+        build_sha_identity_verified: response.identity.build_sha_identity_verified
+            && response.build_git_sha == request.build_git_sha,
+        case_identity_verified: response.identity.protocol_version_verified
+            && response.protocol_version == WORKER_PROTOCOL_VERSION
+            && response.worker_id == request.worker_id
+            && response.case_name == request.case_name
+            && response.prompt_sha256 == request.prompt_sha256,
+        config_identity_verified: response.identity.config_identity_verified
+            && response.resolved_config_sha256 == request.resolved_config_sha256,
+        expected_adapter_identity_verified: response.identity.expected_adapter_verified
+            && response.expected_adapter_name == request.expected_adapter_name,
+        prompt_token_identity_verified: response.identity.prompt_token_identity_verified
+            && response.prompt_token_ids_sha256 == request.prompt_token_ids_sha256,
+        output_token_limit_verified: response.identity.output_token_limit_verified
+            && response.output_token_limit == request.output_token_limit,
+        greedy_sampling_identity_verified: response.identity.greedy_sampling_identity_verified
+            && response.sampling == request.sampling,
+    }
+}
+
+pub fn parse_hybrid_worker_request_exact(bytes: &[u8]) -> Result<HybridWorkerRequest, String> {
+    parse_exact_json(bytes, "worker request")
+}
+
+pub fn parse_hybrid_worker_response_exact(bytes: &[u8]) -> Result<HybridWorkerResponse, String> {
+    parse_exact_json(bytes, "worker response")
+}
+
+fn parse_exact_json<T>(bytes: &[u8], label: &str) -> Result<T, String>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    if bytes.is_empty() {
+        return Err(format!("missing {label}"));
+    }
+    let mut deserializer = serde_json::Deserializer::from_slice(bytes);
+    let value = T::deserialize(&mut deserializer)
+        .map_err(|error| format!("malformed {label}: {error}"))?;
+    deserializer
+        .end()
+        .map_err(|error| format!("trailing or duplicated {label} output: {error}"))?;
+    Ok(value)
+}
+
+pub fn hybrid_worker_id(
+    build_git_sha: &str,
+    executable_sha256: &str,
+    case_index: usize,
+    case_name: &str,
+) -> String {
+    let mut hasher = Sha256::new();
+    hash_len_prefixed(&mut hasher, build_git_sha.as_bytes());
+    hash_len_prefixed(&mut hasher, executable_sha256.as_bytes());
+    hasher.update((case_index as u64).to_le_bytes());
+    hash_len_prefixed(&mut hasher, case_name.as_bytes());
+    format!("greedy-hybrid-{:x}", hasher.finalize())
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
@@ -418,6 +751,8 @@ pub struct CaseReport {
     pub cpu: Option<PlaneRunEvidence>,
     pub hybrid: Option<PlaneRunEvidence>,
     pub comparison: Option<CaseComparisonEvidence>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub worker_failure: Option<HybridWorkerFailureEvidence>,
     pub failure: Option<QualificationFailure>,
 }
 
@@ -436,6 +771,7 @@ impl CaseReport {
             cpu: None,
             hybrid: None,
             comparison: None,
+            worker_failure: None,
             failure: None,
         }
     }
@@ -511,6 +847,8 @@ pub struct GreedyParityChecks {
     pub fresh_state_every_run: bool,
     pub unique_execution_context_every_run: bool,
     pub controlled_background_shutdown_every_run: bool,
+    pub hybrid_worker_processes_exact: bool,
+    pub unique_hybrid_worker_identity: bool,
     pub cpu_plans_exact: bool,
     pub cpu_counter_invariants: bool,
     pub cpu_gpu_io_zero: bool,
@@ -541,6 +879,8 @@ impl GreedyParityChecks {
             && self.fresh_state_every_run
             && self.unique_execution_context_every_run
             && self.controlled_background_shutdown_every_run
+            && self.hybrid_worker_processes_exact
+            && self.unique_hybrid_worker_identity
             && self.cpu_plans_exact
             && self.cpu_counter_invariants
             && self.cpu_gpu_io_zero
@@ -571,6 +911,7 @@ pub struct GreedyParityReport {
     pub model_identity: Option<ModelIdentityEvidence>,
     pub source_preflight: Option<StrictHybridPreflightEvidence>,
     pub resolved_config_sha256: Option<String>,
+    pub orchestrator_executable_sha256: Option<String>,
     pub corpus: CorpusEvidence,
     pub sampling: GreedySamplingEvidence,
     pub expected_adapter_name: String,
@@ -596,6 +937,7 @@ impl GreedyParityReport {
             model_identity: None,
             source_preflight: None,
             resolved_config_sha256: None,
+            orchestrator_executable_sha256: None,
             corpus: CorpusEvidence::fixed(),
             sampling: GreedySamplingEvidence::fixed(),
             expected_adapter_name,
@@ -617,6 +959,7 @@ impl GreedyParityReport {
                     && report.prompt == fixed.prompt
                     && report.prompt_sha256 == sha256_hex(fixed.prompt.as_bytes())
                     && report.output_token_limit == OUTPUT_TOKEN_LIMIT
+                    && report.worker_failure.is_none()
                     && report.failure.is_none()
                     && report.cpu.is_some()
                     && report.hybrid.is_some()
@@ -695,6 +1038,32 @@ impl GreedyParityReport {
                     && hybrid.background_shutdown.controlled_shutdown_requested
                     && hybrid.background_shutdown.all_runtime_resources_released
             });
+        let hybrid_worker_processes_exact = exact_run_count
+            && self
+                .orchestrator_executable_sha256
+                .as_deref()
+                .is_some_and(is_sha256_hex)
+            && collected.iter().all(|(_, cpu, hybrid, _)| {
+                cpu.worker_process.is_none()
+                    && hybrid.worker_process.as_ref().is_some_and(|process| {
+                        process.is_exact()
+                            && Some(process.executable_sha256.as_str())
+                                == self.orchestrator_executable_sha256.as_deref()
+                            && Some(process.build_git_sha.as_str())
+                                == self.provenance.git_sha.as_deref()
+                    })
+            });
+        let worker_ids: HashSet<&str> = collected
+            .iter()
+            .filter_map(|(_, _, hybrid, _)| {
+                hybrid
+                    .worker_process
+                    .as_ref()
+                    .map(|process| process.worker_id.as_str())
+            })
+            .collect();
+        let unique_hybrid_worker_identity =
+            hybrid_worker_processes_exact && worker_ids.len() == CORPUS_CASE_COUNT;
         let cpu_plans_exact = exact_run_count
             && collected
                 .iter()
@@ -782,6 +1151,8 @@ impl GreedyParityReport {
             fresh_state_every_run,
             unique_execution_context_every_run,
             controlled_background_shutdown_every_run,
+            hybrid_worker_processes_exact,
+            unique_hybrid_worker_identity,
             cpu_plans_exact,
             cpu_counter_invariants,
             cpu_gpu_io_zero,
@@ -832,6 +1203,7 @@ impl GreedyParityReport {
             || self.model_identity.is_none()
             || self.source_preflight.is_none()
             || self.resolved_config_sha256.is_none()
+            || self.orchestrator_executable_sha256.is_none()
         {
             return Err(QualificationFailure::new(
                 crate::qualification::FailureStage::Postcondition,
@@ -917,7 +1289,7 @@ mod tests {
     fn plane_evidence(case_index: usize, hybrid: bool, ids: &[u32]) -> PlaneRunEvidence {
         let context_id = format!("{}-{case_index}", if hybrid { "hybrid" } else { "cpu" });
         PlaneRunEvidence {
-            plane: if hybrid { "hybrid" } else { "cpu" },
+            plane: if hybrid { "hybrid" } else { "cpu" }.to_string(),
             model_load: model_load(),
             execution_plan: plan(context_id.clone(), hybrid),
             routed_expert_gpu_failure_policy: if hybrid {
@@ -974,6 +1346,7 @@ mod tests {
                 all_runtime_resources_released: true,
                 poll_iterations: 1,
             },
+            worker_process: None,
         }
     }
 
@@ -1027,6 +1400,7 @@ mod tests {
             routed_expert_dtype: "q4_0".to_string(),
         });
         report.resolved_config_sha256 = Some("11".repeat(32));
+        report.orchestrator_executable_sha256 = Some("22".repeat(32));
         for (index, fixed) in FIXED_CORPUS.into_iter().enumerate() {
             let prompt_ids = vec![10 + index as u32, 20 + index as u32];
             let ids: Vec<u32> = (0..OUTPUT_TOKEN_LIMIT)
@@ -1036,6 +1410,38 @@ mod tests {
             let prompt_hash = case.prompt_token_ids_sha256.clone();
             let mut cpu = plane_evidence(index, false, &ids);
             let mut hybrid = plane_evidence(index, true, &ids);
+            hybrid.worker_process = Some(HybridWorkerProcessEvidence {
+                worker_id: hybrid_worker_id(
+                    report.provenance.git_sha.as_deref().unwrap(),
+                    report
+                        .orchestrator_executable_sha256
+                        .as_deref()
+                        .unwrap(),
+                    index,
+                    fixed.name,
+                ),
+                child_process_spawned: true,
+                process_id: Some(1000 + index as u32),
+                executable_sha256: report
+                    .orchestrator_executable_sha256
+                    .clone()
+                    .unwrap(),
+                build_git_sha: report.provenance.git_sha.clone().unwrap(),
+                executable_identity_verified: true,
+                build_sha_identity_verified: true,
+                case_identity_verified: true,
+                config_identity_verified: true,
+                expected_adapter_identity_verified: true,
+                prompt_token_identity_verified: true,
+                output_token_limit_verified: true,
+                greedy_sampling_identity_verified: true,
+                normal_zero_exit: true,
+                exit_code: Some(0),
+                signal: None,
+                process_reaped: true,
+                timed_out: false,
+                evidence_emitted: true,
+            });
             cpu.generation.prompt_token_ids_sha256 = prompt_hash.clone();
             hybrid.generation.prompt_token_ids_sha256 = prompt_hash;
             case.comparison = Some(
@@ -1520,5 +1926,239 @@ mod tests {
             .generated_token_ids_sha256 = "copied".to_string();
         assert!(bad_hash.finish().is_err());
         assert!(!bad_hash.checks.tokenized_once_and_shared);
+    }
+
+    fn worker_request() -> HybridWorkerRequest {
+        HybridWorkerRequest::new(
+            hybrid_worker_id(&"a".repeat(40), &"b".repeat(64), 0, FIXED_CORPUS[0].name),
+            FIXED_CORPUS[0],
+            "c".repeat(64),
+            "NVIDIA L4".to_string(),
+            vec![17, 29, 41, 53],
+            "b".repeat(64),
+            "a".repeat(40),
+        )
+    }
+
+    fn verified_worker_identity() -> HybridWorkerIdentityEvidence {
+        HybridWorkerIdentityEvidence {
+            protocol_version_verified: true,
+            case_identity_verified: true,
+            config_identity_verified: true,
+            expected_adapter_verified: true,
+            prompt_token_identity_verified: true,
+            output_token_limit_verified: true,
+            greedy_sampling_identity_verified: true,
+            executable_identity_verified: true,
+            build_sha_identity_verified: true,
+        }
+    }
+
+    fn worker_response(request: &HybridWorkerRequest) -> HybridWorkerResponse {
+        HybridWorkerResponse::from_request(
+            request,
+            &request.resolved_config_sha256,
+            &request.executable_sha256,
+            Some(&request.build_git_sha),
+            verified_worker_identity(),
+            Some(plane_evidence(0, true, &[1, 2, 3])),
+            None,
+        )
+    }
+
+    #[test]
+    fn greedy_parity_worker_transport_preserves_exact_token_ids_without_prompt_text() {
+        let request = worker_request();
+        let json = serde_json::to_vec(&request).unwrap();
+        assert!(!json
+            .windows(FIXED_CORPUS[0].prompt.len())
+            .any(|window| window == FIXED_CORPUS[0].prompt.as_bytes()));
+        let parsed = parse_hybrid_worker_request_exact(&json).unwrap();
+        assert_eq!(parsed, request);
+        assert_eq!(parsed.prompt_token_ids, vec![17, 29, 41, 53]);
+        assert_eq!(
+            parsed.prompt_token_ids_sha256,
+            token_ids_sha256(&[17, 29, 41, 53])
+        );
+    }
+
+    #[test]
+    fn greedy_parity_worker_request_validates_every_frozen_identity() {
+        let request = worker_request();
+        let valid = validate_hybrid_worker_request(
+            &request,
+            &request.resolved_config_sha256,
+            &request.executable_sha256,
+            Some(&request.build_git_sha),
+        );
+        assert!(valid.all_verified());
+
+        let mut drift = request.clone();
+        drift.prompt_token_ids[0] ^= 1;
+        assert!(!validate_hybrid_worker_request(
+            &drift,
+            &drift.resolved_config_sha256,
+            &drift.executable_sha256,
+            Some(&drift.build_git_sha),
+        )
+        .prompt_token_identity_verified);
+        let mut drift = request.clone();
+        drift.prompt_sha256 = "d".repeat(64);
+        assert!(!validate_hybrid_worker_request(
+            &drift,
+            &drift.resolved_config_sha256,
+            &drift.executable_sha256,
+            Some(&drift.build_git_sha),
+        )
+        .case_identity_verified);
+        assert!(!validate_hybrid_worker_request(
+            &request,
+            &"d".repeat(64),
+            &request.executable_sha256,
+            Some(&request.build_git_sha),
+        )
+        .config_identity_verified);
+    }
+
+    #[test]
+    fn greedy_parity_worker_response_requires_exact_parent_identities() {
+        let request = worker_request();
+        let response = worker_response(&request);
+        assert!(validate_hybrid_worker_response(&request, &response).all_verified());
+
+        let mut wrong_case = worker_response(&request);
+        wrong_case.case_name = FIXED_CORPUS[1].name.to_string();
+        assert!(!validate_hybrid_worker_response(&request, &wrong_case)
+            .case_identity_verified);
+        let mut wrong_config = worker_response(&request);
+        wrong_config.resolved_config_sha256 = "d".repeat(64);
+        assert!(!validate_hybrid_worker_response(&request, &wrong_config)
+            .config_identity_verified);
+        let mut wrong_token = worker_response(&request);
+        wrong_token.prompt_token_ids_sha256 = "e".repeat(64);
+        assert!(!validate_hybrid_worker_response(&request, &wrong_token)
+            .prompt_token_identity_verified);
+    }
+
+    #[test]
+    fn greedy_parity_worker_output_rejects_missing_malformed_duplicate_and_trailing_data() {
+        let request = worker_request();
+        let valid = serde_json::to_vec(&worker_response(&request)).unwrap();
+        assert!(parse_hybrid_worker_response_exact(&valid).is_ok());
+        assert!(parse_hybrid_worker_response_exact(b"").is_err());
+        assert!(parse_hybrid_worker_response_exact(b"{broken").is_err());
+
+        let mut duplicated = valid.clone();
+        duplicated.extend_from_slice(&valid);
+        assert!(parse_hybrid_worker_response_exact(&duplicated).is_err());
+        let mut trailing = valid;
+        trailing.extend_from_slice(b"unexpected");
+        assert!(parse_hybrid_worker_response_exact(&trailing).is_err());
+    }
+
+    #[test]
+    fn greedy_parity_process_evidence_is_fail_closed_for_absence_or_false_fields() {
+        let mut missing = passing_report();
+        missing.cases[0]
+            .hybrid
+            .as_mut()
+            .unwrap()
+            .worker_process = None;
+        assert!(missing.finish().is_err());
+        assert!(!missing.checks.hybrid_worker_processes_exact);
+
+        let original = passing_report().cases[0]
+            .hybrid
+            .as_ref()
+            .unwrap()
+            .worker_process
+            .clone()
+            .unwrap();
+        let mutations: [fn(&mut HybridWorkerProcessEvidence); 14] = [
+            |value| value.child_process_spawned = false,
+            |value| value.process_id = None,
+            |value| value.executable_identity_verified = false,
+            |value| value.build_sha_identity_verified = false,
+            |value| value.case_identity_verified = false,
+            |value| value.config_identity_verified = false,
+            |value| value.expected_adapter_identity_verified = false,
+            |value| value.prompt_token_identity_verified = false,
+            |value| value.output_token_limit_verified = false,
+            |value| value.greedy_sampling_identity_verified = false,
+            |value| value.normal_zero_exit = false,
+            |value| value.process_reaped = false,
+            |value| value.timed_out = true,
+            |value| value.evidence_emitted = false,
+        ];
+        for mutate in mutations {
+            let mut evidence = original.clone();
+            mutate(&mut evidence);
+            assert!(!evidence.is_exact());
+        }
+    }
+
+    #[test]
+    fn greedy_parity_requires_unique_worker_identity_for_all_four_cases() {
+        let mut report = passing_report();
+        report.finish().unwrap();
+        assert!(report.checks.unique_hybrid_worker_identity);
+
+        let reused = report.cases[0]
+            .hybrid
+            .as_ref()
+            .unwrap()
+            .worker_process
+            .as_ref()
+            .unwrap()
+            .worker_id
+            .clone();
+        report.cases[1]
+            .hybrid
+            .as_mut()
+            .unwrap()
+            .worker_process
+            .as_mut()
+            .unwrap()
+            .worker_id = reused;
+        assert!(report.finish().is_err());
+        assert!(!report.checks.unique_hybrid_worker_identity);
+    }
+
+    #[test]
+    fn greedy_parity_failure_report_preserves_completed_cases_and_worker_diagnostics() {
+        let mut report = passing_report();
+        report.cases.truncate(2);
+        let mut failed = CaseReport::new(FIXED_CORPUS[2], vec![1, 2]);
+        failed.worker_failure = Some(HybridWorkerFailureEvidence {
+            worker_id: "worker-3".to_string(),
+            case_name: FIXED_CORPUS[2].name.to_string(),
+            child_process_spawned: true,
+            process_id: Some(123),
+            exit_code: None,
+            signal: Some(15),
+            timed_out: false,
+            process_reaped: true,
+            evidence_emitted: false,
+            identity_validation_succeeded: false,
+            identity_validation: None,
+            stderr: "bounded diagnostic".to_string(),
+            stderr_truncated: false,
+        });
+        failed.failure = Some(QualificationFailure::new(
+            crate::qualification::FailureStage::Inference,
+            "hybrid-worker-failed",
+            "worker terminated",
+        ));
+        report.cases.push(failed);
+        report.fail(QualificationFailure::new(
+            crate::qualification::FailureStage::Inference,
+            "hybrid-worker-failed",
+            "worker terminated",
+        ));
+        let json = serde_json::to_value(&report).unwrap();
+        assert_eq!(json["cases"].as_array().unwrap().len(), 3);
+        assert!(json["cases"][0]["comparison"].is_object());
+        assert!(json["cases"][1]["comparison"].is_object());
+        assert_eq!(json["cases"][2]["worker_failure"]["signal"], 15);
     }
 }

--- a/rust-engine/src/greedy_parity.rs
+++ b/rust-engine/src/greedy_parity.rs
@@ -1,0 +1,1496 @@
+//! Fail-closed fixed-corpus CPU-versus-Hybrid greedy-token qualification.
+//!
+//! The corpus, comparison, evidence, and PASS derivation live here so they are
+//! hardware-independent. `main.rs` owns the deliberately private runtime
+//! factory that executes the existing real-model path on the selected device.
+
+use crate::backend::{GpuDeviceIdentity, GpuExpertIoSnapshot, GpuExpertMemorySnapshot};
+use crate::engine::RoutedExpertExecutionSnapshot;
+use crate::qualification::{
+    BuildProvenance, ExecutionPlanEvidence, ExpertMetadataEvidence, QualificationArtifacts,
+    QualificationFailure, QualificationStatus,
+};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use std::collections::HashSet;
+
+pub const SCHEMA_VERSION: &str = "mer.strict-hybrid-q4-greedy-parity.v1";
+pub const MODE: &str = "strict-hybrid-q4-greedy-parity";
+pub const CORPUS_ID: &str = "qwen3-coder-30b-a3b-greedy-v1";
+pub const CORPUS_VERSION: u32 = 1;
+pub const OUTPUT_TOKEN_LIMIT: usize = 16;
+pub const CORPUS_CASE_COUNT: usize = 4;
+pub const MAX_DECODED_PREFIX_BYTES: usize = 512;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FixedCorpusCase {
+    pub name: &'static str,
+    pub behavior: &'static str,
+    pub prompt: &'static str,
+}
+
+pub const FIXED_CORPUS: [FixedCorpusCase; CORPUS_CASE_COUNT] = [
+    FixedCorpusCase {
+        name: "rust-generation",
+        behavior: "Rust code generation",
+        prompt: "Write a Rust function named is_even that accepts an i64 and returns a bool. Return only the function.",
+    },
+    FixedCorpusCase {
+        name: "rust-debugging",
+        behavior: "Rust code correction",
+        prompt: "Fix this Rust code and return only the corrected code:\nfn add(a: i32, b: i32) -> i32 { a - b }",
+    },
+    FixedCorpusCase {
+        name: "json-transformation",
+        behavior: "Structured JSON transformation",
+        prompt: "Transform this JSON into one compact JSON object with keys in alphabetical order: {\"z\":3,\"a\":1,\"m\":2}",
+    },
+    FixedCorpusCase {
+        name: "multilingual-spanish",
+        behavior: "Short multilingual instruction",
+        prompt: "Responde en español con una frase breve: ¿Qué hace un compilador?",
+    },
+];
+
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}
+
+fn hash_len_prefixed(hasher: &mut Sha256, bytes: &[u8]) {
+    hasher.update((bytes.len() as u64).to_le_bytes());
+    hasher.update(bytes);
+}
+
+pub fn corpus_sha256() -> String {
+    let mut hasher = Sha256::new();
+    hash_len_prefixed(&mut hasher, CORPUS_ID.as_bytes());
+    hasher.update(CORPUS_VERSION.to_le_bytes());
+    hasher.update((OUTPUT_TOKEN_LIMIT as u64).to_le_bytes());
+    for case in FIXED_CORPUS {
+        hash_len_prefixed(&mut hasher, case.name.as_bytes());
+        hash_len_prefixed(&mut hasher, case.behavior.as_bytes());
+        hash_len_prefixed(&mut hasher, case.prompt.as_bytes());
+    }
+    format!("{:x}", hasher.finalize())
+}
+
+pub fn token_ids_sha256(ids: &[u32]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update((ids.len() as u64).to_le_bytes());
+    for id in ids {
+        hasher.update(id.to_le_bytes());
+    }
+    format!("{:x}", hasher.finalize())
+}
+
+fn is_sha256_hex(value: &str) -> bool {
+    value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct CorpusEvidence {
+    pub id: &'static str,
+    pub version: u32,
+    pub sha256: String,
+    pub case_count: usize,
+    pub output_token_limit: usize,
+}
+
+impl CorpusEvidence {
+    pub fn fixed() -> Self {
+        Self {
+            id: CORPUS_ID,
+            version: CORPUS_VERSION,
+            sha256: corpus_sha256(),
+            case_count: CORPUS_CASE_COUNT,
+            output_token_limit: OUTPUT_TOKEN_LIMIT,
+        }
+    }
+
+    fn is_exact(&self) -> bool {
+        self.id == CORPUS_ID
+            && self.version == CORPUS_VERSION
+            && self.sha256 == corpus_sha256()
+            && self.case_count == CORPUS_CASE_COUNT
+            && self.output_token_limit == OUTPUT_TOKEN_LIMIT
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Serialize)]
+pub struct GreedySamplingEvidence {
+    pub temperature: f32,
+    pub top_p: f32,
+    pub top_k: usize,
+    pub seed: u64,
+    pub deterministic_greedy: bool,
+}
+
+impl GreedySamplingEvidence {
+    pub const fn fixed() -> Self {
+        Self {
+            temperature: 0.0,
+            top_p: 1.0,
+            top_k: 0,
+            seed: 0,
+            deterministic_greedy: true,
+        }
+    }
+
+    fn is_exact(&self) -> bool {
+        self.temperature == 0.0
+            && self.top_p == 1.0
+            && self.top_k == 0
+            && self.seed == 0
+            && self.deterministic_greedy
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ModelIdentityEvidence {
+    pub architecture: String,
+    pub num_layers: usize,
+    pub num_experts_per_layer: u32,
+    pub total_experts: u64,
+    pub top_k: usize,
+    pub d_model: usize,
+    pub d_ff: usize,
+    pub routed_expert_dtype: String,
+}
+
+impl ModelIdentityEvidence {
+    pub(crate) fn is_qwen3_coder_30b_a3b_q4_0(&self) -> bool {
+        self.architecture == "qwen3_moe"
+            && self.num_layers == 48
+            && self.num_experts_per_layer == 128
+            && self.total_experts == 6_144
+            && self.top_k == 8
+            && self.d_model == 2_048
+            && self.d_ff == 768
+            && self.routed_expert_dtype == "q4_0"
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct StrictHybridPreflightEvidence {
+    pub real_transformer_enabled: bool,
+    pub weights_dir_configured: bool,
+    pub strict_weights: bool,
+    pub allow_seeded_fallback: bool,
+    pub allow_degraded_experts: bool,
+    pub allow_attention_fallback: bool,
+    pub allow_truncated_expert_payloads: bool,
+    pub distributed_enabled: bool,
+    pub gpu_cache_enabled: bool,
+    pub gpu_expert_capacity_bytes: u64,
+    pub requested_mode: String,
+    pub routed_expert_dtype: String,
+}
+
+impl StrictHybridPreflightEvidence {
+    fn is_exact(&self) -> bool {
+        self.real_transformer_enabled
+            && self.weights_dir_configured
+            && self.strict_weights
+            && !self.allow_seeded_fallback
+            && !self.allow_degraded_experts
+            && !self.allow_attention_fallback
+            && !self.allow_truncated_expert_payloads
+            && !self.distributed_enabled
+            && self.gpu_cache_enabled
+            && self.gpu_expert_capacity_bytes > 0
+            && self.requested_mode == "hybrid"
+            && self.routed_expert_dtype == "q4_0"
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ModelLoadEvidence {
+    pub strict: bool,
+    pub loader: String,
+    pub loaded_tensors: usize,
+    pub required_tensors: usize,
+    pub optional_probed: usize,
+    pub optional_loaded: usize,
+    pub seeded_fallback_remained: bool,
+}
+
+impl ModelLoadEvidence {
+    fn is_strict_complete(&self) -> bool {
+        self.strict
+            && self.loaded_tensors == self.required_tensors
+            && self.required_tensors > 0
+            && !self.seeded_fallback_remained
+            && self.loader != "seeded"
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize)]
+pub struct RuntimeCacheSnapshot {
+    pub ram_entries: usize,
+    pub ram_hits: u64,
+    pub ram_misses: u64,
+    pub bytes_read: u64,
+    pub prefetch_completed: u64,
+    pub predictor_observations: u64,
+    pub logical_gpu_hits: u64,
+    pub logical_gpu_misses: u64,
+    pub logical_gpu_promotions: u64,
+    pub logical_admitted_bytes: u64,
+    pub logical_anchor_entries: usize,
+    pub logical_lru_entries: usize,
+    pub physical_entries: usize,
+    pub physical_installs: u64,
+    pub physical_evictions: u64,
+    pub stale_retirements: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct InitialStateEvidence {
+    pub context_id: String,
+    pub resolved_config_sha256: String,
+    pub kv_cache_count: usize,
+    pub kv_sequence_lengths: Vec<usize>,
+    pub all_kv_empty: bool,
+    pub cache: RuntimeCacheSnapshot,
+    pub routed: RoutedExpertExecutionSnapshot,
+    pub gpu_io_available: bool,
+    pub gpu_io: GpuExpertIoSnapshot,
+}
+
+impl InitialStateEvidence {
+    fn is_clean(&self) -> bool {
+        self.kv_cache_count > 0
+            && self.kv_sequence_lengths.len() == self.kv_cache_count
+            && self.all_kv_empty
+            && self.kv_sequence_lengths.iter().all(|&len| len == 0)
+            && self.cache == RuntimeCacheSnapshot::default()
+            && self.routed == RoutedExpertExecutionSnapshot::default()
+            && self.gpu_io == GpuExpertIoSnapshot::default()
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TerminationReason {
+    LengthLimit,
+    /// Typed failure evidence can represent a stop-reason mismatch even
+    /// though the fixed-corpus command currently always runs to its limit.
+    #[allow(dead_code)]
+    EndOfSequence,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct GenerationEvidence {
+    pub prompt_token_ids_sha256: String,
+    pub generated_token_ids: Vec<u32>,
+    pub generated_token_ids_sha256: String,
+    pub generated_text_sha256: String,
+    pub generated_token_count: usize,
+    pub termination_reason: TerminationReason,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize)]
+pub struct BackgroundShutdownEvidence {
+    pub controlled_shutdown_requested: bool,
+    pub all_runtime_resources_released: bool,
+    pub poll_iterations: u32,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct PlaneRunEvidence {
+    pub plane: &'static str,
+    pub model_load: ModelLoadEvidence,
+    pub execution_plan: ExecutionPlanEvidence,
+    pub routed_expert_gpu_failure_policy: String,
+    pub device: Option<GpuDeviceIdentity>,
+    pub initial_state: InitialStateEvidence,
+    pub generation: GenerationEvidence,
+    pub routed_execution_delta: RoutedExpertExecutionSnapshot,
+    pub gpu_io_delta: GpuExpertIoSnapshot,
+    pub attention_softmax_nonfinite_fallbacks: u64,
+    pub gpu_memory_before: Option<GpuExpertMemorySnapshot>,
+    pub gpu_memory_after: Option<GpuExpertMemorySnapshot>,
+    pub background_shutdown: BackgroundShutdownEvidence,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct FirstDivergenceEvidence {
+    pub position: usize,
+    pub cpu_token_id: Option<u32>,
+    pub hybrid_token_id: Option<u32>,
+    pub cpu_decoded_prefix: String,
+    pub hybrid_decoded_prefix: String,
+    pub cpu_prefix_truncated: bool,
+    pub hybrid_prefix_truncated: bool,
+    pub cpu_generated_length: usize,
+    pub hybrid_generated_length: usize,
+    pub cpu_termination_reason: TerminationReason,
+    pub hybrid_termination_reason: TerminationReason,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct CaseComparisonEvidence {
+    pub exact_token_ids: bool,
+    pub equal_generated_count: bool,
+    pub equal_termination_reason: bool,
+    pub equal_generated_text_hash: bool,
+    pub first_divergence: Option<FirstDivergenceEvidence>,
+}
+
+fn bounded_utf8_prefix(value: String) -> (String, bool) {
+    if value.len() <= MAX_DECODED_PREFIX_BYTES {
+        return (value, false);
+    }
+    let mut end = MAX_DECODED_PREFIX_BYTES;
+    while !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    (value[..end].to_string(), true)
+}
+
+pub fn compare_generations<F>(
+    cpu: &GenerationEvidence,
+    hybrid: &GenerationEvidence,
+    mut decode: F,
+) -> Result<CaseComparisonEvidence, String>
+where
+    F: FnMut(&[u32]) -> Result<String, String>,
+{
+    let equal_generated_count = cpu.generated_token_count == hybrid.generated_token_count;
+    let equal_termination_reason = cpu.termination_reason == hybrid.termination_reason;
+    let equal_generated_text_hash = cpu.generated_text_sha256 == hybrid.generated_text_sha256;
+    let exact_token_ids = cpu.generated_token_ids == hybrid.generated_token_ids;
+
+    let any_divergence = !exact_token_ids
+        || !equal_generated_count
+        || !equal_termination_reason
+        || !equal_generated_text_hash;
+    let first_divergence = if !any_divergence {
+        None
+    } else {
+        let common = cpu
+            .generated_token_ids
+            .len()
+            .min(hybrid.generated_token_ids.len());
+        let position = (0..common)
+            .find(|&index| cpu.generated_token_ids[index] != hybrid.generated_token_ids[index])
+            .unwrap_or(common);
+        let cpu_end = (position + 1).min(cpu.generated_token_ids.len());
+        let hybrid_end = (position + 1).min(hybrid.generated_token_ids.len());
+        let (cpu_decoded_prefix, cpu_prefix_truncated) =
+            bounded_utf8_prefix(decode(&cpu.generated_token_ids[..cpu_end])?);
+        let (hybrid_decoded_prefix, hybrid_prefix_truncated) =
+            bounded_utf8_prefix(decode(&hybrid.generated_token_ids[..hybrid_end])?);
+        Some(FirstDivergenceEvidence {
+            position,
+            cpu_token_id: cpu.generated_token_ids.get(position).copied(),
+            hybrid_token_id: hybrid.generated_token_ids.get(position).copied(),
+            cpu_decoded_prefix,
+            hybrid_decoded_prefix,
+            cpu_prefix_truncated,
+            hybrid_prefix_truncated,
+            cpu_generated_length: cpu.generated_token_ids.len(),
+            hybrid_generated_length: hybrid.generated_token_ids.len(),
+            cpu_termination_reason: cpu.termination_reason,
+            hybrid_termination_reason: hybrid.termination_reason,
+        })
+    };
+
+    Ok(CaseComparisonEvidence {
+        exact_token_ids,
+        equal_generated_count,
+        equal_termination_reason,
+        equal_generated_text_hash,
+        first_divergence,
+    })
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct CaseReport {
+    pub name: &'static str,
+    pub behavior: &'static str,
+    pub prompt: &'static str,
+    pub prompt_sha256: String,
+    pub prompt_token_ids: Vec<u32>,
+    pub prompt_token_ids_sha256: String,
+    pub tokenization_calls: u32,
+    pub output_token_limit: usize,
+    pub cpu: Option<PlaneRunEvidence>,
+    pub hybrid: Option<PlaneRunEvidence>,
+    pub comparison: Option<CaseComparisonEvidence>,
+    pub failure: Option<QualificationFailure>,
+}
+
+impl CaseReport {
+    pub fn new(case: FixedCorpusCase, prompt_token_ids: Vec<u32>) -> Self {
+        let prompt_token_ids_sha256 = token_ids_sha256(&prompt_token_ids);
+        Self {
+            name: case.name,
+            behavior: case.behavior,
+            prompt: case.prompt,
+            prompt_sha256: sha256_hex(case.prompt.as_bytes()),
+            prompt_token_ids,
+            prompt_token_ids_sha256,
+            tokenization_calls: 1,
+            output_token_limit: OUTPUT_TOKEN_LIMIT,
+            cpu: None,
+            hybrid: None,
+            comparison: None,
+            failure: None,
+        }
+    }
+}
+
+pub(crate) fn cpu_plan_exact(plan: &ExecutionPlanEvidence) -> bool {
+    plan.requested == "cpu"
+        && plan.resolved == "cpu"
+        && plan.embeddings == "cpu"
+        && plan.lm_head == "cpu"
+        && plan.dense_projections == "cpu"
+        && plan.attention == "cpu"
+        && plan.kv == "cpu"
+        && plan.router == "cpu"
+        && plan.routed_experts == "cpu"
+        && plan.routed_expert_dtype == "q4_0"
+        && !plan.fallback_occurred
+        && plan.reason.is_none()
+}
+
+pub(crate) fn hybrid_plan_exact(plan: &ExecutionPlanEvidence) -> bool {
+    plan.requested == "hybrid"
+        && plan.resolved == "hybrid-cpu-attention-gpu-experts"
+        && plan.embeddings == "cpu"
+        && plan.lm_head == "cpu"
+        && plan.dense_projections == "cpu"
+        && plan.attention == "cpu"
+        && plan.kv == "cpu"
+        && plan.router == "cpu"
+        && plan.routed_experts == "gpu"
+        && plan.routed_expert_dtype == "q4_0"
+        && !plan.fallback_occurred
+        && plan.reason.is_none()
+}
+
+fn cpu_counters_exact(routed: RoutedExpertExecutionSnapshot) -> bool {
+    routed.selected_routed_experts > 0
+        && routed.cpu_routed_expert_dispatches == routed.selected_routed_experts
+        && routed.gpu_dispatch_attempts == 0
+        && routed.gpu_dispatch_successes == 0
+        && routed.gpu_dispatch_failures == 0
+        && routed.gpu_cpu_fallbacks == 0
+        && routed.degraded_expert_substitutions == 0
+}
+
+fn hybrid_counters_exact(routed: RoutedExpertExecutionSnapshot) -> bool {
+    routed.selected_routed_experts > 0
+        && routed.gpu_dispatch_attempts == routed.selected_routed_experts
+        && routed.gpu_dispatch_successes == routed.gpu_dispatch_attempts
+        && routed.gpu_dispatch_failures == 0
+        && routed.cpu_routed_expert_dispatches == 0
+        && routed.gpu_cpu_fallbacks == 0
+        && routed.degraded_expert_substitutions == 0
+}
+
+fn gpu_io_observed(io: GpuExpertIoSnapshot) -> bool {
+    io.hidden_state_uploads > 0
+        && io.hidden_state_upload_bytes > 0
+        && io.queue_submissions > 0
+        && io.map_requests > 0
+        && io.readback_completions > 0
+        && io.readback_bytes > 0
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
+pub struct GreedyParityChecks {
+    pub clean_build: bool,
+    pub strict_real_checkpoint: bool,
+    pub qwen3_coder_model_identity: bool,
+    pub canonical_q4_0_layout: bool,
+    pub fixed_corpus_identity: bool,
+    pub fixed_greedy_sampling: bool,
+    pub resolved_config_identity: bool,
+    pub tokenized_once_and_shared: bool,
+    pub fresh_state_every_run: bool,
+    pub unique_execution_context_every_run: bool,
+    pub controlled_background_shutdown_every_run: bool,
+    pub cpu_plans_exact: bool,
+    pub cpu_counter_invariants: bool,
+    pub cpu_gpu_io_zero: bool,
+    pub hybrid_plans_exact: bool,
+    pub hardware_adapter_exact_match: bool,
+    pub software_adapter_false: bool,
+    pub strict_gpu_failure_policy: bool,
+    pub hybrid_counter_invariants: bool,
+    pub hybrid_gpu_io_observed: bool,
+    pub hybrid_memory_ledger_valid: bool,
+    pub zero_gpu_failures_fallbacks_or_degraded: bool,
+    pub exact_generated_token_ids: bool,
+    pub identical_generated_token_count: bool,
+    pub identical_termination_reason: bool,
+    pub identical_generated_text_hash: bool,
+}
+
+impl GreedyParityChecks {
+    fn passes(&self) -> bool {
+        self.clean_build
+            && self.strict_real_checkpoint
+            && self.qwen3_coder_model_identity
+            && self.canonical_q4_0_layout
+            && self.fixed_corpus_identity
+            && self.fixed_greedy_sampling
+            && self.resolved_config_identity
+            && self.tokenized_once_and_shared
+            && self.fresh_state_every_run
+            && self.unique_execution_context_every_run
+            && self.controlled_background_shutdown_every_run
+            && self.cpu_plans_exact
+            && self.cpu_counter_invariants
+            && self.cpu_gpu_io_zero
+            && self.hybrid_plans_exact
+            && self.hardware_adapter_exact_match
+            && self.software_adapter_false
+            && self.strict_gpu_failure_policy
+            && self.hybrid_counter_invariants
+            && self.hybrid_gpu_io_observed
+            && self.hybrid_memory_ledger_valid
+            && self.zero_gpu_failures_fallbacks_or_degraded
+            && self.exact_generated_token_ids
+            && self.identical_generated_token_count
+            && self.identical_termination_reason
+            && self.identical_generated_text_hash
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct GreedyParityReport {
+    pub schema_version: &'static str,
+    pub mode: &'static str,
+    pub status: QualificationStatus,
+    pub failure: Option<QualificationFailure>,
+    pub provenance: BuildProvenance,
+    pub artifacts: QualificationArtifacts,
+    pub expert_metadata: Option<ExpertMetadataEvidence>,
+    pub model_identity: Option<ModelIdentityEvidence>,
+    pub source_preflight: Option<StrictHybridPreflightEvidence>,
+    pub resolved_config_sha256: Option<String>,
+    pub corpus: CorpusEvidence,
+    pub sampling: GreedySamplingEvidence,
+    pub expected_adapter_name: String,
+    pub cases: Vec<CaseReport>,
+    pub checks: GreedyParityChecks,
+}
+
+impl GreedyParityReport {
+    pub fn new(
+        provenance: BuildProvenance,
+        artifacts: QualificationArtifacts,
+        expert_metadata: Option<ExpertMetadataEvidence>,
+        expected_adapter_name: String,
+    ) -> Self {
+        Self {
+            schema_version: SCHEMA_VERSION,
+            mode: MODE,
+            status: QualificationStatus::Fail,
+            failure: None,
+            provenance,
+            artifacts,
+            expert_metadata,
+            model_identity: None,
+            source_preflight: None,
+            resolved_config_sha256: None,
+            corpus: CorpusEvidence::fixed(),
+            sampling: GreedySamplingEvidence::fixed(),
+            expected_adapter_name,
+            cases: Vec::new(),
+            checks: GreedyParityChecks::default(),
+        }
+    }
+
+    pub fn fail(&mut self, failure: QualificationFailure) {
+        self.status = QualificationStatus::Fail;
+        self.failure = Some(failure);
+    }
+
+    fn derive_checks(&self) -> GreedyParityChecks {
+        let cases_complete = self.cases.len() == CORPUS_CASE_COUNT
+            && self.cases.iter().zip(FIXED_CORPUS).all(|(report, fixed)| {
+                report.name == fixed.name
+                    && report.behavior == fixed.behavior
+                    && report.prompt == fixed.prompt
+                    && report.prompt_sha256 == sha256_hex(fixed.prompt.as_bytes())
+                    && report.output_token_limit == OUTPUT_TOKEN_LIMIT
+                    && report.failure.is_none()
+                    && report.cpu.is_some()
+                    && report.hybrid.is_some()
+                    && report.comparison.is_some()
+            });
+        let runs = self.cases.iter().filter_map(|case| {
+            Some((
+                case,
+                case.cpu.as_ref()?,
+                case.hybrid.as_ref()?,
+                case.comparison.as_ref()?,
+            ))
+        });
+        let collected: Vec<_> = runs.collect();
+        let exact_run_count = cases_complete && collected.len() == CORPUS_CASE_COUNT;
+        let config_hash = self.resolved_config_sha256.as_deref();
+
+        let strict_real_checkpoint = exact_run_count
+            && self
+                .source_preflight
+                .as_ref()
+                .is_some_and(StrictHybridPreflightEvidence::is_exact)
+            && collected.iter().all(|(_, cpu, hybrid, _)| {
+                cpu.model_load.is_strict_complete() && hybrid.model_load.is_strict_complete()
+            });
+        let resolved_config_identity = exact_run_count
+            && config_hash.is_some_and(is_sha256_hex)
+            && collected.iter().all(|(_, cpu, hybrid, _)| {
+                Some(cpu.initial_state.resolved_config_sha256.as_str()) == config_hash
+                    && Some(hybrid.initial_state.resolved_config_sha256.as_str()) == config_hash
+            });
+        let tokenized_once_and_shared = exact_run_count
+            && collected.iter().all(|(case, cpu, hybrid, _)| {
+                !case.prompt_token_ids.is_empty()
+                    && case.tokenization_calls == 1
+                    && case.prompt_token_ids_sha256 == token_ids_sha256(&case.prompt_token_ids)
+                    && cpu.generation.prompt_token_ids_sha256 == case.prompt_token_ids_sha256
+                    && hybrid.generation.prompt_token_ids_sha256 == case.prompt_token_ids_sha256
+                    && cpu.generation.generated_token_count == OUTPUT_TOKEN_LIMIT
+                    && hybrid.generation.generated_token_count == OUTPUT_TOKEN_LIMIT
+                    && cpu.generation.generated_token_count
+                        == cpu.generation.generated_token_ids.len()
+                    && hybrid.generation.generated_token_count
+                        == hybrid.generation.generated_token_ids.len()
+                    && cpu.generation.generated_token_ids_sha256
+                        == token_ids_sha256(&cpu.generation.generated_token_ids)
+                    && hybrid.generation.generated_token_ids_sha256
+                        == token_ids_sha256(&hybrid.generation.generated_token_ids)
+                    && is_sha256_hex(&cpu.generation.generated_text_sha256)
+                    && is_sha256_hex(&hybrid.generation.generated_text_sha256)
+                    && cpu.generation.termination_reason == TerminationReason::LengthLimit
+                    && hybrid.generation.termination_reason == TerminationReason::LengthLimit
+            });
+        let fresh_state_every_run = exact_run_count
+            && collected.iter().all(|(_, cpu, hybrid, _)| {
+                cpu.initial_state.is_clean()
+                    && hybrid.initial_state.is_clean()
+                    && cpu.initial_state.context_id == cpu.execution_plan.context_id
+                    && hybrid.initial_state.context_id == hybrid.execution_plan.context_id
+            });
+        let context_ids: HashSet<&str> = collected
+            .iter()
+            .flat_map(|(_, cpu, hybrid, _)| {
+                [
+                    cpu.execution_plan.context_id.as_str(),
+                    hybrid.execution_plan.context_id.as_str(),
+                ]
+            })
+            .collect();
+        let unique_execution_context_every_run =
+            exact_run_count && context_ids.len() == CORPUS_CASE_COUNT * 2;
+        let controlled_background_shutdown_every_run = exact_run_count
+            && collected.iter().all(|(_, cpu, hybrid, _)| {
+                cpu.background_shutdown.controlled_shutdown_requested
+                    && cpu.background_shutdown.all_runtime_resources_released
+                    && hybrid.background_shutdown.controlled_shutdown_requested
+                    && hybrid.background_shutdown.all_runtime_resources_released
+            });
+        let cpu_plans_exact = exact_run_count
+            && collected
+                .iter()
+                .all(|(_, cpu, _, _)| cpu.plane == "cpu" && cpu_plan_exact(&cpu.execution_plan));
+        let cpu_counter_invariants = exact_run_count
+            && collected
+                .iter()
+                .all(|(_, cpu, _, _)| cpu_counters_exact(cpu.routed_execution_delta));
+        let cpu_gpu_io_zero = exact_run_count
+            && collected.iter().all(|(_, cpu, _, _)| {
+                cpu.device.is_none()
+                    && !cpu.initial_state.gpu_io_available
+                    && cpu.initial_state.gpu_io == GpuExpertIoSnapshot::default()
+                    && cpu.gpu_io_delta == GpuExpertIoSnapshot::default()
+                    && cpu.gpu_memory_before.is_none()
+                    && cpu.gpu_memory_after.is_none()
+            });
+        let hybrid_plans_exact = exact_run_count
+            && collected.iter().all(|(_, _, hybrid, _)| {
+                hybrid.plane == "hybrid" && hybrid_plan_exact(&hybrid.execution_plan)
+            });
+        let hardware_adapter_exact_match = exact_run_count
+            && !self.expected_adapter_name.is_empty()
+            && collected.iter().all(|(_, _, hybrid, _)| {
+                hybrid.device.as_ref().is_some_and(|device| {
+                    device.name == self.expected_adapter_name
+                        && !device.device_type.eq_ignore_ascii_case("cpu")
+                })
+            });
+        let software_adapter_false = exact_run_count
+            && collected.iter().all(|(_, _, hybrid, _)| {
+                hybrid
+                    .device
+                    .as_ref()
+                    .is_some_and(|device| !device.software_adapter)
+            });
+        let hybrid_counter_invariants = exact_run_count
+            && collected
+                .iter()
+                .all(|(_, _, hybrid, _)| hybrid_counters_exact(hybrid.routed_execution_delta));
+        let hybrid_gpu_io_observed = exact_run_count
+            && collected.iter().all(|(_, _, hybrid, _)| {
+                hybrid.initial_state.gpu_io_available && gpu_io_observed(hybrid.gpu_io_delta)
+            });
+        let hybrid_memory_ledger_valid = exact_run_count
+            && collected.iter().all(|(_, _, hybrid, _)| {
+                hybrid
+                    .gpu_memory_before
+                    .is_some_and(|snapshot| crate::qualification::validate_memory(snapshot).is_ok())
+                    && hybrid.gpu_memory_after.is_some_and(|snapshot| {
+                        crate::qualification::validate_memory(snapshot).is_ok()
+                    })
+            });
+        let zero_gpu_failures_fallbacks_or_degraded = exact_run_count
+            && collected.iter().all(|(_, cpu, hybrid, _)| {
+                cpu.routed_execution_delta.gpu_dispatch_failures == 0
+                    && cpu.routed_execution_delta.gpu_cpu_fallbacks == 0
+                    && cpu.routed_execution_delta.degraded_expert_substitutions == 0
+                    && cpu.attention_softmax_nonfinite_fallbacks == 0
+                    && hybrid.routed_execution_delta.gpu_dispatch_failures == 0
+                    && hybrid.routed_execution_delta.cpu_routed_expert_dispatches == 0
+                    && hybrid.routed_execution_delta.gpu_cpu_fallbacks == 0
+                    && hybrid.routed_execution_delta.degraded_expert_substitutions == 0
+                    && hybrid.attention_softmax_nonfinite_fallbacks == 0
+            });
+
+        GreedyParityChecks {
+            clean_build: self.provenance.git_sha.as_deref().is_some_and(|sha| {
+                sha.len() == 40 && sha.bytes().all(|byte| byte.is_ascii_hexdigit())
+            }) && self.provenance.dirty == Some(false),
+            strict_real_checkpoint,
+            qwen3_coder_model_identity: self
+                .model_identity
+                .as_ref()
+                .is_some_and(ModelIdentityEvidence::is_qwen3_coder_30b_a3b_q4_0),
+            canonical_q4_0_layout: self.expert_metadata.as_ref().is_some_and(|metadata| {
+                !metadata.explicitly_synthetic
+                    && metadata.q4_0_layout.as_deref()
+                        == Some(crate::inference::Q4_0_LAYOUT_STANDARD_V1)
+            }),
+            fixed_corpus_identity: self.corpus.is_exact() && cases_complete,
+            fixed_greedy_sampling: self.sampling.is_exact(),
+            resolved_config_identity,
+            tokenized_once_and_shared,
+            fresh_state_every_run,
+            unique_execution_context_every_run,
+            controlled_background_shutdown_every_run,
+            cpu_plans_exact,
+            cpu_counter_invariants,
+            cpu_gpu_io_zero,
+            hybrid_plans_exact,
+            hardware_adapter_exact_match,
+            software_adapter_false,
+            strict_gpu_failure_policy: exact_run_count
+                && collected.iter().all(|(_, _, hybrid, _)| {
+                    hybrid.routed_expert_gpu_failure_policy == "strict-fail-closed"
+                }),
+            hybrid_counter_invariants,
+            hybrid_gpu_io_observed,
+            hybrid_memory_ledger_valid,
+            zero_gpu_failures_fallbacks_or_degraded,
+            exact_generated_token_ids: exact_run_count
+                && collected.iter().all(|(_, cpu, hybrid, comparison)| {
+                    comparison.exact_token_ids
+                        && comparison.first_divergence.is_none()
+                        && cpu.generation.generated_token_ids
+                            == hybrid.generation.generated_token_ids
+                }),
+            identical_generated_token_count: exact_run_count
+                && collected.iter().all(|(_, cpu, hybrid, comparison)| {
+                    comparison.equal_generated_count
+                        && cpu.generation.generated_token_count
+                            == hybrid.generation.generated_token_count
+                }),
+            identical_termination_reason: exact_run_count
+                && collected.iter().all(|(_, cpu, hybrid, comparison)| {
+                    comparison.equal_termination_reason
+                        && cpu.generation.termination_reason == hybrid.generation.termination_reason
+                }),
+            identical_generated_text_hash: exact_run_count
+                && collected.iter().all(|(_, cpu, hybrid, comparison)| {
+                    comparison.equal_generated_text_hash
+                        && cpu.generation.generated_text_sha256
+                            == hybrid.generation.generated_text_sha256
+                }),
+        }
+    }
+
+    pub fn finish(&mut self) -> Result<(), QualificationFailure> {
+        self.checks = self.derive_checks();
+        if self.artifacts.config.is_none()
+            || self.artifacts.tokenizer.is_none()
+            || self.artifacts.expert_metadata.is_none()
+            || self.artifacts.weights_config.is_none()
+            || self.model_identity.is_none()
+            || self.source_preflight.is_none()
+            || self.resolved_config_sha256.is_none()
+        {
+            return Err(QualificationFailure::new(
+                crate::qualification::FailureStage::Postcondition,
+                "greedy-parity-evidence-incomplete",
+                "one or more mandatory fixed-corpus parity evidence sections are absent",
+            ));
+        }
+        if !self.checks.passes() {
+            return Err(QualificationFailure::new(
+                crate::qualification::FailureStage::Postcondition,
+                "greedy-parity-check-failed",
+                "one or more required fixed-corpus greedy parity checks are false",
+            ));
+        }
+        self.status = QualificationStatus::Pass;
+        self.failure = None;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn artifact() -> crate::qualification::ArtifactDigest {
+        crate::qualification::ArtifactDigest {
+            configured_path: "artifact".to_string(),
+            canonical_path: "/artifact".to_string(),
+            byte_length: 1,
+            sha256: "00".repeat(32),
+        }
+    }
+
+    fn model_load() -> ModelLoadEvidence {
+        ModelLoadEvidence {
+            strict: true,
+            loader: "safetensors".to_string(),
+            loaded_tensors: 10,
+            required_tensors: 10,
+            optional_probed: 0,
+            optional_loaded: 0,
+            seeded_fallback_remained: false,
+        }
+    }
+
+    fn plan(context_id: String, hybrid: bool) -> ExecutionPlanEvidence {
+        ExecutionPlanEvidence {
+            context_id,
+            requested: if hybrid { "hybrid" } else { "cpu" }.to_string(),
+            resolved: if hybrid {
+                "hybrid-cpu-attention-gpu-experts"
+            } else {
+                "cpu"
+            }
+            .to_string(),
+            embeddings: "cpu".to_string(),
+            lm_head: "cpu".to_string(),
+            dense_projections: "cpu".to_string(),
+            attention: "cpu".to_string(),
+            kv: "cpu".to_string(),
+            router: "cpu".to_string(),
+            routed_experts: if hybrid { "gpu" } else { "cpu" }.to_string(),
+            routed_expert_dtype: "q4_0".to_string(),
+            fallback_occurred: false,
+            reason: None,
+        }
+    }
+
+    fn initial_state(context_id: String, hybrid: bool) -> InitialStateEvidence {
+        InitialStateEvidence {
+            context_id,
+            resolved_config_sha256: "11".repeat(32),
+            kv_cache_count: 48,
+            kv_sequence_lengths: vec![0; 48],
+            all_kv_empty: true,
+            cache: RuntimeCacheSnapshot::default(),
+            routed: RoutedExpertExecutionSnapshot::default(),
+            gpu_io_available: hybrid,
+            gpu_io: GpuExpertIoSnapshot::default(),
+        }
+    }
+
+    fn plane_evidence(case_index: usize, hybrid: bool, ids: &[u32]) -> PlaneRunEvidence {
+        let context_id = format!("{}-{case_index}", if hybrid { "hybrid" } else { "cpu" });
+        PlaneRunEvidence {
+            plane: if hybrid { "hybrid" } else { "cpu" },
+            model_load: model_load(),
+            execution_plan: plan(context_id.clone(), hybrid),
+            routed_expert_gpu_failure_policy: if hybrid {
+                "strict-fail-closed"
+            } else {
+                "serving-cpu-fallback"
+            }
+            .to_string(),
+            device: hybrid.then(|| GpuDeviceIdentity {
+                name: "NVIDIA L4".to_string(),
+                vendor_id: 0x10de,
+                device_id: 1,
+                device_type: "DiscreteGpu".to_string(),
+                wgpu_backend: "vulkan".to_string(),
+                driver: "driver".to_string(),
+                driver_info: "info".to_string(),
+                compute_plane: "wgpu-vulkan".to_string(),
+                software_adapter: false,
+            }),
+            initial_state: initial_state(context_id, hybrid),
+            generation: generation(ids, "same"),
+            routed_execution_delta: if hybrid {
+                RoutedExpertExecutionSnapshot {
+                    selected_routed_experts: 8,
+                    gpu_dispatch_attempts: 8,
+                    gpu_dispatch_successes: 8,
+                    ..Default::default()
+                }
+            } else {
+                RoutedExpertExecutionSnapshot {
+                    selected_routed_experts: 8,
+                    cpu_routed_expert_dispatches: 8,
+                    ..Default::default()
+                }
+            },
+            gpu_io_delta: if hybrid {
+                GpuExpertIoSnapshot {
+                    hidden_state_uploads: 1,
+                    hidden_state_upload_bytes: 4,
+                    queue_submissions: 1,
+                    map_requests: 1,
+                    readback_completions: 1,
+                    readback_bytes: 4,
+                    ..Default::default()
+                }
+            } else {
+                GpuExpertIoSnapshot::default()
+            },
+            attention_softmax_nonfinite_fallbacks: 0,
+            gpu_memory_before: hybrid.then(GpuExpertMemorySnapshot::default),
+            gpu_memory_after: hybrid.then(GpuExpertMemorySnapshot::default),
+            background_shutdown: BackgroundShutdownEvidence {
+                controlled_shutdown_requested: true,
+                all_runtime_resources_released: true,
+                poll_iterations: 1,
+            },
+        }
+    }
+
+    fn passing_report() -> GreedyParityReport {
+        let artifact = artifact();
+        let mut report = GreedyParityReport::new(
+            BuildProvenance {
+                git_sha: Some("0123456789abcdef0123456789abcdef01234567".to_string()),
+                dirty: Some(false),
+                package_version: "test".to_string(),
+            },
+            QualificationArtifacts {
+                config: Some(artifact.clone()),
+                tokenizer: Some(artifact.clone()),
+                expert_metadata: Some(artifact.clone()),
+                weights_config: Some(artifact),
+                expert_data_directory: "/data".to_string(),
+                ..Default::default()
+            },
+            Some(ExpertMetadataEvidence {
+                dtype: Some("q4_0".to_string()),
+                q4_0_layout: Some(crate::inference::Q4_0_LAYOUT_STANDARD_V1.to_string()),
+                conversion_mode: Some("full".to_string()),
+                source: Some("Qwen3-Coder-30B-A3B".to_string()),
+                explicitly_synthetic: false,
+            }),
+            "NVIDIA L4".to_string(),
+        );
+        report.model_identity = Some(ModelIdentityEvidence {
+            architecture: "qwen3_moe".to_string(),
+            num_layers: 48,
+            num_experts_per_layer: 128,
+            total_experts: 6_144,
+            top_k: 8,
+            d_model: 2_048,
+            d_ff: 768,
+            routed_expert_dtype: "q4_0".to_string(),
+        });
+        report.source_preflight = Some(StrictHybridPreflightEvidence {
+            real_transformer_enabled: true,
+            weights_dir_configured: true,
+            strict_weights: true,
+            allow_seeded_fallback: false,
+            allow_degraded_experts: false,
+            allow_attention_fallback: false,
+            allow_truncated_expert_payloads: false,
+            distributed_enabled: false,
+            gpu_cache_enabled: true,
+            gpu_expert_capacity_bytes: 1,
+            requested_mode: "hybrid".to_string(),
+            routed_expert_dtype: "q4_0".to_string(),
+        });
+        report.resolved_config_sha256 = Some("11".repeat(32));
+        for (index, fixed) in FIXED_CORPUS.into_iter().enumerate() {
+            let prompt_ids = vec![10 + index as u32, 20 + index as u32];
+            let ids: Vec<u32> = (0..OUTPUT_TOKEN_LIMIT)
+                .map(|offset| 100 + index as u32 + offset as u32)
+                .collect();
+            let mut case = CaseReport::new(fixed, prompt_ids);
+            let prompt_hash = case.prompt_token_ids_sha256.clone();
+            let mut cpu = plane_evidence(index, false, &ids);
+            let mut hybrid = plane_evidence(index, true, &ids);
+            cpu.generation.prompt_token_ids_sha256 = prompt_hash.clone();
+            hybrid.generation.prompt_token_ids_sha256 = prompt_hash;
+            case.comparison = Some(
+                compare_generations(&cpu.generation, &hybrid.generation, |_| {
+                    Ok("same".to_string())
+                })
+                .unwrap(),
+            );
+            case.cpu = Some(cpu);
+            case.hybrid = Some(hybrid);
+            report.cases.push(case);
+        }
+        report
+    }
+
+    fn generation(ids: &[u32], text: &str) -> GenerationEvidence {
+        GenerationEvidence {
+            prompt_token_ids_sha256: token_ids_sha256(&[7, 8]),
+            generated_token_ids: ids.to_vec(),
+            generated_token_ids_sha256: token_ids_sha256(ids),
+            generated_text_sha256: sha256_hex(text.as_bytes()),
+            generated_token_count: ids.len(),
+            termination_reason: TerminationReason::LengthLimit,
+        }
+    }
+
+    #[test]
+    fn greedy_parity_fixed_corpus_contract_is_versioned_and_nontrivial() {
+        assert_eq!(FIXED_CORPUS.len(), 4);
+        assert_eq!(OUTPUT_TOKEN_LIMIT, 16);
+        assert_eq!(FIXED_CORPUS[0].name, "rust-generation");
+        assert_eq!(FIXED_CORPUS[1].name, "rust-debugging");
+        assert_eq!(FIXED_CORPUS[2].name, "json-transformation");
+        assert_eq!(FIXED_CORPUS[3].name, "multilingual-spanish");
+        assert!(FIXED_CORPUS.iter().all(|case| !case.prompt.is_empty()));
+        assert!(FIXED_CORPUS[3].prompt.contains('¿'));
+        assert_eq!(corpus_sha256().len(), 64);
+        assert!(CorpusEvidence::fixed().is_exact());
+    }
+
+    #[test]
+    fn greedy_parity_sampling_contract_is_exact() {
+        assert!(GreedySamplingEvidence::fixed().is_exact());
+        let mut drift = GreedySamplingEvidence::fixed();
+        drift.seed = 1;
+        assert!(!drift.is_exact());
+        drift = GreedySamplingEvidence::fixed();
+        drift.temperature = f32::NAN;
+        assert!(!drift.is_exact());
+    }
+
+    #[test]
+    fn greedy_parity_exact_match_has_no_divergence() {
+        let cpu = generation(&[1, 2, 3], "same");
+        let hybrid = generation(&[1, 2, 3], "same");
+        let result = compare_generations(&cpu, &hybrid, |ids| Ok(format!("{ids:?}"))).unwrap();
+        assert!(result.exact_token_ids);
+        assert!(result.equal_generated_count);
+        assert!(result.equal_termination_reason);
+        assert!(result.equal_generated_text_hash);
+        assert_eq!(result.first_divergence, None);
+    }
+
+    #[test]
+    fn greedy_parity_first_middle_and_final_token_divergences_are_exact() {
+        for (position, hybrid_ids) in [(0, vec![9, 2, 3]), (1, vec![1, 9, 3]), (2, vec![1, 2, 9])] {
+            let cpu = generation(&[1, 2, 3], "cpu");
+            let hybrid = generation(&hybrid_ids, "hybrid");
+            let result = compare_generations(&cpu, &hybrid, |ids| Ok(format!("{ids:?}"))).unwrap();
+            let divergence = result.first_divergence.unwrap();
+            assert_eq!(divergence.position, position);
+            assert_eq!(
+                divergence.cpu_token_id,
+                Some(cpu.generated_token_ids[position])
+            );
+            assert_eq!(divergence.hybrid_token_id, Some(hybrid_ids[position]));
+        }
+    }
+
+    #[test]
+    fn greedy_parity_length_divergence_preserves_nullable_token_id() {
+        let cpu = generation(&[1, 2], "cpu");
+        let hybrid = generation(&[1, 2, 3], "hybrid");
+        let result = compare_generations(&cpu, &hybrid, |ids| Ok(format!("{ids:?}"))).unwrap();
+        let divergence = result.first_divergence.unwrap();
+        assert_eq!(divergence.position, 2);
+        assert_eq!(divergence.cpu_token_id, None);
+        assert_eq!(divergence.hybrid_token_id, Some(3));
+        assert!(!result.equal_generated_count);
+    }
+
+    #[test]
+    fn greedy_parity_count_stop_and_text_hash_divergences_are_independent() {
+        let cpu = generation(&[1, 2], "cpu");
+
+        let mut count = cpu.clone();
+        count.generated_token_count = 3;
+        let result = compare_generations(&cpu, &count, |_| Ok("same-prefix".to_string())).unwrap();
+        assert!(result.exact_token_ids);
+        assert!(!result.equal_generated_count);
+        assert!(result.equal_termination_reason);
+        assert!(result.equal_generated_text_hash);
+        assert!(result.first_divergence.is_some());
+
+        let mut stop = cpu.clone();
+        stop.termination_reason = TerminationReason::EndOfSequence;
+        let result = compare_generations(&cpu, &stop, |_| Ok("same-prefix".to_string())).unwrap();
+        assert!(result.exact_token_ids);
+        assert!(result.equal_generated_count);
+        assert!(!result.equal_termination_reason);
+        assert!(result.equal_generated_text_hash);
+        assert!(result.first_divergence.is_some());
+
+        let mut text_hash = cpu.clone();
+        text_hash.generated_text_sha256 = sha256_hex(b"hybrid");
+        let result =
+            compare_generations(&cpu, &text_hash, |_| Ok("same-prefix".to_string())).unwrap();
+        assert!(result.exact_token_ids);
+        assert!(result.equal_generated_count);
+        assert!(result.equal_termination_reason);
+        assert!(!result.equal_generated_text_hash);
+        assert!(result.first_divergence.is_some());
+    }
+
+    #[test]
+    fn greedy_parity_decoded_failure_prefixes_are_utf8_bounded() {
+        let cpu = generation(&[1], "cpu");
+        let hybrid = generation(&[2], "hybrid");
+        let value = "é".repeat(400);
+        let result = compare_generations(&cpu, &hybrid, |_| Ok(value.clone())).unwrap();
+        let divergence = result.first_divergence.unwrap();
+        assert!(divergence.cpu_prefix_truncated);
+        assert!(divergence.hybrid_prefix_truncated);
+        assert!(divergence.cpu_decoded_prefix.len() <= MAX_DECODED_PREFIX_BYTES);
+        assert!(divergence
+            .cpu_decoded_prefix
+            .is_char_boundary(divergence.cpu_decoded_prefix.len()));
+    }
+
+    #[test]
+    fn greedy_parity_cpu_and_hybrid_counter_contracts_reject_false_confidence() {
+        let cpu = RoutedExpertExecutionSnapshot {
+            selected_routed_experts: 8,
+            cpu_routed_expert_dispatches: 8,
+            ..Default::default()
+        };
+        assert!(cpu_counters_exact(cpu));
+        assert!(!cpu_counters_exact(RoutedExpertExecutionSnapshot {
+            gpu_dispatch_attempts: 1,
+            ..cpu
+        }));
+
+        let hybrid = RoutedExpertExecutionSnapshot {
+            selected_routed_experts: 8,
+            gpu_dispatch_attempts: 8,
+            gpu_dispatch_successes: 8,
+            ..Default::default()
+        };
+        assert!(hybrid_counters_exact(hybrid));
+        assert!(!hybrid_counters_exact(RoutedExpertExecutionSnapshot {
+            gpu_dispatch_failures: 1,
+            ..hybrid
+        }));
+        assert!(!hybrid_counters_exact(RoutedExpertExecutionSnapshot {
+            cpu_routed_expert_dispatches: 1,
+            ..hybrid
+        }));
+    }
+
+    #[test]
+    fn greedy_parity_gpu_io_requires_every_observed_operation() {
+        let complete = GpuExpertIoSnapshot {
+            hidden_state_uploads: 1,
+            hidden_state_upload_bytes: 4,
+            queue_submissions: 1,
+            map_requests: 1,
+            readback_completions: 1,
+            readback_bytes: 4,
+            ..Default::default()
+        };
+        assert!(gpu_io_observed(complete));
+        for missing in 0..6 {
+            let mut candidate = complete;
+            match missing {
+                0 => candidate.hidden_state_uploads = 0,
+                1 => candidate.hidden_state_upload_bytes = 0,
+                2 => candidate.queue_submissions = 0,
+                3 => candidate.map_requests = 0,
+                4 => candidate.readback_completions = 0,
+                _ => candidate.readback_bytes = 0,
+            }
+            assert!(!gpu_io_observed(candidate));
+        }
+    }
+
+    #[test]
+    fn greedy_parity_cpu_and_hybrid_plan_validators_are_plane_exact() {
+        let cpu = ExecutionPlanEvidence {
+            context_id: "ctx-cpu".to_string(),
+            requested: "cpu".to_string(),
+            resolved: "cpu".to_string(),
+            embeddings: "cpu".to_string(),
+            lm_head: "cpu".to_string(),
+            dense_projections: "cpu".to_string(),
+            attention: "cpu".to_string(),
+            kv: "cpu".to_string(),
+            router: "cpu".to_string(),
+            routed_experts: "cpu".to_string(),
+            routed_expert_dtype: "q4_0".to_string(),
+            fallback_occurred: false,
+            reason: None,
+        };
+        assert!(cpu_plan_exact(&cpu));
+        let mut hybrid = cpu.clone();
+        hybrid.context_id = "ctx-hybrid".to_string();
+        hybrid.requested = "hybrid".to_string();
+        hybrid.resolved = "hybrid-cpu-attention-gpu-experts".to_string();
+        hybrid.routed_experts = "gpu".to_string();
+        assert!(hybrid_plan_exact(&hybrid));
+        hybrid.attention = "gpu".to_string();
+        assert!(!hybrid_plan_exact(&hybrid));
+    }
+
+    #[test]
+    fn greedy_parity_clean_initial_state_rejects_any_residue() {
+        let clean = InitialStateEvidence {
+            context_id: "ctx".to_string(),
+            resolved_config_sha256: "hash".to_string(),
+            kv_cache_count: 2,
+            kv_sequence_lengths: vec![0, 0],
+            all_kv_empty: true,
+            cache: RuntimeCacheSnapshot::default(),
+            routed: RoutedExpertExecutionSnapshot::default(),
+            gpu_io_available: false,
+            gpu_io: GpuExpertIoSnapshot::default(),
+        };
+        assert!(clean.is_clean());
+        let mut dirty = clean.clone();
+        dirty.cache.logical_lru_entries = 1;
+        assert!(!dirty.is_clean());
+        let mut dirty = clean.clone();
+        dirty.kv_sequence_lengths[0] = 1;
+        assert!(!dirty.is_clean());
+    }
+
+    #[test]
+    fn greedy_parity_missing_evidence_and_nullable_provenance_never_pass() {
+        let mut report = GreedyParityReport::new(
+            BuildProvenance {
+                git_sha: Some("a".repeat(40)),
+                dirty: None,
+                package_version: "0.1.0".to_string(),
+            },
+            QualificationArtifacts::default(),
+            None,
+            "NVIDIA L4".to_string(),
+        );
+        let failure = report.finish().unwrap_err();
+        assert_eq!(failure.code, "greedy-parity-evidence-incomplete");
+        assert_eq!(report.status, QualificationStatus::Fail);
+        assert!(!report.checks.clean_build);
+        assert!(!report.checks.hardware_adapter_exact_match);
+        assert!(!report.checks.software_adapter_false);
+    }
+
+    #[test]
+    fn greedy_parity_failure_state_is_explicit_and_serializable() {
+        let mut report = GreedyParityReport::new(
+            BuildProvenance {
+                git_sha: Some("a".repeat(40)),
+                dirty: Some(false),
+                package_version: "0.1.0".to_string(),
+            },
+            QualificationArtifacts::default(),
+            None,
+            "NVIDIA L4".to_string(),
+        );
+        let failure = QualificationFailure::new(
+            crate::qualification::FailureStage::Inference,
+            "token-divergence",
+            "case rust-generation diverged at position 0",
+        );
+        report.fail(failure.clone());
+        let json = serde_json::to_value(&report).unwrap();
+        assert_eq!(json["status"], "fail");
+        assert_eq!(json["failure"]["code"], "token-divergence");
+        assert_eq!(report.failure, Some(failure));
+    }
+
+    #[test]
+    fn greedy_parity_complete_observed_contract_passes() {
+        let mut report = passing_report();
+        report.finish().unwrap();
+        assert_eq!(report.status, QualificationStatus::Pass);
+        assert!(report.checks.passes());
+        let json = serde_json::to_value(&report).unwrap();
+        assert_eq!(
+            json["cases"][0]["hybrid"]["device"]["software_adapter"],
+            false
+        );
+    }
+
+    #[test]
+    fn greedy_parity_cannot_pass_with_configuration_or_context_drift() {
+        let mut preflight_drift = passing_report();
+        preflight_drift
+            .source_preflight
+            .as_mut()
+            .unwrap()
+            .allow_degraded_experts = true;
+        assert!(preflight_drift.finish().is_err());
+        assert!(!preflight_drift.checks.strict_real_checkpoint);
+
+        let mut config_drift = passing_report();
+        config_drift.cases[2]
+            .hybrid
+            .as_mut()
+            .unwrap()
+            .initial_state
+            .resolved_config_sha256 = "drift".to_string();
+        assert!(config_drift.finish().is_err());
+        assert!(!config_drift.checks.resolved_config_identity);
+
+        let mut context_reuse = passing_report();
+        let reused = context_reuse.cases[0]
+            .cpu
+            .as_ref()
+            .unwrap()
+            .execution_plan
+            .context_id
+            .clone();
+        context_reuse.cases[1]
+            .cpu
+            .as_mut()
+            .unwrap()
+            .execution_plan
+            .context_id = reused.clone();
+        context_reuse.cases[1]
+            .cpu
+            .as_mut()
+            .unwrap()
+            .initial_state
+            .context_id = reused;
+        assert!(context_reuse.finish().is_err());
+        assert!(!context_reuse.checks.unique_execution_context_every_run);
+    }
+
+    #[test]
+    fn greedy_parity_cannot_pass_with_dirty_state_or_background_leak() {
+        let mut dirty = passing_report();
+        dirty.cases[0]
+            .cpu
+            .as_mut()
+            .unwrap()
+            .initial_state
+            .cache
+            .ram_entries = 1;
+        assert!(dirty.finish().is_err());
+        assert!(!dirty.checks.fresh_state_every_run);
+
+        let mut leaked = passing_report();
+        leaked.cases[3]
+            .hybrid
+            .as_mut()
+            .unwrap()
+            .background_shutdown
+            .all_runtime_resources_released = false;
+        assert!(leaked.finish().is_err());
+        assert!(!leaked.checks.controlled_background_shutdown_every_run);
+    }
+
+    #[test]
+    fn greedy_parity_cannot_pass_with_counter_or_gpu_io_gaps() {
+        let mut cpu = passing_report();
+        cpu.cases[0]
+            .cpu
+            .as_mut()
+            .unwrap()
+            .routed_execution_delta
+            .cpu_routed_expert_dispatches = 7;
+        assert!(cpu.finish().is_err());
+        assert!(!cpu.checks.cpu_counter_invariants);
+
+        let mut hybrid = passing_report();
+        hybrid.cases[1]
+            .hybrid
+            .as_mut()
+            .unwrap()
+            .gpu_io_delta
+            .map_requests = 0;
+        assert!(hybrid.finish().is_err());
+        assert!(!hybrid.checks.hybrid_gpu_io_observed);
+
+        let mut attention = passing_report();
+        attention.cases[1]
+            .cpu
+            .as_mut()
+            .unwrap()
+            .attention_softmax_nonfinite_fallbacks = 1;
+        assert!(attention.finish().is_err());
+        assert!(!attention.checks.zero_gpu_failures_fallbacks_or_degraded);
+
+        let mut invalid_memory = passing_report();
+        invalid_memory.cases[2]
+            .hybrid
+            .as_mut()
+            .unwrap()
+            .gpu_memory_after
+            .as_mut()
+            .unwrap()
+            .total_tracked_bytes = 1;
+        assert!(invalid_memory.finish().is_err());
+        assert!(!invalid_memory.checks.hybrid_memory_ledger_valid);
+    }
+
+    #[test]
+    fn greedy_parity_cannot_pass_with_nullable_or_software_device_evidence() {
+        let mut missing = passing_report();
+        missing.cases[0].hybrid.as_mut().unwrap().device = None;
+        assert!(missing.finish().is_err());
+        assert!(!missing.checks.software_adapter_false);
+
+        let mut software = passing_report();
+        software.cases[0]
+            .hybrid
+            .as_mut()
+            .unwrap()
+            .device
+            .as_mut()
+            .unwrap()
+            .software_adapter = true;
+        assert!(software.finish().is_err());
+        assert!(!software.checks.software_adapter_false);
+    }
+
+    #[test]
+    fn greedy_parity_rederives_token_checks_instead_of_trusting_flags() {
+        let mut report = passing_report();
+        let hybrid = report.cases[0].hybrid.as_mut().unwrap();
+        hybrid.generation.generated_token_ids[4] ^= 1;
+        // Leave the stored comparison flags untouched to simulate copied or
+        // stale intended evidence. PASS must still be impossible.
+        assert!(report.finish().is_err());
+        assert!(!report.checks.exact_generated_token_ids);
+
+        let mut bad_hash = passing_report();
+        bad_hash.cases[0]
+            .cpu
+            .as_mut()
+            .unwrap()
+            .generation
+            .generated_token_ids_sha256 = "copied".to_string();
+        assert!(bad_hash.finish().is_err());
+        assert!(!bad_hash.checks.tokenized_once_and_shared);
+    }
+}

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -3722,6 +3722,7 @@ async fn execute_greedy_parity_plane(
         watchdog,
         case_name,
         None,
+        None,
     )
     .await
 }
@@ -3738,6 +3739,7 @@ async fn execute_greedy_parity_plane_with_logits(
     watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
     case_name: &str,
     first_token_logit_bits: &mut Vec<u32>,
+    route_capture: &mut Option<crate::engine::RoutedFfnDiagnosticCapture>,
 ) -> Result<crate::greedy_parity::PlaneRunEvidence, Box<dyn std::error::Error>> {
     execute_greedy_parity_plane_internal(
         spec,
@@ -3750,6 +3752,7 @@ async fn execute_greedy_parity_plane_with_logits(
         watchdog,
         case_name,
         Some(first_token_logit_bits),
+        Some(route_capture),
     )
     .await
 }
@@ -3766,6 +3769,7 @@ async fn execute_greedy_parity_plane_internal(
     watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
     case_name: &str,
     first_token_logit_bits: Option<&mut Vec<u32>>,
+    route_capture: Option<&mut Option<crate::engine::RoutedFfnDiagnosticCapture>>,
 ) -> Result<crate::greedy_parity::PlaneRunEvidence, Box<dyn std::error::Error>> {
     use crate::qualification::{gpu_io_delta, routed_execution_delta, validate_memory};
 
@@ -3856,6 +3860,17 @@ async fn execute_greedy_parity_plane_internal(
         if let Some(snapshot) = memory_before {
             validate_memory(snapshot).map_err(|failure| failure.detail)?;
         }
+        if route_capture.is_some() {
+            let target_token_idx = prompt_token_ids
+                .len()
+                .checked_sub(1)
+                .and_then(|position| position.checked_mul(runtime.model.config.num_layers))
+                .and_then(|token_idx| u64::try_from(token_idx).ok())
+                .ok_or("layer-0 route capture token index overflowed")?;
+            runtime
+                .engine
+                .arm_layer0_route_capture(target_token_idx)?;
+        }
         let measured = with_progress_timeout(
             format!("greedy parity {case_name} {plane} inference"),
             watchdog,
@@ -3869,6 +3884,14 @@ async fn execute_greedy_parity_plane_internal(
             ),
         )
         .await?;
+        if let Some(destination) = route_capture {
+            *destination = Some(
+                runtime
+                    .engine
+                    .take_layer0_route_capture()
+                    .ok_or("final-prompt layer-0 routed-FFN input was not captured")?,
+            );
+        }
         let routed_after = runtime.engine.routed_expert_execution_snapshot();
         let io_after_option = runtime.engine.gpu_expert_io_snapshot();
         let io_after = io_after_option.unwrap_or_default();
@@ -4294,6 +4317,7 @@ async fn cmd_greedy_parity_logit_worker_internal(
             chosen_token_id: None,
             first_token_logit_bits: None,
             first_token_logit_bits_sha256: None,
+            route_capture: None,
             failure: Some(detail.clone()),
         };
         emit_logit_worker_response(&response)?;
@@ -4312,6 +4336,7 @@ async fn cmd_greedy_parity_logit_worker_internal(
         RealCliRuntimeMode::IsolatedGreedyParityHybrid,
     )?;
     let mut logit_bits = Vec::new();
+    let mut route_capture = None;
     let attempt = execute_greedy_parity_plane_with_logits(
         &spec,
         mode,
@@ -4323,6 +4348,7 @@ async fn cmd_greedy_parity_logit_worker_internal(
         args.progress_watchdog,
         &request.base.case_name,
         &mut logit_bits,
+        &mut route_capture,
     )
     .await;
     match attempt {
@@ -4356,6 +4382,7 @@ async fn cmd_greedy_parity_logit_worker_internal(
                 chosen_token_id: Some(chosen_token_id),
                 first_token_logit_bits: Some(logit_bits),
                 first_token_logit_bits_sha256: Some(logit_sha256),
+                route_capture,
                 failure: None,
             };
             emit_logit_worker_response(&response)
@@ -4379,6 +4406,7 @@ async fn cmd_greedy_parity_logit_worker_internal(
                 chosen_token_id: None,
                 first_token_logit_bits: None,
                 first_token_logit_bits_sha256: None,
+                route_capture: None,
                 failure: Some(detail.clone()),
             };
             emit_logit_worker_response(&response)?;
@@ -4570,6 +4598,7 @@ struct CompletedLogitWorker {
     run: crate::numerical_diagnostics::RepeatedRunEvidence,
     first_token_logit_bits: Vec<u32>,
     chosen_token_id: u32,
+    route_capture: crate::engine::RoutedFfnDiagnosticCapture,
 }
 
 async fn execute_logit_diagnostic_worker(
@@ -4651,6 +4680,7 @@ async fn execute_logit_diagnostic_worker(
                 && response.chosen_token_id.is_some()
                 && response.first_token_logit_bits.is_some()
                 && response.first_token_logit_bits_sha256.is_some()
+                && response.route_capture.is_some()
         });
     let exit_code = capture.status.code();
     let signal = child_exit_signal(&capture.status);
@@ -4702,6 +4732,10 @@ async fn execute_logit_diagnostic_worker(
         let chosen_token_id = response
             .chosen_token_id
             .ok_or("logit worker omitted chosen token")?;
+        let route_capture = response
+            .route_capture
+            .clone()
+            .ok_or("logit worker omitted layer-0 route capture")?;
         let logits: Vec<f32> = logit_bits.iter().copied().map(f32::from_bits).collect();
         if crate::numerical_diagnostics::top_logits(&logits, 1)
             .first()
@@ -4737,6 +4771,7 @@ async fn execute_logit_diagnostic_worker(
             },
             first_token_logit_bits: logit_bits,
             chosen_token_id,
+            route_capture,
         })
     })();
     completed.map_err(|detail| {
@@ -4792,6 +4827,78 @@ fn fail_numerical_diagnostic(
     }
 }
 
+async fn execute_actual_input_q4_shadow(
+    spec: &ResolvedRealCliSpec,
+    tokenizer: Arc<crate::tokenizer::Tokenizer>,
+    expected_adapter_name: &str,
+    capture: &crate::engine::RoutedFfnDiagnosticCapture,
+) -> Result<crate::numerical_diagnostics::ActualInputQ4ShadowEvidence, String> {
+    let runtime = build_isolated_greedy_runtime(
+        spec,
+        RealCliRuntimeMode::IsolatedGreedyParityHybrid,
+        tokenizer,
+    )
+    .await
+    .map_err(|error| error.to_string())?;
+    let attempt = async {
+        let plan: crate::qualification::ExecutionPlanEvidence =
+            runtime.engine.execution_context().plan().into();
+        if !crate::greedy_parity::hybrid_plan_exact(&plan)
+            || runtime.engine.routed_expert_gpu_failure_policy()
+                != crate::engine::RoutedExpertGpuFailurePolicy::StrictFailClosed
+        {
+            return Err("Q4 shadow runtime did not retain the exact strict Hybrid plan".to_string());
+        }
+        let device = runtime
+            .engine
+            .gpu_device_identity()
+            .ok_or("Q4 shadow runtime has no authoritative GPU identity")?;
+        if device.software_adapter
+            || device.device_type.eq_ignore_ascii_case("cpu")
+            || device.name != expected_adapter_name
+        {
+            return Err(format!(
+                "Q4 shadow selected adapter {:?}, expected exact hardware adapter {:?}",
+                device.name, expected_adapter_name
+            ));
+        }
+        let input: Vec<f32> = capture
+            .input_bits
+            .iter()
+            .map(|bits| half::f16::from_f32(f32::from_bits(*bits)).to_f32())
+            .collect();
+        let inputs = vec![input.clone(), input];
+        let mut outputs = Vec::with_capacity(capture.expert_ids.len());
+        for &global_expert_id in &capture.expert_ids {
+            let execution = runtime
+                .engine
+                .qualify_q4_0_complete_expert(global_expert_id, 0, &inputs)
+                .await?;
+            let dispatch = execution
+                .dispatches
+                .into_iter()
+                .next()
+                .ok_or("Q4 shadow expert returned no production dispatch")?;
+            outputs.push(crate::numerical_diagnostics::Q4ShadowExpertOutput {
+                global_expert_id,
+                cpu_f32: dispatch.cpu_f32,
+                gpu_f16: dispatch.gpu_f16,
+            });
+        }
+        crate::numerical_diagnostics::build_actual_input_q4_shadow(capture, outputs)
+    }
+    .await;
+    let shutdown = runtime.shutdown_isolated().await.map_err(|error| error.to_string());
+    match (attempt, shutdown) {
+        (Ok(evidence), Ok(_)) => Ok(evidence),
+        (Err(error), Ok(_)) => Err(error),
+        (Ok(_), Err(error)) => Err(error),
+        (Err(error), Err(shutdown_error)) => {
+            Err(format!("{error}; isolated shutdown also failed: {shutdown_error}"))
+        }
+    }
+}
+
 async fn cmd_diagnose_hybrid_q4_greedy_divergence(
     args: DiagnoseHybridQ4GreedyDivergenceArgs,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -4841,7 +4948,7 @@ async fn cmd_diagnose_hybrid_q4_greedy_divergence(
         .and_then(|bytes| u64::try_from(bytes).ok())
         .unwrap_or(0);
     let preflight = PreflightEvidence {
-        provenance,
+        provenance: provenance.clone(),
         real_transformer_enabled: cfg.real_transformer.enabled,
         weights_dir_configured: cfg.real_transformer.weights_dir.is_some(),
         strict_weights: cfg.real_transformer.strict_weights,
@@ -4883,6 +4990,7 @@ async fn cmd_diagnose_hybrid_q4_greedy_divergence(
     let prompt_sha256 = crate::greedy_parity::sha256_hex(fixed.prompt.as_bytes());
     let prompt_token_ids_sha256 = crate::greedy_parity::token_ids_sha256(&prompt_token_ids);
     let mut report = crate::numerical_diagnostics::DiagnosticReport::new(
+        provenance,
         build_git_sha.clone(),
         executable_sha256.clone(),
         resolved_config_sha256.clone(),
@@ -4999,6 +5107,61 @@ async fn cmd_diagnose_hybrid_q4_greedy_divergence(
             )
         }
     });
+    let route_captures: Vec<_> = completed
+        .iter()
+        .map(|worker| (worker.run.plane, worker.route_capture.clone()))
+        .collect();
+    let expected_token_idx = prompt_token_ids
+        .len()
+        .checked_sub(1)
+        .and_then(|position| position.checked_mul(spec.cfg.model.num_layers))
+        .and_then(|token_idx| u64::try_from(token_idx).ok())
+        .ok_or("layer-0 route capture token index overflowed")?;
+    let route_evidence = match crate::numerical_diagnostics::reconcile_route_captures(
+        &route_captures,
+        expected_token_idx,
+    ) {
+        Ok(evidence) => evidence,
+        Err(error) => {
+            return fail_numerical_diagnostic(
+                report,
+                "layer0-route-capture-invalid",
+                error,
+                &args.report_out,
+            )
+        }
+    };
+    let route_matches = route_evidence.exact_capture_match;
+    report.route_capture = Some(route_evidence);
+    if !route_matches {
+        return fail_numerical_diagnostic(
+            report,
+            "cpu-hybrid-layer0-route-mismatch",
+            "CPU/Hybrid layer-0 input, selected experts, or routing-weight bits differ; Q4 shadow dispatch was not performed",
+            &args.report_out,
+        );
+    }
+    let shadow_capture = &route_captures[0].1;
+    report.actual_input_q4_shadow = Some(
+        match execute_actual_input_q4_shadow(
+            &spec,
+            tokenizer,
+            &args.expected_adapter_name,
+            shadow_capture,
+        )
+        .await
+        {
+            Ok(evidence) => evidence,
+            Err(error) => {
+                return fail_numerical_diagnostic(
+                    report,
+                    "actual-input-q4-shadow-failed",
+                    error,
+                    &args.report_out,
+                )
+            }
+        },
+    );
     if let Err(error) = report.finish() {
         return fail_numerical_diagnostic(
             report,

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -3729,6 +3729,34 @@ async fn execute_greedy_parity_plane(
 }
 
 #[allow(clippy::too_many_arguments)]
+async fn execute_greedy_parity_boundary_reference_plane(
+    spec: &ResolvedRealCliSpec,
+    tokenizer: Arc<crate::tokenizer::Tokenizer>,
+    prompt_token_ids: &[u32],
+    prompt_token_ids_sha256: &str,
+    resolved_config_sha256: &str,
+    expected_adapter_name: &str,
+    watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+    case_name: &str,
+) -> Result<crate::greedy_parity::PlaneRunEvidence, Box<dyn std::error::Error>> {
+    execute_greedy_parity_plane_internal(
+        spec,
+        RealCliRuntimeMode::IsolatedGreedyParityCpu,
+        tokenizer,
+        prompt_token_ids,
+        prompt_token_ids_sha256,
+        resolved_config_sha256,
+        expected_adapter_name,
+        watchdog,
+        case_name,
+        None,
+        None,
+        true,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
 async fn execute_greedy_parity_plane_with_logits(
     spec: &ResolvedRealCliSpec,
     mode: RealCliRuntimeMode,
@@ -5508,6 +5536,32 @@ async fn cmd_qualify_hybrid_q4_greedy_parity(
         };
         case.cpu = Some(cpu);
 
+        let boundary_reference = execute_greedy_parity_boundary_reference_plane(
+            &spec,
+            tokenizer.clone(),
+            &case.prompt_token_ids,
+            &case.prompt_token_ids_sha256,
+            &resolved_config_sha256,
+            &args.expected_adapter_name,
+            args.progress_watchdog,
+            fixed.name,
+        )
+        .await;
+        let boundary_reference = match boundary_reference {
+            Ok(reference) => reference,
+            Err(error) => {
+                let mut failure = qualification_inference_failure(error.as_ref());
+                failure.detail = format!(
+                    "fixed case {} CPU Hybrid-boundary reference: {error}",
+                    fixed.name
+                );
+                case.failure = Some(failure.clone());
+                report.cases.push(case);
+                return fail_greedy_parity(report, failure, args.report_out.as_deref());
+            }
+        };
+        case.boundary_reference = Some(boundary_reference);
+
         let worker_request = crate::greedy_parity::HybridWorkerRequest::new(
             crate::greedy_parity::hybrid_worker_id(
                 &build_git_sha,
@@ -5550,52 +5604,83 @@ async fn cmd_qualify_hybrid_q4_greedy_parity(
             }
         };
         case.hybrid = Some(hybrid);
-        let (cpu_generation, hybrid_generation) = match (&case.cpu, &case.hybrid) {
-            (Some(cpu), Some(hybrid)) => (&cpu.generation, &hybrid.generation),
+        let (cpu_generation, boundary_generation, hybrid_generation) =
+            match (&case.cpu, &case.boundary_reference, &case.hybrid) {
+            (Some(cpu), Some(boundary), Some(hybrid)) => (
+                &cpu.generation,
+                &boundary.generation,
+                &hybrid.generation,
+            ),
             _ => {
                 let failure = QualificationFailure::new(
                     FailureStage::Postcondition,
                     "plane-evidence-incomplete",
-                    format!("fixed case {} lost successful plane evidence", fixed.name),
+                    format!(
+                        "fixed case {} lost successful CPU, boundary-reference, or Hybrid evidence",
+                        fixed.name
+                    ),
                 );
                 case.failure = Some(failure.clone());
                 report.cases.push(case);
                 return fail_greedy_parity(report, failure, args.report_out.as_deref());
             }
         };
-        let comparison = crate::greedy_parity::compare_generations(
+        let ordinary_comparison = crate::greedy_parity::compare_generations(
             cpu_generation,
             hybrid_generation,
             |ids| tokenizer.decode(ids).map_err(|error| error.to_string()),
         );
-        let comparison = match comparison {
+        let ordinary_comparison = match ordinary_comparison {
             Ok(comparison) => comparison,
             Err(error) => {
                 let failure = QualificationFailure::new(
                     FailureStage::Postcondition,
                     "divergence-evidence-decode-failed",
-                    format!("fixed case {}: {error}", fixed.name),
+                    format!("fixed case {} ordinary CPU comparison: {error}", fixed.name),
                 );
                 case.failure = Some(failure.clone());
                 report.cases.push(case);
                 return fail_greedy_parity(report, failure, args.report_out.as_deref());
             }
         };
-        let diverged = !comparison.exact_token_ids
-            || !comparison.equal_generated_count
-            || !comparison.equal_termination_reason
-            || !comparison.equal_generated_text_hash;
-        let divergence_position = comparison
+        case.ordinary_cpu_vs_hybrid = Some(ordinary_comparison);
+
+        let boundary_comparison = crate::greedy_parity::compare_generations(
+            boundary_generation,
+            hybrid_generation,
+            |ids| tokenizer.decode(ids).map_err(|error| error.to_string()),
+        );
+        let boundary_comparison = match boundary_comparison {
+            Ok(comparison) => comparison,
+            Err(error) => {
+                let failure = QualificationFailure::new(
+                    FailureStage::Postcondition,
+                    "divergence-evidence-decode-failed",
+                    format!(
+                        "fixed case {} CPU Hybrid-boundary comparison: {error}",
+                        fixed.name
+                    ),
+                );
+                case.failure = Some(failure.clone());
+                report.cases.push(case);
+                return fail_greedy_parity(report, failure, args.report_out.as_deref());
+            }
+        };
+        let diverged = !boundary_comparison.exact_token_ids
+            || !boundary_comparison.equal_generated_count
+            || !boundary_comparison.equal_termination_reason
+            || !boundary_comparison.equal_generated_text_hash;
+        let divergence_position = boundary_comparison
             .first_divergence
             .as_ref()
             .map(|evidence| evidence.position);
-        case.comparison = Some(comparison);
+        case.boundary_reference_vs_hybrid = Some(boundary_comparison);
         if diverged {
             let failure = QualificationFailure::new(
                 FailureStage::Postcondition,
-                "greedy-token-divergence",
+                "boundary-reference-greedy-token-divergence",
                 format!(
-                    "fixed case {} diverged at position {:?}",
+                    "fixed case {} Hybrid diverged from the CPU Hybrid-boundary reference at position {:?}",
                     fixed.name, divergence_position
                 ),
             );

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -160,6 +160,7 @@ mod parallel;
 mod prefetch_governor;
 mod pregate;
 mod qualification;
+mod greedy_parity;
 mod q4_parity;
 mod rayon_autotune;
 mod residency;
@@ -895,6 +896,20 @@ enum Cmd {
         report_out: Option<PathBuf>,
     },
 
+    /// Compare fixed-corpus greedy token IDs between isolated strict CPU and
+    /// strict Hybrid Q4_0 real-checkpoint execution.
+    QualifyHybridQ4GreedyParity {
+        /// Path to the strict Hybrid native-Q4_0 TOML config.
+        #[arg(long)]
+        config: PathBuf,
+        /// Exact wgpu adapter name required for every Hybrid corpus case.
+        #[arg(long)]
+        expected_adapter_name: String,
+        /// Write the typed JSON report here instead of stdout.
+        #[arg(long)]
+        report_out: Option<PathBuf>,
+    },
+
     /// Benchmark dense matvec backends on the target Qwen3-Coder CPU shapes.
     ///
     /// This is intentionally separate from `bench-real`: it isolates Q/K/V/O,
@@ -1537,11 +1552,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // runtime controls before CPU placement / Rayon exist. The command
     // handlers still own their normal config reconciliation and runtime
     // construction below.
-    let startup_config = match &cli.cmd {
+    let mut startup_config = match &cli.cmd {
         Cmd::Serve { config }
         | Cmd::BenchReal { config, .. }
         | Cmd::QualifyHybridQ4 { config, .. }
-        | Cmd::QualifyHybridQ4Parity { config, .. } => {
+        | Cmd::QualifyHybridQ4Parity { config, .. }
+        | Cmd::QualifyHybridQ4GreedyParity { config, .. } => {
             Some(crate::config::Config::from_file(config)?)
         }
         _ => None,
@@ -1664,6 +1680,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Cmd::Serve { .. }
             | Cmd::QualifyHybridQ4 { .. }
             | Cmd::QualifyHybridQ4Parity { .. }
+            | Cmd::QualifyHybridQ4GreedyParity { .. }
     ) && !run_gpu_requested
     {
         crate::backend::install_default();
@@ -1938,6 +1955,26 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 },
             ))
         }
+        Cmd::QualifyHybridQ4GreedyParity {
+            config,
+            expected_adapter_name,
+            report_out,
+        } => {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()?;
+            rt.block_on(cmd_qualify_hybrid_q4_greedy_parity(
+                QualifyHybridQ4GreedyParityArgs {
+                    config,
+                    parsed_config: startup_config
+                        .take()
+                        .ok_or("greedy parity startup config was not parsed")?,
+                    expected_adapter_name,
+                    report_out,
+                    progress_watchdog,
+                },
+            ))
+        }
         Cmd::MatvecMicrobench {
             backend,
             warmup_runs,
@@ -2167,6 +2204,14 @@ struct QualifyHybridQ4ParityArgs {
     progress_watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
 }
 
+struct QualifyHybridQ4GreedyParityArgs {
+    config: PathBuf,
+    parsed_config: crate::config::Config,
+    expected_adapter_name: String,
+    report_out: Option<PathBuf>,
+    progress_watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+}
+
 struct MatvecMicrobenchArgs {
     backends: Vec<crate::parallel::DenseMatvecBackend>,
     warmup_runs: usize,
@@ -2284,6 +2329,104 @@ struct BenchRealRuntime {
     engine: Arc<Engine>,
     model: Arc<crate::model::RealModel>,
     tokenizer: Arc<crate::tokenizer::Tokenizer>,
+    isolated_cache: Option<Arc<MultiLayerExpertCache>>,
+    isolated_shutdown: Option<IsolatedRuntimeShutdownWitness>,
+}
+
+/// Type-specific weak references to every mutable resource family that an
+/// isolated qualification runtime can hand to background work. Controlled
+/// shutdown consumes the runtime, closes its producer channels, and waits for
+/// these references to become un-upgradeable before the next plane is built.
+struct IsolatedRuntimeShutdownWitness {
+    engine: std::sync::Weak<Engine>,
+    model: std::sync::Weak<crate::model::RealModel>,
+    cache: std::sync::Weak<MultiLayerExpertCache>,
+    storage: std::sync::Weak<NvmeStorage>,
+    predictor: std::sync::Weak<PredictiveLoader>,
+    execution_context: std::sync::Weak<crate::backend::ExecutionContext>,
+    gpu_cache: std::sync::Weak<crate::expert_cache::GpuExpertCache>,
+    speculator: Option<std::sync::Weak<NeuralSpeculator>>,
+    affinity: Option<std::sync::Weak<LayeredExpertAffinity>>,
+}
+
+impl IsolatedRuntimeShutdownWitness {
+    fn all_released(&self) -> bool {
+        self.engine.upgrade().is_none()
+            && self.model.upgrade().is_none()
+            && self.cache.upgrade().is_none()
+            && self.storage.upgrade().is_none()
+            && self.predictor.upgrade().is_none()
+            && self.execution_context.upgrade().is_none()
+            && self.gpu_cache.upgrade().is_none()
+            && self
+                .speculator
+                .as_ref()
+                .map_or(true, |weak| weak.upgrade().is_none())
+            && self
+                .affinity
+                .as_ref()
+                .map_or(true, |weak| weak.upgrade().is_none())
+    }
+
+    async fn wait_for_release(
+        self,
+    ) -> Result<crate::greedy_parity::BackgroundShutdownEvidence, String> {
+        const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(10);
+        const SHUTDOWN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+        wait_for_isolated_release(
+            || self.all_released(),
+            POLL_INTERVAL,
+            SHUTDOWN_TIMEOUT,
+        )
+        .await
+    }
+}
+
+async fn wait_for_isolated_release<F>(
+    mut all_released: F,
+    poll_interval: std::time::Duration,
+    shutdown_timeout: std::time::Duration,
+) -> Result<crate::greedy_parity::BackgroundShutdownEvidence, String>
+where
+    F: FnMut() -> bool,
+{
+    let started = Instant::now();
+    let mut poll_iterations = 0u32;
+    loop {
+        poll_iterations = poll_iterations.saturating_add(1);
+        if all_released() {
+            return Ok(crate::greedy_parity::BackgroundShutdownEvidence {
+                controlled_shutdown_requested: true,
+                all_runtime_resources_released: true,
+                poll_iterations,
+            });
+        }
+        if started.elapsed() >= shutdown_timeout {
+            return Err(format!(
+                "isolated runtime background resources remained live after {}s",
+                shutdown_timeout.as_secs_f64()
+            ));
+        }
+        tokio::time::sleep(poll_interval).await;
+    }
+}
+
+impl BenchRealRuntime {
+    async fn shutdown_isolated(
+        mut self,
+    ) -> Result<crate::greedy_parity::BackgroundShutdownEvidence, String> {
+        let witness = self
+            .isolated_shutdown
+            .take()
+            .ok_or_else(|| "runtime was not constructed by the isolated qualification factory".to_string())?;
+        // Dropping the Engine closes the GPU-promotion and neural-speculator
+        // producer channels. Affinity's owned handle joins its worker in Drop;
+        // outstanding prefetch work releases cache/storage/predictor Arcs when
+        // it completes. The weak witness below proves all of those resource
+        // families are gone before another case/plane is constructed.
+        drop(self);
+        witness.wait_for_release().await
+    }
 }
 
 #[derive(Serialize)]
@@ -3339,6 +3482,638 @@ async fn cmd_qualify_hybrid_q4_parity(
     emit_q4_parity_report(&report, args.report_out.as_deref())
 }
 
+fn emit_greedy_parity_report(
+    report: &crate::greedy_parity::GreedyParityReport,
+    report_out: Option<&Path>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut json = serde_json::to_vec_pretty(report)?;
+    json.push(b'\n');
+    if let Some(path) = report_out {
+        std::fs::write(path, json)?;
+        eprintln!("greedy-token parity report written to {}", path.display());
+    } else {
+        use std::io::Write as _;
+        std::io::stdout().write_all(&json)?;
+    }
+    Ok(())
+}
+
+fn fail_greedy_parity(
+    mut report: crate::greedy_parity::GreedyParityReport,
+    failure: crate::qualification::QualificationFailure,
+    report_out: Option<&Path>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let summary = format!("{}: {}", failure.code, failure.detail);
+    report.fail(failure);
+    match emit_greedy_parity_report(&report, report_out) {
+        Ok(()) => Err(summary.into()),
+        Err(emit_error) => Err(format!(
+            "{summary}; additionally failed to emit greedy-token parity report: {emit_error}"
+        )
+        .into()),
+    }
+}
+
+fn greedy_parity_model_identity(
+    spec: &ResolvedRealCliSpec,
+) -> crate::greedy_parity::ModelIdentityEvidence {
+    crate::greedy_parity::ModelIdentityEvidence {
+        architecture: spec.architecture.model_type().to_string(),
+        num_layers: spec.cfg.model.num_layers,
+        num_experts_per_layer: spec.cfg.model.num_experts,
+        total_experts: (spec.cfg.model.num_layers as u64)
+            .saturating_mul(spec.cfg.model.num_experts as u64),
+        top_k: spec.cfg.model.top_k,
+        d_model: spec.cfg.model.d_model,
+        d_ff: spec.cfg.model.d_ff,
+        routed_expert_dtype: spec.cfg.model.dtype.as_str().to_string(),
+    }
+}
+
+fn greedy_parity_model_load(
+    runtime: &BenchRealRuntime,
+) -> crate::greedy_parity::ModelLoadEvidence {
+    let load = &runtime.model.load_status;
+    crate::greedy_parity::ModelLoadEvidence {
+        strict: load.strict,
+        loader: load.loader.to_string(),
+        loaded_tensors: load.loaded_tensors,
+        required_tensors: load.required_tensors,
+        optional_probed: load.optional_probed,
+        optional_loaded: load.optional_loaded,
+        seeded_fallback_remained: load.seeded_fallback_remained,
+    }
+}
+
+fn greedy_parity_runtime_cache_snapshot(
+    runtime: &BenchRealRuntime,
+) -> crate::greedy_parity::RuntimeCacheSnapshot {
+    let report = runtime.engine.report();
+    let gpu_cache = runtime.engine.execution_context().gpu_expert_cache();
+    let memory = runtime.engine.gpu_expert_memory_snapshot();
+    crate::greedy_parity::RuntimeCacheSnapshot {
+        ram_entries: runtime
+            .isolated_cache
+            .as_ref()
+            .map_or(0, |cache| cache.len()),
+        ram_hits: report.hits,
+        ram_misses: report.misses,
+        bytes_read: report.bytes_read,
+        prefetch_completed: report.prefetch_completed,
+        predictor_observations: report.predictor_observations,
+        logical_gpu_hits: gpu_cache.hits(),
+        logical_gpu_misses: gpu_cache.misses(),
+        logical_gpu_promotions: gpu_cache.promotions(),
+        logical_admitted_bytes: gpu_cache.used_bytes(),
+        logical_anchor_entries: gpu_cache.anchor_len(),
+        logical_lru_entries: gpu_cache.lru_len(),
+        physical_entries: memory.map_or(0, |snapshot| snapshot.physical_entries),
+        physical_installs: memory.map_or(0, |snapshot| snapshot.physical_installs),
+        physical_evictions: memory.map_or(0, |snapshot| snapshot.physical_evictions),
+        stale_retirements: memory.map_or(0, |snapshot| snapshot.stale_retirements),
+    }
+}
+
+fn greedy_parity_failure_policy_name(
+    policy: crate::engine::RoutedExpertGpuFailurePolicy,
+) -> &'static str {
+    match policy {
+        crate::engine::RoutedExpertGpuFailurePolicy::StrictFailClosed => "strict-fail-closed",
+        crate::engine::RoutedExpertGpuFailurePolicy::ServingCpuFallback => {
+            "serving-cpu-fallback"
+        }
+    }
+}
+
+// Qualification call sites deliberately name every frozen/shared input; this
+// makes configuration and token-ID drift reviewable at the boundary.
+#[allow(clippy::too_many_arguments)]
+async fn execute_greedy_parity_plane(
+    spec: &ResolvedRealCliSpec,
+    mode: RealCliRuntimeMode,
+    tokenizer: Arc<crate::tokenizer::Tokenizer>,
+    prompt_token_ids: &[u32],
+    prompt_token_ids_sha256: &str,
+    resolved_config_sha256: &str,
+    expected_adapter_name: &str,
+    watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+    case_name: &str,
+) -> Result<crate::greedy_parity::PlaneRunEvidence, Box<dyn std::error::Error>> {
+    use crate::qualification::{gpu_io_delta, routed_execution_delta, validate_memory};
+
+    let runtime = build_isolated_greedy_runtime(spec, mode, tokenizer).await?;
+    let attempt = async {
+        let context = runtime.engine.execution_context();
+        let execution_plan: crate::qualification::ExecutionPlanEvidence = context.plan().into();
+        let plane = match mode {
+            RealCliRuntimeMode::IsolatedGreedyParityCpu => "cpu",
+            RealCliRuntimeMode::IsolatedGreedyParityHybrid => "hybrid",
+            _ => return Err("non-isolated mode reached greedy parity execution".into()),
+        };
+        let device = runtime.engine.gpu_device_identity();
+        match mode {
+            RealCliRuntimeMode::IsolatedGreedyParityCpu => {
+                if !crate::greedy_parity::cpu_plan_exact(&execution_plan) {
+                    return Err(format!(
+                        "CPU control did not resolve every component to CPU: {execution_plan:?}"
+                    )
+                    .into());
+                }
+                if device.is_some() {
+                    return Err("CPU control unexpectedly exposes a GPU device identity".into());
+                }
+            }
+            RealCliRuntimeMode::IsolatedGreedyParityHybrid => {
+                if !crate::greedy_parity::hybrid_plan_exact(&execution_plan) {
+                    return Err(format!(
+                        "Hybrid run did not resolve the strict component plan: {execution_plan:?}"
+                    )
+                    .into());
+                }
+                let selected = device.as_ref().ok_or(
+                    "strict Hybrid run has no authoritative GPU device identity",
+                )?;
+                if selected.software_adapter
+                    || selected.device_type.eq_ignore_ascii_case("cpu")
+                {
+                    return Err(format!(
+                        "strict Hybrid selected software adapter {:?}",
+                        selected.name
+                    )
+                    .into());
+                }
+                if selected.name != expected_adapter_name {
+                    return Err(format!(
+                        "strict Hybrid selected adapter {:?}, expected exact name {:?}",
+                        selected.name, expected_adapter_name
+                    )
+                    .into());
+                }
+                if runtime.engine.routed_expert_gpu_failure_policy()
+                    != crate::engine::RoutedExpertGpuFailurePolicy::StrictFailClosed
+                {
+                    return Err("strict Hybrid engine does not use StrictFailClosed".into());
+                }
+            }
+            _ => unreachable!("isolated modes checked above"),
+        }
+
+        let cache_before = greedy_parity_runtime_cache_snapshot(&runtime);
+        let observed_config_sha256 = resolved_real_runtime_identity_sha256(
+            &runtime.cfg,
+            runtime.model.config.architecture,
+            runtime.model.config.first_k_dense_replace,
+            &runtime.model.config.advanced,
+        )?;
+        if observed_config_sha256 != resolved_config_sha256 {
+            return Err(format!(
+                "{plane} runtime identity {observed_config_sha256} drifted from frozen specification {resolved_config_sha256}"
+            )
+            .into());
+        }
+        let routed_before = runtime.engine.routed_expert_execution_snapshot();
+        let io_before_option = runtime.engine.gpu_expert_io_snapshot();
+        let io_before = io_before_option.unwrap_or_default();
+        let memory_before = runtime.engine.gpu_expert_memory_snapshot();
+        let attention_softmax_before = crate::transformer::nonfinite_softmax_fallbacks();
+        if cache_before != crate::greedy_parity::RuntimeCacheSnapshot::default()
+            || routed_before != crate::engine::RoutedExpertExecutionSnapshot::default()
+            || io_before != crate::backend::GpuExpertIoSnapshot::default()
+        {
+            return Err(format!(
+                "{plane} isolated runtime did not start from clean cache/counter state"
+            )
+            .into());
+        }
+        if let Some(snapshot) = memory_before {
+            validate_memory(snapshot).map_err(|failure| failure.detail)?;
+        }
+        let measured = with_progress_timeout(
+            format!("greedy parity {case_name} {plane} inference"),
+            watchdog,
+            run_real_once_from_token_ids(
+                &runtime,
+                prompt_token_ids,
+                crate::greedy_parity::OUTPUT_TOKEN_LIMIT,
+                crate::sampling::SamplingParams::greedy(),
+                0,
+            ),
+        )
+        .await?;
+        let routed_after = runtime.engine.routed_expert_execution_snapshot();
+        let io_after_option = runtime.engine.gpu_expert_io_snapshot();
+        let io_after = io_after_option.unwrap_or_default();
+        let memory_after = runtime.engine.gpu_expert_memory_snapshot();
+        let attention_softmax_nonfinite_fallbacks =
+            crate::transformer::nonfinite_softmax_fallbacks()
+                .saturating_sub(attention_softmax_before);
+        if let Some(snapshot) = memory_after {
+            validate_memory(snapshot).map_err(|failure| failure.detail)?;
+        }
+        if mode == RealCliRuntimeMode::IsolatedGreedyParityHybrid
+            && (io_before_option.is_none()
+                || io_after_option.is_none()
+                || memory_before.is_none()
+                || memory_after.is_none())
+        {
+            return Err("strict Hybrid GPU evidence disappeared during inference".into());
+        }
+        if mode == RealCliRuntimeMode::IsolatedGreedyParityCpu
+            && (io_before_option.is_some()
+                || io_after_option.is_some()
+                || memory_before.is_some()
+                || memory_after.is_some())
+        {
+            return Err("CPU control unexpectedly exposed GPU I/O or memory evidence".into());
+        }
+
+        let routed_delta = routed_execution_delta(routed_before, routed_after)
+            .map_err(|failure| failure.detail)?;
+        let gpu_io_delta = gpu_io_delta(io_before, io_after).map_err(|failure| failure.detail)?;
+        let generated_token_ids = measured.report.output_token_ids;
+        let generated_text = measured.report.output_text;
+        let generation = crate::greedy_parity::GenerationEvidence {
+            prompt_token_ids_sha256: prompt_token_ids_sha256.to_string(),
+            generated_token_ids_sha256: crate::greedy_parity::token_ids_sha256(
+                &generated_token_ids,
+            ),
+            generated_text_sha256: crate::greedy_parity::sha256_hex(generated_text.as_bytes()),
+            generated_token_count: generated_token_ids.len(),
+            generated_token_ids,
+            termination_reason: crate::greedy_parity::TerminationReason::LengthLimit,
+        };
+        let initial_kv_sequence_lengths = measured.initial_kv_sequence_lengths;
+        let initial_state = crate::greedy_parity::InitialStateEvidence {
+            context_id: execution_plan.context_id.clone(),
+            resolved_config_sha256: observed_config_sha256,
+            kv_cache_count: initial_kv_sequence_lengths.len(),
+            all_kv_empty: initial_kv_sequence_lengths.iter().all(|&length| length == 0),
+            kv_sequence_lengths: initial_kv_sequence_lengths,
+            cache: cache_before,
+            routed: routed_before,
+            gpu_io_available: io_before_option.is_some(),
+            gpu_io: io_before,
+        };
+        Ok(crate::greedy_parity::PlaneRunEvidence {
+            plane,
+            model_load: greedy_parity_model_load(&runtime),
+            execution_plan,
+            routed_expert_gpu_failure_policy: greedy_parity_failure_policy_name(
+                runtime.engine.routed_expert_gpu_failure_policy(),
+            )
+            .to_string(),
+            device,
+            initial_state,
+            generation,
+            routed_execution_delta: routed_delta,
+            gpu_io_delta,
+            attention_softmax_nonfinite_fallbacks,
+            gpu_memory_before: memory_before,
+            gpu_memory_after: memory_after,
+            background_shutdown: crate::greedy_parity::BackgroundShutdownEvidence::default(),
+        })
+    }
+    .await;
+
+    // Always consume and shut down a successfully constructed isolated runtime,
+    // including when inference or evidence validation failed.
+    let shutdown = runtime.shutdown_isolated().await;
+    match (attempt, shutdown) {
+        (Ok(mut evidence), Ok(shutdown)) => {
+            evidence.background_shutdown = shutdown;
+            Ok(evidence)
+        }
+        (Err(error), Ok(_)) => Err(error),
+        (Ok(_), Err(shutdown_error)) => Err(shutdown_error.into()),
+        (Err(error), Err(shutdown_error)) => {
+            Err(format!("{error}; isolated shutdown also failed: {shutdown_error}").into())
+        }
+    }
+}
+
+async fn cmd_qualify_hybrid_q4_greedy_parity(
+    args: QualifyHybridQ4GreedyParityArgs,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use crate::qualification::{
+        validate_preflight, BuildProvenance, FailureStage, PreflightEvidence,
+        QualificationChecks, QualificationFailure,
+    };
+
+    // The supplied Hybrid config is parsed exactly once. Reconciliation below
+    // produces one frozen spec from which both isolated planes are derived.
+    let cfg = args.parsed_config;
+    let provenance = BuildProvenance::embedded();
+    let (artifacts, artifact_errors) = qualification_artifacts(&args.config, &cfg);
+    let metadata_path = cfg.model.data_dir.join("metadata.json");
+    let metadata_result = crate::qualification::read_expert_metadata(&metadata_path);
+    let metadata = metadata_result.clone().ok();
+    let mut report = crate::greedy_parity::GreedyParityReport::new(
+        provenance.clone(),
+        artifacts,
+        metadata.clone(),
+        args.expected_adapter_name.clone(),
+    );
+
+    if args.expected_adapter_name.is_empty() {
+        return fail_greedy_parity(
+            report,
+            QualificationFailure::new(
+                FailureStage::Preflight,
+                "expected-adapter-name-empty",
+                "--expected-adapter-name must be a non-empty exact adapter name",
+            ),
+            args.report_out.as_deref(),
+        );
+    }
+    if args.progress_watchdog.timeout.is_none() {
+        return fail_greedy_parity(
+            report,
+            QualificationFailure::new(
+                FailureStage::Preflight,
+                "progress-watchdog-required",
+                "greedy parity requires a positive performance.progress_timeout_secs or --progress-timeout-secs",
+            ),
+            args.report_out.as_deref(),
+        );
+    }
+    if !artifact_errors.is_empty() {
+        return fail_greedy_parity(
+            report,
+            qualification_artifact_failure(&artifact_errors),
+            args.report_out.as_deref(),
+        );
+    }
+    let metadata = match metadata_result {
+        Ok(metadata) => metadata,
+        Err(detail) => {
+            return fail_greedy_parity(
+                report,
+                qualification_metadata_failure(detail),
+                args.report_out.as_deref(),
+            );
+        }
+    };
+    let weight_policy = cfg.real_transformer.resolve_weight_policy();
+    if !matches!(weight_policy, Ok(crate::config::RealWeightPolicy::StrictReal)) {
+        return fail_greedy_parity(
+            report,
+            QualificationFailure::new(
+                FailureStage::Preflight,
+                "non-strict-weight-policy",
+                weight_policy
+                    .err()
+                    .unwrap_or_else(|| "resolved weight policy is SeededDev".to_string()),
+            ),
+            args.report_out.as_deref(),
+        );
+    }
+    let capacity_bytes = cfg
+        .gpu_cache
+        .vram_capacity_mb
+        .checked_mul(1024 * 1024)
+        .and_then(|bytes| u64::try_from(bytes).ok())
+        .unwrap_or(0);
+    let preflight = PreflightEvidence {
+        provenance,
+        real_transformer_enabled: cfg.real_transformer.enabled,
+        weights_dir_configured: cfg.real_transformer.weights_dir.is_some(),
+        strict_weights: cfg.real_transformer.strict_weights,
+        allow_seeded_fallback: cfg.real_transformer.allow_seeded_fallback,
+        allow_degraded_experts: cfg.real_transformer.allow_degraded_experts,
+        allow_attention_fallback: cfg.real_transformer.allow_nonfinite_attention_fallback,
+        allow_truncated_expert_payloads: cfg.real_transformer.allow_truncated_expert_payloads,
+        distributed_enabled: cfg.distributed.enabled,
+        gpu_cache_enabled: cfg.gpu_cache.enabled,
+        gpu_expert_capacity_bytes: capacity_bytes,
+        requested_mode: cfg.real_transformer.compute_offload,
+        routed_expert_dtype: cfg.model.dtype,
+        metadata,
+    };
+    report.source_preflight = Some(crate::greedy_parity::StrictHybridPreflightEvidence {
+        real_transformer_enabled: preflight.real_transformer_enabled,
+        weights_dir_configured: preflight.weights_dir_configured,
+        strict_weights: preflight.strict_weights,
+        allow_seeded_fallback: preflight.allow_seeded_fallback,
+        allow_degraded_experts: preflight.allow_degraded_experts,
+        allow_attention_fallback: preflight.allow_attention_fallback,
+        allow_truncated_expert_payloads: preflight.allow_truncated_expert_payloads,
+        distributed_enabled: preflight.distributed_enabled,
+        gpu_cache_enabled: preflight.gpu_cache_enabled,
+        gpu_expert_capacity_bytes: preflight.gpu_expert_capacity_bytes,
+        requested_mode: match preflight.requested_mode {
+            crate::backend::ComputeOffload::Cpu => "cpu",
+            crate::backend::ComputeOffload::Gpu => "gpu",
+            crate::backend::ComputeOffload::Auto => "auto",
+            crate::backend::ComputeOffload::Hybrid => "hybrid",
+        }
+        .to_string(),
+        routed_expert_dtype: preflight.routed_expert_dtype.as_str().to_string(),
+    });
+    let mut base_checks = QualificationChecks::default();
+    if let Err(failure) = validate_preflight(&preflight, &mut base_checks) {
+        return fail_greedy_parity(report, failure, args.report_out.as_deref());
+    }
+    let spec = match resolve_real_cli_spec_from_config(
+        cfg,
+        RealCliRuntimeMode::IsolatedGreedyParityHybrid,
+    ) {
+        Ok(spec) => spec,
+        Err(error) => {
+            return fail_greedy_parity(
+                report,
+                QualificationFailure::new(
+                    FailureStage::Preflight,
+                    "configuration-reconciliation-failed",
+                    error.to_string(),
+                ),
+                args.report_out.as_deref(),
+            );
+        }
+    };
+    let identity = greedy_parity_model_identity(&spec);
+    if !identity.is_qwen3_coder_30b_a3b_q4_0() {
+        report.model_identity = Some(identity);
+        return fail_greedy_parity(
+            report,
+            QualificationFailure::new(
+                FailureStage::Preflight,
+                "unexpected-model-identity",
+                "fixed corpus is qualified only for Qwen3-Coder 30B-A3B Q4_0 geometry",
+            ),
+            args.report_out.as_deref(),
+        );
+    }
+    report.model_identity = Some(identity);
+    let resolved_config_sha256 = match resolved_real_cli_spec_sha256(&spec) {
+        Ok(hash) => hash,
+        Err(error) => {
+            return fail_greedy_parity(
+                report,
+                QualificationFailure::new(
+                    FailureStage::Preflight,
+                    "resolved-config-hash-failed",
+                    error.to_string(),
+                ),
+                args.report_out.as_deref(),
+            );
+        }
+    };
+    report.resolved_config_sha256 = Some(resolved_config_sha256.clone());
+    let tokenizer = match load_real_cli_tokenizer(
+        &spec.cfg,
+        RealCliRuntimeMode::IsolatedGreedyParityHybrid,
+    ) {
+        Ok(tokenizer) => tokenizer,
+        Err(error) => {
+            return fail_greedy_parity(
+                report,
+                QualificationFailure::new(
+                    FailureStage::Startup,
+                    "tokenizer-load-failed",
+                    error.to_string(),
+                ),
+                args.report_out.as_deref(),
+            );
+        }
+    };
+
+    for fixed in crate::greedy_parity::FIXED_CORPUS {
+        // The sole encode call for this case happens here. Both fresh runtimes
+        // receive the same immutable ID slice and shared tokenizer instance.
+        let prompt_token_ids = match tokenizer.encode(fixed.prompt) {
+            Ok(ids) if !ids.is_empty() => ids,
+            Ok(_) => {
+                return fail_greedy_parity(
+                    report,
+                    QualificationFailure::new(
+                        FailureStage::Inference,
+                        "prompt-tokenization-empty",
+                        format!("fixed case {} encoded to zero tokens", fixed.name),
+                    ),
+                    args.report_out.as_deref(),
+                );
+            }
+            Err(error) => {
+                return fail_greedy_parity(
+                    report,
+                    QualificationFailure::new(
+                        FailureStage::Inference,
+                        "prompt-tokenization-failed",
+                        format!("fixed case {}: {error}", fixed.name),
+                    ),
+                    args.report_out.as_deref(),
+                );
+            }
+        };
+        let mut case = crate::greedy_parity::CaseReport::new(fixed, prompt_token_ids);
+        let cpu = execute_greedy_parity_plane(
+            &spec,
+            RealCliRuntimeMode::IsolatedGreedyParityCpu,
+            tokenizer.clone(),
+            &case.prompt_token_ids,
+            &case.prompt_token_ids_sha256,
+            &resolved_config_sha256,
+            &args.expected_adapter_name,
+            args.progress_watchdog,
+            fixed.name,
+        )
+        .await;
+        let cpu = match cpu {
+            Ok(cpu) => cpu,
+            Err(error) => {
+                let mut failure = qualification_inference_failure(error.as_ref());
+                failure.detail = format!("fixed case {} CPU control: {error}", fixed.name);
+                case.failure = Some(failure.clone());
+                report.cases.push(case);
+                return fail_greedy_parity(report, failure, args.report_out.as_deref());
+            }
+        };
+        case.cpu = Some(cpu);
+
+        let hybrid = execute_greedy_parity_plane(
+            &spec,
+            RealCliRuntimeMode::IsolatedGreedyParityHybrid,
+            tokenizer.clone(),
+            &case.prompt_token_ids,
+            &case.prompt_token_ids_sha256,
+            &resolved_config_sha256,
+            &args.expected_adapter_name,
+            args.progress_watchdog,
+            fixed.name,
+        )
+        .await;
+        let hybrid = match hybrid {
+            Ok(hybrid) => hybrid,
+            Err(error) => {
+                let mut failure = qualification_inference_failure(error.as_ref());
+                failure.detail = format!("fixed case {} strict Hybrid: {error}", fixed.name);
+                case.failure = Some(failure.clone());
+                report.cases.push(case);
+                return fail_greedy_parity(report, failure, args.report_out.as_deref());
+            }
+        };
+        case.hybrid = Some(hybrid);
+        let (cpu_generation, hybrid_generation) = match (&case.cpu, &case.hybrid) {
+            (Some(cpu), Some(hybrid)) => (&cpu.generation, &hybrid.generation),
+            _ => {
+                let failure = QualificationFailure::new(
+                    FailureStage::Postcondition,
+                    "plane-evidence-incomplete",
+                    format!("fixed case {} lost successful plane evidence", fixed.name),
+                );
+                case.failure = Some(failure.clone());
+                report.cases.push(case);
+                return fail_greedy_parity(report, failure, args.report_out.as_deref());
+            }
+        };
+        let comparison = crate::greedy_parity::compare_generations(
+            cpu_generation,
+            hybrid_generation,
+            |ids| tokenizer.decode(ids).map_err(|error| error.to_string()),
+        );
+        let comparison = match comparison {
+            Ok(comparison) => comparison,
+            Err(error) => {
+                let failure = QualificationFailure::new(
+                    FailureStage::Postcondition,
+                    "divergence-evidence-decode-failed",
+                    format!("fixed case {}: {error}", fixed.name),
+                );
+                case.failure = Some(failure.clone());
+                report.cases.push(case);
+                return fail_greedy_parity(report, failure, args.report_out.as_deref());
+            }
+        };
+        let diverged = !comparison.exact_token_ids
+            || !comparison.equal_generated_count
+            || !comparison.equal_termination_reason
+            || !comparison.equal_generated_text_hash;
+        let divergence_position = comparison
+            .first_divergence
+            .as_ref()
+            .map(|evidence| evidence.position);
+        case.comparison = Some(comparison);
+        if diverged {
+            let failure = QualificationFailure::new(
+                FailureStage::Postcondition,
+                "greedy-token-divergence",
+                format!(
+                    "fixed case {} diverged at position {:?}",
+                    fixed.name, divergence_position
+                ),
+            );
+            case.failure = Some(failure.clone());
+            report.cases.push(case);
+            return fail_greedy_parity(report, failure, args.report_out.as_deref());
+        }
+        report.cases.push(case);
+    }
+    if let Err(failure) = report.finish() {
+        return fail_greedy_parity(report, failure, args.report_out.as_deref());
+    }
+    emit_greedy_parity_report(&report, args.report_out.as_deref())
+}
+
 async fn with_progress_timeout<T, F>(
     label: String,
     watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
@@ -4319,6 +5094,42 @@ fn validate_bench_real_policies(cfg: &crate::config::Config) -> Result<(), Strin
 enum RealCliRuntimeMode {
     BenchReal,
     StrictHybridQualification,
+    IsolatedGreedyParityCpu,
+    IsolatedGreedyParityHybrid,
+}
+
+impl RealCliRuntimeMode {
+    fn is_isolated(self) -> bool {
+        matches!(
+            self,
+            Self::IsolatedGreedyParityCpu | Self::IsolatedGreedyParityHybrid
+        )
+    }
+
+    fn installs_logical_gpu_cache(self) -> bool {
+        matches!(
+            self,
+            Self::StrictHybridQualification | Self::IsolatedGreedyParityHybrid
+        )
+    }
+
+    fn tokenizer_command(self) -> &'static str {
+        match self {
+            Self::BenchReal => "bench-real",
+            Self::StrictHybridQualification => "qualify-hybrid-q4",
+            Self::IsolatedGreedyParityCpu | Self::IsolatedGreedyParityHybrid => {
+                "qualify-hybrid-q4-greedy-parity"
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+struct ResolvedRealCliSpec {
+    cfg: crate::config::Config,
+    architecture: crate::architecture::Architecture,
+    first_k_dense_replace: usize,
+    advanced: crate::model::AdvancedConfig,
 }
 
 fn strict_hybrid_gpu_geometry(
@@ -4358,10 +5169,42 @@ async fn build_real_cli_runtime(
     mode: RealCliRuntimeMode,
 ) -> Result<BenchRealRuntime, Box<dyn std::error::Error>> {
     use crate::config::Config;
-    use crate::metrics::Metrics;
-    use crate::tokenizer::Tokenizer;
 
-    let mut cfg = Config::from_file(config_path)?;
+    let cfg = Config::from_file(config_path)?;
+    let spec = resolve_real_cli_spec_from_config(cfg, mode)?;
+    let execution_context = match mode {
+        RealCliRuntimeMode::BenchReal => {
+            crate::backend::install_default();
+            let context = crate::backend::current_execution_context();
+            let b = crate::backend::current();
+            info!(
+                backend = b.device_name(),
+                compute_plane = b.compute_plane(),
+                "bench-real math backend installed"
+            );
+            context
+        }
+        RealCliRuntimeMode::StrictHybridQualification => {
+            let context = resolve_isolated_real_cli_context(
+                &spec,
+                spec.cfg.real_transformer.compute_offload,
+            )?;
+            crate::backend::set_execution_context(context.clone())
+                .map_err(|e| format!("failed to install qualification execution context: {e}"))?;
+            context
+        }
+        RealCliRuntimeMode::IsolatedGreedyParityCpu
+        | RealCliRuntimeMode::IsolatedGreedyParityHybrid => {
+            return Err("isolated qualification runtimes must use the private isolated factory".into());
+        }
+    };
+    build_real_cli_runtime_from_spec(&spec, mode, execution_context, None).await
+}
+
+fn resolve_real_cli_spec_from_config(
+    mut cfg: crate::config::Config,
+    mode: RealCliRuntimeMode,
+) -> Result<ResolvedRealCliSpec, Box<dyn std::error::Error>> {
     crate::parallel::set_dense_matvec_backend(cfg.real_transformer.dense_matvec_backend);
     if mode == RealCliRuntimeMode::BenchReal {
         validate_bench_real_policies(&cfg)?;
@@ -4377,46 +5220,126 @@ async fn build_real_cli_runtime(
         resolved_first_k_dense_replace,
         &resolved_advanced,
     )?;
+    Ok(ResolvedRealCliSpec {
+        cfg,
+        architecture: resolved_architecture,
+        first_k_dense_replace: resolved_first_k_dense_replace,
+        advanced: resolved_advanced,
+    })
+}
 
-    let execution_context = match mode {
-        RealCliRuntimeMode::BenchReal => {
-            crate::backend::install_default();
-            let context = crate::backend::current_execution_context();
-            let b = crate::backend::current();
-            info!(
-                backend = b.device_name(),
-                compute_plane = b.compute_plane(),
-                "bench-real math backend installed"
-            );
-            context
-        }
-        RealCliRuntimeMode::StrictHybridQualification => {
-            let capacity_bytes = cfg
-                .gpu_cache
-                .vram_capacity_mb
-                .checked_mul(1024 * 1024)
-                .ok_or("gpu_cache.vram_capacity_mb overflows usize")?;
-            let gpu_cache = Arc::new(crate::expert_cache::GpuExpertCache::new(
-                capacity_bytes,
-                cfg.gpu_cache.vram_anchor_ratio,
-                cfg.gpu_cache.promote_after_hits,
-            ));
-            let context = crate::backend::resolve_execution_context(
-                cfg.real_transformer.compute_offload,
-                true,
-                strict_hybrid_gpu_geometry(&cfg, &resolved_advanced),
-                crate::backend::RoutedExpertGpuSpec {
-                    dtype: cfg.model.dtype,
-                    d_model: cfg.model.d_model,
-                    d_ff: cfg.model.d_ff,
-                },
-                gpu_cache,
-            )?;
-            crate::backend::set_execution_context(context.clone())
-                .map_err(|e| format!("failed to install qualification execution context: {e}"))?;
-            context
-        }
+fn resolve_isolated_real_cli_context(
+    spec: &ResolvedRealCliSpec,
+    requested: crate::backend::ComputeOffload,
+) -> Result<Arc<crate::backend::ExecutionContext>, Box<dyn std::error::Error>> {
+    let cfg = &spec.cfg;
+    let capacity_bytes = if requested == crate::backend::ComputeOffload::Hybrid {
+        cfg.gpu_cache
+            .vram_capacity_mb
+            .checked_mul(1024 * 1024)
+            .ok_or("gpu_cache.vram_capacity_mb overflows usize")?
+    } else {
+        0
     };
+    let gpu_cache = Arc::new(crate::expert_cache::GpuExpertCache::new(
+        capacity_bytes,
+        cfg.gpu_cache.vram_anchor_ratio,
+        cfg.gpu_cache.promote_after_hits,
+    ));
+    Ok(crate::backend::resolve_execution_context(
+        requested,
+        true,
+        strict_hybrid_gpu_geometry(cfg, &spec.advanced),
+        crate::backend::RoutedExpertGpuSpec {
+            dtype: cfg.model.dtype,
+            d_model: cfg.model.d_model,
+            d_ff: cfg.model.d_ff,
+        },
+        gpu_cache,
+    )?)
+}
+
+fn resolved_real_cli_spec_sha256(
+    spec: &ResolvedRealCliSpec,
+) -> Result<String, Box<dyn std::error::Error>> {
+    resolved_real_runtime_identity_sha256(
+        &spec.cfg,
+        spec.architecture,
+        spec.first_k_dense_replace,
+        &spec.advanced,
+    )
+}
+
+fn resolved_real_runtime_identity_sha256(
+    cfg: &crate::config::Config,
+    architecture: crate::architecture::Architecture,
+    first_k_dense_replace: usize,
+    advanced: &crate::model::AdvancedConfig,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let mut bytes = serde_json::to_vec(cfg)?;
+    bytes.extend_from_slice(architecture.model_type().as_bytes());
+    bytes.extend_from_slice(&(first_k_dense_replace as u64).to_le_bytes());
+    bytes.extend_from_slice(format!("{advanced:?}").as_bytes());
+    Ok(crate::greedy_parity::sha256_hex(&bytes))
+}
+
+/// Private qualification-only factory. It deliberately constructs an
+/// execution context without installing it in the process-global OnceLock.
+/// Every invocation builds a new storage/cache/predictor/model/engine family.
+async fn build_isolated_greedy_runtime(
+    spec: &ResolvedRealCliSpec,
+    mode: RealCliRuntimeMode,
+    tokenizer: Arc<crate::tokenizer::Tokenizer>,
+) -> Result<BenchRealRuntime, Box<dyn std::error::Error>> {
+    let requested = match mode {
+        RealCliRuntimeMode::IsolatedGreedyParityCpu => crate::backend::ComputeOffload::Cpu,
+        RealCliRuntimeMode::IsolatedGreedyParityHybrid => {
+            crate::backend::ComputeOffload::Hybrid
+        }
+        _ => return Err("non-isolated runtime mode passed to isolated factory".into()),
+    };
+    let context = resolve_isolated_real_cli_context(spec, requested)?;
+    build_real_cli_runtime_from_spec(spec, mode, context, Some(tokenizer)).await
+}
+
+fn load_real_cli_tokenizer(
+    cfg: &crate::config::Config,
+    mode: RealCliRuntimeMode,
+) -> Result<Arc<crate::tokenizer::Tokenizer>, Box<dyn std::error::Error>> {
+    let command = mode.tokenizer_command();
+    match cfg.tokenizer.path.as_ref() {
+        Some(path) => crate::tokenizer::Tokenizer::from_file(path)
+            .map(Arc::new)
+            .map_err(|error| {
+                format!(
+                    "{command} failed to load tokenizer {}: {error}",
+                    path.display()
+                )
+                .into()
+            }),
+        None if mode == RealCliRuntimeMode::BenchReal => Err(
+            "bench-real requires tokenizer.path; byte tokenizer fallback is not a production benchmark"
+                .into(),
+        ),
+        None => Err(format!(
+            "{command} requires tokenizer.path; byte tokenizer fallback is not permitted"
+        )
+        .into()),
+    }
+}
+
+async fn build_real_cli_runtime_from_spec(
+    spec: &ResolvedRealCliSpec,
+    mode: RealCliRuntimeMode,
+    execution_context: Arc<crate::backend::ExecutionContext>,
+    tokenizer_override: Option<Arc<crate::tokenizer::Tokenizer>>,
+) -> Result<BenchRealRuntime, Box<dyn std::error::Error>> {
+    use crate::metrics::Metrics;
+
+    let cfg = spec.cfg.clone();
+    let resolved_architecture = spec.architecture;
+    let resolved_first_k_dense_replace = spec.first_k_dense_replace;
+    let resolved_advanced = spec.advanced.clone();
 
     if !cfg.model.data_dir.is_dir() {
         return Err(format!(
@@ -4446,6 +5369,7 @@ async fn build_real_cli_runtime(
         cfg.model.expert_size,
     )?;
     let storage = Arc::new(storage);
+    let storage_shutdown = Arc::downgrade(&storage);
     let total_experts_for_files =
         (cfg.model.num_layers as u32).saturating_mul(cfg.model.num_experts);
     if !storage.is_packed() {
@@ -4488,6 +5412,7 @@ async fn build_real_cli_runtime(
             Arc::new(MultiLayerExpertCache::with_capacities(caps, per_layer))
         }
     };
+    let cache_shutdown = Arc::downgrade(&cache);
     let total_experts: u32 = (cfg.model.num_layers as u32)
         .saturating_mul(cfg.model.num_experts)
         .max(cfg.model.num_experts);
@@ -4497,6 +5422,7 @@ async fn build_real_cli_runtime(
         resolve_predict_min_prob(cfg.storage.predict_min_prob, total_experts),
         0xC0FFEE,
     ));
+    let predictor_shutdown = Arc::downgrade(&predictor);
 
     let rt = &cfg.real_transformer;
     let head_dim = if rt.head_dim == 0 {
@@ -4563,8 +5489,12 @@ async fn build_real_cli_runtime(
     );
     let router = crate::gating::Router::Linear(Arc::new(model.layers[0].gate.clone()));
     let metrics = Metrics::new();
+    let execution_context_shutdown = Arc::downgrade(&execution_context);
+    let gpu_cache_shutdown = Arc::downgrade(execution_context.gpu_expert_cache());
+    let mut speculator_shutdown = None;
+    let mut affinity_shutdown = None;
     let mut engine_builder = Engine::with_options_and_execution_context(
-        cache,
+        cache.clone(),
         pool,
         storage,
         router,
@@ -4615,6 +5545,7 @@ async fn build_real_cli_runtime(
             total_experts,
             0xC0FFEE,
         ));
+        speculator_shutdown = Some(Arc::downgrade(&spec));
         engine_builder = engine_builder.with_speculator(spec, top_k);
     }
     if cfg.predictive.affinity_enabled {
@@ -4622,6 +5553,7 @@ async fn build_real_cli_runtime(
             cfg.model.num_layers.max(1),
             cfg.model.num_experts,
         ));
+        affinity_shutdown = Some(Arc::downgrade(&affinity));
         engine_builder = engine_builder.with_affinity(
             affinity,
             cfg.predictive.affinity_neighbors_k,
@@ -4648,7 +5580,7 @@ async fn build_real_cli_runtime(
         ));
         engine_builder = engine_builder.with_pregate(pregate);
     }
-    if mode == RealCliRuntimeMode::StrictHybridQualification {
+    if mode.installs_logical_gpu_cache() {
         engine_builder.install_gpu_cache();
         engine_builder = engine_builder.with_routed_expert_gpu_failure_policy(
             crate::engine::RoutedExpertGpuFailurePolicy::StrictFailClosed,
@@ -4656,51 +5588,41 @@ async fn build_real_cli_runtime(
     }
     let engine = Arc::new(engine_builder.with_metrics(metrics));
 
-    let tokenizer = match cfg.tokenizer.path.as_ref() {
-        Some(p) => match Tokenizer::from_file(p) {
-            Ok(t) => Arc::new(t),
-            Err(e) => {
-                let detail = match mode {
-                    RealCliRuntimeMode::BenchReal => {
-                        format!("bench-real failed to load tokenizer {}: {e}", p.display())
-                    }
-                    RealCliRuntimeMode::StrictHybridQualification => format!(
-                        "qualify-hybrid-q4 failed to load tokenizer {}: {e}",
-                        p.display()
-                    ),
-                };
-                return Err(detail.into());
-            }
-        },
-        None => {
-            let detail = match mode {
-                RealCliRuntimeMode::BenchReal => "bench-real requires tokenizer.path; byte tokenizer fallback is not a production benchmark",
-                RealCliRuntimeMode::StrictHybridQualification => "qualify-hybrid-q4 requires tokenizer.path; byte tokenizer fallback is not permitted",
-            };
-            return Err(detail.into());
-        }
+    let tokenizer = match tokenizer_override {
+        Some(tokenizer) => tokenizer,
+        None => load_real_cli_tokenizer(&cfg, mode)?,
     };
     // The tokenizer must be addressable by the reconciled model vocabulary
     // (Finding 4): every emittable token id must be < model.vocab_size.
     tokenizer
         .validate_vocab_compat(model.config.vocab_size)
         .map_err(|e| -> Box<dyn std::error::Error> {
-            match mode {
-                RealCliRuntimeMode::BenchReal => {
-                    format!("bench-real tokenizer is incompatible with the model: {e}").into()
-                }
-                RealCliRuntimeMode::StrictHybridQualification => {
-                    format!("qualify-hybrid-q4 tokenizer is incompatible with the model: {e}")
-                        .into()
-                }
-            }
+            format!(
+                "{} tokenizer is incompatible with the model: {e}",
+                mode.tokenizer_command()
+            )
+            .into()
         })?;
+
+    let isolated_shutdown = mode.is_isolated().then(|| IsolatedRuntimeShutdownWitness {
+        engine: Arc::downgrade(&engine),
+        model: Arc::downgrade(&model),
+        cache: cache_shutdown,
+        storage: storage_shutdown,
+        predictor: predictor_shutdown,
+        execution_context: execution_context_shutdown,
+        gpu_cache: gpu_cache_shutdown,
+        speculator: speculator_shutdown,
+        affinity: affinity_shutdown,
+    });
 
     Ok(BenchRealRuntime {
         cfg,
         engine,
         model,
         tokenizer,
+        isolated_cache: mode.is_isolated().then_some(cache),
+        isolated_shutdown,
     })
 }
 
@@ -5019,8 +5941,34 @@ async fn run_bench_real_once(
     if prompt_ids.is_empty() {
         return Err("bench-real prompt encoded to zero tokens".into());
     }
+    Ok(
+        run_real_once_from_token_ids(runtime, &prompt_ids, output_tokens, params, run_index)
+            .await?
+            .report,
+    )
+}
+
+struct PreTokenizedRealRun {
+    report: BenchRealRunReport,
+    initial_kv_sequence_lengths: Vec<usize>,
+}
+
+/// Execute the existing production-authentic real-model path from caller-owned
+/// token IDs. The fixed-corpus qualifier uses this seam to prove both planes
+/// receive the exact same single tokenization result.
+async fn run_real_once_from_token_ids(
+    runtime: &BenchRealRuntime,
+    prompt_ids: &[u32],
+    output_tokens: usize,
+    params: crate::sampling::SamplingParams,
+    run_index: usize,
+) -> Result<PreTokenizedRealRun, Box<dyn std::error::Error>> {
+    if prompt_ids.is_empty() {
+        return Err("pre-tokenized real-model prompt contains zero tokens".into());
+    }
     let stage_timings = crate::stage_timing::StageTimings::default();
     let mut kv = runtime.model.fresh_kv_caches();
+    let initial_kv_sequence_lengths = kv.iter().map(|cache| cache.seq_len).collect();
     let pre = runtime.engine.report();
     let total_started = Instant::now();
     let prompt_started = Instant::now();
@@ -5124,7 +6072,7 @@ async fn run_bench_real_once(
     let output_text = runtime.tokenizer.decode(&completion_ids)?;
     let stage_timings = stage_timings.snapshot();
 
-    Ok(BenchRealRunReport {
+    let report = BenchRealRunReport {
         run_index,
         prompt_tokens: prompt_ids.len(),
         completion_tokens: output_tokens,
@@ -5151,6 +6099,10 @@ async fn run_bench_real_once(
         output_token_ids: completion_ids,
         output_text,
         stage_timings,
+    };
+    Ok(PreTokenizedRealRun {
+        report,
+        initial_kv_sequence_lengths,
     })
 }
 
@@ -8831,6 +9783,148 @@ mod tests {
         assert_eq!(expert_id, 257);
         assert_eq!(expected_adapter_name, "NVIDIA L4");
         assert_eq!(report_out, None);
+    }
+
+    #[test]
+    fn greedy_parity_cli_requires_one_config_and_exact_adapter() {
+        let cli = <Cli as clap::Parser>::try_parse_from([
+            "micro-expert-router",
+            "qualify-hybrid-q4-greedy-parity",
+            "--config",
+            "strict-hybrid.toml",
+            "--expected-adapter-name",
+            "NVIDIA L4",
+            "--report-out",
+            "report.json",
+        ])
+        .unwrap();
+        let Cmd::QualifyHybridQ4GreedyParity {
+            config,
+            expected_adapter_name,
+            report_out,
+        } = cli.cmd
+        else {
+            panic!("expected qualify-hybrid-q4-greedy-parity command");
+        };
+        assert_eq!(config, PathBuf::from("strict-hybrid.toml"));
+        assert_eq!(expected_adapter_name, "NVIDIA L4");
+        assert_eq!(report_out, Some(PathBuf::from("report.json")));
+
+        let error = <Cli as clap::Parser>::try_parse_from([
+            "micro-expert-router",
+            "qualify-hybrid-q4-greedy-parity",
+            "--config",
+            "strict-hybrid.toml",
+            "--cpu-config",
+            "cpu.toml",
+            "--expected-adapter-name",
+            "NVIDIA L4",
+        ])
+        .unwrap_err();
+        assert!(error.to_string().contains("--cpu-config"));
+    }
+
+    #[test]
+    fn greedy_parity_failure_report_is_written_and_returns_error() {
+        let dir = tempdir_unique("greedy-parity-failure");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("report.json");
+        let report = crate::greedy_parity::GreedyParityReport::new(
+            crate::qualification::BuildProvenance {
+                git_sha: Some("0".repeat(40)),
+                dirty: Some(false),
+                package_version: "test".to_string(),
+            },
+            crate::qualification::QualificationArtifacts::default(),
+            None,
+            "NVIDIA L4".to_string(),
+        );
+        let failure = crate::qualification::QualificationFailure::new(
+            crate::qualification::FailureStage::Postcondition,
+            "test-failure",
+            "typed failure must produce a nonzero command result",
+        );
+        assert!(fail_greedy_parity(report, failure, Some(&path)).is_err());
+        let json: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert_eq!(json["status"], "fail");
+        assert_eq!(json["failure"]["code"], "test-failure");
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn greedy_parity_isolated_contexts_are_distinct_and_cpu_exact() {
+        let global_before = crate::backend::current_execution_context();
+        let mut cfg = bench_real_ok_cfg();
+        cfg.model.d_model = 32;
+        cfg.model.d_ff = 32;
+        cfg.model.dtype = crate::inference::WeightDtype::Q4_0;
+        cfg.real_transformer.num_heads = 1;
+        cfg.real_transformer.num_kv_heads = 1;
+        cfg.real_transformer.head_dim = 32;
+        let spec = ResolvedRealCliSpec {
+            cfg,
+            architecture: crate::architecture::Architecture::Qwen3Moe,
+            first_k_dense_replace: 0,
+            advanced: crate::model::AdvancedConfig::default(),
+        };
+        let first = resolve_isolated_real_cli_context(
+            &spec,
+            crate::backend::ComputeOffload::Cpu,
+        )
+        .unwrap();
+        let second = resolve_isolated_real_cli_context(
+            &spec,
+            crate::backend::ComputeOffload::Cpu,
+        )
+        .unwrap();
+        assert_ne!(first.id(), second.id());
+        assert!(!Arc::ptr_eq(
+            first.gpu_expert_cache(),
+            second.gpu_expert_cache()
+        ));
+        assert!(crate::greedy_parity::cpu_plan_exact(&first.plan().into()));
+        assert!(crate::greedy_parity::cpu_plan_exact(&second.plan().into()));
+        let global_after = crate::backend::current_execution_context();
+        assert!(Arc::ptr_eq(&global_before, &global_after));
+        assert_ne!(first.id(), global_after.id());
+        assert_ne!(second.id(), global_after.id());
+        assert!(RealCliRuntimeMode::IsolatedGreedyParityCpu.is_isolated());
+        assert!(RealCliRuntimeMode::IsolatedGreedyParityHybrid.is_isolated());
+        assert!(!RealCliRuntimeMode::BenchReal.is_isolated());
+    }
+
+    #[tokio::test]
+    async fn greedy_parity_shutdown_waits_for_background_reference_release() {
+        let owner = Arc::new(());
+        let weak = Arc::downgrade(&owner);
+        let background = tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            drop(owner);
+        });
+        let evidence = wait_for_isolated_release(
+            || weak.upgrade().is_none(),
+            std::time::Duration::from_millis(1),
+            std::time::Duration::from_secs(1),
+        )
+        .await
+        .unwrap();
+        background.await.unwrap();
+        assert!(evidence.controlled_shutdown_requested);
+        assert!(evidence.all_runtime_resources_released);
+        assert!(evidence.poll_iterations > 1);
+    }
+
+    #[tokio::test]
+    async fn greedy_parity_shutdown_timeout_fails_closed() {
+        let error = wait_for_isolated_release(
+            || false,
+            std::time::Duration::from_millis(1),
+            std::time::Duration::from_millis(5),
+        )
+        .await
+        .unwrap_err();
+        assert!(error.contains("background resources remained live"));
     }
 
     #[test]

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -910,6 +910,14 @@ enum Cmd {
         report_out: Option<PathBuf>,
     },
 
+    /// Private same-binary worker for one strict-Hybrid greedy-parity plane.
+    #[command(name = "greedy-parity-hybrid-worker-internal", hide = true)]
+    GreedyParityHybridWorkerInternal {
+        /// The same strict Hybrid config parsed by the parent orchestrator.
+        #[arg(long)]
+        config: PathBuf,
+    },
+
     /// Benchmark dense matvec backends on the target Qwen3-Coder CPU shapes.
     ///
     /// This is intentionally separate from `bench-real`: it isolates Q/K/V/O,
@@ -1063,13 +1071,25 @@ fn parse_positive_f64_value(s: &str) -> Result<f64, String> {
     }
 }
 
-fn init_logging(filter: &str) {
+fn init_logging(filter: &str, worker_protocol_stdout: bool) {
     let env_filter = EnvFilter::try_new(filter).unwrap_or_else(|_| EnvFilter::new("info"));
-    let _ = tracing_subscriber::fmt()
-        .with_env_filter(env_filter)
-        .with_target(false)
-        .with_level(true)
-        .try_init();
+    if worker_protocol_stdout {
+        // The private worker reserves stdout for exactly one typed JSON value.
+        // All inherited diagnostics must stay on stderr or the parent rejects
+        // the protocol as corrupted.
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(env_filter)
+            .with_target(false)
+            .with_level(true)
+            .with_writer(std::io::stderr)
+            .try_init();
+    } else {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(env_filter)
+            .with_target(false)
+            .with_level(true)
+            .try_init();
+    }
 }
 
 fn rayon_env_override_present() -> bool {
@@ -1546,7 +1566,11 @@ fn parse_autotune_probe_output(
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let raw_args: Vec<OsString> = std::env::args_os().collect();
     let cli = Cli::parse();
-    init_logging(&cli.log);
+    let worker_protocol_stdout = matches!(
+        cli.cmd,
+        Cmd::GreedyParityHybridWorkerInternal { .. }
+    );
+    init_logging(&cli.log, worker_protocol_stdout);
 
     // Load only enough startup configuration to resolve process-level
     // runtime controls before CPU placement / Rayon exist. The command
@@ -1557,7 +1581,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         | Cmd::BenchReal { config, .. }
         | Cmd::QualifyHybridQ4 { config, .. }
         | Cmd::QualifyHybridQ4Parity { config, .. }
-        | Cmd::QualifyHybridQ4GreedyParity { config, .. } => {
+        | Cmd::QualifyHybridQ4GreedyParity { config, .. }
+        | Cmd::GreedyParityHybridWorkerInternal { config } => {
             Some(crate::config::Config::from_file(config)?)
         }
         _ => None,
@@ -1681,6 +1706,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             | Cmd::QualifyHybridQ4 { .. }
             | Cmd::QualifyHybridQ4Parity { .. }
             | Cmd::QualifyHybridQ4GreedyParity { .. }
+            | Cmd::GreedyParityHybridWorkerInternal { .. }
     ) && !run_gpu_requested
     {
         crate::backend::install_default();
@@ -1975,6 +2001,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 },
             ))
         }
+        Cmd::GreedyParityHybridWorkerInternal { config: _ } => {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()?;
+            rt.block_on(cmd_greedy_parity_hybrid_worker_internal(
+                GreedyParityHybridWorkerArgs {
+                    parsed_config: startup_config
+                        .take()
+                        .ok_or("greedy parity worker startup config was not parsed")?,
+                    progress_watchdog,
+                },
+            ))
+        }
         Cmd::MatvecMicrobench {
             backend,
             warmup_runs,
@@ -2209,6 +2248,11 @@ struct QualifyHybridQ4GreedyParityArgs {
     parsed_config: crate::config::Config,
     expected_adapter_name: String,
     report_out: Option<PathBuf>,
+    progress_watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+}
+
+struct GreedyParityHybridWorkerArgs {
+    parsed_config: crate::config::Config,
     progress_watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
 }
 
@@ -3755,7 +3799,7 @@ async fn execute_greedy_parity_plane(
             gpu_io: io_before,
         };
         Ok(crate::greedy_parity::PlaneRunEvidence {
-            plane,
+            plane: plane.to_string(),
             model_load: greedy_parity_model_load(&runtime),
             execution_plan,
             routed_expert_gpu_failure_policy: greedy_parity_failure_policy_name(
@@ -3771,6 +3815,7 @@ async fn execute_greedy_parity_plane(
             gpu_memory_before: memory_before,
             gpu_memory_after: memory_after,
             background_shutdown: crate::greedy_parity::BackgroundShutdownEvidence::default(),
+            worker_process: None,
         })
     }
     .await;
@@ -3789,6 +3834,444 @@ async fn execute_greedy_parity_plane(
             Err(format!("{error}; isolated shutdown also failed: {shutdown_error}").into())
         }
     }
+}
+
+#[derive(Debug)]
+struct BoundedChildOutput {
+    bytes: Vec<u8>,
+    truncated: bool,
+}
+
+#[derive(Debug)]
+struct GreedyParityWorkerCapture {
+    process_id: u32,
+    status: std::process::ExitStatus,
+    timed_out: bool,
+    reaped: bool,
+    stdout: BoundedChildOutput,
+    stderr: BoundedChildOutput,
+    transport_error: Option<String>,
+}
+
+fn read_child_output_bounded(
+    mut reader: impl std::io::Read,
+    limit: usize,
+) -> std::io::Result<BoundedChildOutput> {
+    let mut retained = Vec::with_capacity(limit.min(8192));
+    let mut buffer = [0_u8; 8192];
+    let mut truncated = false;
+    loop {
+        let read = reader.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        let remaining = limit.saturating_sub(retained.len());
+        let keep = remaining.min(read);
+        retained.extend_from_slice(&buffer[..keep]);
+        truncated |= keep != read;
+    }
+    Ok(BoundedChildOutput {
+        bytes: retained,
+        truncated,
+    })
+}
+
+#[cfg(unix)]
+fn child_exit_signal(status: &std::process::ExitStatus) -> Option<i32> {
+    use std::os::unix::process::ExitStatusExt as _;
+    status.signal()
+}
+
+#[cfg(not(unix))]
+fn child_exit_signal(_status: &std::process::ExitStatus) -> Option<i32> {
+    None
+}
+
+/// Spawn, feed, drain, bound, and reap one worker. Both pipes are drained on
+/// dedicated threads so verbose diagnostics cannot deadlock the child. A
+/// timeout always kills and then waits for the exact child before returning.
+async fn run_greedy_parity_worker_process(
+    mut command: std::process::Command,
+    request_json: Vec<u8>,
+    timeout: Duration,
+) -> Result<GreedyParityWorkerCapture, String> {
+    use std::io::Write as _;
+    use std::process::Stdio;
+
+    command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = command
+        .spawn()
+        .map_err(|error| format!("failed to spawn Hybrid worker: {error}"))?;
+    let process_id = child.id();
+    let stdout = match child.stdout.take() {
+        Some(stdout) => stdout,
+        None => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err("spawned Hybrid worker has no stdout pipe".to_string());
+        }
+    };
+    let stderr = match child.stderr.take() {
+        Some(stderr) => stderr,
+        None => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err("spawned Hybrid worker has no stderr pipe".to_string());
+        }
+    };
+    let stdout_thread = std::thread::spawn(move || {
+        read_child_output_bounded(stdout, crate::greedy_parity::MAX_WORKER_STDOUT_BYTES)
+    });
+    let stderr_thread = std::thread::spawn(move || {
+        read_child_output_bounded(stderr, crate::greedy_parity::MAX_WORKER_STDERR_BYTES)
+    });
+
+    let mut transport_error = None;
+    match child.stdin.take() {
+        Some(mut stdin) => {
+            if let Err(error) = stdin.write_all(&request_json) {
+                transport_error = Some(format!("failed to write Hybrid worker request: {error}"));
+                let _ = child.kill();
+            }
+        }
+        None => {
+            transport_error = Some("spawned Hybrid worker has no stdin pipe".to_string());
+            let _ = child.kill();
+        }
+    }
+
+    let started = Instant::now();
+    let mut timed_out = false;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) if started.elapsed() < timeout && transport_error.is_none() => {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+            Ok(None) => {
+                timed_out = transport_error.is_none();
+                if let Err(error) = child.kill() {
+                    transport_error.get_or_insert_with(|| {
+                        format!("failed to kill Hybrid worker after timeout: {error}")
+                    });
+                }
+                break child
+                    .wait()
+                    .map_err(|error| format!("failed to reap Hybrid worker: {error}"))?;
+            }
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(format!("failed to query Hybrid worker status: {error}"));
+            }
+        }
+    };
+
+    let stdout = stdout_thread
+        .join()
+        .map_err(|_| "Hybrid worker stdout reader thread panicked".to_string())?
+        .map_err(|error| format!("failed to read Hybrid worker stdout: {error}"))?;
+    let stderr = stderr_thread
+        .join()
+        .map_err(|_| "Hybrid worker stderr reader thread panicked".to_string())?
+        .map_err(|error| format!("failed to read Hybrid worker stderr: {error}"))?;
+    Ok(GreedyParityWorkerCapture {
+        process_id,
+        status,
+        timed_out,
+        reaped: true,
+        stdout,
+        stderr,
+        transport_error,
+    })
+}
+
+fn current_executable_identity() -> Result<(PathBuf, String), Box<dyn std::error::Error>> {
+    let executable = std::env::current_exe()?;
+    let digest = crate::qualification::hash_small_file(&executable)?;
+    Ok((executable, digest.sha256))
+}
+
+fn emit_hybrid_worker_response(
+    response: &crate::greedy_parity::HybridWorkerResponse,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use std::io::Write as _;
+    let stdout = std::io::stdout();
+    let mut locked = stdout.lock();
+    serde_json::to_writer(&mut locked, response)?;
+    locked.write_all(b"\n")?;
+    locked.flush()?;
+    Ok(())
+}
+
+/// Hidden same-binary entry point. It never tokenizes: the only prompt input
+/// accepted is the parent's typed token-ID vector on stdin.
+async fn cmd_greedy_parity_hybrid_worker_internal(
+    args: GreedyParityHybridWorkerArgs,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use std::io::Read as _;
+
+    let mut input = Vec::new();
+    std::io::stdin()
+        .take((crate::greedy_parity::MAX_WORKER_STDOUT_BYTES + 1) as u64)
+        .read_to_end(&mut input)?;
+    if input.len() > crate::greedy_parity::MAX_WORKER_STDOUT_BYTES {
+        return Err("Hybrid worker request exceeds the private protocol limit".into());
+    }
+    let request = crate::greedy_parity::parse_hybrid_worker_request_exact(&input)?;
+    let spec = resolve_real_cli_spec_from_config(
+        args.parsed_config,
+        RealCliRuntimeMode::IsolatedGreedyParityHybrid,
+    )?;
+    let observed_config_sha256 = resolved_real_cli_spec_sha256(&spec)?;
+    let (_, observed_executable_sha256) = current_executable_identity()?;
+    let provenance = crate::qualification::BuildProvenance::embedded();
+    let identity = crate::greedy_parity::validate_hybrid_worker_request(
+        &request,
+        &observed_config_sha256,
+        &observed_executable_sha256,
+        provenance.git_sha.as_deref(),
+    );
+    if !identity.all_verified() {
+        let response = crate::greedy_parity::HybridWorkerResponse::from_request(
+            &request,
+            &observed_config_sha256,
+            &observed_executable_sha256,
+            provenance.git_sha.as_deref(),
+            identity,
+            None,
+            Some("Hybrid worker request identity validation failed".to_string()),
+        );
+        emit_hybrid_worker_response(&response)?;
+        return Err("Hybrid worker request identity validation failed".into());
+    }
+
+    let tokenizer = load_real_cli_tokenizer(
+        &spec.cfg,
+        RealCliRuntimeMode::IsolatedGreedyParityHybrid,
+    )?;
+    let attempt = execute_greedy_parity_plane(
+        &spec,
+        RealCliRuntimeMode::IsolatedGreedyParityHybrid,
+        tokenizer,
+        &request.prompt_token_ids,
+        &request.prompt_token_ids_sha256,
+        &request.resolved_config_sha256,
+        &request.expected_adapter_name,
+        args.progress_watchdog,
+        &request.case_name,
+    )
+    .await;
+    match attempt {
+        Ok(plane) => {
+            let response = crate::greedy_parity::HybridWorkerResponse::from_request(
+                &request,
+                &observed_config_sha256,
+                &observed_executable_sha256,
+                provenance.git_sha.as_deref(),
+                identity,
+                Some(plane),
+                None,
+            );
+            emit_hybrid_worker_response(&response)
+        }
+        Err(error) => {
+            let detail = error.to_string();
+            let response = crate::greedy_parity::HybridWorkerResponse::from_request(
+                &request,
+                &observed_config_sha256,
+                &observed_executable_sha256,
+                provenance.git_sha.as_deref(),
+                identity,
+                None,
+                Some(detail.clone()),
+            );
+            emit_hybrid_worker_response(&response)?;
+            Err(detail.into())
+        }
+    }
+}
+
+#[derive(Debug)]
+struct GreedyParityWorkerCaseFailure {
+    detail: String,
+    evidence: crate::greedy_parity::HybridWorkerFailureEvidence,
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn execute_greedy_parity_hybrid_worker(
+    executable: &Path,
+    config: &Path,
+    request: &crate::greedy_parity::HybridWorkerRequest,
+    timeout: Duration,
+) -> Result<crate::greedy_parity::PlaneRunEvidence, GreedyParityWorkerCaseFailure> {
+    let request_json = serde_json::to_vec(request).map_err(|error| {
+        GreedyParityWorkerCaseFailure {
+            detail: format!("failed to serialize Hybrid worker request: {error}"),
+            evidence: crate::greedy_parity::HybridWorkerFailureEvidence {
+                worker_id: request.worker_id.clone(),
+                case_name: request.case_name.clone(),
+                child_process_spawned: false,
+                process_id: None,
+                exit_code: None,
+                signal: None,
+                timed_out: false,
+                process_reaped: false,
+                evidence_emitted: false,
+                identity_validation_succeeded: false,
+                identity_validation: None,
+                stderr: String::new(),
+                stderr_truncated: false,
+            },
+        }
+    })?;
+    let mut command = Command::new(executable);
+    command
+        .arg("--progress-timeout-secs")
+        .arg(timeout.as_secs().to_string())
+        .arg("greedy-parity-hybrid-worker-internal")
+        .arg("--config")
+        .arg(config);
+    let capture = run_greedy_parity_worker_process(command, request_json, timeout)
+        .await
+        .map_err(|detail| GreedyParityWorkerCaseFailure {
+            detail,
+            evidence: crate::greedy_parity::HybridWorkerFailureEvidence {
+                worker_id: request.worker_id.clone(),
+                case_name: request.case_name.clone(),
+                child_process_spawned: false,
+                process_id: None,
+                exit_code: None,
+                signal: None,
+                timed_out: false,
+                process_reaped: false,
+                evidence_emitted: false,
+                identity_validation_succeeded: false,
+                identity_validation: None,
+                stderr: String::new(),
+                stderr_truncated: false,
+            },
+        })?;
+
+    let stderr = String::from_utf8_lossy(&capture.stderr.bytes).into_owned();
+    if !stderr.is_empty() {
+        eprintln!(
+            "greedy parity Hybrid worker {} stderr{}:\n{}",
+            request.case_name,
+            if capture.stderr.truncated {
+                " (bounded/truncated)"
+            } else {
+                ""
+            },
+            stderr
+        );
+    }
+    let response_result = if capture.stdout.truncated {
+        Err(format!(
+            "Hybrid worker stdout exceeded {} bytes",
+            crate::greedy_parity::MAX_WORKER_STDOUT_BYTES
+        ))
+    } else {
+        crate::greedy_parity::parse_hybrid_worker_response_exact(&capture.stdout.bytes)
+    };
+    let response = response_result.as_ref().ok();
+    let validation = response.map(|response| {
+        crate::greedy_parity::validate_hybrid_worker_response(request, response)
+    });
+    let exit_code = capture.status.code();
+    let signal = child_exit_signal(&capture.status);
+    let normal_zero_exit = capture.status.success()
+        && exit_code == Some(0)
+        && signal.is_none()
+        && !capture.timed_out
+        && capture.transport_error.is_none();
+    let process = crate::greedy_parity::HybridWorkerProcessEvidence {
+        worker_id: request.worker_id.clone(),
+        child_process_spawned: true,
+        process_id: Some(capture.process_id),
+        executable_sha256: request.executable_sha256.clone(),
+        build_git_sha: request.build_git_sha.clone(),
+        executable_identity_verified: validation
+            .is_some_and(|value| value.executable_identity_verified),
+        build_sha_identity_verified: validation
+            .is_some_and(|value| value.build_sha_identity_verified),
+        case_identity_verified: validation.is_some_and(|value| value.case_identity_verified),
+        config_identity_verified: validation
+            .is_some_and(|value| value.config_identity_verified),
+        expected_adapter_identity_verified: validation
+            .is_some_and(|value| value.expected_adapter_identity_verified),
+        prompt_token_identity_verified: validation
+            .is_some_and(|value| value.prompt_token_identity_verified),
+        output_token_limit_verified: validation
+            .is_some_and(|value| value.output_token_limit_verified),
+        greedy_sampling_identity_verified: validation
+            .is_some_and(|value| value.greedy_sampling_identity_verified),
+        normal_zero_exit,
+        exit_code,
+        signal,
+        process_reaped: capture.reaped,
+        timed_out: capture.timed_out,
+        evidence_emitted: response.is_some(),
+    };
+    let response_failure = response.and_then(|response| response.failure.as_deref());
+    let success = process.normal_zero_exit
+        && process.process_reaped
+        && validation.is_some_and(|value| value.all_verified())
+        && response.is_some_and(|response| {
+            response.failure.is_none()
+                && response.plane.is_some()
+                && response
+                    .plane
+                    .as_ref()
+                    .is_some_and(|plane| plane.worker_process.is_none())
+        });
+    if success {
+        let mut plane = response.unwrap().plane.clone().unwrap();
+        plane.worker_process = Some(process);
+        return Ok(plane);
+    }
+
+    let parse_detail = response_result.as_ref().err().cloned();
+    let detail = [
+        capture.transport_error.as_deref(),
+        parse_detail.as_deref(),
+        response_failure,
+        (!normal_zero_exit).then_some("Hybrid worker did not exit normally with status zero"),
+        (!capture.reaped).then_some("Hybrid worker was not reaped"),
+        validation
+            .is_some_and(|value| !value.all_verified())
+            .then_some("Hybrid worker response identity validation failed"),
+    ]
+    .into_iter()
+    .flatten()
+    .collect::<Vec<_>>()
+    .join("; ");
+    Err(GreedyParityWorkerCaseFailure {
+        detail: if detail.is_empty() {
+            "Hybrid worker emitted no successful plane evidence".to_string()
+        } else {
+            detail
+        },
+        evidence: crate::greedy_parity::HybridWorkerFailureEvidence {
+            worker_id: request.worker_id.clone(),
+            case_name: request.case_name.clone(),
+            child_process_spawned: true,
+            process_id: Some(capture.process_id),
+            exit_code,
+            signal,
+            timed_out: capture.timed_out,
+            process_reaped: capture.reaped,
+            evidence_emitted: response.is_some(),
+            identity_validation_succeeded: validation
+                .is_some_and(|value| value.all_verified()),
+            identity_validation: validation,
+            stderr,
+            stderr_truncated: capture.stderr.truncated,
+        },
+    })
 }
 
 async fn cmd_qualify_hybrid_q4_greedy_parity(
@@ -3959,6 +4442,43 @@ async fn cmd_qualify_hybrid_q4_greedy_parity(
         }
     };
     report.resolved_config_sha256 = Some(resolved_config_sha256.clone());
+    let worker_timeout = args
+        .progress_watchdog
+        .timeout
+        .expect("positive progress timeout checked above");
+    let (worker_executable, executable_sha256) = match current_executable_identity() {
+        Ok(identity) => identity,
+        Err(error) => {
+            return fail_greedy_parity(
+                report,
+                QualificationFailure::new(
+                    FailureStage::Startup,
+                    "worker-executable-identity-failed",
+                    error.to_string(),
+                ),
+                args.report_out.as_deref(),
+            );
+        }
+    };
+    report.orchestrator_executable_sha256 = Some(executable_sha256.clone());
+    let build_git_sha = match report.provenance.git_sha.clone() {
+        Some(sha)
+            if sha.len() == 40 && sha.bytes().all(|byte| byte.is_ascii_hexdigit()) =>
+        {
+            sha
+        }
+        _ => {
+            return fail_greedy_parity(
+                report,
+                QualificationFailure::new(
+                    FailureStage::Preflight,
+                    "worker-build-identity-unavailable",
+                    "same-binary worker isolation requires an embedded immutable build git SHA",
+                ),
+                args.report_out.as_deref(),
+            );
+        }
+    };
     let tokenizer = match load_real_cli_tokenizer(
         &spec.cfg,
         RealCliRuntimeMode::IsolatedGreedyParityHybrid,
@@ -3977,9 +4497,13 @@ async fn cmd_qualify_hybrid_q4_greedy_parity(
         }
     };
 
-    for fixed in crate::greedy_parity::FIXED_CORPUS {
-        // The sole encode call for this case happens here. Both fresh runtimes
-        // receive the same immutable ID slice and shared tokenizer instance.
+    for (case_index, fixed) in crate::greedy_parity::FIXED_CORPUS
+        .into_iter()
+        .enumerate()
+    {
+        // The sole encode call for this case happens here. The CPU runtime
+        // receives this immutable ID slice directly; the same IDs and frozen
+        // tokenizer artifact identity cross the typed worker protocol.
         let prompt_token_ids = match tokenizer.encode(fixed.prompt) {
             Ok(ids) if !ids.is_empty() => ids,
             Ok(_) => {
@@ -4030,23 +4554,42 @@ async fn cmd_qualify_hybrid_q4_greedy_parity(
         };
         case.cpu = Some(cpu);
 
-        let hybrid = execute_greedy_parity_plane(
-            &spec,
-            RealCliRuntimeMode::IsolatedGreedyParityHybrid,
-            tokenizer.clone(),
-            &case.prompt_token_ids,
-            &case.prompt_token_ids_sha256,
-            &resolved_config_sha256,
-            &args.expected_adapter_name,
-            args.progress_watchdog,
-            fixed.name,
+        let worker_request = crate::greedy_parity::HybridWorkerRequest::new(
+            crate::greedy_parity::hybrid_worker_id(
+                &build_git_sha,
+                &executable_sha256,
+                case_index,
+                fixed.name,
+            ),
+            fixed,
+            resolved_config_sha256.clone(),
+            args.expected_adapter_name.clone(),
+            case.prompt_token_ids.clone(),
+            executable_sha256.clone(),
+            build_git_sha.clone(),
+        );
+        let hybrid = execute_greedy_parity_hybrid_worker(
+            &worker_executable,
+            &args.config,
+            &worker_request,
+            worker_timeout,
         )
         .await;
         let hybrid = match hybrid {
             Ok(hybrid) => hybrid,
-            Err(error) => {
-                let mut failure = qualification_inference_failure(error.as_ref());
-                failure.detail = format!("fixed case {} strict Hybrid: {error}", fixed.name);
+            Err(worker_error) => {
+                let mut failure = QualificationFailure::new(
+                    FailureStage::Inference,
+                    "hybrid-worker-failed",
+                    format!(
+                        "fixed case {} strict Hybrid worker: {}",
+                        fixed.name, worker_error.detail
+                    ),
+                );
+                if worker_error.evidence.timed_out {
+                    failure.code = "hybrid-worker-timeout".to_string();
+                }
+                case.worker_failure = Some(worker_error.evidence);
                 case.failure = Some(failure.clone());
                 report.cases.push(case);
                 return fail_greedy_parity(report, failure, args.report_out.as_deref());
@@ -9925,6 +10468,119 @@ mod tests {
         .await
         .unwrap_err();
         assert!(error.contains("background resources remained live"));
+    }
+
+    #[test]
+    fn greedy_parity_internal_worker_command_is_hidden_and_non_recursive() {
+        let cli = <Cli as clap::Parser>::try_parse_from([
+            "micro-expert-router",
+            "greedy-parity-hybrid-worker-internal",
+            "--config",
+            "strict-hybrid.toml",
+        ])
+        .unwrap();
+        assert!(matches!(
+            cli.cmd,
+            Cmd::GreedyParityHybridWorkerInternal { config }
+                if config == Path::new("strict-hybrid.toml")
+        ));
+        let help = <Cli as clap::CommandFactory>::command()
+            .render_long_help()
+            .to_string();
+        assert!(!help.contains("greedy-parity-hybrid-worker-internal"));
+    }
+
+    #[test]
+    fn greedy_parity_worker_stderr_is_bounded_while_input_is_fully_drained() {
+        let input = vec![b'x'; crate::greedy_parity::MAX_WORKER_STDERR_BYTES + 4096];
+        let bounded = read_child_output_bounded(
+            std::io::Cursor::new(input),
+            crate::greedy_parity::MAX_WORKER_STDERR_BYTES,
+        )
+        .unwrap();
+        assert_eq!(
+            bounded.bytes.len(),
+            crate::greedy_parity::MAX_WORKER_STDERR_BYTES
+        );
+        assert!(bounded.truncated);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn greedy_parity_worker_supervisor_observes_success_and_zero_exit() {
+        let mut command = Command::new("sh");
+        command
+            .arg("-c")
+            .arg("cat >/dev/null; printf '{\"ok\":true}'; printf diagnostic >&2");
+        let capture = run_greedy_parity_worker_process(
+            command,
+            br#"{"request":true}"#.to_vec(),
+            Duration::from_secs(2),
+        )
+        .await
+        .unwrap();
+        assert_eq!(capture.status.code(), Some(0));
+        assert_eq!(child_exit_signal(&capture.status), None);
+        assert!(capture.reaped);
+        assert!(!capture.timed_out);
+        assert_eq!(capture.stdout.bytes, br#"{"ok":true}"#);
+        assert_eq!(capture.stderr.bytes, b"diagnostic");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn greedy_parity_worker_supervisor_preserves_nonzero_exit() {
+        let mut command = Command::new("sh");
+        command.arg("-c").arg("cat >/dev/null; exit 7");
+        let capture = run_greedy_parity_worker_process(
+            command,
+            b"request".to_vec(),
+            Duration::from_secs(2),
+        )
+        .await
+        .unwrap();
+        assert_eq!(capture.status.code(), Some(7));
+        assert!(capture.reaped);
+        assert!(!capture.timed_out);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn greedy_parity_worker_supervisor_preserves_signal_termination() {
+        let mut command = Command::new("sh");
+        command
+            .arg("-c")
+            .arg("cat >/dev/null; kill -TERM $$");
+        let capture = run_greedy_parity_worker_process(
+            command,
+            b"request".to_vec(),
+            Duration::from_secs(2),
+        )
+        .await
+        .unwrap();
+        assert_eq!(capture.status.code(), None);
+        assert_eq!(child_exit_signal(&capture.status), Some(15));
+        assert!(capture.reaped);
+        assert!(!capture.timed_out);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn greedy_parity_worker_timeout_kills_and_reaps_exact_child() {
+        let mut command = Command::new("sleep");
+        command.arg("2");
+        let started = Instant::now();
+        let capture = run_greedy_parity_worker_process(
+            command,
+            b"request".to_vec(),
+            Duration::from_millis(20),
+        )
+        .await
+        .unwrap();
+        assert!(capture.timed_out);
+        assert!(capture.reaped);
+        assert!(child_exit_signal(&capture.status).is_some());
+        assert!(started.elapsed() < Duration::from_secs(1));
     }
 
     #[test]

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -3723,6 +3723,7 @@ async fn execute_greedy_parity_plane(
         case_name,
         None,
         None,
+        false,
     )
     .await
 }
@@ -3740,6 +3741,7 @@ async fn execute_greedy_parity_plane_with_logits(
     case_name: &str,
     first_token_logit_bits: &mut Vec<u32>,
     route_capture: &mut Option<crate::engine::RoutedFfnDiagnosticCapture>,
+    cpu_q4_boundary_emulation: bool,
 ) -> Result<crate::greedy_parity::PlaneRunEvidence, Box<dyn std::error::Error>> {
     execute_greedy_parity_plane_internal(
         spec,
@@ -3753,6 +3755,7 @@ async fn execute_greedy_parity_plane_with_logits(
         case_name,
         Some(first_token_logit_bits),
         Some(route_capture),
+        cpu_q4_boundary_emulation,
     )
     .await
 }
@@ -3770,11 +3773,15 @@ async fn execute_greedy_parity_plane_internal(
     case_name: &str,
     first_token_logit_bits: Option<&mut Vec<u32>>,
     route_capture: Option<&mut Option<crate::engine::RoutedFfnDiagnosticCapture>>,
+    cpu_q4_boundary_emulation: bool,
 ) -> Result<crate::greedy_parity::PlaneRunEvidence, Box<dyn std::error::Error>> {
     use crate::qualification::{gpu_io_delta, routed_execution_delta, validate_memory};
 
     let runtime = build_isolated_greedy_runtime(spec, mode, tokenizer).await?;
     let attempt = async {
+        if cpu_q4_boundary_emulation {
+            runtime.engine.enable_cpu_q4_boundary_emulation()?;
+        }
         let context = runtime.engine.execution_context();
         let execution_plan: crate::qualification::ExecutionPlanEvidence = context.plan().into();
         let plane = match mode {
@@ -4327,6 +4334,9 @@ async fn cmd_greedy_parity_logit_worker_internal(
         crate::numerical_diagnostics::DiagnosticPlane::Cpu => {
             RealCliRuntimeMode::IsolatedGreedyParityCpu
         }
+        crate::numerical_diagnostics::DiagnosticPlane::CpuBoundaryEmulation => {
+            RealCliRuntimeMode::IsolatedGreedyParityCpu
+        }
         crate::numerical_diagnostics::DiagnosticPlane::Hybrid => {
             RealCliRuntimeMode::IsolatedGreedyParityHybrid
         }
@@ -4349,6 +4359,8 @@ async fn cmd_greedy_parity_logit_worker_internal(
         &request.base.case_name,
         &mut logit_bits,
         &mut route_capture,
+        request.plane
+            == crate::numerical_diagnostics::DiagnosticPlane::CpuBoundaryEmulation,
     )
     .await;
     match attempt {
@@ -4999,9 +5011,10 @@ async fn cmd_diagnose_hybrid_q4_greedy_divergence(
         prompt_token_ids_sha256,
         prompt_token_ids.len(),
     );
-    let mut completed = Vec::with_capacity(4);
+    let mut completed = Vec::with_capacity(6);
     for plane in [
         crate::numerical_diagnostics::DiagnosticPlane::Cpu,
+        crate::numerical_diagnostics::DiagnosticPlane::CpuBoundaryEmulation,
         crate::numerical_diagnostics::DiagnosticPlane::Hybrid,
     ] {
         for run_index in 0..crate::numerical_diagnostics::REPEATED_RUNS_PER_PLANE {
@@ -5056,6 +5069,7 @@ async fn cmd_diagnose_hybrid_q4_greedy_divergence(
         crate::numerical_diagnostics::validate_repeated_run_identity(&report.runs);
     report.reproducibility = Some(reproducibility.clone());
     if !reproducibility.cpu_bitwise_reproducible
+        || !reproducibility.cpu_boundary_emulation_bitwise_reproducible
         || !reproducibility.hybrid_bitwise_reproducible
         || !reproducibility.all_worker_ids_unique
         || !reproducibility.all_process_ids_unique
@@ -5065,7 +5079,7 @@ async fn cmd_diagnose_hybrid_q4_greedy_divergence(
         return fail_numerical_diagnostic(
             report,
             "logit-diagnostic-reproducibility-failed",
-            "fresh CPU/Hybrid runs were nondeterministic or process evidence was incomplete",
+            "fresh CPU/boundary-emulation/Hybrid runs were nondeterministic or process evidence was incomplete",
             &args.report_out,
         );
     }
@@ -5077,6 +5091,13 @@ async fn cmd_diagnose_hybrid_q4_greedy_divergence(
         .iter()
         .find(|worker| worker.run.plane == crate::numerical_diagnostics::DiagnosticPlane::Hybrid)
         .ok_or("missing Hybrid logit diagnostic run")?;
+    let boundary = completed
+        .iter()
+        .find(|worker| {
+            worker.run.plane
+                == crate::numerical_diagnostics::DiagnosticPlane::CpuBoundaryEmulation
+        })
+        .ok_or("missing CPU boundary-emulation logit diagnostic run")?;
     let cpu_logits: Vec<f32> = cpu
         .first_token_logit_bits
         .iter()
@@ -5084,6 +5105,12 @@ async fn cmd_diagnose_hybrid_q4_greedy_divergence(
         .map(f32::from_bits)
         .collect();
     let hybrid_logits: Vec<f32> = hybrid
+        .first_token_logit_bits
+        .iter()
+        .copied()
+        .map(f32::from_bits)
+        .collect();
+    let boundary_logits: Vec<f32> = boundary
         .first_token_logit_bits
         .iter()
         .copied()
@@ -5107,8 +5134,36 @@ async fn cmd_diagnose_hybrid_q4_greedy_divergence(
             )
         }
     });
+    report.cpu_boundary_emulation = Some(match
+        crate::numerical_diagnostics::build_boundary_plane_evidence(
+            &cpu_logits,
+            &hybrid_logits,
+            &boundary_logits,
+            cpu.chosen_token_id,
+            hybrid.chosen_token_id,
+            boundary.chosen_token_id,
+            boundary.run.generated_token_ids_sha256.clone(),
+        )
+    {
+        Ok(evidence) => evidence,
+        Err(error) => {
+            return fail_numerical_diagnostic(
+                report,
+                "cpu-boundary-emulation-comparison-failed",
+                error,
+                &args.report_out,
+            )
+        }
+    });
     let route_captures: Vec<_> = completed
         .iter()
+        .filter(|worker| {
+            matches!(
+                worker.run.plane,
+                crate::numerical_diagnostics::DiagnosticPlane::Cpu
+                    | crate::numerical_diagnostics::DiagnosticPlane::Hybrid
+            )
+        })
         .map(|worker| (worker.run.plane, worker.route_capture.clone()))
         .collect();
     let expected_token_idx = prompt_token_ids

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -161,6 +161,7 @@ mod prefetch_governor;
 mod pregate;
 mod qualification;
 mod greedy_parity;
+mod numerical_diagnostics;
 mod q4_parity;
 mod rayon_autotune;
 mod residency;
@@ -910,10 +911,31 @@ enum Cmd {
         report_out: Option<PathBuf>,
     },
 
+    /// Collect reproducibility and complete first-token CPU/Hybrid logit
+    /// evidence for the fixed json-transformation case.
+    DiagnoseHybridQ4GreedyDivergence {
+        /// Path to the strict Hybrid native-Q4_0 TOML config.
+        #[arg(long)]
+        config: PathBuf,
+        /// Exact wgpu adapter name required for Hybrid diagnostic workers.
+        #[arg(long)]
+        expected_adapter_name: String,
+        /// Required typed diagnostic JSON destination.
+        #[arg(long)]
+        report_out: PathBuf,
+    },
+
     /// Private same-binary worker for one strict-Hybrid greedy-parity plane.
     #[command(name = "greedy-parity-hybrid-worker-internal", hide = true)]
     GreedyParityHybridWorkerInternal {
         /// The same strict Hybrid config parsed by the parent orchestrator.
+        #[arg(long)]
+        config: PathBuf,
+    },
+
+    /// Private same-binary CPU/Hybrid first-token logit worker.
+    #[command(name = "greedy-parity-logit-worker-internal", hide = true)]
+    GreedyParityLogitWorkerInternal {
         #[arg(long)]
         config: PathBuf,
     },
@@ -1569,6 +1591,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let worker_protocol_stdout = matches!(
         cli.cmd,
         Cmd::GreedyParityHybridWorkerInternal { .. }
+            | Cmd::GreedyParityLogitWorkerInternal { .. }
     );
     init_logging(&cli.log, worker_protocol_stdout);
 
@@ -1582,7 +1605,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         | Cmd::QualifyHybridQ4 { config, .. }
         | Cmd::QualifyHybridQ4Parity { config, .. }
         | Cmd::QualifyHybridQ4GreedyParity { config, .. }
-        | Cmd::GreedyParityHybridWorkerInternal { config } => {
+        | Cmd::DiagnoseHybridQ4GreedyDivergence { config, .. }
+        | Cmd::GreedyParityHybridWorkerInternal { config }
+        | Cmd::GreedyParityLogitWorkerInternal { config } => {
             Some(crate::config::Config::from_file(config)?)
         }
         _ => None,
@@ -1706,7 +1731,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             | Cmd::QualifyHybridQ4 { .. }
             | Cmd::QualifyHybridQ4Parity { .. }
             | Cmd::QualifyHybridQ4GreedyParity { .. }
+            | Cmd::DiagnoseHybridQ4GreedyDivergence { .. }
             | Cmd::GreedyParityHybridWorkerInternal { .. }
+            | Cmd::GreedyParityLogitWorkerInternal { .. }
     ) && !run_gpu_requested
     {
         crate::backend::install_default();
@@ -2001,6 +2028,26 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 },
             ))
         }
+        Cmd::DiagnoseHybridQ4GreedyDivergence {
+            config,
+            expected_adapter_name,
+            report_out,
+        } => {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()?;
+            rt.block_on(cmd_diagnose_hybrid_q4_greedy_divergence(
+                DiagnoseHybridQ4GreedyDivergenceArgs {
+                    config,
+                    parsed_config: startup_config
+                        .take()
+                        .ok_or("logit diagnostic startup config was not parsed")?,
+                    expected_adapter_name,
+                    report_out,
+                    progress_watchdog,
+                },
+            ))
+        }
         Cmd::GreedyParityHybridWorkerInternal { config: _ } => {
             let rt = tokio::runtime::Builder::new_multi_thread()
                 .enable_all()
@@ -2010,6 +2057,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     parsed_config: startup_config
                         .take()
                         .ok_or("greedy parity worker startup config was not parsed")?,
+                    progress_watchdog,
+                },
+            ))
+        }
+        Cmd::GreedyParityLogitWorkerInternal { config: _ } => {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()?;
+            rt.block_on(cmd_greedy_parity_logit_worker_internal(
+                GreedyParityHybridWorkerArgs {
+                    parsed_config: startup_config
+                        .take()
+                        .ok_or("logit diagnostic worker startup config was not parsed")?,
                     progress_watchdog,
                 },
             ))
@@ -2253,6 +2313,14 @@ struct QualifyHybridQ4GreedyParityArgs {
 
 struct GreedyParityHybridWorkerArgs {
     parsed_config: crate::config::Config,
+    progress_watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+}
+
+struct DiagnoseHybridQ4GreedyDivergenceArgs {
+    config: PathBuf,
+    parsed_config: crate::config::Config,
+    expected_adapter_name: String,
+    report_out: PathBuf,
     progress_watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
 }
 
@@ -3643,6 +3711,62 @@ async fn execute_greedy_parity_plane(
     watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
     case_name: &str,
 ) -> Result<crate::greedy_parity::PlaneRunEvidence, Box<dyn std::error::Error>> {
+    execute_greedy_parity_plane_internal(
+        spec,
+        mode,
+        tokenizer,
+        prompt_token_ids,
+        prompt_token_ids_sha256,
+        resolved_config_sha256,
+        expected_adapter_name,
+        watchdog,
+        case_name,
+        None,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn execute_greedy_parity_plane_with_logits(
+    spec: &ResolvedRealCliSpec,
+    mode: RealCliRuntimeMode,
+    tokenizer: Arc<crate::tokenizer::Tokenizer>,
+    prompt_token_ids: &[u32],
+    prompt_token_ids_sha256: &str,
+    resolved_config_sha256: &str,
+    expected_adapter_name: &str,
+    watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+    case_name: &str,
+    first_token_logit_bits: &mut Vec<u32>,
+) -> Result<crate::greedy_parity::PlaneRunEvidence, Box<dyn std::error::Error>> {
+    execute_greedy_parity_plane_internal(
+        spec,
+        mode,
+        tokenizer,
+        prompt_token_ids,
+        prompt_token_ids_sha256,
+        resolved_config_sha256,
+        expected_adapter_name,
+        watchdog,
+        case_name,
+        Some(first_token_logit_bits),
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn execute_greedy_parity_plane_internal(
+    spec: &ResolvedRealCliSpec,
+    mode: RealCliRuntimeMode,
+    tokenizer: Arc<crate::tokenizer::Tokenizer>,
+    prompt_token_ids: &[u32],
+    prompt_token_ids_sha256: &str,
+    resolved_config_sha256: &str,
+    expected_adapter_name: &str,
+    watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+    case_name: &str,
+    first_token_logit_bits: Option<&mut Vec<u32>>,
+) -> Result<crate::greedy_parity::PlaneRunEvidence, Box<dyn std::error::Error>> {
     use crate::qualification::{gpu_io_delta, routed_execution_delta, validate_memory};
 
     let runtime = build_isolated_greedy_runtime(spec, mode, tokenizer).await?;
@@ -3735,12 +3859,13 @@ async fn execute_greedy_parity_plane(
         let measured = with_progress_timeout(
             format!("greedy parity {case_name} {plane} inference"),
             watchdog,
-            run_real_once_from_token_ids(
+            run_real_once_from_token_ids_internal(
                 &runtime,
                 prompt_token_ids,
                 crate::greedy_parity::OUTPUT_TOKEN_LIMIT,
                 crate::sampling::SamplingParams::greedy(),
                 0,
+                first_token_logit_bits,
             ),
         )
         .await?;
@@ -3891,9 +4016,26 @@ fn child_exit_signal(_status: &std::process::ExitStatus) -> Option<i32> {
 /// dedicated threads so verbose diagnostics cannot deadlock the child. A
 /// timeout always kills and then waits for the exact child before returning.
 async fn run_greedy_parity_worker_process(
+    command: std::process::Command,
+    request_json: Vec<u8>,
+    timeout: Duration,
+) -> Result<GreedyParityWorkerCapture, String> {
+    run_greedy_parity_worker_process_with_limits(
+        command,
+        request_json,
+        timeout,
+        crate::greedy_parity::MAX_WORKER_STDOUT_BYTES,
+        crate::greedy_parity::MAX_WORKER_STDERR_BYTES,
+    )
+    .await
+}
+
+async fn run_greedy_parity_worker_process_with_limits(
     mut command: std::process::Command,
     request_json: Vec<u8>,
     timeout: Duration,
+    stdout_limit: usize,
+    stderr_limit: usize,
 ) -> Result<GreedyParityWorkerCapture, String> {
     use std::io::Write as _;
     use std::process::Stdio;
@@ -3922,12 +4064,10 @@ async fn run_greedy_parity_worker_process(
             return Err("spawned Hybrid worker has no stderr pipe".to_string());
         }
     };
-    let stdout_thread = std::thread::spawn(move || {
-        read_child_output_bounded(stdout, crate::greedy_parity::MAX_WORKER_STDOUT_BYTES)
-    });
-    let stderr_thread = std::thread::spawn(move || {
-        read_child_output_bounded(stderr, crate::greedy_parity::MAX_WORKER_STDERR_BYTES)
-    });
+    let stdout_thread =
+        std::thread::spawn(move || read_child_output_bounded(stdout, stdout_limit));
+    let stderr_thread =
+        std::thread::spawn(move || read_child_output_bounded(stderr, stderr_limit));
 
     let mut transport_error = None;
     match child.stdin.take() {
@@ -4090,6 +4230,158 @@ async fn cmd_greedy_parity_hybrid_worker_internal(
                 Some(detail.clone()),
             );
             emit_hybrid_worker_response(&response)?;
+            Err(detail.into())
+        }
+    }
+}
+
+fn emit_logit_worker_response(
+    response: &crate::numerical_diagnostics::DiagnosticWorkerResponse,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use std::io::Write as _;
+    let stdout = std::io::stdout();
+    let mut locked = stdout.lock();
+    serde_json::to_writer(&mut locked, response)?;
+    locked.write_all(b"\n")?;
+    locked.flush()?;
+    Ok(())
+}
+
+/// Hidden same-binary worker. The request embeds the existing greedy-parity
+/// identity contract; the only new controls are plane and repeated-run index.
+async fn cmd_greedy_parity_logit_worker_internal(
+    args: GreedyParityHybridWorkerArgs,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use std::io::Read as _;
+
+    let mut input = Vec::new();
+    std::io::stdin()
+        .take((crate::greedy_parity::MAX_WORKER_STDOUT_BYTES + 1) as u64)
+        .read_to_end(&mut input)?;
+    if input.len() > crate::greedy_parity::MAX_WORKER_STDOUT_BYTES {
+        return Err("logit worker request exceeds the private protocol limit".into());
+    }
+    let request = crate::numerical_diagnostics::parse_worker_request_exact(&input)?;
+    request.validate_static()?;
+    let spec = resolve_real_cli_spec_from_config(
+        args.parsed_config,
+        RealCliRuntimeMode::IsolatedGreedyParityHybrid,
+    )?;
+    let observed_config_sha256 = resolved_real_cli_spec_sha256(&spec)?;
+    let (_, observed_executable_sha256) = current_executable_identity()?;
+    let provenance = crate::qualification::BuildProvenance::embedded();
+    let identity = crate::greedy_parity::validate_hybrid_worker_request(
+        &request.base,
+        &observed_config_sha256,
+        &observed_executable_sha256,
+        provenance.git_sha.as_deref(),
+    );
+    if !identity.all_verified() {
+        let detail = "logit worker request identity validation failed".to_string();
+        let response = crate::numerical_diagnostics::DiagnosticWorkerResponse {
+            protocol_version: crate::numerical_diagnostics::WORKER_PROTOCOL_VERSION.to_string(),
+            plane: request.plane,
+            run_index: request.run_index,
+            base: crate::greedy_parity::HybridWorkerResponse::from_request(
+                &request.base,
+                &observed_config_sha256,
+                &observed_executable_sha256,
+                provenance.git_sha.as_deref(),
+                identity,
+                None,
+                Some(detail.clone()),
+            ),
+            chosen_token_id: None,
+            first_token_logit_bits: None,
+            first_token_logit_bits_sha256: None,
+            failure: Some(detail.clone()),
+        };
+        emit_logit_worker_response(&response)?;
+        return Err(detail.into());
+    }
+    let mode = match request.plane {
+        crate::numerical_diagnostics::DiagnosticPlane::Cpu => {
+            RealCliRuntimeMode::IsolatedGreedyParityCpu
+        }
+        crate::numerical_diagnostics::DiagnosticPlane::Hybrid => {
+            RealCliRuntimeMode::IsolatedGreedyParityHybrid
+        }
+    };
+    let tokenizer = load_real_cli_tokenizer(
+        &spec.cfg,
+        RealCliRuntimeMode::IsolatedGreedyParityHybrid,
+    )?;
+    let mut logit_bits = Vec::new();
+    let attempt = execute_greedy_parity_plane_with_logits(
+        &spec,
+        mode,
+        tokenizer,
+        &request.base.prompt_token_ids,
+        &request.base.prompt_token_ids_sha256,
+        &request.base.resolved_config_sha256,
+        &request.base.expected_adapter_name,
+        args.progress_watchdog,
+        &request.base.case_name,
+        &mut logit_bits,
+    )
+    .await;
+    match attempt {
+        Ok(plane) => {
+            if logit_bits.is_empty()
+                || logit_bits.len() > crate::numerical_diagnostics::MAX_VOCAB_SIZE
+            {
+                return Err("logit worker captured an invalid vocabulary vector".into());
+            }
+            let chosen_token_id = plane
+                .generation
+                .generated_token_ids
+                .first()
+                .copied()
+                .ok_or("logit worker generated no first token")?;
+            let logit_sha256 = crate::numerical_diagnostics::f32_bits_sha256(&logit_bits);
+            let response = crate::numerical_diagnostics::DiagnosticWorkerResponse {
+                protocol_version: crate::numerical_diagnostics::WORKER_PROTOCOL_VERSION
+                    .to_string(),
+                plane: request.plane,
+                run_index: request.run_index,
+                base: crate::greedy_parity::HybridWorkerResponse::from_request(
+                    &request.base,
+                    &observed_config_sha256,
+                    &observed_executable_sha256,
+                    provenance.git_sha.as_deref(),
+                    identity,
+                    Some(plane),
+                    None,
+                ),
+                chosen_token_id: Some(chosen_token_id),
+                first_token_logit_bits: Some(logit_bits),
+                first_token_logit_bits_sha256: Some(logit_sha256),
+                failure: None,
+            };
+            emit_logit_worker_response(&response)
+        }
+        Err(error) => {
+            let detail = error.to_string();
+            let response = crate::numerical_diagnostics::DiagnosticWorkerResponse {
+                protocol_version: crate::numerical_diagnostics::WORKER_PROTOCOL_VERSION
+                    .to_string(),
+                plane: request.plane,
+                run_index: request.run_index,
+                base: crate::greedy_parity::HybridWorkerResponse::from_request(
+                    &request.base,
+                    &observed_config_sha256,
+                    &observed_executable_sha256,
+                    provenance.git_sha.as_deref(),
+                    identity,
+                    None,
+                    Some(detail.clone()),
+                ),
+                chosen_token_id: None,
+                first_token_logit_bits: None,
+                first_token_logit_bits_sha256: None,
+                failure: Some(detail.clone()),
+            };
+            emit_logit_worker_response(&response)?;
             Err(detail.into())
         }
     }
@@ -4272,6 +4564,450 @@ async fn execute_greedy_parity_hybrid_worker(
             stderr_truncated: capture.stderr.truncated,
         },
     })
+}
+
+struct CompletedLogitWorker {
+    run: crate::numerical_diagnostics::RepeatedRunEvidence,
+    first_token_logit_bits: Vec<u32>,
+    chosen_token_id: u32,
+}
+
+async fn execute_logit_diagnostic_worker(
+    executable: &Path,
+    config: &Path,
+    request: &crate::numerical_diagnostics::DiagnosticWorkerRequest,
+    timeout: Duration,
+) -> Result<
+    CompletedLogitWorker,
+    crate::numerical_diagnostics::DiagnosticWorkerFailureEvidence,
+> {
+    let empty_process = || crate::greedy_parity::HybridWorkerProcessEvidence {
+        worker_id: request.base.worker_id.clone(),
+        executable_sha256: request.base.executable_sha256.clone(),
+        build_git_sha: request.base.build_git_sha.clone(),
+        ..Default::default()
+    };
+    let request_json = serde_json::to_vec(request).map_err(|error| {
+        crate::numerical_diagnostics::DiagnosticWorkerFailureEvidence {
+            worker_id: request.base.worker_id.clone(),
+            plane: request.plane,
+            run_index: request.run_index,
+            detail: format!("failed to serialize logit worker request: {error}"),
+            process: empty_process(),
+            stderr: String::new(),
+            stderr_truncated: false,
+        }
+    })?;
+    let mut command = Command::new(executable);
+    command
+        .arg("--progress-timeout-secs")
+        .arg(timeout.as_secs().to_string())
+        .arg("greedy-parity-logit-worker-internal")
+        .arg("--config")
+        .arg(config);
+    let capture = run_greedy_parity_worker_process_with_limits(
+        command,
+        request_json,
+        timeout,
+        crate::numerical_diagnostics::MAX_WORKER_STDOUT_BYTES,
+        crate::greedy_parity::MAX_WORKER_STDERR_BYTES,
+    )
+    .await
+    .map_err(|detail| crate::numerical_diagnostics::DiagnosticWorkerFailureEvidence {
+        worker_id: request.base.worker_id.clone(),
+        plane: request.plane,
+        run_index: request.run_index,
+        detail,
+        process: empty_process(),
+        stderr: String::new(),
+        stderr_truncated: false,
+    })?;
+    let stderr = String::from_utf8_lossy(&capture.stderr.bytes).into_owned();
+    let response_result = if capture.stdout.truncated {
+        Err(format!(
+            "logit worker stdout exceeded {} bytes",
+            crate::numerical_diagnostics::MAX_WORKER_STDOUT_BYTES
+        ))
+    } else {
+        crate::numerical_diagnostics::parse_worker_response_exact(&capture.stdout.bytes)
+    };
+    let parse_detail = response_result.as_ref().err().cloned();
+    let response = response_result.as_ref().ok();
+    let validation = response.map(|response| {
+        crate::greedy_parity::validate_hybrid_worker_response(&request.base, &response.base)
+    });
+    let response_identity_exact = response.is_some_and(|response| {
+        response.protocol_version == crate::numerical_diagnostics::WORKER_PROTOCOL_VERSION
+            && response.plane == request.plane
+            && response.run_index == request.run_index
+            && response.base.worker_id == request.base.worker_id
+    });
+    let identity_attested = response_identity_exact
+        && validation.is_some_and(|value| value.all_verified())
+        && response.is_some_and(|response| {
+            response.failure.is_none()
+                && response.base.failure.is_none()
+                && response.base.plane.is_some()
+                && response.chosen_token_id.is_some()
+                && response.first_token_logit_bits.is_some()
+                && response.first_token_logit_bits_sha256.is_some()
+        });
+    let exit_code = capture.status.code();
+    let signal = child_exit_signal(&capture.status);
+    let normal_zero_exit = capture.status.success()
+        && exit_code == Some(0)
+        && signal.is_none()
+        && !capture.timed_out
+        && capture.transport_error.is_none();
+    let process = crate::greedy_parity::HybridWorkerProcessEvidence {
+        worker_id: request.base.worker_id.clone(),
+        child_process_spawned: true,
+        process_id: Some(capture.process_id),
+        executable_sha256: request.base.executable_sha256.clone(),
+        build_git_sha: request.base.build_git_sha.clone(),
+        executable_identity_verified: identity_attested,
+        build_sha_identity_verified: identity_attested,
+        case_identity_verified: identity_attested,
+        config_identity_verified: identity_attested,
+        expected_adapter_identity_verified: identity_attested,
+        prompt_token_identity_verified: identity_attested,
+        output_token_limit_verified: identity_attested,
+        greedy_sampling_identity_verified: identity_attested,
+        normal_zero_exit,
+        exit_code,
+        signal,
+        process_reaped: capture.reaped,
+        timed_out: capture.timed_out,
+        evidence_emitted: response.is_some(),
+    };
+    let completed = (|| -> Result<CompletedLogitWorker, String> {
+        if !normal_zero_exit || !capture.reaped || !identity_attested {
+            return Err("logit worker did not exit/reap with exact identity".to_string());
+        }
+        let response = response.ok_or("logit worker emitted no response")?;
+        let logit_bits = response
+            .first_token_logit_bits
+            .clone()
+            .ok_or("logit worker omitted complete logits")?;
+        let logit_sha256 = response
+            .first_token_logit_bits_sha256
+            .clone()
+            .ok_or("logit worker omitted logit hash")?;
+        if logit_bits.is_empty()
+            || logit_bits.len() > crate::numerical_diagnostics::MAX_VOCAB_SIZE
+            || crate::numerical_diagnostics::f32_bits_sha256(&logit_bits) != logit_sha256
+        {
+            return Err("logit worker vector is malformed or hash-mismatched".to_string());
+        }
+        let chosen_token_id = response
+            .chosen_token_id
+            .ok_or("logit worker omitted chosen token")?;
+        let logits: Vec<f32> = logit_bits.iter().copied().map(f32::from_bits).collect();
+        if crate::numerical_diagnostics::top_logits(&logits, 1)
+            .first()
+            .map(|item| item.token_id)
+            != Some(chosen_token_id)
+        {
+            return Err("complete logits disagree with production greedy token".to_string());
+        }
+        let mut plane = response
+            .base
+            .plane
+            .clone()
+            .ok_or("logit worker omitted plane evidence")?;
+        if plane.worker_process.is_some()
+            || plane.generation.generated_token_ids.first().copied() != Some(chosen_token_id)
+        {
+            return Err("logit worker plane evidence is malformed".to_string());
+        }
+        plane.worker_process = Some(process.clone());
+        let generated_token_ids = plane.generation.generated_token_ids.clone();
+        Ok(CompletedLogitWorker {
+            run: crate::numerical_diagnostics::RepeatedRunEvidence {
+                plane: request.plane,
+                run_index: request.run_index,
+                worker_id: request.base.worker_id.clone(),
+                generated_token_ids_sha256: crate::greedy_parity::token_ids_sha256(
+                    &generated_token_ids,
+                ),
+                generated_token_ids,
+                first_token_logit_bits_sha256: logit_sha256,
+                process: process.clone(),
+                plane_evidence: plane,
+            },
+            first_token_logit_bits: logit_bits,
+            chosen_token_id,
+        })
+    })();
+    completed.map_err(|detail| {
+        let response_failure = response.and_then(|response| {
+            response
+                .failure
+                .clone()
+                .or_else(|| response.base.failure.clone())
+        });
+        crate::numerical_diagnostics::DiagnosticWorkerFailureEvidence {
+            worker_id: request.base.worker_id.clone(),
+            plane: request.plane,
+            run_index: request.run_index,
+            detail: [
+                Some(detail),
+                capture.transport_error,
+                parse_detail,
+                response_failure,
+            ]
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>()
+            .join("; "),
+            process,
+            stderr,
+            stderr_truncated: capture.stderr.truncated,
+        }
+    })
+}
+
+fn emit_numerical_diagnostic_report(
+    report: &crate::numerical_diagnostics::DiagnosticReport,
+    path: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut bytes = serde_json::to_vec_pretty(report)?;
+    bytes.push(b'\n');
+    std::fs::write(path, bytes)?;
+    eprintln!("logit diagnostic report written to {}", path.display());
+    Ok(())
+}
+
+fn fail_numerical_diagnostic(
+    mut report: crate::numerical_diagnostics::DiagnosticReport,
+    code: &str,
+    detail: impl Into<String>,
+    path: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let detail = detail.into();
+    report.fail(code, detail.clone());
+    match emit_numerical_diagnostic_report(&report, path) {
+        Ok(()) => Err(format!("{code}: {detail}").into()),
+        Err(error) => Err(format!("{code}: {detail}; report emission failed: {error}").into()),
+    }
+}
+
+async fn cmd_diagnose_hybrid_q4_greedy_divergence(
+    args: DiagnoseHybridQ4GreedyDivergenceArgs,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use crate::qualification::{
+        validate_preflight, BuildProvenance, PreflightEvidence, QualificationChecks,
+    };
+
+    let cfg = args.parsed_config;
+    let provenance = BuildProvenance::embedded();
+    let build_git_sha = provenance
+        .git_sha
+        .clone()
+        .filter(|sha| sha.len() == 40 && sha.bytes().all(|byte| byte.is_ascii_hexdigit()))
+        .ok_or("logit diagnostic requires embedded immutable build SHA")?;
+    if provenance.dirty != Some(false) {
+        return Err("logit diagnostic requires clean build provenance".into());
+    }
+    if args.expected_adapter_name.is_empty() {
+        return Err("--expected-adapter-name must be non-empty".into());
+    }
+    let worker_timeout = args
+        .progress_watchdog
+        .timeout
+        .ok_or("logit diagnostic requires a positive progress timeout")?;
+    let (_, artifact_errors) = qualification_artifacts(&args.config, &cfg);
+    if !artifact_errors.is_empty() {
+        return Err(format!(
+            "logit diagnostic artifact preflight failed: {}",
+            artifact_errors.join("; ")
+        )
+        .into());
+    }
+    let metadata = crate::qualification::read_expert_metadata(
+        &cfg.model.data_dir.join("metadata.json"),
+    )
+    .map_err(|error| format!("logit diagnostic metadata preflight failed: {error}"))?;
+    if !matches!(
+        cfg.real_transformer.resolve_weight_policy(),
+        Ok(crate::config::RealWeightPolicy::StrictReal)
+    ) {
+        return Err("logit diagnostic requires the strict real-weight policy".into());
+    }
+    let capacity_bytes = cfg
+        .gpu_cache
+        .vram_capacity_mb
+        .checked_mul(1024 * 1024)
+        .and_then(|bytes| u64::try_from(bytes).ok())
+        .unwrap_or(0);
+    let preflight = PreflightEvidence {
+        provenance,
+        real_transformer_enabled: cfg.real_transformer.enabled,
+        weights_dir_configured: cfg.real_transformer.weights_dir.is_some(),
+        strict_weights: cfg.real_transformer.strict_weights,
+        allow_seeded_fallback: cfg.real_transformer.allow_seeded_fallback,
+        allow_degraded_experts: cfg.real_transformer.allow_degraded_experts,
+        allow_attention_fallback: cfg.real_transformer.allow_nonfinite_attention_fallback,
+        allow_truncated_expert_payloads: cfg.real_transformer.allow_truncated_expert_payloads,
+        distributed_enabled: cfg.distributed.enabled,
+        gpu_cache_enabled: cfg.gpu_cache.enabled,
+        gpu_expert_capacity_bytes: capacity_bytes,
+        requested_mode: cfg.real_transformer.compute_offload,
+        routed_expert_dtype: cfg.model.dtype,
+        metadata,
+    };
+    validate_preflight(&preflight, &mut QualificationChecks::default())
+        .map_err(|failure| format!("{}: {}", failure.code, failure.detail))?;
+    let spec = resolve_real_cli_spec_from_config(
+        cfg,
+        RealCliRuntimeMode::IsolatedGreedyParityHybrid,
+    )?;
+    if !greedy_parity_model_identity(&spec).is_qwen3_coder_30b_a3b_q4_0() {
+        return Err("logit diagnostic requires exact Qwen3-Coder 30B-A3B Q4_0 geometry".into());
+    }
+    let resolved_config_sha256 = resolved_real_cli_spec_sha256(&spec)?;
+    let (worker_executable, executable_sha256) = current_executable_identity()?;
+    let tokenizer = load_real_cli_tokenizer(
+        &spec.cfg,
+        RealCliRuntimeMode::IsolatedGreedyParityHybrid,
+    )?;
+    let fixed = crate::greedy_parity::fixed_case(
+        crate::numerical_diagnostics::TARGET_CASE,
+    )
+    .ok_or("json-transformation fixed corpus case is unavailable")?;
+    // Parent-only tokenization: every worker receives this identical vector.
+    let prompt_token_ids = tokenizer.encode(fixed.prompt)?;
+    if prompt_token_ids.is_empty() {
+        return Err("json-transformation prompt encoded to zero tokens".into());
+    }
+    let prompt_sha256 = crate::greedy_parity::sha256_hex(fixed.prompt.as_bytes());
+    let prompt_token_ids_sha256 = crate::greedy_parity::token_ids_sha256(&prompt_token_ids);
+    let mut report = crate::numerical_diagnostics::DiagnosticReport::new(
+        build_git_sha.clone(),
+        executable_sha256.clone(),
+        resolved_config_sha256.clone(),
+        args.expected_adapter_name.clone(),
+        prompt_sha256,
+        prompt_token_ids_sha256,
+        prompt_token_ids.len(),
+    );
+    let mut completed = Vec::with_capacity(4);
+    for plane in [
+        crate::numerical_diagnostics::DiagnosticPlane::Cpu,
+        crate::numerical_diagnostics::DiagnosticPlane::Hybrid,
+    ] {
+        for run_index in 0..crate::numerical_diagnostics::REPEATED_RUNS_PER_PLANE {
+            let worker_id = crate::numerical_diagnostics::diagnostic_worker_id(
+                &build_git_sha,
+                &executable_sha256,
+                plane,
+                run_index,
+            );
+            let base = crate::greedy_parity::HybridWorkerRequest::new(
+                worker_id,
+                fixed,
+                resolved_config_sha256.clone(),
+                args.expected_adapter_name.clone(),
+                prompt_token_ids.clone(),
+                executable_sha256.clone(),
+                build_git_sha.clone(),
+            );
+            let request = crate::numerical_diagnostics::DiagnosticWorkerRequest::new(
+                plane,
+                run_index,
+                base,
+            );
+            match execute_logit_diagnostic_worker(
+                &worker_executable,
+                &args.config,
+                &request,
+                worker_timeout,
+            )
+            .await
+            {
+                Ok(worker) => completed.push(worker),
+                Err(failure) => {
+                    let detail = failure.detail.clone();
+                    report.runs = completed.iter().map(|worker| worker.run.clone()).collect();
+                    report.reproducibility = Some(
+                        crate::numerical_diagnostics::validate_repeated_run_identity(&report.runs),
+                    );
+                    report.worker_failures.push(failure);
+                    return fail_numerical_diagnostic(
+                        report,
+                        "logit-diagnostic-worker-failed",
+                        detail,
+                        &args.report_out,
+                    );
+                }
+            }
+        }
+    }
+    report.runs = completed.iter().map(|worker| worker.run.clone()).collect();
+    let reproducibility =
+        crate::numerical_diagnostics::validate_repeated_run_identity(&report.runs);
+    report.reproducibility = Some(reproducibility.clone());
+    if !reproducibility.cpu_bitwise_reproducible
+        || !reproducibility.hybrid_bitwise_reproducible
+        || !reproducibility.all_worker_ids_unique
+        || !reproducibility.all_process_ids_unique
+        || !reproducibility.every_worker_exited_zero_and_reaped
+        || !reproducibility.no_retries
+    {
+        return fail_numerical_diagnostic(
+            report,
+            "logit-diagnostic-reproducibility-failed",
+            "fresh CPU/Hybrid runs were nondeterministic or process evidence was incomplete",
+            &args.report_out,
+        );
+    }
+    let cpu = completed
+        .iter()
+        .find(|worker| worker.run.plane == crate::numerical_diagnostics::DiagnosticPlane::Cpu)
+        .ok_or("missing CPU logit diagnostic run")?;
+    let hybrid = completed
+        .iter()
+        .find(|worker| worker.run.plane == crate::numerical_diagnostics::DiagnosticPlane::Hybrid)
+        .ok_or("missing Hybrid logit diagnostic run")?;
+    let cpu_logits: Vec<f32> = cpu
+        .first_token_logit_bits
+        .iter()
+        .copied()
+        .map(f32::from_bits)
+        .collect();
+    let hybrid_logits: Vec<f32> = hybrid
+        .first_token_logit_bits
+        .iter()
+        .copied()
+        .map(f32::from_bits)
+        .collect();
+    report.first_token_logits = Some(match
+        crate::numerical_diagnostics::build_first_token_logit_evidence(
+            &cpu_logits,
+            &hybrid_logits,
+            cpu.chosen_token_id,
+            hybrid.chosen_token_id,
+        )
+    {
+        Ok(evidence) => evidence,
+        Err(error) => {
+            return fail_numerical_diagnostic(
+                report,
+                "first-token-logit-comparison-failed",
+                error,
+                &args.report_out,
+            )
+        }
+    });
+    if let Err(error) = report.finish() {
+        return fail_numerical_diagnostic(
+            report,
+            "logit-diagnostic-evidence-incomplete",
+            error,
+            &args.report_out,
+        );
+    }
+    emit_numerical_diagnostic_report(&report, &args.report_out)
 }
 
 async fn cmd_qualify_hybrid_q4_greedy_parity(
@@ -6506,6 +7242,28 @@ async fn run_real_once_from_token_ids(
     params: crate::sampling::SamplingParams,
     run_index: usize,
 ) -> Result<PreTokenizedRealRun, Box<dyn std::error::Error>> {
+    run_real_once_from_token_ids_internal(
+        runtime,
+        prompt_ids,
+        output_tokens,
+        params,
+        run_index,
+        None,
+    )
+    .await
+}
+
+/// Sole pre-tokenized inference implementation. The private logit diagnostic
+/// may copy the exact first-token row-dot results immediately before the
+/// unchanged production greedy selector; all normal callers pass `None`.
+async fn run_real_once_from_token_ids_internal(
+    runtime: &BenchRealRuntime,
+    prompt_ids: &[u32],
+    output_tokens: usize,
+    params: crate::sampling::SamplingParams,
+    run_index: usize,
+    first_token_logit_bits: Option<&mut Vec<u32>>,
+) -> Result<PreTokenizedRealRun, Box<dyn std::error::Error>> {
     if prompt_ids.is_empty() {
         return Err("pre-tokenized real-model prompt contains zero tokens".into());
     }
@@ -6554,6 +7312,19 @@ async fn run_real_once_from_token_ids(
     let prompt_elapsed = prompt_started.elapsed();
     stage_timings.record(crate::stage_timing::TOTAL_PROMPT, prompt_elapsed);
     let prompt_seconds = prompt_elapsed.as_secs_f64();
+    if let Some(bits) = first_token_logit_bits {
+        if !bits.is_empty() {
+            return Err("first-token logit capture destination was not empty".into());
+        }
+        bits.extend(
+            runtime
+                .model
+                .lm_head
+                .diagnostic_greedy_logits(&final_hidden)
+                .into_iter()
+                .map(f32::to_bits),
+        );
+    }
     let first = runtime.model.sample_hidden_with_timing(
         &final_hidden,
         &params,
@@ -10368,6 +11139,42 @@ mod tests {
     }
 
     #[test]
+    fn logit_diagnostic_cli_requires_report_and_exact_adapter() {
+        let cli = <Cli as clap::Parser>::try_parse_from([
+            "micro-expert-router",
+            "diagnose-hybrid-q4-greedy-divergence",
+            "--config",
+            "strict-hybrid.toml",
+            "--expected-adapter-name",
+            "NVIDIA L4",
+            "--report-out",
+            "diagnostic.json",
+        ])
+        .unwrap();
+        let Cmd::DiagnoseHybridQ4GreedyDivergence {
+            config,
+            expected_adapter_name,
+            report_out,
+        } = cli.cmd
+        else {
+            panic!("expected logit diagnostic command");
+        };
+        assert_eq!(config, PathBuf::from("strict-hybrid.toml"));
+        assert_eq!(expected_adapter_name, "NVIDIA L4");
+        assert_eq!(report_out, PathBuf::from("diagnostic.json"));
+
+        let missing_report = <Cli as clap::Parser>::try_parse_from([
+            "micro-expert-router",
+            "diagnose-hybrid-q4-greedy-divergence",
+            "--config",
+            "strict-hybrid.toml",
+            "--expected-adapter-name",
+            "NVIDIA L4",
+        ]);
+        assert!(missing_report.is_err());
+    }
+
+    #[test]
     fn greedy_parity_failure_report_is_written_and_returns_error() {
         let dir = tempdir_unique("greedy-parity-failure");
         std::fs::create_dir_all(&dir).unwrap();
@@ -10488,6 +11295,19 @@ mod tests {
             .render_long_help()
             .to_string();
         assert!(!help.contains("greedy-parity-hybrid-worker-internal"));
+        let diagnostic = <Cli as clap::Parser>::try_parse_from([
+            "micro-expert-router",
+            "greedy-parity-logit-worker-internal",
+            "--config",
+            "strict-hybrid.toml",
+        ])
+        .unwrap();
+        assert!(matches!(
+            diagnostic.cmd,
+            Cmd::GreedyParityLogitWorkerInternal { config }
+                if config == Path::new("strict-hybrid.toml")
+        ));
+        assert!(!help.contains("greedy-parity-logit-worker-internal"));
     }
 
     #[test]

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -3810,6 +3810,16 @@ async fn execute_greedy_parity_plane_internal(
         if cpu_q4_boundary_emulation {
             runtime.engine.enable_cpu_q4_boundary_emulation()?;
         }
+        let boundary_emulation_before =
+            runtime.engine.cpu_q4_boundary_emulation_snapshot();
+        if boundary_emulation_before.enabled != cpu_q4_boundary_emulation
+            || boundary_emulation_before.routed_expert_dispatches != 0
+        {
+            return Err(format!(
+                "{case_name} runtime Q4 boundary-emulation state did not start clean or match the requested execution mode"
+            )
+            .into());
+        }
         let context = runtime.engine.execution_context();
         let execution_plan: crate::qualification::ExecutionPlanEvidence = context.plan().into();
         let plane = match mode {
@@ -3928,6 +3938,8 @@ async fn execute_greedy_parity_plane_internal(
             );
         }
         let routed_after = runtime.engine.routed_expert_execution_snapshot();
+        let cpu_q4_boundary_emulation =
+            runtime.engine.cpu_q4_boundary_emulation_snapshot();
         let io_after_option = runtime.engine.gpu_expert_io_snapshot();
         let io_after = io_after_option.unwrap_or_default();
         let memory_after = runtime.engine.gpu_expert_memory_snapshot();
@@ -3989,6 +4001,7 @@ async fn execute_greedy_parity_plane_internal(
                 runtime.engine.routed_expert_gpu_failure_policy(),
             )
             .to_string(),
+            cpu_q4_boundary_emulation,
             device,
             initial_state,
             generation,

--- a/rust-engine/src/numerical_diagnostics.rs
+++ b/rust-engine/src/numerical_diagnostics.rs
@@ -30,6 +30,7 @@ pub const MAX_WORKER_STDOUT_BYTES: usize = 4 * 1024 * 1024;
 #[serde(rename_all = "snake_case")]
 pub enum DiagnosticPlane {
     Cpu,
+    CpuBoundaryEmulation,
     Hybrid,
 }
 
@@ -37,6 +38,7 @@ impl DiagnosticPlane {
     pub fn as_str(self) -> &'static str {
         match self {
             Self::Cpu => "cpu",
+            Self::CpuBoundaryEmulation => "cpu-boundary-emulation",
             Self::Hybrid => "hybrid",
         }
     }
@@ -144,6 +146,21 @@ pub fn f32_bits_sha256(bits: &[u32]) -> String {
         hasher.update(value.to_le_bytes());
     }
     format!("{:x}", hasher.finalize())
+}
+
+pub(crate) fn round_trip_f16_values(
+    values: &[f32],
+) -> Result<Vec<f32>, crate::inference::ExpertWeightsError> {
+    let rounded: Vec<f32> = values
+        .iter()
+        .map(|value| half::f16::from_f32(*value).to_f32())
+        .collect();
+    if rounded.iter().any(|value| !value.is_finite()) {
+        return Err(crate::inference::ExpertWeightsError::InvalidLayout(
+            "diagnostic f16 precision boundary produced a nonfinite value".to_string(),
+        ));
+    }
+    Ok(rounded)
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
@@ -602,6 +619,67 @@ pub struct FirstTokenLogitEvidence {
     pub token_5212_hybrid: RankedLogitEvidence,
 }
 
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct BoundaryPlaneEvidence {
+    pub chosen_token_id: u32,
+    pub generated_token_ids_sha256: String,
+    pub first_token_logit_bits_sha256: String,
+    pub top_16: Vec<RankedLogitEvidence>,
+    pub token_715: RankedLogitEvidence,
+    pub token_5212: RankedLogitEvidence,
+    pub token_715_minus_5212_margin: FloatEvidence,
+    pub versus_cpu: VectorComparisonEvidence,
+    pub versus_hybrid: VectorComparisonEvidence,
+    pub matches_cpu_chosen_token: bool,
+    pub matches_hybrid_chosen_token: bool,
+    pub matches_cpu_complete_logit_hash: bool,
+    pub matches_hybrid_complete_logit_hash: bool,
+}
+
+pub fn build_boundary_plane_evidence(
+    cpu: &[f32],
+    hybrid: &[f32],
+    boundary: &[f32],
+    cpu_chosen: u32,
+    hybrid_chosen: u32,
+    boundary_chosen: u32,
+    generated_token_ids_sha256: String,
+) -> Result<BoundaryPlaneEvidence, String> {
+    if cpu.len() != hybrid.len() || cpu.len() != boundary.len() || boundary.len() <= 5212 {
+        return Err(
+            "boundary-emulation logit vectors differ in length or are incomplete".to_string(),
+        );
+    }
+    let top_16 = top_logits(boundary, TOP_LOGIT_COUNT);
+    if top_16.first().map(|entry| entry.token_id) != Some(boundary_chosen) {
+        return Err(
+            "boundary-emulation logits disagree with production greedy selection".to_string(),
+        );
+    }
+    let cpu_hash = f32_bits_sha256(&cpu.iter().map(|value| value.to_bits()).collect::<Vec<_>>());
+    let hybrid_hash =
+        f32_bits_sha256(&hybrid.iter().map(|value| value.to_bits()).collect::<Vec<_>>());
+    let boundary_hash =
+        f32_bits_sha256(&boundary.iter().map(|value| value.to_bits()).collect::<Vec<_>>());
+    Ok(BoundaryPlaneEvidence {
+        chosen_token_id: boundary_chosen,
+        generated_token_ids_sha256,
+        first_token_logit_bits_sha256: boundary_hash.clone(),
+        token_715: ranked_logit_for(boundary, 715)
+            .ok_or("boundary-emulation token 715 is unavailable")?,
+        token_5212: ranked_logit_for(boundary, 5212)
+            .ok_or("boundary-emulation token 5212 is unavailable")?,
+        token_715_minus_5212_margin: FloatEvidence::new(boundary[715] - boundary[5212]),
+        versus_cpu: compare_vectors(cpu, boundary)?,
+        versus_hybrid: compare_vectors(hybrid, boundary)?,
+        matches_cpu_chosen_token: boundary_chosen == cpu_chosen,
+        matches_hybrid_chosen_token: boundary_chosen == hybrid_chosen,
+        matches_cpu_complete_logit_hash: boundary_hash == cpu_hash,
+        matches_hybrid_complete_logit_hash: boundary_hash == hybrid_hash,
+        top_16,
+    })
+}
+
 fn top_margin(top: &[RankedLogitEvidence]) -> Result<f32, String> {
     let first = top
         .first()
@@ -675,6 +753,7 @@ pub struct RepeatedRunEvidence {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct ReproducibilityEvidence {
     pub cpu_bitwise_reproducible: bool,
+    pub cpu_boundary_emulation_bitwise_reproducible: bool,
     pub hybrid_bitwise_reproducible: bool,
     pub all_worker_ids_unique: bool,
     pub all_process_ids_unique: bool,
@@ -688,6 +767,10 @@ pub fn validate_repeated_run_identity(runs: &[RepeatedRunEvidence]) -> Reproduci
         .iter()
         .filter(|run| run.plane == DiagnosticPlane::Hybrid)
         .collect();
+    let boundary: Vec<_> = runs
+        .iter()
+        .filter(|run| run.plane == DiagnosticPlane::CpuBoundaryEmulation)
+        .collect();
     let worker_ids: HashSet<_> = runs.iter().map(|run| run.worker_id.as_str()).collect();
     let process_ids: Vec<_> = runs.iter().filter_map(|run| run.process.process_id).collect();
     let unique_process_ids: HashSet<_> = process_ids.iter().copied().collect();
@@ -700,6 +783,7 @@ pub fn validate_repeated_run_identity(runs: &[RepeatedRunEvidence]) -> Reproduci
     };
     ReproducibilityEvidence {
         cpu_bitwise_reproducible: reproducible(&cpu),
+        cpu_boundary_emulation_bitwise_reproducible: reproducible(&boundary),
         hybrid_bitwise_reproducible: reproducible(&hybrid),
         all_worker_ids_unique: worker_ids.len() == runs.len(),
         all_process_ids_unique: process_ids.len() == runs.len()
@@ -725,8 +809,13 @@ pub fn validate_repeated_run_identity(runs: &[RepeatedRunEvidence]) -> Reproduci
                 && run.process.process_reaped
                 && run.process.evidence_emitted
         }),
-        no_retries: runs.len() == REPEATED_RUNS_PER_PLANE * 2
+        no_retries: runs.len() == REPEATED_RUNS_PER_PLANE * 3
             && cpu.iter().map(|run| run.run_index).collect::<BTreeSet<_>>()
+                == BTreeSet::from([0, 1])
+            && boundary
+                .iter()
+                .map(|run| run.run_index)
+                .collect::<BTreeSet<_>>()
                 == BTreeSet::from([0, 1])
             && hybrid
                 .iter()
@@ -773,6 +862,7 @@ pub struct DiagnosticReport {
     pub worker_failures: Vec<DiagnosticWorkerFailureEvidence>,
     pub reproducibility: Option<ReproducibilityEvidence>,
     pub first_token_logits: Option<FirstTokenLogitEvidence>,
+    pub cpu_boundary_emulation: Option<BoundaryPlaneEvidence>,
     pub route_capture: Option<RouteCaptureEvidence>,
     pub actual_input_q4_shadow: Option<ActualInputQ4ShadowEvidence>,
 }
@@ -808,6 +898,7 @@ impl DiagnosticReport {
             worker_failures: Vec::new(),
             reproducibility: None,
             first_token_logits: None,
+            cpu_boundary_emulation: None,
             route_capture: None,
             actual_input_q4_shadow: None,
         }
@@ -829,9 +920,10 @@ impl DiagnosticReport {
             .reproducibility
             .as_ref()
             .ok_or("diagnostic has no reproducibility evidence")?;
-        if self.runs.len() != REPEATED_RUNS_PER_PLANE * 2
+        if self.runs.len() != REPEATED_RUNS_PER_PLANE * 3
             || reproducibility != &validate_repeated_run_identity(&self.runs)
             || !reproducibility.cpu_bitwise_reproducible
+            || !reproducibility.cpu_boundary_emulation_bitwise_reproducible
             || !reproducibility.hybrid_bitwise_reproducible
             || !reproducibility.all_worker_ids_unique
             || !reproducibility.all_process_ids_unique
@@ -839,6 +931,7 @@ impl DiagnosticReport {
             || !reproducibility.no_retries
             || !self.worker_failures.is_empty()
             || self.first_token_logits.is_none()
+            || self.cpu_boundary_emulation.is_none()
             || !self
                 .route_capture
                 .as_ref()
@@ -849,6 +942,7 @@ impl DiagnosticReport {
                     && is_sha256_hex(&shadow.effective_f16_input_sha256)
             })
             || !self.first_token_evidence_exact()
+            || !self.boundary_evidence_exact()
             || !self.runs.iter().all(|run| self.run_evidence_exact(run))
         {
             return Err("logit diagnostic evidence is partial or mismatched".to_string());
@@ -899,6 +993,41 @@ impl DiagnosticReport {
             && evidence.token_5212_hybrid.token_id == 5212
     }
 
+    fn boundary_evidence_exact(&self) -> bool {
+        let Some(evidence) = self.cpu_boundary_emulation.as_ref() else {
+            return false;
+        };
+        let find = |plane| self.runs.iter().find(|run| run.plane == plane);
+        let (Some(cpu), Some(boundary), Some(hybrid)) = (
+            find(DiagnosticPlane::Cpu),
+            find(DiagnosticPlane::CpuBoundaryEmulation),
+            find(DiagnosticPlane::Hybrid),
+        ) else {
+            return false;
+        };
+        let cpu_chosen = cpu.generated_token_ids.first().copied();
+        let boundary_chosen = boundary.generated_token_ids.first().copied();
+        let hybrid_chosen = hybrid.generated_token_ids.first().copied();
+        evidence.chosen_token_id == boundary_chosen.unwrap_or(u32::MAX)
+            && evidence.generated_token_ids_sha256 == boundary.generated_token_ids_sha256
+            && evidence.first_token_logit_bits_sha256
+                == boundary.first_token_logit_bits_sha256
+            && evidence.top_16.len() == TOP_LOGIT_COUNT
+            && evidence.top_16.first().map(|entry| entry.token_id) == boundary_chosen
+            && evidence.token_715.token_id == 715
+            && evidence.token_5212.token_id == 5212
+            && evidence.versus_cpu.length == evidence.versus_hybrid.length
+            && evidence.versus_cpu.length > 5212
+            && evidence.matches_cpu_chosen_token == (boundary_chosen == cpu_chosen)
+            && evidence.matches_hybrid_chosen_token == (boundary_chosen == hybrid_chosen)
+            && evidence.matches_cpu_complete_logit_hash
+                == (boundary.first_token_logit_bits_sha256
+                    == cpu.first_token_logit_bits_sha256)
+            && evidence.matches_hybrid_complete_logit_hash
+                == (boundary.first_token_logit_bits_sha256
+                    == hybrid.first_token_logit_bits_sha256)
+    }
+
     fn run_evidence_exact(&self, run: &RepeatedRunEvidence) -> bool {
         let plane = &run.plane_evidence;
         let routed = plane.routed_execution_delta;
@@ -939,7 +1068,7 @@ impl DiagnosticReport {
             return false;
         }
         match run.plane {
-            DiagnosticPlane::Cpu => {
+            DiagnosticPlane::Cpu | DiagnosticPlane::CpuBoundaryEmulation => {
                 plane.plane == "cpu"
                     && crate::greedy_parity::cpu_plan_exact(&plane.execution_plan)
                     && plane.device.is_none()
@@ -985,6 +1114,127 @@ impl DiagnosticReport {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn repeated_run(
+        plane: DiagnosticPlane,
+        run_index: usize,
+        generated_token: u32,
+        logit_hash: char,
+        process_id: u32,
+    ) -> RepeatedRunEvidence {
+        let worker_id = format!("{}-{run_index}", plane.as_str());
+        let generated_token_ids = vec![generated_token];
+        let generated_token_ids_sha256 = token_ids_sha256(&generated_token_ids);
+        let process = HybridWorkerProcessEvidence {
+            worker_id: worker_id.clone(),
+            child_process_spawned: true,
+            process_id: Some(process_id),
+            executable_sha256: "e".repeat(64),
+            build_git_sha: "a".repeat(40),
+            executable_identity_verified: true,
+            build_sha_identity_verified: true,
+            case_identity_verified: true,
+            config_identity_verified: true,
+            expected_adapter_identity_verified: true,
+            prompt_token_identity_verified: true,
+            output_token_limit_verified: true,
+            greedy_sampling_identity_verified: true,
+            normal_zero_exit: true,
+            exit_code: Some(0),
+            signal: None,
+            process_reaped: true,
+            timed_out: false,
+            evidence_emitted: true,
+        };
+        let context_id = format!("context-{worker_id}");
+        let plane_evidence = PlaneRunEvidence {
+            plane: "cpu".to_string(),
+            model_load: crate::greedy_parity::ModelLoadEvidence {
+                strict: true,
+                loader: "safetensors".to_string(),
+                loaded_tensors: 1,
+                required_tensors: 1,
+                optional_probed: 0,
+                optional_loaded: 0,
+                seeded_fallback_remained: false,
+            },
+            execution_plan: crate::qualification::ExecutionPlanEvidence {
+                context_id: context_id.clone(),
+                requested: "cpu".to_string(),
+                resolved: "cpu".to_string(),
+                embeddings: "cpu".to_string(),
+                lm_head: "cpu".to_string(),
+                dense_projections: "cpu".to_string(),
+                attention: "cpu".to_string(),
+                kv: "cpu".to_string(),
+                router: "cpu".to_string(),
+                routed_experts: "cpu".to_string(),
+                routed_expert_dtype: "q4_0".to_string(),
+                fallback_occurred: false,
+                reason: None,
+            },
+            routed_expert_gpu_failure_policy: "serving-cpu-fallback".to_string(),
+            device: None,
+            initial_state: crate::greedy_parity::InitialStateEvidence {
+                context_id,
+                resolved_config_sha256: "c".repeat(64),
+                kv_cache_count: 1,
+                kv_sequence_lengths: vec![0],
+                all_kv_empty: true,
+                cache: crate::greedy_parity::RuntimeCacheSnapshot::default(),
+                routed: crate::engine::RoutedExpertExecutionSnapshot::default(),
+                gpu_io_available: false,
+                gpu_io: GpuExpertIoSnapshot::default(),
+            },
+            generation: crate::greedy_parity::GenerationEvidence {
+                prompt_token_ids_sha256: "p".repeat(64),
+                generated_token_ids: generated_token_ids.clone(),
+                generated_token_ids_sha256: generated_token_ids_sha256.clone(),
+                generated_text_sha256: "t".repeat(64),
+                generated_token_count: 1,
+                termination_reason: crate::greedy_parity::TerminationReason::LengthLimit,
+            },
+            routed_execution_delta: crate::engine::RoutedExpertExecutionSnapshot {
+                selected_routed_experts: 1,
+                cpu_routed_expert_dispatches: 1,
+                ..Default::default()
+            },
+            gpu_io_delta: GpuExpertIoSnapshot::default(),
+            attention_softmax_nonfinite_fallbacks: 0,
+            gpu_memory_before: None,
+            gpu_memory_after: None,
+            background_shutdown: crate::greedy_parity::BackgroundShutdownEvidence {
+                controlled_shutdown_requested: true,
+                all_runtime_resources_released: true,
+                poll_iterations: 1,
+            },
+            worker_process: Some(process.clone()),
+        };
+        RepeatedRunEvidence {
+            plane,
+            run_index,
+            worker_id,
+            generated_token_ids,
+            generated_token_ids_sha256,
+            first_token_logit_bits_sha256: logit_hash.to_string().repeat(64),
+            process,
+            plane_evidence,
+        }
+    }
+
+    #[test]
+    fn boundary_conversion_matches_production_f16_round_trip_and_fails_nonfinite() {
+        let values = [1.0003, -0.0, 65504.0];
+        let rounded = round_trip_f16_values(&values).unwrap();
+        assert_eq!(
+            rounded[0].to_bits(),
+            half::f16::from_f32(values[0]).to_f32().to_bits()
+        );
+        assert_eq!(rounded[1].to_bits(), (-0.0f32).to_bits());
+        assert_eq!(rounded[2], 65504.0);
+        assert!(round_trip_f16_values(&[70000.0]).is_err());
+        assert!(round_trip_f16_values(&[f32::NAN]).is_err());
+    }
 
     #[test]
     fn top_logits_use_total_order_and_lower_token_id_for_ties() {
@@ -1059,6 +1309,65 @@ mod tests {
     }
 
     #[test]
+    fn boundary_report_compares_complete_logits_and_chosen_token() {
+        let mut cpu = vec![-10.0; 6000];
+        cpu[715] = 4.0;
+        cpu[5212] = 3.75;
+        let mut hybrid = cpu.clone();
+        hybrid[715] = 3.8;
+        hybrid[5212] = 4.0;
+        let boundary = hybrid.clone();
+        let generated_hash = token_ids_sha256(&[5212]);
+        let evidence = build_boundary_plane_evidence(
+            &cpu,
+            &hybrid,
+            &boundary,
+            715,
+            5212,
+            5212,
+            generated_hash.clone(),
+        )
+        .unwrap();
+        assert_eq!(evidence.generated_token_ids_sha256, generated_hash);
+        assert_eq!(evidence.top_16[0].token_id, 5212);
+        assert_eq!(evidence.token_715.rank, 2);
+        assert_eq!(evidence.token_5212.rank, 1);
+        assert!(evidence.versus_hybrid.exact_f32_bits);
+        assert!(!evidence.versus_cpu.exact_f32_bits);
+        assert!(!evidence.matches_cpu_chosen_token);
+        assert!(evidence.matches_hybrid_chosen_token);
+        assert!(!evidence.matches_cpu_complete_logit_hash);
+        assert!(evidence.matches_hybrid_complete_logit_hash);
+    }
+
+    #[test]
+    fn reproducibility_requires_two_exact_unique_runs_for_all_three_planes() {
+        let mut runs = Vec::new();
+        for (plane, token, hash, pid) in [
+            (DiagnosticPlane::Cpu, 715, 'a', 10),
+            (DiagnosticPlane::CpuBoundaryEmulation, 5212, 'b', 20),
+            (DiagnosticPlane::Hybrid, 5212, 'c', 30),
+        ] {
+            runs.push(repeated_run(plane, 0, token, hash, pid));
+            runs.push(repeated_run(plane, 1, token, hash, pid + 1));
+        }
+        let exact = validate_repeated_run_identity(&runs);
+        assert!(exact.cpu_bitwise_reproducible);
+        assert!(exact.cpu_boundary_emulation_bitwise_reproducible);
+        assert!(exact.hybrid_bitwise_reproducible);
+        assert!(exact.all_worker_ids_unique);
+        assert!(exact.all_process_ids_unique);
+        assert!(exact.every_worker_exited_zero_and_reaped);
+        assert!(exact.no_retries);
+
+        runs[3].first_token_logit_bits_sha256 = "d".repeat(64);
+        let mismatch = validate_repeated_run_identity(&runs);
+        assert!(mismatch.cpu_bitwise_reproducible);
+        assert!(!mismatch.cpu_boundary_emulation_bitwise_reproducible);
+        assert!(mismatch.hybrid_bitwise_reproducible);
+    }
+
+    #[test]
     fn worker_protocol_rejects_unknown_and_trailing_documents() {
         let base = HybridWorkerRequest::new(
             "worker".to_string(),
@@ -1072,6 +1381,16 @@ mod tests {
         let request = DiagnosticWorkerRequest::new(DiagnosticPlane::Cpu, 0, base);
         let encoded = serde_json::to_vec(&request).unwrap();
         assert_eq!(parse_worker_request_exact(&encoded).unwrap(), request);
+        let mut boundary: serde_json::Value = serde_json::from_slice(&encoded).unwrap();
+        boundary["plane"] = serde_json::json!("cpu_boundary_emulation");
+        assert_eq!(
+            parse_worker_request_exact(&serde_json::to_vec(&boundary).unwrap())
+                .unwrap()
+                .plane,
+            DiagnosticPlane::CpuBoundaryEmulation
+        );
+        boundary["plane"] = serde_json::json!("unrecognized_plane");
+        assert!(parse_worker_request_exact(&serde_json::to_vec(&boundary).unwrap()).is_err());
         let mut unknown: serde_json::Value = serde_json::from_slice(&encoded).unwrap();
         unknown["unknown"] = serde_json::json!(true);
         assert!(parse_worker_request_exact(&serde_json::to_vec(&unknown).unwrap()).is_err());

--- a/rust-engine/src/numerical_diagnostics.rs
+++ b/rust-engine/src/numerical_diagnostics.rs
@@ -1068,9 +1068,28 @@ impl DiagnosticReport {
             return false;
         }
         match run.plane {
-            DiagnosticPlane::Cpu | DiagnosticPlane::CpuBoundaryEmulation => {
+            DiagnosticPlane::Cpu => {
                 plane.plane == "cpu"
                     && crate::greedy_parity::cpu_plan_exact(&plane.execution_plan)
+                    && plane.cpu_q4_boundary_emulation
+                        == crate::engine::CpuQ4BoundaryEmulationSnapshot::default()
+                    && plane.device.is_none()
+                    && !initial.gpu_io_available
+                    && routed.selected_routed_experts > 0
+                    && routed.cpu_routed_expert_dispatches == routed.selected_routed_experts
+                    && routed.gpu_dispatch_attempts == 0
+                    && io == GpuExpertIoSnapshot::default()
+                    && plane.gpu_memory_before.is_none()
+                    && plane.gpu_memory_after.is_none()
+            }
+            DiagnosticPlane::CpuBoundaryEmulation => {
+                plane.plane == "cpu"
+                    && crate::greedy_parity::cpu_plan_exact(&plane.execution_plan)
+                    && plane.cpu_q4_boundary_emulation.enabled
+                    && plane
+                        .cpu_q4_boundary_emulation
+                        .routed_expert_dispatches
+                        == routed.cpu_routed_expert_dispatches
                     && plane.device.is_none()
                     && !initial.gpu_io_available
                     && routed.selected_routed_experts > 0
@@ -1083,6 +1102,8 @@ impl DiagnosticReport {
             DiagnosticPlane::Hybrid => {
                 plane.plane == "hybrid"
                     && crate::greedy_parity::hybrid_plan_exact(&plane.execution_plan)
+                    && plane.cpu_q4_boundary_emulation
+                        == crate::engine::CpuQ4BoundaryEmulationSnapshot::default()
                     && plane.device.as_ref().is_some_and(|device| {
                         !device.software_adapter
                             && !device.device_type.eq_ignore_ascii_case("cpu")
@@ -1123,7 +1144,8 @@ mod tests {
         process_id: u32,
     ) -> RepeatedRunEvidence {
         let worker_id = format!("{}-{run_index}", plane.as_str());
-        let generated_token_ids = vec![generated_token];
+        let mut generated_token_ids = vec![generated_token];
+        generated_token_ids.resize(crate::greedy_parity::OUTPUT_TOKEN_LIMIT, generated_token);
         let generated_token_ids_sha256 = token_ids_sha256(&generated_token_ids);
         let process = HybridWorkerProcessEvidence {
             worker_id: worker_id.clone(),
@@ -1174,6 +1196,8 @@ mod tests {
                 reason: None,
             },
             routed_expert_gpu_failure_policy: "serving-cpu-fallback".to_string(),
+            cpu_q4_boundary_emulation:
+                crate::engine::CpuQ4BoundaryEmulationSnapshot::default(),
             device: None,
             initial_state: crate::greedy_parity::InitialStateEvidence {
                 context_id,
@@ -1191,7 +1215,7 @@ mod tests {
                 generated_token_ids: generated_token_ids.clone(),
                 generated_token_ids_sha256: generated_token_ids_sha256.clone(),
                 generated_text_sha256: "t".repeat(64),
-                generated_token_count: 1,
+                generated_token_count: crate::greedy_parity::OUTPUT_TOKEN_LIMIT,
                 termination_reason: crate::greedy_parity::TerminationReason::LengthLimit,
             },
             routed_execution_delta: crate::engine::RoutedExpertExecutionSnapshot {
@@ -1365,6 +1389,45 @@ mod tests {
         assert!(mismatch.cpu_bitwise_reproducible);
         assert!(!mismatch.cpu_boundary_emulation_bitwise_reproducible);
         assert!(mismatch.hybrid_bitwise_reproducible);
+    }
+
+    #[test]
+    fn diagnostic_boundary_role_requires_runtime_observed_emulation() {
+        let report = DiagnosticReport::new(
+            crate::qualification::BuildProvenance {
+                git_sha: Some("a".repeat(40)),
+                dirty: Some(false),
+                package_version: "test".to_string(),
+            },
+            "a".repeat(40),
+            "e".repeat(64),
+            "c".repeat(64),
+            "NVIDIA L4".to_string(),
+            "d".repeat(64),
+            "p".repeat(64),
+            2,
+        );
+        let ordinary_cpu_substitute =
+            repeated_run(DiagnosticPlane::CpuBoundaryEmulation, 0, 5212, 'b', 20);
+        assert!(!report.run_evidence_exact(&ordinary_cpu_substitute));
+
+        let mut observed_boundary = ordinary_cpu_substitute;
+        observed_boundary
+            .plane_evidence
+            .cpu_q4_boundary_emulation = crate::engine::CpuQ4BoundaryEmulationSnapshot {
+            enabled: true,
+            routed_expert_dispatches: 1,
+        };
+        assert!(report.run_evidence_exact(&observed_boundary));
+
+        let mut ordinary_cpu = repeated_run(DiagnosticPlane::Cpu, 0, 715, 'a', 10);
+        assert!(report.run_evidence_exact(&ordinary_cpu));
+        ordinary_cpu.plane_evidence.cpu_q4_boundary_emulation =
+            crate::engine::CpuQ4BoundaryEmulationSnapshot {
+                enabled: true,
+                routed_expert_dispatches: 1,
+            };
+        assert!(!report.run_evidence_exact(&ordinary_cpu));
     }
 
     #[test]

--- a/rust-engine/src/numerical_diagnostics.rs
+++ b/rust-engine/src/numerical_diagnostics.rs
@@ -21,6 +21,8 @@ pub const WORKER_PROTOCOL_VERSION: &str =
 pub const TARGET_CASE: &str = "json-transformation";
 pub const REPEATED_RUNS_PER_PLANE: usize = 2;
 pub const TOP_LOGIT_COUNT: usize = 16;
+pub const SHADOW_EXPERT_COUNT: usize = 8;
+pub const SHADOW_D_MODEL: usize = 2048;
 pub const MAX_VOCAB_SIZE: usize = 262_144;
 pub const MAX_WORKER_STDOUT_BYTES: usize = 4 * 1024 * 1024;
 
@@ -88,6 +90,7 @@ pub struct DiagnosticWorkerResponse {
     pub chosen_token_id: Option<u32>,
     pub first_token_logit_bits: Option<Vec<u32>>,
     pub first_token_logit_bits_sha256: Option<String>,
+    pub route_capture: Option<crate::engine::RoutedFfnDiagnosticCapture>,
     pub failure: Option<String>,
 }
 
@@ -141,6 +144,225 @@ pub fn f32_bits_sha256(bits: &[u32]) -> String {
         hasher.update(value.to_le_bytes());
     }
     format!("{:x}", hasher.finalize())
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct RouteCaptureEvidence {
+    pub token_idx: u64,
+    pub layer: u32,
+    pub cpu_input_sha256: String,
+    pub hybrid_input_sha256: String,
+    pub input_hashes_match: bool,
+    pub cpu_expert_ids: Vec<u32>,
+    pub hybrid_expert_ids: Vec<u32>,
+    pub expert_ids_match: bool,
+    pub cpu_routing_weight_bits: Vec<u32>,
+    pub hybrid_routing_weight_bits: Vec<u32>,
+    pub routing_weight_bits_match: bool,
+    pub all_repeated_captures_match: bool,
+    pub exact_capture_match: bool,
+}
+
+pub fn reconcile_route_captures(
+    captures: &[(DiagnosticPlane, crate::engine::RoutedFfnDiagnosticCapture)],
+    expected_token_idx: u64,
+) -> Result<RouteCaptureEvidence, String> {
+    if captures.len() != REPEATED_RUNS_PER_PLANE * 2 {
+        return Err("route capture count is incomplete".to_string());
+    }
+    for (_, capture) in captures {
+        if capture.token_idx != expected_token_idx
+            || capture.layer != 0
+            || capture.input_bits.len() != SHADOW_D_MODEL
+            || capture.expert_ids.len() != SHADOW_EXPERT_COUNT
+            || capture.routing_weight_bits.len() != SHADOW_EXPERT_COUNT
+            || capture.expert_ids.iter().any(|expert| *expert >= 128)
+            || capture.expert_ids.iter().copied().collect::<HashSet<_>>().len()
+                != SHADOW_EXPERT_COUNT
+            || capture
+                .input_bits
+                .iter()
+                .chain(&capture.routing_weight_bits)
+                .any(|bits| !f32::from_bits(*bits).is_finite())
+        {
+            return Err("layer-0 route capture is malformed".to_string());
+        }
+    }
+    let cpu: Vec<_> = captures
+        .iter()
+        .filter(|(plane, _)| *plane == DiagnosticPlane::Cpu)
+        .map(|(_, capture)| capture)
+        .collect();
+    let hybrid: Vec<_> = captures
+        .iter()
+        .filter(|(plane, _)| *plane == DiagnosticPlane::Hybrid)
+        .map(|(_, capture)| capture)
+        .collect();
+    if cpu.len() != REPEATED_RUNS_PER_PLANE || hybrid.len() != REPEATED_RUNS_PER_PLANE {
+        return Err("route captures do not cover both repeated planes".to_string());
+    }
+    let cpu_input_sha256 = f32_bits_sha256(&cpu[0].input_bits);
+    let hybrid_input_sha256 = f32_bits_sha256(&hybrid[0].input_bits);
+    let input_hashes_match = cpu_input_sha256 == hybrid_input_sha256;
+    let expert_ids_match = cpu[0].expert_ids == hybrid[0].expert_ids;
+    let routing_weight_bits_match =
+        cpu[0].routing_weight_bits == hybrid[0].routing_weight_bits;
+    let all_repeated_captures_match = captures
+        .iter()
+        .all(|(_, capture)| capture == &captures[0].1);
+    Ok(RouteCaptureEvidence {
+        token_idx: expected_token_idx,
+        layer: 0,
+        cpu_input_sha256,
+        hybrid_input_sha256,
+        input_hashes_match,
+        cpu_expert_ids: cpu[0].expert_ids.clone(),
+        hybrid_expert_ids: hybrid[0].expert_ids.clone(),
+        expert_ids_match,
+        cpu_routing_weight_bits: cpu[0].routing_weight_bits.clone(),
+        hybrid_routing_weight_bits: hybrid[0].routing_weight_bits.clone(),
+        routing_weight_bits_match,
+        all_repeated_captures_match,
+        exact_capture_match: input_hashes_match
+            && expert_ids_match
+            && routing_weight_bits_match
+            && all_repeated_captures_match,
+    })
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct Q4ShadowOutputComparison {
+    pub cpu_f32_sha256: String,
+    pub cpu_f16_sha256: String,
+    pub gpu_f16_sha256: String,
+    pub max_absolute_error: f32,
+    pub rms_error: f64,
+    pub tolerance_pass: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct Q4ShadowExpertEvidence {
+    pub global_expert_id: u32,
+    pub routing_weight: FloatEvidence,
+    pub output: Q4ShadowOutputComparison,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct ActualInputQ4ShadowEvidence {
+    pub captured_input_sha256: String,
+    pub effective_f16_input_sha256: String,
+    pub tolerance: crate::q4_parity::ErrorTolerance,
+    pub experts: Vec<Q4ShadowExpertEvidence>,
+    pub weighted_aggregate: Q4ShadowOutputComparison,
+    pub all_experts_within_tolerance: bool,
+    pub weighted_aggregate_within_tolerance: bool,
+}
+
+pub struct Q4ShadowExpertOutput {
+    pub global_expert_id: u32,
+    pub cpu_f32: Vec<f32>,
+    pub gpu_f16: Vec<f32>,
+}
+
+fn hash_f32(values: &[f32]) -> String {
+    f32_bits_sha256(&values.iter().copied().map(f32::to_bits).collect::<Vec<_>>())
+}
+
+fn compare_q4_shadow_output(
+    cpu_f32: &[f32],
+    cpu_f16: &[f32],
+    gpu_f16: &[f32],
+) -> Result<Q4ShadowOutputComparison, String> {
+    if cpu_f32.len() != cpu_f16.len()
+        || cpu_f32.len() != gpu_f16.len()
+        || cpu_f32.is_empty()
+    {
+        return Err("Q4 shadow output lengths differ or are empty".to_string());
+    }
+    if cpu_f32
+        .iter()
+        .chain(cpu_f16.iter())
+        .chain(gpu_f16)
+        .any(|value| !value.is_finite())
+    {
+        return Err("Q4 shadow output contains a nonfinite value".to_string());
+    }
+    let tolerance = crate::q4_parity::COMPLETE_TOLERANCE;
+    let mut max_absolute_error = 0.0f32;
+    let mut squared_error = 0.0f64;
+    let mut tolerance_pass = true;
+    for (&cpu, &gpu) in cpu_f16.iter().zip(gpu_f16) {
+        let absolute = (gpu - cpu).abs();
+        max_absolute_error = max_absolute_error.max(absolute);
+        squared_error += f64::from(absolute) * f64::from(absolute);
+        tolerance_pass &= absolute <= tolerance.absolute + tolerance.relative * cpu.abs();
+    }
+    Ok(Q4ShadowOutputComparison {
+        cpu_f32_sha256: hash_f32(cpu_f32),
+        cpu_f16_sha256: hash_f32(cpu_f16),
+        gpu_f16_sha256: hash_f32(gpu_f16),
+        max_absolute_error,
+        rms_error: (squared_error / cpu_f16.len() as f64).sqrt(),
+        tolerance_pass,
+    })
+}
+
+pub fn build_actual_input_q4_shadow(
+    capture: &crate::engine::RoutedFfnDiagnosticCapture,
+    outputs: Vec<Q4ShadowExpertOutput>,
+) -> Result<ActualInputQ4ShadowEvidence, String> {
+    if outputs.len() != SHADOW_EXPERT_COUNT
+        || capture.expert_ids.len() != outputs.len()
+        || capture.routing_weight_bits.len() != outputs.len()
+    {
+        return Err("Q4 shadow expert output count is invalid".to_string());
+    }
+    let effective_input: Vec<f32> = capture
+        .input_bits
+        .iter()
+        .map(|bits| half::f16::from_f32(f32::from_bits(*bits)).to_f32())
+        .collect();
+    let mut cpu_aggregate = vec![0.0f32; SHADOW_D_MODEL];
+    let mut cpu_f16_aggregate = vec![0.0f32; SHADOW_D_MODEL];
+    let mut gpu_aggregate = vec![0.0f32; SHADOW_D_MODEL];
+    let mut experts = Vec::with_capacity(outputs.len());
+    for (slot, output) in outputs.into_iter().enumerate() {
+        if output.global_expert_id != capture.expert_ids[slot]
+            || output.cpu_f32.len() != SHADOW_D_MODEL
+            || output.gpu_f16.len() != SHADOW_D_MODEL
+        {
+            return Err("Q4 shadow expert identity or geometry is invalid".to_string());
+        }
+        let weight = f32::from_bits(capture.routing_weight_bits[slot]);
+        let cpu_f16: Vec<f32> = output
+            .cpu_f32
+            .iter()
+            .map(|value| half::f16::from_f32(*value).to_f32())
+            .collect();
+        for index in 0..SHADOW_D_MODEL {
+            cpu_aggregate[index] += weight * output.cpu_f32[index];
+            cpu_f16_aggregate[index] += weight * cpu_f16[index];
+            gpu_aggregate[index] += weight * output.gpu_f16[index];
+        }
+        experts.push(Q4ShadowExpertEvidence {
+            global_expert_id: output.global_expert_id,
+            routing_weight: FloatEvidence::new(weight),
+            output: compare_q4_shadow_output(&output.cpu_f32, &cpu_f16, &output.gpu_f16)?,
+        });
+    }
+    let weighted_aggregate =
+        compare_q4_shadow_output(&cpu_aggregate, &cpu_f16_aggregate, &gpu_aggregate)?;
+    Ok(ActualInputQ4ShadowEvidence {
+        captured_input_sha256: f32_bits_sha256(&capture.input_bits),
+        effective_f16_input_sha256: hash_f32(&effective_input),
+        tolerance: crate::q4_parity::COMPLETE_TOLERANCE,
+        all_experts_within_tolerance: experts
+            .iter()
+            .all(|expert| expert.output.tolerance_pass),
+        weighted_aggregate_within_tolerance: weighted_aggregate.tolerance_pass,
+        experts,
+        weighted_aggregate,
+    })
 }
 
 fn is_sha256_hex(value: &str) -> bool {
@@ -440,6 +662,7 @@ pub fn build_first_token_logit_evidence(
 #[derive(Clone, Debug, Serialize)]
 pub struct RepeatedRunEvidence {
     pub plane: DiagnosticPlane,
+    #[serde(rename = "repeat_index")]
     pub run_index: usize,
     pub worker_id: String,
     pub generated_token_ids: Vec<u32>,
@@ -537,6 +760,7 @@ pub struct DiagnosticReport {
     pub qualification_pass: bool,
     pub diagnostic_complete: bool,
     pub failure: Option<DiagnosticFailure>,
+    pub provenance: crate::qualification::BuildProvenance,
     pub build_git_sha: String,
     pub executable_sha256: String,
     pub resolved_config_sha256: String,
@@ -549,11 +773,14 @@ pub struct DiagnosticReport {
     pub worker_failures: Vec<DiagnosticWorkerFailureEvidence>,
     pub reproducibility: Option<ReproducibilityEvidence>,
     pub first_token_logits: Option<FirstTokenLogitEvidence>,
+    pub route_capture: Option<RouteCaptureEvidence>,
+    pub actual_input_q4_shadow: Option<ActualInputQ4ShadowEvidence>,
 }
 
 impl DiagnosticReport {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
+        provenance: crate::qualification::BuildProvenance,
         build_git_sha: String,
         executable_sha256: String,
         resolved_config_sha256: String,
@@ -568,6 +795,7 @@ impl DiagnosticReport {
             qualification_pass: false,
             diagnostic_complete: false,
             failure: None,
+            provenance,
             build_git_sha,
             executable_sha256,
             resolved_config_sha256,
@@ -580,6 +808,8 @@ impl DiagnosticReport {
             worker_failures: Vec::new(),
             reproducibility: None,
             first_token_logits: None,
+            route_capture: None,
+            actual_input_q4_shadow: None,
         }
     }
 
@@ -609,6 +839,15 @@ impl DiagnosticReport {
             || !reproducibility.no_retries
             || !self.worker_failures.is_empty()
             || self.first_token_logits.is_none()
+            || !self
+                .route_capture
+                .as_ref()
+                .is_some_and(|capture| capture.exact_capture_match)
+            || !self.actual_input_q4_shadow.as_ref().is_some_and(|shadow| {
+                shadow.experts.len() == SHADOW_EXPERT_COUNT
+                    && is_sha256_hex(&shadow.captured_input_sha256)
+                    && is_sha256_hex(&shadow.effective_f16_input_sha256)
+            })
             || !self.first_token_evidence_exact()
             || !self.runs.iter().all(|run| self.run_evidence_exact(run))
         {
@@ -844,6 +1083,11 @@ mod tests {
     #[test]
     fn diagnostic_report_can_never_claim_qualification_pass() {
         let mut report = DiagnosticReport::new(
+            crate::qualification::BuildProvenance {
+                git_sha: Some("a".repeat(40)),
+                dirty: Some(false),
+                package_version: "test".to_string(),
+            },
             "a".repeat(40),
             "b".repeat(64),
             "c".repeat(64),
@@ -858,5 +1102,57 @@ mod tests {
         report.fail("test", "failure");
         assert!(!report.qualification_pass);
         assert!(!report.diagnostic_complete);
+    }
+
+    fn route_capture(input_bits: Vec<u32>) -> crate::engine::RoutedFfnDiagnosticCapture {
+        crate::engine::RoutedFfnDiagnosticCapture {
+            token_idx: 96,
+            layer: 0,
+            input_bits,
+            expert_ids: (0..SHADOW_EXPERT_COUNT as u32).collect(),
+            routing_weight_bits: vec![(0.125f32).to_bits(); SHADOW_EXPERT_COUNT],
+        }
+    }
+
+    #[test]
+    fn route_capture_requires_exact_cpu_hybrid_inputs_experts_and_weights() {
+        let exact = route_capture(vec![(0.5f32).to_bits(); SHADOW_D_MODEL]);
+        let captures = vec![
+            (DiagnosticPlane::Cpu, exact.clone()),
+            (DiagnosticPlane::Cpu, exact.clone()),
+            (DiagnosticPlane::Hybrid, exact.clone()),
+            (DiagnosticPlane::Hybrid, exact.clone()),
+        ];
+        let evidence = reconcile_route_captures(&captures, 96).unwrap();
+        assert!(evidence.exact_capture_match);
+        assert!(evidence.all_repeated_captures_match);
+
+        let mut mismatched = captures;
+        mismatched[2].1.input_bits[17] = (0.25f32).to_bits();
+        let evidence = reconcile_route_captures(&mismatched, 96).unwrap();
+        assert!(!evidence.input_hashes_match);
+        assert!(!evidence.exact_capture_match);
+    }
+
+    #[test]
+    fn actual_input_shadow_uses_complete_q4_tolerance_without_serializing_vectors() {
+        let capture = route_capture(vec![(0.5f32).to_bits(); SHADOW_D_MODEL]);
+        let outputs = capture
+            .expert_ids
+            .iter()
+            .map(|&global_expert_id| Q4ShadowExpertOutput {
+                global_expert_id,
+                cpu_f32: vec![1.0; SHADOW_D_MODEL],
+                gpu_f16: vec![1.001; SHADOW_D_MODEL],
+            })
+            .collect();
+        let evidence = build_actual_input_q4_shadow(&capture, outputs).unwrap();
+        assert_eq!(evidence.tolerance, crate::q4_parity::COMPLETE_TOLERANCE);
+        assert!(evidence.all_experts_within_tolerance);
+        assert!(evidence.weighted_aggregate_within_tolerance);
+        let json = serde_json::to_string(&evidence).unwrap();
+        assert!(!json.contains("input_bits"));
+        assert!(!json.contains("cpu_f32\""));
+        assert!(!json.contains("gpu_f16\""));
     }
 }

--- a/rust-engine/src/numerical_diagnostics.rs
+++ b/rust-engine/src/numerical_diagnostics.rs
@@ -1,0 +1,862 @@
+//! Phase-A first-token numerical diagnostics for fixed-corpus greedy parity.
+//!
+//! This module is deliberately separate from the exact-token qualification
+//! report. Workers return the complete first-token logit vector as bounded,
+//! typed f32 bits; the final report retains only hashes and comparison
+//! evidence. Diagnostic completion can never become qualification PASS.
+
+use crate::backend::GpuExpertIoSnapshot;
+use crate::greedy_parity::{
+    token_ids_sha256, HybridWorkerProcessEvidence, HybridWorkerRequest,
+    HybridWorkerResponse, PlaneRunEvidence,
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+
+pub const SCHEMA_VERSION: &str = "mer.strict-hybrid-q4-greedy-logit-diagnostic.v1";
+pub const MODE: &str = "strict-hybrid-q4-greedy-logit-diagnostic";
+pub const WORKER_PROTOCOL_VERSION: &str =
+    "mer.strict-hybrid-q4-greedy-logit-worker.v1";
+pub const TARGET_CASE: &str = "json-transformation";
+pub const REPEATED_RUNS_PER_PLANE: usize = 2;
+pub const TOP_LOGIT_COUNT: usize = 16;
+pub const MAX_VOCAB_SIZE: usize = 262_144;
+pub const MAX_WORKER_STDOUT_BYTES: usize = 4 * 1024 * 1024;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DiagnosticPlane {
+    Cpu,
+    Hybrid,
+}
+
+impl DiagnosticPlane {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Cpu => "cpu",
+            Self::Hybrid => "hybrid",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiagnosticWorkerRequest {
+    pub protocol_version: String,
+    pub plane: DiagnosticPlane,
+    pub run_index: usize,
+    /// Reuse the established identity/config/token/executable contract.
+    pub base: HybridWorkerRequest,
+}
+
+impl DiagnosticWorkerRequest {
+    pub fn new(plane: DiagnosticPlane, run_index: usize, base: HybridWorkerRequest) -> Self {
+        Self {
+            protocol_version: WORKER_PROTOCOL_VERSION.to_string(),
+            plane,
+            run_index,
+            base,
+        }
+    }
+
+    pub fn validate_static(&self) -> Result<(), String> {
+        if self.protocol_version != WORKER_PROTOCOL_VERSION
+            || self.run_index >= REPEATED_RUNS_PER_PLANE
+            || self.base.case_name != TARGET_CASE
+            || self.base.prompt_token_ids.is_empty()
+            || self.base.prompt_token_ids_sha256
+                != token_ids_sha256(&self.base.prompt_token_ids)
+            || self.base.output_token_limit != crate::greedy_parity::OUTPUT_TOKEN_LIMIT
+            || self.base.worker_id.is_empty()
+            || self.base.expected_adapter_name.is_empty()
+        {
+            return Err("logit diagnostic worker request is malformed".to_string());
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiagnosticWorkerResponse {
+    pub protocol_version: String,
+    pub plane: DiagnosticPlane,
+    pub run_index: usize,
+    /// Reuse the existing typed worker identity and plane evidence.
+    pub base: HybridWorkerResponse,
+    pub chosen_token_id: Option<u32>,
+    pub first_token_logit_bits: Option<Vec<u32>>,
+    pub first_token_logit_bits_sha256: Option<String>,
+    pub failure: Option<String>,
+}
+
+pub fn parse_worker_request_exact(bytes: &[u8]) -> Result<DiagnosticWorkerRequest, String> {
+    parse_exact_json(bytes, "logit diagnostic worker request")
+}
+
+pub fn parse_worker_response_exact(bytes: &[u8]) -> Result<DiagnosticWorkerResponse, String> {
+    parse_exact_json(bytes, "logit diagnostic worker response")
+}
+
+fn parse_exact_json<T>(bytes: &[u8], label: &str) -> Result<T, String>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    if bytes.is_empty() {
+        return Err(format!("missing {label}"));
+    }
+    let mut deserializer = serde_json::Deserializer::from_slice(bytes);
+    let value = T::deserialize(&mut deserializer)
+        .map_err(|error| format!("malformed {label}: {error}"))?;
+    deserializer
+        .end()
+        .map_err(|error| format!("trailing or duplicated {label}: {error}"))?;
+    Ok(value)
+}
+
+pub fn diagnostic_worker_id(
+    build_git_sha: &str,
+    executable_sha256: &str,
+    plane: DiagnosticPlane,
+    run_index: usize,
+) -> String {
+    let mut hasher = Sha256::new();
+    hash_string(&mut hasher, build_git_sha);
+    hash_string(&mut hasher, executable_sha256);
+    hash_string(&mut hasher, plane.as_str());
+    hasher.update((run_index as u64).to_le_bytes());
+    format!("greedy-logit-{}-{:x}", plane.as_str(), hasher.finalize())
+}
+
+fn hash_string(hasher: &mut Sha256, value: &str) {
+    hasher.update((value.len() as u64).to_le_bytes());
+    hasher.update(value.as_bytes());
+}
+
+pub fn f32_bits_sha256(bits: &[u32]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update((bits.len() as u64).to_le_bytes());
+    for value in bits {
+        hasher.update(value.to_le_bytes());
+    }
+    format!("{:x}", hasher.finalize())
+}
+
+fn is_sha256_hex(value: &str) -> bool {
+    value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct FloatEvidence {
+    /// Nonfinite values are JSON `null`; exact bits and class remain present.
+    pub value: Option<f32>,
+    pub class: &'static str,
+    pub bits: u32,
+}
+
+impl FloatEvidence {
+    pub fn new(value: f32) -> Self {
+        let class = if value.is_nan() {
+            "nan"
+        } else if value == f32::INFINITY {
+            "positive-infinity"
+        } else if value == f32::NEG_INFINITY {
+            "negative-infinity"
+        } else if value == 0.0 && value.is_sign_negative() {
+            "negative-zero"
+        } else {
+            "finite"
+        };
+        Self {
+            value: value.is_finite().then_some(value),
+            class,
+            bits: value.to_bits(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct RankedLogitEvidence {
+    pub token_id: u32,
+    pub rank: usize,
+    pub logit: FloatEvidence,
+}
+
+fn ranked_logits(logits: &[f32]) -> Vec<(usize, f32)> {
+    let mut ranked: Vec<_> = logits.iter().copied().enumerate().collect();
+    ranked.sort_by(|(left_id, left), (right_id, right)| {
+        right
+            .total_cmp(left)
+            .then_with(|| left_id.cmp(right_id))
+    });
+    ranked
+}
+
+pub fn top_logits(logits: &[f32], count: usize) -> Vec<RankedLogitEvidence> {
+    ranked_logits(logits)
+        .into_iter()
+        .take(count.min(logits.len()))
+        .enumerate()
+        .map(|(rank, (token_id, value))| RankedLogitEvidence {
+            token_id: token_id as u32,
+            rank: rank + 1,
+            logit: FloatEvidence::new(value),
+        })
+        .collect()
+}
+
+fn ranked_logit_for(logits: &[f32], token_id: u32) -> Option<RankedLogitEvidence> {
+    ranked_logits(logits)
+        .into_iter()
+        .enumerate()
+        .find(|(_, (id, _))| *id == token_id as usize)
+        .map(|(rank, (_, value))| RankedLogitEvidence {
+            token_id,
+            rank: rank + 1,
+            logit: FloatEvidence::new(value),
+        })
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct CandidateComparisonEvidence {
+    pub token_id: u32,
+    pub cpu_rank: usize,
+    pub hybrid_rank: usize,
+    pub cpu: FloatEvidence,
+    pub hybrid: FloatEvidence,
+    pub absolute_difference: Option<f32>,
+    pub relative_difference: Option<f32>,
+}
+
+fn finite_differences(reference: f32, actual: f32) -> (Option<f32>, Option<f32>) {
+    if !reference.is_finite() || !actual.is_finite() {
+        return (None, None);
+    }
+    let absolute = (actual - reference).abs();
+    if !absolute.is_finite() {
+        return (None, None);
+    }
+    let relative = if reference == 0.0 {
+        (absolute == 0.0).then_some(0.0)
+    } else {
+        let relative = absolute / reference.abs();
+        relative.is_finite().then_some(relative)
+    };
+    (Some(absolute), relative)
+}
+
+pub fn union_candidate_comparison(
+    cpu: &[f32],
+    hybrid: &[f32],
+    count: usize,
+) -> Result<Vec<CandidateComparisonEvidence>, String> {
+    if cpu.len() != hybrid.len() || cpu.is_empty() {
+        return Err("logit vector lengths differ or are empty".to_string());
+    }
+    let cpu_ranked = ranked_logits(cpu);
+    let hybrid_ranked = ranked_logits(hybrid);
+    let mut ids = BTreeSet::new();
+    ids.extend(cpu_ranked.iter().take(count).map(|(id, _)| *id));
+    ids.extend(hybrid_ranked.iter().take(count).map(|(id, _)| *id));
+    let cpu_ranks: BTreeMap<_, _> = cpu_ranked
+        .iter()
+        .enumerate()
+        .map(|(rank, (id, _))| (*id, rank + 1))
+        .collect();
+    let hybrid_ranks: BTreeMap<_, _> = hybrid_ranked
+        .iter()
+        .enumerate()
+        .map(|(rank, (id, _))| (*id, rank + 1))
+        .collect();
+    Ok(ids
+        .into_iter()
+        .map(|token_id| {
+            let cpu_value = cpu[token_id];
+            let hybrid_value = hybrid[token_id];
+            let (absolute_difference, relative_difference) =
+                finite_differences(cpu_value, hybrid_value);
+            CandidateComparisonEvidence {
+                token_id: token_id as u32,
+                cpu_rank: cpu_ranks[&token_id],
+                hybrid_rank: hybrid_ranks[&token_id],
+                cpu: FloatEvidence::new(cpu_value),
+                hybrid: FloatEvidence::new(hybrid_value),
+                absolute_difference,
+                relative_difference,
+            }
+        })
+        .collect())
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct MaxErrorEvidence {
+    pub index: usize,
+    pub cpu: FloatEvidence,
+    pub hybrid: FloatEvidence,
+    pub absolute_error: Option<f32>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct VectorComparisonEvidence {
+    pub length: usize,
+    pub exact_f32_bits: bool,
+    pub max_absolute_error: Option<f32>,
+    pub rms_error: Option<f64>,
+    pub cpu_nonfinite_count: usize,
+    pub hybrid_nonfinite_count: usize,
+    pub nonfinite_bit_mismatch_count: usize,
+    pub max_error: Option<MaxErrorEvidence>,
+}
+
+pub fn compare_vectors(cpu: &[f32], hybrid: &[f32]) -> Result<VectorComparisonEvidence, String> {
+    if cpu.len() != hybrid.len() || cpu.is_empty() {
+        return Err("logit vector lengths differ or are empty".to_string());
+    }
+    let mut exact = true;
+    let mut cpu_nonfinite = 0usize;
+    let mut hybrid_nonfinite = 0usize;
+    let mut nonfinite_bit_mismatch = 0usize;
+    let mut finite_pairs = 0usize;
+    let mut squared_error = 0.0f64;
+    let mut max_absolute = -1.0f32;
+    let mut max_error = None;
+    for (index, (&left, &right)) in cpu.iter().zip(hybrid).enumerate() {
+        exact &= left.to_bits() == right.to_bits();
+        cpu_nonfinite += usize::from(!left.is_finite());
+        hybrid_nonfinite += usize::from(!right.is_finite());
+        if !left.is_finite() || !right.is_finite() {
+            nonfinite_bit_mismatch += usize::from(left.to_bits() != right.to_bits());
+            continue;
+        }
+        finite_pairs += 1;
+        let absolute = (right - left).abs();
+        squared_error += f64::from(absolute) * f64::from(absolute);
+        if absolute > max_absolute {
+            max_absolute = absolute;
+            max_error = Some(MaxErrorEvidence {
+                index,
+                cpu: FloatEvidence::new(left),
+                hybrid: FloatEvidence::new(right),
+                absolute_error: absolute.is_finite().then_some(absolute),
+            });
+        }
+    }
+    Ok(VectorComparisonEvidence {
+        length: cpu.len(),
+        exact_f32_bits: exact,
+        max_absolute_error: (finite_pairs > 0 && max_absolute.is_finite()).then_some(max_absolute),
+        rms_error: (finite_pairs > 0)
+            .then_some((squared_error / finite_pairs as f64).sqrt())
+            .filter(|value| value.is_finite()),
+        cpu_nonfinite_count: cpu_nonfinite,
+        hybrid_nonfinite_count: hybrid_nonfinite,
+        nonfinite_bit_mismatch_count: nonfinite_bit_mismatch,
+        max_error,
+    })
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct PairMarginEvidence {
+    pub cpu_token_715_minus_5212: FloatEvidence,
+    pub hybrid_token_715_minus_5212: FloatEvidence,
+    pub cross_plane_margin_change: FloatEvidence,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct FirstTokenLogitEvidence {
+    pub cpu_chosen_token_id: u32,
+    pub hybrid_chosen_token_id: u32,
+    pub cpu_top_16: Vec<RankedLogitEvidence>,
+    pub hybrid_top_16: Vec<RankedLogitEvidence>,
+    pub cpu_top_1_top_2_margin: FloatEvidence,
+    pub hybrid_top_1_top_2_margin: FloatEvidence,
+    pub token_715_vs_5212_margin: PairMarginEvidence,
+    pub union_top_16: Vec<CandidateComparisonEvidence>,
+    pub full_vector: VectorComparisonEvidence,
+    pub token_715_cpu: RankedLogitEvidence,
+    pub token_715_hybrid: RankedLogitEvidence,
+    pub token_5212_cpu: RankedLogitEvidence,
+    pub token_5212_hybrid: RankedLogitEvidence,
+}
+
+fn top_margin(top: &[RankedLogitEvidence]) -> Result<f32, String> {
+    let first = top
+        .first()
+        .ok_or("top-logit evidence is empty")?
+        .logit
+        .bits;
+    let second = top
+        .get(1)
+        .ok_or("top-logit evidence has fewer than two entries")?
+        .logit
+        .bits;
+    Ok(f32::from_bits(first) - f32::from_bits(second))
+}
+
+pub fn build_first_token_logit_evidence(
+    cpu: &[f32],
+    hybrid: &[f32],
+    cpu_chosen: u32,
+    hybrid_chosen: u32,
+) -> Result<FirstTokenLogitEvidence, String> {
+    if cpu.len() != hybrid.len() || cpu.len() <= 5212 {
+        return Err("complete logit vectors do not cover required tokens".to_string());
+    }
+    let cpu_top = top_logits(cpu, TOP_LOGIT_COUNT);
+    let hybrid_top = top_logits(hybrid, TOP_LOGIT_COUNT);
+    if cpu_top.first().map(|item| item.token_id) != Some(cpu_chosen)
+        || hybrid_top.first().map(|item| item.token_id) != Some(hybrid_chosen)
+    {
+        return Err("captured logits disagree with production greedy selection".to_string());
+    }
+    let cpu_pair_margin = cpu[715] - cpu[5212];
+    let hybrid_pair_margin = hybrid[715] - hybrid[5212];
+    Ok(FirstTokenLogitEvidence {
+        cpu_chosen_token_id: cpu_chosen,
+        hybrid_chosen_token_id: hybrid_chosen,
+        cpu_top_1_top_2_margin: FloatEvidence::new(top_margin(&cpu_top)?),
+        hybrid_top_1_top_2_margin: FloatEvidence::new(top_margin(&hybrid_top)?),
+        token_715_vs_5212_margin: PairMarginEvidence {
+            cpu_token_715_minus_5212: FloatEvidence::new(cpu_pair_margin),
+            hybrid_token_715_minus_5212: FloatEvidence::new(hybrid_pair_margin),
+            cross_plane_margin_change: FloatEvidence::new(
+                hybrid_pair_margin - cpu_pair_margin,
+            ),
+        },
+        union_top_16: union_candidate_comparison(cpu, hybrid, TOP_LOGIT_COUNT)?,
+        full_vector: compare_vectors(cpu, hybrid)?,
+        token_715_cpu: ranked_logit_for(cpu, 715).ok_or("CPU token 715 is unavailable")?,
+        token_715_hybrid: ranked_logit_for(hybrid, 715)
+            .ok_or("Hybrid token 715 is unavailable")?,
+        token_5212_cpu: ranked_logit_for(cpu, 5212).ok_or("CPU token 5212 is unavailable")?,
+        token_5212_hybrid: ranked_logit_for(hybrid, 5212)
+            .ok_or("Hybrid token 5212 is unavailable")?,
+        cpu_top_16: cpu_top,
+        hybrid_top_16: hybrid_top,
+    })
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct RepeatedRunEvidence {
+    pub plane: DiagnosticPlane,
+    pub run_index: usize,
+    pub worker_id: String,
+    pub generated_token_ids: Vec<u32>,
+    pub generated_token_ids_sha256: String,
+    pub first_token_logit_bits_sha256: String,
+    pub process: HybridWorkerProcessEvidence,
+    pub plane_evidence: PlaneRunEvidence,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ReproducibilityEvidence {
+    pub cpu_bitwise_reproducible: bool,
+    pub hybrid_bitwise_reproducible: bool,
+    pub all_worker_ids_unique: bool,
+    pub all_process_ids_unique: bool,
+    pub every_worker_exited_zero_and_reaped: bool,
+    pub no_retries: bool,
+}
+
+pub fn validate_repeated_run_identity(runs: &[RepeatedRunEvidence]) -> ReproducibilityEvidence {
+    let cpu: Vec<_> = runs.iter().filter(|run| run.plane == DiagnosticPlane::Cpu).collect();
+    let hybrid: Vec<_> = runs
+        .iter()
+        .filter(|run| run.plane == DiagnosticPlane::Hybrid)
+        .collect();
+    let worker_ids: HashSet<_> = runs.iter().map(|run| run.worker_id.as_str()).collect();
+    let process_ids: Vec<_> = runs.iter().filter_map(|run| run.process.process_id).collect();
+    let unique_process_ids: HashSet<_> = process_ids.iter().copied().collect();
+    let reproducible = |plane: &[&RepeatedRunEvidence]| {
+        plane.len() == REPEATED_RUNS_PER_PLANE
+            && plane[0].generated_token_ids == plane[1].generated_token_ids
+            && plane[0].generated_token_ids_sha256 == plane[1].generated_token_ids_sha256
+            && plane[0].first_token_logit_bits_sha256
+                == plane[1].first_token_logit_bits_sha256
+    };
+    ReproducibilityEvidence {
+        cpu_bitwise_reproducible: reproducible(&cpu),
+        hybrid_bitwise_reproducible: reproducible(&hybrid),
+        all_worker_ids_unique: worker_ids.len() == runs.len(),
+        all_process_ids_unique: process_ids.len() == runs.len()
+            && unique_process_ids.len() == process_ids.len(),
+        every_worker_exited_zero_and_reaped: runs.iter().all(|run| {
+            run.worker_id == run.process.worker_id
+                && run.plane_evidence.worker_process.as_ref() == Some(&run.process)
+                && run.generated_token_ids_sha256 == token_ids_sha256(&run.generated_token_ids)
+                && run.plane_evidence.generation.generated_token_ids == run.generated_token_ids
+                && run.process.child_process_spawned
+                && run.process.executable_identity_verified
+                && run.process.build_sha_identity_verified
+                && run.process.case_identity_verified
+                && run.process.config_identity_verified
+                && run.process.expected_adapter_identity_verified
+                && run.process.prompt_token_identity_verified
+                && run.process.output_token_limit_verified
+                && run.process.greedy_sampling_identity_verified
+                && run.process.normal_zero_exit
+                && run.process.exit_code == Some(0)
+                && run.process.signal.is_none()
+                && !run.process.timed_out
+                && run.process.process_reaped
+                && run.process.evidence_emitted
+        }),
+        no_retries: runs.len() == REPEATED_RUNS_PER_PLANE * 2
+            && cpu.iter().map(|run| run.run_index).collect::<BTreeSet<_>>()
+                == BTreeSet::from([0, 1])
+            && hybrid
+                .iter()
+                .map(|run| run.run_index)
+                .collect::<BTreeSet<_>>()
+                == BTreeSet::from([0, 1]),
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct DiagnosticFailure {
+    pub code: String,
+    pub detail: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct DiagnosticWorkerFailureEvidence {
+    pub worker_id: String,
+    pub plane: DiagnosticPlane,
+    pub run_index: usize,
+    pub detail: String,
+    pub process: HybridWorkerProcessEvidence,
+    pub stderr: String,
+    pub stderr_truncated: bool,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct DiagnosticReport {
+    pub schema_version: &'static str,
+    pub mode: &'static str,
+    pub qualification_pass: bool,
+    pub diagnostic_complete: bool,
+    pub failure: Option<DiagnosticFailure>,
+    pub build_git_sha: String,
+    pub executable_sha256: String,
+    pub resolved_config_sha256: String,
+    pub expected_adapter_name: String,
+    pub case_name: &'static str,
+    pub prompt_sha256: String,
+    pub prompt_token_ids_sha256: String,
+    pub prompt_token_count: usize,
+    pub runs: Vec<RepeatedRunEvidence>,
+    pub worker_failures: Vec<DiagnosticWorkerFailureEvidence>,
+    pub reproducibility: Option<ReproducibilityEvidence>,
+    pub first_token_logits: Option<FirstTokenLogitEvidence>,
+}
+
+impl DiagnosticReport {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        build_git_sha: String,
+        executable_sha256: String,
+        resolved_config_sha256: String,
+        expected_adapter_name: String,
+        prompt_sha256: String,
+        prompt_token_ids_sha256: String,
+        prompt_token_count: usize,
+    ) -> Self {
+        Self {
+            schema_version: SCHEMA_VERSION,
+            mode: MODE,
+            qualification_pass: false,
+            diagnostic_complete: false,
+            failure: None,
+            build_git_sha,
+            executable_sha256,
+            resolved_config_sha256,
+            expected_adapter_name,
+            case_name: TARGET_CASE,
+            prompt_sha256,
+            prompt_token_ids_sha256,
+            prompt_token_count,
+            runs: Vec::new(),
+            worker_failures: Vec::new(),
+            reproducibility: None,
+            first_token_logits: None,
+        }
+    }
+
+    pub fn fail(&mut self, code: impl Into<String>, detail: impl Into<String>) {
+        self.qualification_pass = false;
+        self.diagnostic_complete = false;
+        self.failure = Some(DiagnosticFailure {
+            code: code.into(),
+            detail: detail.into(),
+        });
+    }
+
+    pub fn finish(&mut self) -> Result<(), String> {
+        self.qualification_pass = false;
+        self.diagnostic_complete = false;
+        let reproducibility = self
+            .reproducibility
+            .as_ref()
+            .ok_or("diagnostic has no reproducibility evidence")?;
+        if self.runs.len() != REPEATED_RUNS_PER_PLANE * 2
+            || reproducibility != &validate_repeated_run_identity(&self.runs)
+            || !reproducibility.cpu_bitwise_reproducible
+            || !reproducibility.hybrid_bitwise_reproducible
+            || !reproducibility.all_worker_ids_unique
+            || !reproducibility.all_process_ids_unique
+            || !reproducibility.every_worker_exited_zero_and_reaped
+            || !reproducibility.no_retries
+            || !self.worker_failures.is_empty()
+            || self.first_token_logits.is_none()
+            || !self.first_token_evidence_exact()
+            || !self.runs.iter().all(|run| self.run_evidence_exact(run))
+        {
+            return Err("logit diagnostic evidence is partial or mismatched".to_string());
+        }
+        self.failure = None;
+        self.diagnostic_complete = true;
+        Ok(())
+    }
+
+    fn first_token_evidence_exact(&self) -> bool {
+        let Some(evidence) = self.first_token_logits.as_ref() else {
+            return false;
+        };
+        let cpu_token = self
+            .runs
+            .iter()
+            .find(|run| run.plane == DiagnosticPlane::Cpu)
+            .and_then(|run| run.generated_token_ids.first())
+            .copied();
+        let hybrid_token = self
+            .runs
+            .iter()
+            .find(|run| run.plane == DiagnosticPlane::Hybrid)
+            .and_then(|run| run.generated_token_ids.first())
+            .copied();
+        let union_ids: HashSet<_> = evidence
+            .union_top_16
+            .iter()
+            .map(|candidate| candidate.token_id)
+            .collect();
+        evidence.cpu_top_16.len() == TOP_LOGIT_COUNT
+            && evidence.hybrid_top_16.len() == TOP_LOGIT_COUNT
+            && evidence.cpu_top_16.first().map(|item| item.token_id) == cpu_token
+            && evidence.hybrid_top_16.first().map(|item| item.token_id) == hybrid_token
+            && evidence.cpu_chosen_token_id == cpu_token.unwrap_or(u32::MAX)
+            && evidence.hybrid_chosen_token_id == hybrid_token.unwrap_or(u32::MAX)
+            && evidence.union_top_16.len() >= TOP_LOGIT_COUNT
+            && evidence.union_top_16.len() <= TOP_LOGIT_COUNT * 2
+            && evidence
+                .cpu_top_16
+                .iter()
+                .chain(&evidence.hybrid_top_16)
+                .all(|item| union_ids.contains(&item.token_id))
+            && evidence.full_vector.length > 5212
+            && evidence.token_715_cpu.token_id == 715
+            && evidence.token_715_hybrid.token_id == 715
+            && evidence.token_5212_cpu.token_id == 5212
+            && evidence.token_5212_hybrid.token_id == 5212
+    }
+
+    fn run_evidence_exact(&self, run: &RepeatedRunEvidence) -> bool {
+        let plane = &run.plane_evidence;
+        let routed = plane.routed_execution_delta;
+        let io = plane.gpu_io_delta;
+        let initial = &plane.initial_state;
+        let common = run.process.executable_sha256 == self.executable_sha256
+            && run.process.build_git_sha == self.build_git_sha
+            && is_sha256_hex(&run.first_token_logit_bits_sha256)
+            && plane.model_load.strict
+            && plane.model_load.loaded_tensors == plane.model_load.required_tensors
+            && plane.model_load.required_tensors > 0
+            && !plane.model_load.seeded_fallback_remained
+            && plane.model_load.loader != "seeded"
+            && initial.context_id == plane.execution_plan.context_id
+            && initial.resolved_config_sha256 == self.resolved_config_sha256
+            && initial.kv_cache_count > 0
+            && initial.kv_sequence_lengths.len() == initial.kv_cache_count
+            && initial.all_kv_empty
+            && initial.kv_sequence_lengths.iter().all(|&length| length == 0)
+            && initial.cache == crate::greedy_parity::RuntimeCacheSnapshot::default()
+            && initial.routed == crate::engine::RoutedExpertExecutionSnapshot::default()
+            && initial.gpu_io == GpuExpertIoSnapshot::default()
+            && plane.generation.prompt_token_ids_sha256 == self.prompt_token_ids_sha256
+            && plane.generation.generated_token_ids_sha256
+                == token_ids_sha256(&plane.generation.generated_token_ids)
+            && plane.generation.generated_token_ids_sha256
+                == run.generated_token_ids_sha256
+            && plane.generation.generated_token_count == crate::greedy_parity::OUTPUT_TOKEN_LIMIT
+            && plane.generation.termination_reason
+                == crate::greedy_parity::TerminationReason::LengthLimit
+            && plane.background_shutdown.controlled_shutdown_requested
+            && plane.background_shutdown.all_runtime_resources_released
+            && plane.attention_softmax_nonfinite_fallbacks == 0
+            && routed.gpu_dispatch_failures == 0
+            && routed.gpu_cpu_fallbacks == 0
+            && routed.degraded_expert_substitutions == 0;
+        if !common {
+            return false;
+        }
+        match run.plane {
+            DiagnosticPlane::Cpu => {
+                plane.plane == "cpu"
+                    && crate::greedy_parity::cpu_plan_exact(&plane.execution_plan)
+                    && plane.device.is_none()
+                    && !initial.gpu_io_available
+                    && routed.selected_routed_experts > 0
+                    && routed.cpu_routed_expert_dispatches == routed.selected_routed_experts
+                    && routed.gpu_dispatch_attempts == 0
+                    && io == GpuExpertIoSnapshot::default()
+                    && plane.gpu_memory_before.is_none()
+                    && plane.gpu_memory_after.is_none()
+            }
+            DiagnosticPlane::Hybrid => {
+                plane.plane == "hybrid"
+                    && crate::greedy_parity::hybrid_plan_exact(&plane.execution_plan)
+                    && plane.device.as_ref().is_some_and(|device| {
+                        !device.software_adapter
+                            && !device.device_type.eq_ignore_ascii_case("cpu")
+                            && device.name == self.expected_adapter_name
+                    })
+                    && initial.gpu_io_available
+                    && plane.routed_expert_gpu_failure_policy == "strict-fail-closed"
+                    && routed.selected_routed_experts > 0
+                    && routed.gpu_dispatch_attempts == routed.selected_routed_experts
+                    && routed.gpu_dispatch_successes == routed.gpu_dispatch_attempts
+                    && routed.cpu_routed_expert_dispatches == 0
+                    && io.hidden_state_uploads > 0
+                    && io.hidden_state_upload_bytes > 0
+                    && io.queue_submissions > 0
+                    && io.map_requests > 0
+                    && io.readback_completions > 0
+                    && io.readback_bytes > 0
+                    && plane.gpu_memory_before.is_some_and(|snapshot| {
+                        crate::qualification::validate_memory(snapshot).is_ok()
+                    })
+                    && plane.gpu_memory_after.is_some_and(|snapshot| {
+                        crate::qualification::validate_memory(snapshot).is_ok()
+                    })
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn top_logits_use_total_order_and_lower_token_id_for_ties() {
+        let evidence = top_logits(&[1.0, 3.0, 3.0, -0.0, 0.0], 5);
+        assert_eq!(
+            evidence.iter().map(|item| item.token_id).collect::<Vec<_>>(),
+            vec![1, 2, 0, 4, 3]
+        );
+        assert_eq!(evidence[4].logit.bits, (-0.0f32).to_bits());
+    }
+
+    #[test]
+    fn float_evidence_preserves_signed_zero_and_nonfinite_bits() {
+        let values = [
+            FloatEvidence::new(-0.0),
+            FloatEvidence::new(f32::from_bits(0x7fc0_1234)),
+            FloatEvidence::new(f32::INFINITY),
+        ];
+        let json = serde_json::to_string(&values).unwrap();
+        assert!(json.contains("negative-zero"));
+        assert!(json.contains("nan"));
+        assert!(json.contains("positive-infinity"));
+        assert_eq!(values[0].bits, (-0.0f32).to_bits());
+    }
+
+    #[test]
+    fn union_comparison_contains_candidates_from_both_planes() {
+        let cpu = [5.0, 4.0, 1.0, 0.0];
+        let hybrid = [1.0, 2.0, 5.0, 4.0];
+        let union = union_candidate_comparison(&cpu, &hybrid, 2).unwrap();
+        assert_eq!(union.iter().map(|item| item.token_id).collect::<Vec<_>>(), vec![0, 1, 2, 3]);
+        assert_eq!(union.iter().find(|item| item.token_id == 0).unwrap().cpu_rank, 1);
+        assert_eq!(union.iter().find(|item| item.token_id == 2).unwrap().hybrid_rank, 1);
+    }
+
+    #[test]
+    fn vector_comparison_records_max_index_rms_and_nonfinite_counts() {
+        let comparison = compare_vectors(&[0.0, 1.0, -2.0], &[0.0, 2.0, 0.0]).unwrap();
+        assert_eq!(comparison.max_absolute_error, Some(2.0));
+        assert_eq!(comparison.max_error.as_ref().unwrap().index, 2);
+        assert!((comparison.rms_error.unwrap() - (5.0f64 / 3.0).sqrt()).abs() < 1e-12);
+        let nonfinite = compare_vectors(&[f32::NAN], &[f32::INFINITY]).unwrap();
+        assert_eq!(nonfinite.cpu_nonfinite_count, 1);
+        assert_eq!(nonfinite.hybrid_nonfinite_count, 1);
+        assert_eq!(nonfinite.nonfinite_bit_mismatch_count, 1);
+    }
+
+    #[test]
+    fn first_token_evidence_preserves_715_5212_margin_change() {
+        let mut cpu = vec![-10.0; 6000];
+        let mut hybrid = cpu.clone();
+        cpu[715] = 4.0;
+        cpu[5212] = 3.75;
+        hybrid[715] = 3.8;
+        hybrid[5212] = 4.0;
+        let evidence = build_first_token_logit_evidence(&cpu, &hybrid, 715, 5212).unwrap();
+        assert_eq!(evidence.token_715_cpu.rank, 1);
+        assert_eq!(evidence.token_5212_hybrid.rank, 1);
+        assert_eq!(evidence.token_715_vs_5212_margin.cpu_token_715_minus_5212.value, Some(0.25));
+        let hybrid_margin = evidence
+            .token_715_vs_5212_margin
+            .hybrid_token_715_minus_5212
+            .value
+            .unwrap();
+        let margin_change = evidence
+            .token_715_vs_5212_margin
+            .cross_plane_margin_change
+            .value
+            .unwrap();
+        assert!((hybrid_margin + 0.2).abs() < 1e-6);
+        assert!((margin_change + 0.45).abs() < 1e-6);
+    }
+
+    #[test]
+    fn worker_protocol_rejects_unknown_and_trailing_documents() {
+        let base = HybridWorkerRequest::new(
+            "worker".to_string(),
+            crate::greedy_parity::fixed_case(TARGET_CASE).unwrap(),
+            "a".repeat(64),
+            "NVIDIA L4".to_string(),
+            vec![1, 2],
+            "b".repeat(64),
+            "c".repeat(40),
+        );
+        let request = DiagnosticWorkerRequest::new(DiagnosticPlane::Cpu, 0, base);
+        let encoded = serde_json::to_vec(&request).unwrap();
+        assert_eq!(parse_worker_request_exact(&encoded).unwrap(), request);
+        let mut unknown: serde_json::Value = serde_json::from_slice(&encoded).unwrap();
+        unknown["unknown"] = serde_json::json!(true);
+        assert!(parse_worker_request_exact(&serde_json::to_vec(&unknown).unwrap()).is_err());
+        let mut trailing = encoded;
+        trailing.extend_from_slice(b"{}");
+        assert!(parse_worker_request_exact(&trailing).is_err());
+    }
+
+    #[test]
+    fn diagnostic_report_can_never_claim_qualification_pass() {
+        let mut report = DiagnosticReport::new(
+            "a".repeat(40),
+            "b".repeat(64),
+            "c".repeat(64),
+            "NVIDIA L4".to_string(),
+            "d".repeat(64),
+            "e".repeat(64),
+            2,
+        );
+        report.qualification_pass = true;
+        assert!(report.finish().is_err());
+        assert!(!report.qualification_pass);
+        report.fail("test", "failure");
+        assert!(!report.qualification_pass);
+        assert!(!report.diagnostic_complete);
+    }
+}

--- a/rust-engine/src/qualification.rs
+++ b/rust-engine/src/qualification.rs
@@ -188,7 +188,7 @@ pub fn read_expert_metadata(path: &Path) -> Result<ExpertMetadataEvidence, Strin
     })
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ExecutionPlanEvidence {
     pub context_id: String,
     pub requested: String,

--- a/rust-engine/src/transformer.rs
+++ b/rust-engine/src/transformer.rs
@@ -1876,6 +1876,13 @@ impl LMHead {
         self.weights.matvec(hidden)
     }
 
+    /// Diagnostic-only full-logit capture through the production greedy
+    /// selector's row kernel. Normal inference retains the allocation-free
+    /// fused argmax path.
+    pub(crate) fn diagnostic_greedy_logits(&self, hidden: &[f32]) -> Vec<f32> {
+        self.weights.diagnostic_greedy_logits(hidden)
+    }
+
     /// One-shot: project `hidden` to logits and sample a next-token id
     /// using the given [`crate::sampling::SamplingParams`]. The
     /// `position` is folded into the sampler's per-step seed so a


### PR DESCRIPTION
## Summary

This PR adds the fixed-corpus CPU/Hybrid greedy token parity qualification for PR6.

The existing strict Hybrid Q4_0 qualification on `main` already establishes raw WGSL Q4_0 parity, complete-expert CPU/GPU numerical parity, physical GPU residency reuse, and fail-closed routed-expert GPU execution.

This PR extends that correctness evidence to the full autoregressive generation path by comparing deterministic greedy generation between the authoritative CPU execution path and strict Hybrid execution over a fixed prompt corpus.

## What this validates

For the same checkpoint, tokenizer, prompts, generation settings, and deterministic greedy decoding:

- run the fixed corpus through the authoritative CPU path;
- run the same corpus through strict Hybrid execution;
- compare generated token IDs/output across the two execution paths;
- fail qualification on any divergence;
- preserve prompt/case identity so failures are attributable to a specific corpus entry;
- ensure the comparison exercises real full-transformer autoregressive generation rather than isolated expert kernels.

The objective is to establish that moving routed Q4_0 expert execution to the GPU does not change greedy model output for the qualified corpus.

## Why this matters

The existing PR6 Q4_0 qualification proves the routed-expert GPU math and residency path independently.

This PR validates the next level of the contract:

`CPU reference inference`
vs.
`CPU transformer + GPU routed experts`

must make the same deterministic greedy token decisions across a fixed corpus.

That provides a stronger end-to-end correctness baseline before subsequent GPU performance and execution-topology work.

## Scope

This PR is a correctness/qualification change.

It does not:

- introduce expert batching;
- optimize routed-expert throughput;
- redesign attention, KV, routing, or dense execution;
- introduce GPU-native full-transformer execution;
- make a production TPS claim;
- change the commercial performance target.

Performance work remains separately measurable from this parity milestone.

## Relationship to existing PR6 qualification

`main` already contains qualification for:

- canonical raw Q4_0 WGSL block parity;
- complete checkpoint-expert CPU/GPU parity;
- strict Hybrid execution-plan validation;
- physical GPU expert installation and generation reuse;
- GPU I/O/readback evidence;
- zero CPU routed-expert fallback/degraded execution in the qualified path.

This PR adds the fixed-corpus full-generation parity layer on top of that existing foundation.

## Follow-up

Once this PR is merged, `main` should be used as the correctness baseline for the next GPU performance phase.

The next major work can proceed independently from PR6 qualification, including:

- routed-expert batching; and
- the GPU-native execution plane while retaining MER's existing storage, cache, residency, and correctness infrastructure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added strict, fixed-corpus CPU and Hybrid greedy-output qualification with structured JSON reports.
  * Added first-token divergence diagnostics with reproducibility, identity, and numerical evidence.
  * Added CLI options for configuration, adapter selection, and report output.

* **Performance**
  * Improved Q4 routed-expert processing through batched GPU execution.

* **Reliability**
  * Added fail-closed validation, parity checks, execution-state checks, and safe handling of unsupported or failed runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->