### PR TITLE
Add GPU-native persistent dense weight plane

### DIFF
--- a/rust-engine/src/backend/gpu_native.rs
+++ b/rust-engine/src/backend/gpu_native.rs
@@ -48,6 +48,12 @@ pub(crate) enum GpuNativeBootstrapError {
         rows: usize,
         cols: usize,
     },
+    DenseWeightRowExceedsDeviceLimit {
+        kind: GpuNativeDenseWeightKind,
+        cols: usize,
+        required: u64,
+        maximum: u64,
+    },
     DenseWeightByteLength {
         kind: GpuNativeDenseWeightKind,
         rows: usize,
@@ -139,6 +145,15 @@ impl fmt::Display for GpuNativeBootstrapError {
             Self::DenseWeightDimensionTooLarge { rows, cols } => write!(
                 f,
                 "GPU-native dense weight shape [{rows}, {cols}] exceeds u32 shader geometry"
+            ),
+            Self::DenseWeightRowExceedsDeviceLimit {
+                kind,
+                cols,
+                required,
+                maximum,
+            } => write!(
+                f,
+                "GPU-native {kind:?} dense weight row with {cols} columns requires {required} bytes, exceeding the physical chunk limit {maximum}"
             ),
             Self::DenseWeightByteLength {
                 kind,
@@ -385,6 +400,187 @@ impl GpuNativeDenseWeightLayout {
     }
 }
 
+/// One independently bindable physical buffer covering complete logical rows.
+/// Q8_0 chunks retain the source tensor's global flat-block convention and can
+/// therefore duplicate the single boundary block shared by adjacent chunks.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct GpuNativeDenseWeightChunkPlan {
+    row_start: usize,
+    row_count: usize,
+    first_block: usize,
+    payload_offset_bytes: usize,
+    payload_bytes: u64,
+    allocation_bytes: u64,
+}
+
+impl GpuNativeDenseWeightChunkPlan {
+    fn row_end(self) -> usize {
+        self.row_start + self.row_count
+    }
+
+    fn contains_row(self, row: usize) -> bool {
+        self.row_start <= row && row < self.row_end()
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct GpuNativeDenseWeightPlan {
+    layout: GpuNativeDenseWeightLayout,
+    chunks: Vec<GpuNativeDenseWeightChunkPlan>,
+    physical_allocation_bytes: u64,
+}
+
+impl GpuNativeDenseWeightPlan {
+    fn try_new(
+        layout: GpuNativeDenseWeightLayout,
+        limits: &wgpu::Limits,
+    ) -> Result<Self, GpuNativeBootstrapError> {
+        let maximum = limits
+            .max_buffer_size
+            .min(u64::from(limits.max_storage_buffer_binding_size));
+        let mut chunks = Vec::new();
+        let mut row_start = 0usize;
+        let mut physical_allocation_bytes = 0u64;
+
+        while row_start < layout.rows {
+            let remaining = layout.rows - row_start;
+            let row_count = match layout.kind {
+                GpuNativeDenseWeightKind::F32 => {
+                    let row_bytes = layout.cols.checked_mul(std::mem::size_of::<f32>()).ok_or(
+                        GpuNativeBootstrapError::DenseWeightShapeOverflow {
+                            rows: layout.rows,
+                            cols: layout.cols,
+                        },
+                    )?;
+                    let row_bytes = u64::try_from(row_bytes).map_err(|_| {
+                        GpuNativeBootstrapError::DenseWeightShapeOverflow {
+                            rows: layout.rows,
+                            cols: layout.cols,
+                        }
+                    })?;
+                    if row_bytes > maximum {
+                        return Err(GpuNativeBootstrapError::DenseWeightRowExceedsDeviceLimit {
+                            kind: layout.kind,
+                            cols: layout.cols,
+                            required: row_bytes,
+                            maximum,
+                        });
+                    }
+                    remaining.min(usize::try_from(maximum / row_bytes).unwrap_or(usize::MAX))
+                }
+                GpuNativeDenseWeightKind::Q8_0 => {
+                    let one_row = Self::q8_chunk(layout, row_start, 1)?;
+                    if one_row.allocation_bytes > maximum {
+                        return Err(GpuNativeBootstrapError::DenseWeightRowExceedsDeviceLimit {
+                            kind: layout.kind,
+                            cols: layout.cols,
+                            required: one_row.allocation_bytes,
+                            maximum,
+                        });
+                    }
+                    let mut low = 1usize;
+                    let mut high = remaining;
+                    while low < high {
+                        let middle = low + (high - low).div_ceil(2);
+                        if Self::q8_chunk(layout, row_start, middle)?.allocation_bytes <= maximum {
+                            low = middle;
+                        } else {
+                            high = middle - 1;
+                        }
+                    }
+                    low
+                }
+            };
+
+            let chunk = match layout.kind {
+                GpuNativeDenseWeightKind::F32 => {
+                    let row_bytes = layout.cols * std::mem::size_of::<f32>();
+                    let payload_offset_bytes = row_start * row_bytes;
+                    let payload_bytes = u64::try_from(row_count * row_bytes).map_err(|_| {
+                        GpuNativeBootstrapError::DenseWeightShapeOverflow {
+                            rows: layout.rows,
+                            cols: layout.cols,
+                        }
+                    })?;
+                    GpuNativeDenseWeightChunkPlan {
+                        row_start,
+                        row_count,
+                        first_block: 0,
+                        payload_offset_bytes,
+                        payload_bytes,
+                        allocation_bytes: payload_bytes,
+                    }
+                }
+                GpuNativeDenseWeightKind::Q8_0 => Self::q8_chunk(layout, row_start, row_count)?,
+            };
+            physical_allocation_bytes = physical_allocation_bytes
+                .checked_add(chunk.allocation_bytes)
+                .ok_or(GpuNativeBootstrapError::DenseWeightShapeOverflow {
+                    rows: layout.rows,
+                    cols: layout.cols,
+                })?;
+            chunks.push(chunk);
+            row_start += row_count;
+        }
+
+        Ok(Self {
+            layout,
+            chunks,
+            physical_allocation_bytes,
+        })
+    }
+
+    fn q8_chunk(
+        layout: GpuNativeDenseWeightLayout,
+        row_start: usize,
+        row_count: usize,
+    ) -> Result<GpuNativeDenseWeightChunkPlan, GpuNativeBootstrapError> {
+        let element_start = row_start.checked_mul(layout.cols).ok_or(
+            GpuNativeBootstrapError::DenseWeightShapeOverflow {
+                rows: layout.rows,
+                cols: layout.cols,
+            },
+        )?;
+        let element_end = row_start
+            .checked_add(row_count)
+            .and_then(|row_end| row_end.checked_mul(layout.cols))
+            .ok_or(GpuNativeBootstrapError::DenseWeightShapeOverflow {
+                rows: layout.rows,
+                cols: layout.cols,
+            })?;
+        let first_block = element_start / Q8_0_BLOCK_ELEMS;
+        let block_end = element_end.div_ceil(Q8_0_BLOCK_ELEMS);
+        let block_count = block_end - first_block;
+        let payload_offset_bytes = first_block.checked_mul(Q8_0_BLOCK_BYTES).ok_or(
+            GpuNativeBootstrapError::DenseWeightShapeOverflow {
+                rows: layout.rows,
+                cols: layout.cols,
+            },
+        )?;
+        let payload_bytes_usize = block_count.checked_mul(Q8_0_BLOCK_BYTES).ok_or(
+            GpuNativeBootstrapError::DenseWeightShapeOverflow {
+                rows: layout.rows,
+                cols: layout.cols,
+            },
+        )?;
+        let allocation_bytes_usize = payload_bytes_usize
+            .checked_add(3)
+            .map(|bytes| bytes & !3)
+            .ok_or(GpuNativeBootstrapError::DenseWeightShapeOverflow {
+                rows: layout.rows,
+                cols: layout.cols,
+            })?;
+        Ok(GpuNativeDenseWeightChunkPlan {
+            row_start,
+            row_count,
+            first_block,
+            payload_offset_bytes,
+            payload_bytes: payload_bytes_usize as u64,
+            allocation_bytes: allocation_bytes_usize as u64,
+        })
+    }
+}
+
 /// Stable model-scoped key used to retrieve a registered dense tensor.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub(crate) struct GpuNativeDenseWeightKey(Arc<str>);
@@ -422,11 +618,16 @@ impl GpuNativeDenseWeightHandle {
     }
 }
 
+struct GpuNativeDenseWeightChunk<B = wgpu::Buffer> {
+    plan: GpuNativeDenseWeightChunkPlan,
+    buffer: B,
+}
+
 struct GpuNativeDenseWeight<B = wgpu::Buffer> {
     weight_id: u64,
     key: GpuNativeDenseWeightKey,
     layout: GpuNativeDenseWeightLayout,
-    buffer: B,
+    chunks: Vec<GpuNativeDenseWeightChunk<B>>,
 }
 
 impl<B> GpuNativeDenseWeight<B> {
@@ -749,10 +950,12 @@ impl<B> fmt::Debug for GpuNativeTokenState<B> {
 #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub(crate) struct GpuNativeExecutionSnapshot {
     pub(crate) dense_weights_registered: u64,
+    pub(crate) dense_weight_chunks: u64,
     pub(crate) dense_weight_uploads: u64,
     pub(crate) dense_weight_upload_bytes: u64,
     pub(crate) dense_weight_resident_bytes: u64,
     pub(crate) dense_gemv_dispatches: u64,
+    pub(crate) dense_gemv_chunk_dispatches: u64,
     pub(crate) embedding_dispatches: u64,
     pub(crate) tokens_submitted: u64,
     pub(crate) tokens_completed: u64,
@@ -775,10 +978,12 @@ pub(crate) struct GpuNativeExecutionSnapshot {
 #[derive(Debug, Default)]
 struct GpuNativeExecutionCounters {
     dense_weights_registered: AtomicU64,
+    dense_weight_chunks: AtomicU64,
     dense_weight_uploads: AtomicU64,
     dense_weight_upload_bytes: AtomicU64,
     dense_weight_resident_bytes: AtomicU64,
     dense_gemv_dispatches: AtomicU64,
+    dense_gemv_chunk_dispatches: AtomicU64,
     embedding_dispatches: AtomicU64,
     tokens_submitted: AtomicU64,
     tokens_completed: AtomicU64,
@@ -802,10 +1007,12 @@ impl GpuNativeExecutionCounters {
     fn snapshot(&self) -> GpuNativeExecutionSnapshot {
         GpuNativeExecutionSnapshot {
             dense_weights_registered: self.dense_weights_registered.load(Ordering::Relaxed),
+            dense_weight_chunks: self.dense_weight_chunks.load(Ordering::Relaxed),
             dense_weight_uploads: self.dense_weight_uploads.load(Ordering::Relaxed),
             dense_weight_upload_bytes: self.dense_weight_upload_bytes.load(Ordering::Relaxed),
             dense_weight_resident_bytes: self.dense_weight_resident_bytes.load(Ordering::Relaxed),
             dense_gemv_dispatches: self.dense_gemv_dispatches.load(Ordering::Relaxed),
+            dense_gemv_chunk_dispatches: self.dense_gemv_chunk_dispatches.load(Ordering::Relaxed),
             embedding_dispatches: self.embedding_dispatches.load(Ordering::Relaxed),
             tokens_submitted: self.tokens_submitted.load(Ordering::Relaxed),
             tokens_completed: self.tokens_completed.load(Ordering::Relaxed),
@@ -826,18 +1033,23 @@ impl GpuNativeExecutionCounters {
         }
     }
 
-    fn record_dense_weight_registration(&self, allocation_bytes: u64) {
+    fn record_dense_weight_registration(&self, chunks: u64, allocation_bytes: u64) {
         self.dense_weights_registered
             .fetch_add(1, Ordering::Relaxed);
-        self.dense_weight_uploads.fetch_add(1, Ordering::Relaxed);
+        self.dense_weight_chunks
+            .fetch_add(chunks, Ordering::Relaxed);
+        self.dense_weight_uploads
+            .fetch_add(chunks, Ordering::Relaxed);
         self.dense_weight_upload_bytes
             .fetch_add(allocation_bytes, Ordering::Relaxed);
         self.dense_weight_resident_bytes
             .fetch_add(allocation_bytes, Ordering::Relaxed);
     }
 
-    fn record_dense_gemv_dispatch(&self) {
+    fn record_dense_gemv_dispatch(&self, chunks: u64) {
         self.dense_gemv_dispatches.fetch_add(1, Ordering::Relaxed);
+        self.dense_gemv_chunk_dispatches
+            .fetch_add(chunks, Ordering::Relaxed);
     }
 
     fn record_embedding_dispatch(&self) {
@@ -861,17 +1073,17 @@ impl GpuNativeExecutionCounters {
 struct GpuNativeGemvPushConstants {
     rows: u32,
     cols: u32,
-    _pad0: u32,
-    _pad1: u32,
+    global_row_base: u32,
+    q8_first_block: u32,
 }
 
 #[repr(C)]
 #[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
 struct GpuNativeEmbeddingPushConstants {
-    token_id: u32,
-    rows: u32,
+    local_row: u32,
+    global_row: u32,
     cols: u32,
-    _pad: u32,
+    q8_first_block: u32,
 }
 
 struct GpuNativeDensePipelines {
@@ -1104,9 +1316,9 @@ impl GpuNativeExecutorContext {
     }
 
     /// Register one immutable model-scoped dense tensor and upload its payload
-    /// exactly once. This is the only dense-weight upload path in the
+    /// exactly once per physical chunk. This is the only dense-weight upload path in the
     /// GPU-native plane; encoded GEMV and embedding calls only bind this
-    /// persistent buffer.
+    /// persistent model-scoped storage.
     pub(crate) fn register_dense_weight(
         &self,
         key: GpuNativeDenseWeightKey,
@@ -1114,8 +1326,7 @@ impl GpuNativeExecutorContext {
     ) -> Result<GpuNativeDenseWeightHandle, GpuNativeBootstrapError> {
         let gpu = self.authoritative_gpu()?;
         let layout = GpuNativeDenseWeightLayout::from_weight(weight)?;
-        let label = format!("gpu_native_dense_weight_{}", key.as_str());
-        layout.validate_for_limits(&label, &gpu.device.limits())?;
+        let plan = GpuNativeDenseWeightPlan::try_new(layout, &gpu.device.limits())?;
 
         // Serialize the duplicate check through insertion so two startup
         // registrars cannot both upload the same stable key.
@@ -1125,36 +1336,67 @@ impl GpuNativeExecutorContext {
                 key: key.as_str().to_string(),
             });
         }
-        let buffer = create_startup_buffer(
-            &gpu.device,
-            &label,
-            layout.allocation_bytes,
-            GpuNativeDenseWeightLayout::usage(),
-        )?;
-        match weight {
-            DenseWeight::F32 { values, .. } => {
-                gpu.queue
-                    .write_buffer(&buffer, 0, bytemuck::cast_slice(values));
+        for (index, chunk) in plan.chunks.iter().enumerate() {
+            super::validate_startup_buffer(
+                &format!("gpu_native_dense_weight_{}_chunk_{index}", key.as_str()),
+                chunk.allocation_bytes,
+                GpuNativeDenseWeightLayout::usage(),
+                &gpu.device.limits(),
+            )?;
+        }
+
+        let mut chunks = Vec::with_capacity(plan.chunks.len());
+        for (index, chunk_plan) in plan.chunks.iter().copied().enumerate() {
+            let label = format!("gpu_native_dense_weight_{}_chunk_{index}", key.as_str());
+            let buffer = create_startup_buffer(
+                &gpu.device,
+                &label,
+                chunk_plan.allocation_bytes,
+                GpuNativeDenseWeightLayout::usage(),
+            )?;
+            match weight {
+                DenseWeight::F32 { values, .. } => {
+                    let value_start = chunk_plan.payload_offset_bytes / std::mem::size_of::<f32>();
+                    let value_count =
+                        chunk_plan.payload_bytes as usize / std::mem::size_of::<f32>();
+                    gpu.queue.write_buffer(
+                        &buffer,
+                        0,
+                        bytemuck::cast_slice(&values[value_start..value_start + value_count]),
+                    );
+                }
+                DenseWeight::Q8_0 { bytes, .. }
+                    if chunk_plan.payload_bytes == chunk_plan.allocation_bytes =>
+                {
+                    let start = chunk_plan.payload_offset_bytes;
+                    let end = start + chunk_plan.payload_bytes as usize;
+                    gpu.queue.write_buffer(&buffer, 0, &bytes[start..end]);
+                }
+                DenseWeight::Q8_0 { bytes, .. } => {
+                    let start = chunk_plan.payload_offset_bytes;
+                    let end = start + chunk_plan.payload_bytes as usize;
+                    let mut upload = Vec::with_capacity(chunk_plan.allocation_bytes as usize);
+                    upload.extend_from_slice(&bytes[start..end]);
+                    upload.resize(chunk_plan.allocation_bytes as usize, 0);
+                    gpu.queue.write_buffer(&buffer, 0, &upload);
+                }
             }
-            DenseWeight::Q8_0 { bytes, .. } if bytes.len() as u64 == layout.allocation_bytes => {
-                gpu.queue.write_buffer(&buffer, 0, bytes);
-            }
-            DenseWeight::Q8_0 { bytes, .. } => {
-                let mut upload = Vec::with_capacity(layout.allocation_bytes as usize);
-                upload.extend_from_slice(bytes);
-                upload.resize(layout.allocation_bytes as usize, 0);
-                gpu.queue.write_buffer(&buffer, 0, &upload);
-            }
+            chunks.push(GpuNativeDenseWeightChunk {
+                plan: chunk_plan,
+                buffer,
+            });
         }
         let registered = GpuNativeDenseWeight {
             weight_id: next_nonzero_id(&NEXT_GPU_NATIVE_WEIGHT_ID, "dense weight"),
             key,
             layout,
-            buffer,
+            chunks,
         };
         let handle = registry.insert(registered)?;
-        self.counters
-            .record_dense_weight_registration(layout.allocation_bytes);
+        self.counters.record_dense_weight_registration(
+            plan.chunks.len() as u64,
+            plan.physical_allocation_bytes,
+        );
         Ok(handle)
     }
 
@@ -1289,47 +1531,53 @@ impl GpuNativeExecutorContext {
                 actual: output_elements,
             });
         }
-        let workgroups = self.checked_workgroups(weight.layout.rows, &gpu.device.limits())?;
-        let bind_group = gpu.device.create_bind_group(&wgpu::BindGroupDescriptor {
-            label: Some("gpu_native_dense_gemv_bind_group"),
-            layout: &self.dense_pipelines.gemv_bind_group_layout,
-            entries: &[
-                wgpu::BindGroupEntry {
-                    binding: 0,
-                    resource: weight.buffer.as_entire_binding(),
-                },
-                wgpu::BindGroupEntry {
-                    binding: 1,
-                    resource: input.as_entire_binding(),
-                },
-                wgpu::BindGroupEntry {
-                    binding: 2,
-                    resource: output.as_entire_binding(),
-                },
-            ],
-        });
+        let workgroups = weight
+            .chunks
+            .iter()
+            .map(|chunk| self.checked_workgroups(chunk.plan.row_count, &gpu.device.limits()))
+            .collect::<Result<Vec<_>, _>>()?;
         let pipeline = match weight.layout.kind {
             GpuNativeDenseWeightKind::F32 => &self.dense_pipelines.f32_gemv,
             GpuNativeDenseWeightKind::Q8_0 => &self.dense_pipelines.q8_0_gemv,
         };
-        let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
-            label: Some("gpu_native_dense_gemv_pass"),
-            timestamp_writes: None,
-        });
-        pass.set_pipeline(pipeline);
-        pass.set_bind_group(0, &bind_group, &[]);
-        pass.set_push_constants(
-            0,
-            bytemuck::bytes_of(&GpuNativeGemvPushConstants {
-                rows: weight.layout.rows as u32,
-                cols: weight.layout.cols as u32,
-                _pad0: 0,
-                _pad1: 0,
-            }),
-        );
-        pass.dispatch_workgroups(workgroups, 1, 1);
-        drop(pass);
-        self.counters.record_dense_gemv_dispatch();
+        for (chunk, workgroups) in weight.chunks.iter().zip(workgroups) {
+            let bind_group = gpu.device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("gpu_native_dense_gemv_chunk_bind_group"),
+                layout: &self.dense_pipelines.gemv_bind_group_layout,
+                entries: &[
+                    wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: chunk.buffer.as_entire_binding(),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: input.as_entire_binding(),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 2,
+                        resource: output.as_entire_binding(),
+                    },
+                ],
+            });
+            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                label: Some("gpu_native_dense_gemv_chunk_pass"),
+                timestamp_writes: None,
+            });
+            pass.set_pipeline(pipeline);
+            pass.set_bind_group(0, &bind_group, &[]);
+            pass.set_push_constants(
+                0,
+                bytemuck::bytes_of(&GpuNativeGemvPushConstants {
+                    rows: chunk.plan.row_count as u32,
+                    cols: weight.layout.cols as u32,
+                    global_row_base: chunk.plan.row_start as u32,
+                    q8_first_block: chunk.plan.first_block as u32,
+                }),
+            );
+            pass.dispatch_workgroups(workgroups, 1, 1);
+        }
+        self.counters
+            .record_dense_gemv_dispatch(weight.chunks.len() as u64);
         Ok(())
     }
 
@@ -1354,13 +1602,18 @@ impl GpuNativeExecutorContext {
             });
         }
         let workgroups = self.checked_workgroups(weight.layout.cols, &gpu.device.limits())?;
+        let chunk = weight
+            .chunks
+            .iter()
+            .find(|chunk| chunk.plan.contains_row(token_id as usize))
+            .expect("validated embedding row must belong to exactly one chunk");
         let bind_group = gpu.device.create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("gpu_native_embedding_bind_group"),
             layout: &self.dense_pipelines.embedding_bind_group_layout,
             entries: &[
                 wgpu::BindGroupEntry {
                     binding: 0,
-                    resource: weight.buffer.as_entire_binding(),
+                    resource: chunk.buffer.as_entire_binding(),
                 },
                 wgpu::BindGroupEntry {
                     binding: 1,
@@ -1381,10 +1634,10 @@ impl GpuNativeExecutorContext {
         pass.set_push_constants(
             0,
             bytemuck::bytes_of(&GpuNativeEmbeddingPushConstants {
-                token_id,
-                rows: weight.layout.rows as u32,
+                local_row: token_id - chunk.plan.row_start as u32,
+                global_row: token_id,
                 cols: weight.layout.cols as u32,
-                _pad: 0,
+                q8_first_block: chunk.plan.first_block as u32,
             }),
         );
         pass.dispatch_workgroups(workgroups, 1, 1);
@@ -1477,6 +1730,19 @@ mod tests {
         scale * (bytes[offset + 2 + in_block] as i8 as f32)
     }
 
+    fn read_q8_chunk_mirror(
+        bytes: &[u8],
+        plan: GpuNativeDenseWeightChunkPlan,
+        global_flat_index: usize,
+    ) -> f32 {
+        let global_block = global_flat_index / Q8_0_BLOCK_ELEMS;
+        let local_block = global_block - plan.first_block;
+        let in_block = global_flat_index % Q8_0_BLOCK_ELEMS;
+        let offset = local_block * Q8_0_BLOCK_BYTES;
+        let scale = half::f16::from_le_bytes([bytes[offset], bytes[offset + 1]]).to_f32();
+        scale * (bytes[offset + 2 + in_block] as i8 as f32)
+    }
+
     fn q8_gemv_mirror(bytes: &[u8], rows: usize, cols: usize, input: &[f32]) -> Vec<f32> {
         (0..rows)
             .map(|row| {
@@ -1505,11 +1771,16 @@ mod tests {
         layout: GpuNativeDenseWeightLayout,
         buffer: B,
     ) -> GpuNativeDenseWeight<B> {
+        let plan = GpuNativeDenseWeightPlan::try_new(layout, &wgpu::Limits::default()).unwrap();
+        assert_eq!(plan.chunks.len(), 1);
         GpuNativeDenseWeight {
             weight_id,
             key: GpuNativeDenseWeightKey::try_new(key).unwrap(),
             layout,
-            buffer,
+            chunks: vec![GpuNativeDenseWeightChunk {
+                plan: plan.chunks[0],
+                buffer,
+            }],
         }
     }
 
@@ -1544,6 +1815,210 @@ mod tests {
         .unwrap();
         assert_eq!(one_block.payload_bytes(), 34);
         assert_eq!(one_block.allocation_bytes(), 36);
+    }
+
+    #[test]
+    fn qwen_dense_weight_plans_fit_physical_storage_limits_without_allocating_payloads() {
+        const ROWS: usize = 151_936;
+        const COLS: usize = 2_048;
+        const STORAGE_LIMIT: u64 = 128 * 1024 * 1024;
+        const BUFFER_LIMIT: u64 = 256 * 1024 * 1024;
+        let limits = wgpu::Limits {
+            max_buffer_size: BUFFER_LIMIT,
+            max_storage_buffer_binding_size: STORAGE_LIMIT as u32,
+            ..wgpu::Limits::default()
+        };
+
+        let elements = ROWS * COLS;
+        let f32_layout = GpuNativeDenseWeightLayout::try_new(
+            GpuNativeDenseWeightKind::F32,
+            ROWS,
+            COLS,
+            elements * std::mem::size_of::<f32>(),
+        )
+        .unwrap();
+        let f32_plan = GpuNativeDenseWeightPlan::try_new(f32_layout, &limits).unwrap();
+        assert_eq!(f32_plan.chunks.len(), 10);
+        assert_eq!(f32_plan.chunks[0].row_count, 16_384);
+        assert_eq!(f32_plan.chunks.last().unwrap().row_count, 4_480);
+        assert!(f32_plan
+            .chunks
+            .iter()
+            .all(|chunk| chunk.allocation_bytes <= STORAGE_LIMIT));
+        assert_eq!(
+            f32_plan
+                .chunks
+                .iter()
+                .map(|chunk| chunk.allocation_bytes)
+                .max(),
+            Some(STORAGE_LIMIT)
+        );
+        for (index, chunk) in f32_plan.chunks.iter().enumerate() {
+            super::super::validate_startup_buffer(
+                &format!("test_qwen_f32_chunk_{index}"),
+                chunk.allocation_bytes,
+                GpuNativeDenseWeightLayout::usage(),
+                &limits,
+            )
+            .unwrap();
+        }
+
+        let q8_bytes = elements.div_ceil(Q8_0_BLOCK_ELEMS) * Q8_0_BLOCK_BYTES;
+        let q8_layout = GpuNativeDenseWeightLayout::try_new(
+            GpuNativeDenseWeightKind::Q8_0,
+            ROWS,
+            COLS,
+            q8_bytes,
+        )
+        .unwrap();
+        let q8_plan = GpuNativeDenseWeightPlan::try_new(q8_layout, &limits).unwrap();
+        assert_eq!(q8_plan.chunks.len(), 3);
+        assert_eq!(q8_plan.chunks[0].row_count, 61_680);
+        assert_eq!(q8_plan.chunks.last().unwrap().row_count, 28_576);
+        assert!(q8_plan
+            .chunks
+            .iter()
+            .all(|chunk| chunk.allocation_bytes <= STORAGE_LIMIT));
+        assert_eq!(
+            q8_plan
+                .chunks
+                .iter()
+                .map(|chunk| chunk.allocation_bytes)
+                .max(),
+            Some(134_215_680)
+        );
+        for (index, chunk) in q8_plan.chunks.iter().enumerate() {
+            super::super::validate_startup_buffer(
+                &format!("test_qwen_q8_chunk_{index}"),
+                chunk.allocation_bytes,
+                GpuNativeDenseWeightLayout::usage(),
+                &limits,
+            )
+            .unwrap();
+        }
+    }
+
+    #[test]
+    fn q8_row_crossing_chunks_preserve_metadata_blocks_gemv_and_embedding() {
+        let rows = 3;
+        let cols = 35;
+        let values = (0..rows * cols)
+            .map(|i| ((i * 17 % 43) as f32 - 21.0) / 7.0)
+            .collect::<Vec<_>>();
+        let source = q8_bytes(&values);
+        let weight = DenseWeight::from_q8_0_bytes(source.clone(), rows, cols).unwrap();
+        let layout = GpuNativeDenseWeightLayout::from_weight(&weight).unwrap();
+        let limits = wgpu::Limits {
+            max_buffer_size: 68,
+            max_storage_buffer_binding_size: 68,
+            ..wgpu::Limits::default()
+        };
+        let plan = GpuNativeDenseWeightPlan::try_new(layout, &limits).unwrap();
+        assert_eq!(plan.chunks.len(), 3);
+        assert_eq!(plan.physical_allocation_bytes, 204);
+        assert_eq!(
+            plan.chunks,
+            vec![
+                GpuNativeDenseWeightChunkPlan {
+                    row_start: 0,
+                    row_count: 1,
+                    first_block: 0,
+                    payload_offset_bytes: 0,
+                    payload_bytes: 68,
+                    allocation_bytes: 68,
+                },
+                GpuNativeDenseWeightChunkPlan {
+                    row_start: 1,
+                    row_count: 1,
+                    first_block: 1,
+                    payload_offset_bytes: 34,
+                    payload_bytes: 68,
+                    allocation_bytes: 68,
+                },
+                GpuNativeDenseWeightChunkPlan {
+                    row_start: 2,
+                    row_count: 1,
+                    first_block: 2,
+                    payload_offset_bytes: 68,
+                    payload_bytes: 68,
+                    allocation_bytes: 68,
+                },
+            ]
+        );
+
+        let chunk_bytes = plan
+            .chunks
+            .iter()
+            .map(|chunk| {
+                &source[chunk.payload_offset_bytes
+                    ..chunk.payload_offset_bytes + chunk.payload_bytes as usize]
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(&chunk_bytes[0][34..68], &chunk_bytes[1][0..34]);
+        assert_eq!(&chunk_bytes[1][34..68], &chunk_bytes[2][0..34]);
+
+        for (chunk, bytes) in plan.chunks.iter().copied().zip(&chunk_bytes) {
+            for row in chunk.row_start..chunk.row_end() {
+                for col in 0..cols {
+                    let flat = row * cols + col;
+                    assert_eq!(
+                        read_q8_chunk_mirror(bytes, chunk, flat),
+                        read_q8_mirror(&source, flat)
+                    );
+                }
+            }
+        }
+
+        let input = (0..cols)
+            .map(|i| ((i * 11 % 19) as f32 - 9.0) / 5.0)
+            .collect::<Vec<_>>();
+        let expected_gemv = weight.matvec(&input);
+        let mut chunked_gemv = vec![0.0; rows];
+        for (chunk, bytes) in plan.chunks.iter().copied().zip(&chunk_bytes) {
+            for row in chunk.row_start..chunk.row_end() {
+                for col in 0..cols {
+                    chunked_gemv[row] +=
+                        read_q8_chunk_mirror(bytes, chunk, row * cols + col) * input[col];
+                }
+            }
+        }
+        assert_close(&chunked_gemv, &expected_gemv, 1e-5);
+
+        for token in 0..rows {
+            let (chunk, bytes) = plan
+                .chunks
+                .iter()
+                .copied()
+                .zip(&chunk_bytes)
+                .find(|(chunk, _)| chunk.contains_row(token))
+                .unwrap();
+            let actual = (0..cols)
+                .map(|col| read_q8_chunk_mirror(bytes, chunk, token * cols + col))
+                .collect::<Vec<_>>();
+            let mut expected = Vec::new();
+            weight.row_dequant_into(token, &mut expected);
+            assert_eq!(actual, expected);
+        }
+    }
+
+    #[test]
+    fn dense_weight_planner_fails_when_one_complete_row_cannot_fit() {
+        let layout =
+            GpuNativeDenseWeightLayout::try_new(GpuNativeDenseWeightKind::F32, 2, 4, 32).unwrap();
+        let limits = wgpu::Limits {
+            max_buffer_size: 15,
+            max_storage_buffer_binding_size: 15,
+            ..wgpu::Limits::default()
+        };
+        assert_eq!(
+            GpuNativeDenseWeightPlan::try_new(layout, &limits),
+            Err(GpuNativeBootstrapError::DenseWeightRowExceedsDeviceLimit {
+                kind: GpuNativeDenseWeightKind::F32,
+                cols: 4,
+                required: 16,
+                maximum: 15,
+            })
+        );
     }
 
     #[test]
@@ -1715,21 +2190,24 @@ mod tests {
     #[test]
     fn registration_and_dispatch_counters_keep_uploads_distinct() {
         let counters = GpuNativeExecutionCounters::default();
-        counters.record_dense_weight_registration(36);
+        counters.record_dense_weight_registration(3, 108);
         let after_registration = counters.snapshot();
         assert_eq!(after_registration.dense_weights_registered, 1);
-        assert_eq!(after_registration.dense_weight_uploads, 1);
-        assert_eq!(after_registration.dense_weight_upload_bytes, 36);
-        assert_eq!(after_registration.dense_weight_resident_bytes, 36);
+        assert_eq!(after_registration.dense_weight_chunks, 3);
+        assert_eq!(after_registration.dense_weight_uploads, 3);
+        assert_eq!(after_registration.dense_weight_upload_bytes, 108);
+        assert_eq!(after_registration.dense_weight_resident_bytes, 108);
         assert_eq!(after_registration.dense_gemv_dispatches, 0);
+        assert_eq!(after_registration.dense_gemv_chunk_dispatches, 0);
 
-        counters.record_dense_gemv_dispatch();
-        counters.record_dense_gemv_dispatch();
+        counters.record_dense_gemv_dispatch(3);
+        counters.record_dense_gemv_dispatch(2);
         counters.record_embedding_dispatch();
         let after_dispatch = counters.snapshot();
-        assert_eq!(after_dispatch.dense_weight_uploads, 1);
-        assert_eq!(after_dispatch.dense_weight_upload_bytes, 36);
+        assert_eq!(after_dispatch.dense_weight_uploads, 3);
+        assert_eq!(after_dispatch.dense_weight_upload_bytes, 108);
         assert_eq!(after_dispatch.dense_gemv_dispatches, 2);
+        assert_eq!(after_dispatch.dense_gemv_chunk_dispatches, 5);
         assert_eq!(after_dispatch.embedding_dispatches, 1);
     }
 
@@ -1744,6 +2222,7 @@ mod tests {
                 GPU_NATIVE_EMBEDDING_SHADER,
                 &["f32_embedding_main", "q8_0_embedding_main"][..],
             ),
+            (GPU_NATIVE_TEST_COMPARE_SHADER, &["compare_main"][..]),
         ] {
             let module = naga::front::wgsl::parse_str(source).expect("GPU-native WGSL must parse");
             naga::valid::Validator::new(
@@ -1759,6 +2238,432 @@ mod tests {
                     .any(|entry| entry.name == *entry_point));
             }
         }
+    }
+
+    const GPU_NATIVE_TEST_COMPARE_SHADER: &str = r#"
+struct PushConstants {
+    elements: u32,
+    tolerance_bits: u32,
+};
+var<push_constant> pc: PushConstants;
+
+@group(0) @binding(0) var<storage, read> ACTUAL: array<f32>;
+@group(0) @binding(1) var<storage, read> EXPECTED: array<f32>;
+@group(0) @binding(2) var<storage, read_write> STATUS: array<atomic<u32>>;
+
+@compute @workgroup_size(64, 1, 1)
+fn compare_main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    if (gid.x >= pc.elements) {
+        return;
+    }
+    let difference = abs(ACTUAL[gid.x] - EXPECTED[gid.x]);
+    if (!(difference <= bitcast<f32>(pc.tolerance_bits))) {
+        atomicStore(&STATUS[0], 1u);
+    }
+}
+"#;
+
+    #[repr(C)]
+    #[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+    struct GpuNativeTestComparePushConstants {
+        elements: u32,
+        tolerance_bits: u32,
+    }
+
+    fn create_test_compare_pipeline(
+        device: &wgpu::Device,
+    ) -> (wgpu::BindGroupLayout, wgpu::ComputePipeline) {
+        let layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("gpu_native_test_compare_bind_group_layout"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: true },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: true },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 2,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: false },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+            ],
+        });
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("gpu_native_test_compare_pipeline_layout"),
+            bind_group_layouts: &[&layout],
+            push_constant_ranges: &[wgpu::PushConstantRange {
+                stages: wgpu::ShaderStages::COMPUTE,
+                range: 0..8,
+            }],
+        });
+        let module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("gpu_native_test_compare_shader"),
+            source: wgpu::ShaderSource::Wgsl(GPU_NATIVE_TEST_COMPARE_SHADER.into()),
+        });
+        let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: Some("gpu_native_test_compare_pipeline"),
+            layout: Some(&pipeline_layout),
+            module: &module,
+            entry_point: "compare_main",
+            compilation_options: wgpu::PipelineCompilationOptions::default(),
+        });
+        (layout, pipeline)
+    }
+
+    fn create_test_expected_buffer(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        label: &str,
+        values: &[f32],
+    ) -> wgpu::Buffer {
+        let buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some(label),
+            size: (values.len() * std::mem::size_of::<f32>()) as u64,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        queue.write_buffer(&buffer, 0, bytemuck::cast_slice(values));
+        buffer
+    }
+
+    fn encode_test_compare(
+        device: &wgpu::Device,
+        encoder: &mut wgpu::CommandEncoder,
+        layout: &wgpu::BindGroupLayout,
+        pipeline: &wgpu::ComputePipeline,
+        actual: &wgpu::Buffer,
+        expected: &wgpu::Buffer,
+        status: &wgpu::Buffer,
+        elements: usize,
+        tolerance: f32,
+    ) {
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("gpu_native_test_compare_bind_group"),
+            layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: actual.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: expected.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: status.as_entire_binding(),
+                },
+            ],
+        });
+        let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+            label: Some("gpu_native_test_compare_pass"),
+            timestamp_writes: None,
+        });
+        pass.set_pipeline(pipeline);
+        pass.set_bind_group(0, &bind_group, &[]);
+        pass.set_push_constants(
+            0,
+            bytemuck::bytes_of(&GpuNativeTestComparePushConstants {
+                elements: elements as u32,
+                tolerance_bits: tolerance.to_bits(),
+            }),
+        );
+        pass.dispatch_workgroups((elements as u32).div_ceil(GPU_NATIVE_WORKGROUP_SIZE), 1, 1);
+    }
+
+    /// Requires an actual hardware WGPU adapter. This intentionally uses the
+    /// production execution-context resolver and maps only its four-byte
+    /// aggregate validation status, never GPU-native hidden or scratch data.
+    #[test]
+    #[ignore = "requires authoritative NVIDIA L4 WGPU validation hardware"]
+    fn live_l4_gpu_native_dense_gemv_embedding_persistence() {
+        use super::super::{
+            resolve_execution_context, ComputeOffload, GpuBackendGeometry, RoutedExpertGpuSpec,
+        };
+        use crate::inference::WeightDtype;
+
+        const COLS: usize = 35;
+        let expert_cache = Arc::new(crate::expert_cache::GpuExpertCache::new(
+            1024 * 1024,
+            0.5,
+            16,
+        ));
+        let execution = resolve_execution_context(
+            ComputeOffload::Gpu,
+            false,
+            GpuBackendGeometry {
+                num_layers: 1,
+                max_seq_len: 8,
+                num_heads: 1,
+                num_kv_heads: 1,
+                head_dim: 8,
+                v_head_dim: 8,
+                q4_truncation_tolerance: 0,
+            },
+            RoutedExpertGpuSpec {
+                dtype: WeightDtype::F32,
+                d_model: 32,
+                d_ff: 64,
+            },
+            expert_cache,
+        )
+        .expect("L4 must construct the authoritative production GPU backend");
+        let executor = execution
+            .create_gpu_native_executor_context(COLS)
+            .expect("GPU-native executor must retain the authoritative backend");
+        let gpu = executor.authoritative_gpu().unwrap();
+
+        let gemv_input_values = (0..COLS)
+            .map(|i| ((i * 11 % 19) as f32 - 9.0) / 5.0)
+            .collect::<Vec<_>>();
+        let f32_gemv_values = (0..3 * COLS)
+            .map(|i| ((i * 17 % 43) as f32 - 21.0) / 7.0)
+            .collect::<Vec<_>>();
+        let f32_gemv_weight = DenseWeight::from_f32(f32_gemv_values, 3, COLS);
+        let q8_gemv_values = (0..3 * COLS)
+            .map(|i| ((i * 23 % 47) as f32 - 23.0) / 9.0)
+            .collect::<Vec<_>>();
+        let q8_gemv_weight =
+            DenseWeight::from_q8_0_bytes(q8_bytes(&q8_gemv_values), 3, COLS).unwrap();
+        let f32_embedding_values = (0..5 * COLS)
+            .map(|i| ((i * 13 % 41) as f32 - 20.0) / 6.0)
+            .collect::<Vec<_>>();
+        let f32_embedding_weight = DenseWeight::from_f32(f32_embedding_values, 5, COLS);
+        let q8_embedding_values = (0..3 * COLS)
+            .map(|i| ((i * 29 % 53) as f32 - 26.0) / 8.0)
+            .collect::<Vec<_>>();
+        let q8_embedding_weight =
+            DenseWeight::from_q8_0_bytes(q8_bytes(&q8_embedding_values), 3, COLS).unwrap();
+
+        let f32_gemv_handle = executor
+            .register_dense_weight(
+                GpuNativeDenseWeightKey::try_new("test.f32_gemv").unwrap(),
+                &f32_gemv_weight,
+            )
+            .unwrap();
+        let q8_gemv_handle = executor
+            .register_dense_weight(
+                GpuNativeDenseWeightKey::try_new("test.q8_gemv").unwrap(),
+                &q8_gemv_weight,
+            )
+            .unwrap();
+        let f32_embedding_handle = executor
+            .register_dense_weight(
+                GpuNativeDenseWeightKey::try_new("test.f32_embedding").unwrap(),
+                &f32_embedding_weight,
+            )
+            .unwrap();
+        let q8_embedding_handle = executor
+            .register_dense_weight(
+                GpuNativeDenseWeightKey::try_new("test.q8_embedding").unwrap(),
+                &q8_embedding_weight,
+            )
+            .unwrap();
+        let registered = executor.execution_snapshot();
+        assert_eq!(registered.dense_weights_registered, 4);
+
+        let input = executor.create_scratch(COLS).unwrap();
+        let f32_output = executor.create_scratch(3).unwrap();
+        let q8_output = executor.create_scratch(3).unwrap();
+        let state = executor.create_token_state().unwrap();
+        gpu.queue
+            .write_buffer(&input.buffer, 0, bytemuck::cast_slice(&gemv_input_values));
+
+        let f32_gemv_expected = create_test_expected_buffer(
+            &gpu.device,
+            &gpu.queue,
+            "gpu_native_test_f32_gemv_expected",
+            &f32_gemv_weight.matvec(&gemv_input_values),
+        );
+        let q8_gemv_expected = create_test_expected_buffer(
+            &gpu.device,
+            &gpu.queue,
+            "gpu_native_test_q8_gemv_expected",
+            &q8_gemv_weight.matvec(&gemv_input_values),
+        );
+        let f32_embedding_expected = [0usize, 2, 4]
+            .into_iter()
+            .map(|row| {
+                let mut expected = Vec::new();
+                f32_embedding_weight.row_dequant_into(row, &mut expected);
+                create_test_expected_buffer(
+                    &gpu.device,
+                    &gpu.queue,
+                    "gpu_native_test_f32_embedding_expected",
+                    &expected,
+                )
+            })
+            .collect::<Vec<_>>();
+        let q8_embedding_expected = [0usize, 1, 2]
+            .into_iter()
+            .map(|row| {
+                let mut expected = Vec::new();
+                q8_embedding_weight.row_dequant_into(row, &mut expected);
+                create_test_expected_buffer(
+                    &gpu.device,
+                    &gpu.queue,
+                    "gpu_native_test_q8_embedding_expected",
+                    &expected,
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let status = gpu.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("gpu_native_test_validation_status"),
+            size: GPU_NATIVE_STATUS_BYTES,
+            usage: wgpu::BufferUsages::STORAGE
+                | wgpu::BufferUsages::COPY_DST
+                | wgpu::BufferUsages::COPY_SRC,
+            mapped_at_creation: false,
+        });
+        gpu.queue.write_buffer(&status, 0, &[0; 4]);
+        let staging = gpu.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("gpu_native_test_validation_staging"),
+            size: GPU_NATIVE_STATUS_BYTES,
+            usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let (compare_layout, compare_pipeline) = create_test_compare_pipeline(&gpu.device);
+        let mut encoder = gpu
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("gpu_native_test_live_l4_encoder"),
+            });
+
+        for _ in 0..2 {
+            executor
+                .encode_dense_gemv_scratch_to_scratch(
+                    &mut encoder,
+                    &f32_gemv_handle,
+                    &input,
+                    &f32_output,
+                )
+                .unwrap();
+            encode_test_compare(
+                &gpu.device,
+                &mut encoder,
+                &compare_layout,
+                &compare_pipeline,
+                &f32_output.buffer,
+                &f32_gemv_expected,
+                &status,
+                3,
+                1e-4,
+            );
+            executor
+                .encode_dense_gemv_scratch_to_scratch(
+                    &mut encoder,
+                    &q8_gemv_handle,
+                    &input,
+                    &q8_output,
+                )
+                .unwrap();
+            encode_test_compare(
+                &gpu.device,
+                &mut encoder,
+                &compare_layout,
+                &compare_pipeline,
+                &q8_output.buffer,
+                &q8_gemv_expected,
+                &status,
+                3,
+                1e-4,
+            );
+        }
+
+        for (token, expected) in [0u32, 2, 4].into_iter().zip(&f32_embedding_expected) {
+            executor
+                .encode_embedding_lookup(&mut encoder, &f32_embedding_handle, token, &state)
+                .unwrap();
+            encode_test_compare(
+                &gpu.device,
+                &mut encoder,
+                &compare_layout,
+                &compare_pipeline,
+                &state.hidden,
+                expected,
+                &status,
+                COLS,
+                1e-6,
+            );
+        }
+        for (token, expected) in [0u32, 1, 2].into_iter().zip(&q8_embedding_expected) {
+            executor
+                .encode_embedding_lookup(&mut encoder, &q8_embedding_handle, token, &state)
+                .unwrap();
+            encode_test_compare(
+                &gpu.device,
+                &mut encoder,
+                &compare_layout,
+                &compare_pipeline,
+                &state.hidden,
+                expected,
+                &status,
+                COLS,
+                1e-6,
+            );
+        }
+
+        let encoded = executor.execution_snapshot();
+        assert_eq!(
+            encoded.dense_weight_uploads,
+            registered.dense_weight_uploads
+        );
+        assert_eq!(
+            encoded.dense_weight_upload_bytes,
+            registered.dense_weight_upload_bytes
+        );
+        assert_eq!(encoded.intermediate_maps, 0);
+        assert_eq!(encoded.intermediate_readbacks, 0);
+        encoder.copy_buffer_to_buffer(&status, 0, &staging, 0, GPU_NATIVE_STATUS_BYTES);
+        gpu.queue.submit(Some(encoder.finish()));
+
+        let slice = staging.slice(..);
+        let (tx, rx) = std::sync::mpsc::sync_channel(1);
+        slice.map_async(wgpu::MapMode::Read, move |result| {
+            let _ = tx.send(result);
+        });
+        gpu.device.poll(wgpu::Maintain::Wait);
+        rx.recv()
+            .expect("validation map callback must be drained")
+            .expect("validation status must map");
+        let mapped = slice.get_mapped_range();
+        let status_value = u32::from_le_bytes(mapped[..4].try_into().unwrap());
+        drop(mapped);
+        staging.unmap();
+        assert_eq!(status_value, 0, "on-device GPU-native comparison failed");
+
+        let completed = executor.execution_snapshot();
+        assert_eq!(
+            completed.dense_weight_uploads,
+            registered.dense_weight_uploads
+        );
+        assert_eq!(
+            completed.dense_weight_upload_bytes,
+            registered.dense_weight_upload_bytes
+        );
+        assert_eq!(completed.intermediate_maps, 0);
+        assert_eq!(completed.intermediate_readbacks, 0);
     }
 
     #[test]

--- a/rust-engine/src/backend/gpu_native.rs
+++ b/rust-engine/src/backend/gpu_native.rs
@@ -1,28 +1,109 @@
-//! Bootstrap ownership for a future GPU-native token loop.
+//! Isolated foundations for a future GPU-native token loop.
 //!
-//! This module deliberately contains no transformer arithmetic and is not
-//! reachable from the current operator-facing execution modes. It establishes
-//! only request-local device state, checked layout arithmetic, authoritative
-//! device reuse, and execution evidence that later slices can build on.
+//! This module is not reachable from current operator-facing execution modes.
+//! It owns request-local device state, persistent dense model weights, and
+//! encoder-only embedding/GEMV primitives on the authoritative WGPU device.
+//! Later slices can compose those pieces without inheriting legacy host-shaped
+//! upload/readback APIs.
 
-// Slice 1 is intentionally not reachable from production token entrypoints.
+// GPU-native slices remain intentionally unreachable from production token entrypoints.
 #![allow(dead_code)]
 
 use super::{create_startup_buffer, BackendBox, GpuDeviceIdentity, GpuStartupAllocationError};
+use crate::dense_tensor::{DenseDType, DenseWeight};
+use crate::inference::{Q8_0_BLOCK_BYTES, Q8_0_BLOCK_ELEMS};
+use parking_lot::Mutex as ParkingMutex;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 const GPU_NATIVE_STATUS_BYTES: u64 = std::mem::size_of::<u32>() as u64;
+const GPU_NATIVE_DENSE_GEMV_SHADER: &str = include_str!("wgpu_shaders/gpu_native_dense_gemv.wgsl");
+const GPU_NATIVE_EMBEDDING_SHADER: &str = include_str!("wgpu_shaders/gpu_native_embedding.wgsl");
+const GPU_NATIVE_WORKGROUP_SIZE: u32 = 64;
 
 /// Typed, fail-closed construction failure for the GPU-native bootstrap.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum GpuNativeBootstrapError {
     GpuBackendUnavailable,
-    DeviceLost { detail: String },
+    DeviceLost {
+        detail: String,
+    },
     InvalidDModel,
-    StateSizeOverflow { d_model: usize },
+    StateSizeOverflow {
+        d_model: usize,
+    },
+    InvalidDenseWeightKey,
+    InvalidDenseWeightShape {
+        rows: usize,
+        cols: usize,
+    },
+    DenseWeightShapeOverflow {
+        rows: usize,
+        cols: usize,
+    },
+    DenseWeightDimensionTooLarge {
+        rows: usize,
+        cols: usize,
+    },
+    DenseWeightByteLength {
+        kind: GpuNativeDenseWeightKind,
+        rows: usize,
+        cols: usize,
+        expected: usize,
+        actual: usize,
+    },
+    DuplicateDenseWeight {
+        key: String,
+    },
+    MissingDenseWeight {
+        key: String,
+    },
+    ForeignDenseWeightHandle,
+    StaleDenseWeightHandle {
+        key: String,
+    },
+    DenseWeightKindMismatch {
+        key: String,
+        expected: GpuNativeDenseWeightKind,
+        actual: GpuNativeDenseWeightKind,
+    },
+    DenseWeightShapeMismatch {
+        key: String,
+        expected_rows: usize,
+        expected_cols: usize,
+        actual_rows: usize,
+        actual_cols: usize,
+    },
+    InvalidScratchElements,
+    ScratchSizeOverflow {
+        elements: usize,
+    },
+    ForeignTokenState,
+    ForeignScratch,
+    AliasedInputOutput,
+    GemvInputLength {
+        expected: usize,
+        actual: usize,
+    },
+    GemvOutputLength {
+        expected: usize,
+        actual: usize,
+    },
+    InvalidEmbeddingToken {
+        token_id: u32,
+        vocab_size: usize,
+    },
+    EmbeddingWidth {
+        expected: usize,
+        actual: usize,
+    },
+    DispatchGeometryUnsupported {
+        workgroups: u64,
+        maximum: u32,
+    },
     Allocation(GpuStartupAllocationError),
 }
 
@@ -44,6 +125,106 @@ impl fmt::Display for GpuNativeBootstrapError {
                 f,
                 "GPU-native token-state size overflows for d_model={d_model}"
             ),
+            Self::InvalidDenseWeightKey => {
+                write!(f, "GPU-native dense weight key must be non-empty")
+            }
+            Self::InvalidDenseWeightShape { rows, cols } => write!(
+                f,
+                "GPU-native dense weight shape [{rows}, {cols}] must be non-empty"
+            ),
+            Self::DenseWeightShapeOverflow { rows, cols } => write!(
+                f,
+                "GPU-native dense weight shape [{rows}, {cols}] overflows"
+            ),
+            Self::DenseWeightDimensionTooLarge { rows, cols } => write!(
+                f,
+                "GPU-native dense weight shape [{rows}, {cols}] exceeds u32 shader geometry"
+            ),
+            Self::DenseWeightByteLength {
+                kind,
+                rows,
+                cols,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "GPU-native {kind:?} dense weight [{rows}, {cols}] has {actual} bytes, expected {expected}"
+            ),
+            Self::DuplicateDenseWeight { key } => {
+                write!(f, "GPU-native dense weight {key:?} is already registered")
+            }
+            Self::MissingDenseWeight { key } => {
+                write!(f, "GPU-native dense weight {key:?} is not registered")
+            }
+            Self::ForeignDenseWeightHandle => write!(
+                f,
+                "GPU-native dense weight handle belongs to a different executor context"
+            ),
+            Self::StaleDenseWeightHandle { key } => {
+                write!(f, "GPU-native dense weight handle for {key:?} is stale")
+            }
+            Self::DenseWeightKindMismatch {
+                key,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "GPU-native dense weight {key:?} has kind {actual:?}, expected {expected:?}"
+            ),
+            Self::DenseWeightShapeMismatch {
+                key,
+                expected_rows,
+                expected_cols,
+                actual_rows,
+                actual_cols,
+            } => write!(
+                f,
+                "GPU-native dense weight {key:?} has shape [{actual_rows}, {actual_cols}], expected [{expected_rows}, {expected_cols}]"
+            ),
+            Self::InvalidScratchElements => {
+                write!(f, "GPU-native scratch length must be non-zero")
+            }
+            Self::ScratchSizeOverflow { elements } => write!(
+                f,
+                "GPU-native scratch size overflows for {elements} elements"
+            ),
+            Self::ForeignTokenState => write!(
+                f,
+                "GPU-native token state belongs to a different executor context"
+            ),
+            Self::ForeignScratch => write!(
+                f,
+                "GPU-native scratch belongs to a different executor context"
+            ),
+            Self::AliasedInputOutput => {
+                write!(f, "GPU-native GEMV input and output buffers must be distinct")
+            }
+            Self::GemvInputLength { expected, actual } => write!(
+                f,
+                "GPU-native GEMV input has {actual} elements, expected {expected}"
+            ),
+            Self::GemvOutputLength { expected, actual } => write!(
+                f,
+                "GPU-native GEMV output has {actual} elements, expected {expected}"
+            ),
+            Self::InvalidEmbeddingToken {
+                token_id,
+                vocab_size,
+            } => write!(
+                f,
+                "GPU-native embedding token {token_id} is outside vocabulary size {vocab_size}"
+            ),
+            Self::EmbeddingWidth { expected, actual } => write!(
+                f,
+                "GPU-native embedding width is {actual}, expected token-state width {expected}"
+            ),
+            Self::DispatchGeometryUnsupported {
+                workgroups,
+                maximum,
+            } => write!(
+                f,
+                "GPU-native dispatch requires {workgroups} workgroups, exceeding device maximum {maximum}"
+            ),
             Self::Allocation(error) => error.fmt(f),
         }
     }
@@ -62,6 +243,292 @@ impl From<GpuStartupAllocationError> for GpuNativeBootstrapError {
     fn from(error: GpuStartupAllocationError) -> Self {
         Self::Allocation(error)
     }
+}
+
+/// Dense storage identity understood by the GPU-native shaders.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum GpuNativeDenseWeightKind {
+    F32,
+    Q8_0,
+}
+
+impl From<DenseDType> for GpuNativeDenseWeightKind {
+    fn from(dtype: DenseDType) -> Self {
+        match dtype {
+            DenseDType::F32 => Self::F32,
+            DenseDType::Q8_0 => Self::Q8_0,
+        }
+    }
+}
+
+/// Checked immutable matrix layout. `payload_bytes` is the exact model
+/// payload; `allocation_bytes` includes only the trailing zero padding WGPU
+/// requires to make a storage-buffer write four-byte aligned.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct GpuNativeDenseWeightLayout {
+    kind: GpuNativeDenseWeightKind,
+    rows: usize,
+    cols: usize,
+    payload_bytes: u64,
+    allocation_bytes: u64,
+}
+
+impl GpuNativeDenseWeightLayout {
+    fn try_new(
+        kind: GpuNativeDenseWeightKind,
+        rows: usize,
+        cols: usize,
+        actual_bytes: usize,
+    ) -> Result<Self, GpuNativeBootstrapError> {
+        if rows == 0 || cols == 0 {
+            return Err(GpuNativeBootstrapError::InvalidDenseWeightShape { rows, cols });
+        }
+        let elements = rows
+            .checked_mul(cols)
+            .ok_or(GpuNativeBootstrapError::DenseWeightShapeOverflow { rows, cols })?;
+        if u32::try_from(rows).is_err()
+            || u32::try_from(cols).is_err()
+            || u32::try_from(elements).is_err()
+        {
+            return Err(GpuNativeBootstrapError::DenseWeightDimensionTooLarge { rows, cols });
+        }
+        let expected_bytes = match kind {
+            GpuNativeDenseWeightKind::F32 => elements
+                .checked_mul(std::mem::size_of::<f32>())
+                .ok_or(GpuNativeBootstrapError::DenseWeightShapeOverflow { rows, cols })?,
+            GpuNativeDenseWeightKind::Q8_0 => elements
+                .div_ceil(Q8_0_BLOCK_ELEMS)
+                .checked_mul(Q8_0_BLOCK_BYTES)
+                .ok_or(GpuNativeBootstrapError::DenseWeightShapeOverflow { rows, cols })?,
+        };
+        if actual_bytes != expected_bytes {
+            return Err(GpuNativeBootstrapError::DenseWeightByteLength {
+                kind,
+                rows,
+                cols,
+                expected: expected_bytes,
+                actual: actual_bytes,
+            });
+        }
+        // Q8 byte extraction also uses u32 offsets in WGSL. F32 indexes an
+        // array<u32> by element, so its already-checked element count is the
+        // relevant bound rather than its four-times-larger byte count.
+        if kind == GpuNativeDenseWeightKind::Q8_0 && u32::try_from(expected_bytes).is_err() {
+            return Err(GpuNativeBootstrapError::DenseWeightDimensionTooLarge { rows, cols });
+        }
+        let allocation_bytes = expected_bytes
+            .checked_add(3)
+            .map(|bytes| bytes & !3)
+            .and_then(|bytes| u64::try_from(bytes).ok())
+            .ok_or(GpuNativeBootstrapError::DenseWeightShapeOverflow { rows, cols })?;
+        let payload_bytes = u64::try_from(expected_bytes)
+            .map_err(|_| GpuNativeBootstrapError::DenseWeightShapeOverflow { rows, cols })?;
+        Ok(Self {
+            kind,
+            rows,
+            cols,
+            payload_bytes,
+            allocation_bytes,
+        })
+    }
+
+    fn from_weight(weight: &DenseWeight) -> Result<Self, GpuNativeBootstrapError> {
+        Self::try_new(
+            weight.dtype().into(),
+            weight.rows(),
+            weight.cols(),
+            weight.resident_bytes(),
+        )
+    }
+
+    pub(crate) const fn kind(self) -> GpuNativeDenseWeightKind {
+        self.kind
+    }
+
+    pub(crate) const fn rows(self) -> usize {
+        self.rows
+    }
+
+    pub(crate) const fn cols(self) -> usize {
+        self.cols
+    }
+
+    pub(crate) const fn payload_bytes(self) -> u64 {
+        self.payload_bytes
+    }
+
+    pub(crate) const fn allocation_bytes(self) -> u64 {
+        self.allocation_bytes
+    }
+
+    fn usage() -> wgpu::BufferUsages {
+        wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST
+    }
+
+    fn validate_for_limits(
+        self,
+        label: &str,
+        limits: &wgpu::Limits,
+    ) -> Result<(), GpuNativeBootstrapError> {
+        super::validate_startup_buffer(label, self.allocation_bytes, Self::usage(), limits)?;
+        Ok(())
+    }
+
+    fn validate_embedding_token(self, token_id: u32) -> Result<(), GpuNativeBootstrapError> {
+        if token_id as usize >= self.rows {
+            return Err(GpuNativeBootstrapError::InvalidEmbeddingToken {
+                token_id,
+                vocab_size: self.rows,
+            });
+        }
+        Ok(())
+    }
+}
+
+/// Stable model-scoped key used to retrieve a registered dense tensor.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct GpuNativeDenseWeightKey(Arc<str>);
+
+impl GpuNativeDenseWeightKey {
+    pub(crate) fn try_new(key: impl Into<String>) -> Result<Self, GpuNativeBootstrapError> {
+        let key = key.into();
+        if key.trim().is_empty() {
+            return Err(GpuNativeBootstrapError::InvalidDenseWeightKey);
+        }
+        Ok(Self(Arc::<str>::from(key)))
+    }
+
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Opaque, context-bound reference to one persistent model weight.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct GpuNativeDenseWeightHandle {
+    context_id: u64,
+    weight_id: u64,
+    key: GpuNativeDenseWeightKey,
+    layout: GpuNativeDenseWeightLayout,
+}
+
+impl GpuNativeDenseWeightHandle {
+    pub(crate) fn key(&self) -> &GpuNativeDenseWeightKey {
+        &self.key
+    }
+
+    pub(crate) const fn layout(&self) -> GpuNativeDenseWeightLayout {
+        self.layout
+    }
+}
+
+struct GpuNativeDenseWeight<B = wgpu::Buffer> {
+    weight_id: u64,
+    key: GpuNativeDenseWeightKey,
+    layout: GpuNativeDenseWeightLayout,
+    buffer: B,
+}
+
+impl<B> GpuNativeDenseWeight<B> {
+    fn handle(&self, context_id: u64) -> GpuNativeDenseWeightHandle {
+        GpuNativeDenseWeightHandle {
+            context_id,
+            weight_id: self.weight_id,
+            key: self.key.clone(),
+            layout: self.layout,
+        }
+    }
+}
+
+struct GpuNativeDenseWeightRegistry<B = wgpu::Buffer> {
+    context_id: u64,
+    weights: HashMap<GpuNativeDenseWeightKey, Arc<GpuNativeDenseWeight<B>>>,
+}
+
+impl<B> GpuNativeDenseWeightRegistry<B> {
+    fn new(context_id: u64) -> Self {
+        Self {
+            context_id,
+            weights: HashMap::new(),
+        }
+    }
+
+    fn insert(
+        &mut self,
+        weight: GpuNativeDenseWeight<B>,
+    ) -> Result<GpuNativeDenseWeightHandle, GpuNativeBootstrapError> {
+        if self.weights.contains_key(&weight.key) {
+            return Err(GpuNativeBootstrapError::DuplicateDenseWeight {
+                key: weight.key.as_str().to_string(),
+            });
+        }
+        let weight = Arc::new(weight);
+        let handle = weight.handle(self.context_id);
+        self.weights.insert(weight.key.clone(), weight);
+        Ok(handle)
+    }
+
+    fn resolve(
+        &self,
+        handle: &GpuNativeDenseWeightHandle,
+    ) -> Result<Arc<GpuNativeDenseWeight<B>>, GpuNativeBootstrapError> {
+        if handle.context_id != self.context_id {
+            return Err(GpuNativeBootstrapError::ForeignDenseWeightHandle);
+        }
+        let weight = self.weights.get(&handle.key).ok_or_else(|| {
+            GpuNativeBootstrapError::MissingDenseWeight {
+                key: handle.key.as_str().to_string(),
+            }
+        })?;
+        if weight.weight_id != handle.weight_id || weight.layout != handle.layout {
+            return Err(GpuNativeBootstrapError::StaleDenseWeightHandle {
+                key: handle.key.as_str().to_string(),
+            });
+        }
+        Ok(weight.clone())
+    }
+
+    fn handle_for(
+        &self,
+        key: &GpuNativeDenseWeightKey,
+        expected_kind: GpuNativeDenseWeightKind,
+        expected_rows: usize,
+        expected_cols: usize,
+    ) -> Result<GpuNativeDenseWeightHandle, GpuNativeBootstrapError> {
+        let weight =
+            self.weights
+                .get(key)
+                .ok_or_else(|| GpuNativeBootstrapError::MissingDenseWeight {
+                    key: key.as_str().to_string(),
+                })?;
+        if weight.layout.kind != expected_kind {
+            return Err(GpuNativeBootstrapError::DenseWeightKindMismatch {
+                key: key.as_str().to_string(),
+                expected: expected_kind,
+                actual: weight.layout.kind,
+            });
+        }
+        if weight.layout.rows != expected_rows || weight.layout.cols != expected_cols {
+            return Err(GpuNativeBootstrapError::DenseWeightShapeMismatch {
+                key: key.as_str().to_string(),
+                expected_rows,
+                expected_cols,
+                actual_rows: weight.layout.rows,
+                actual_cols: weight.layout.cols,
+            });
+        }
+        Ok(weight.handle(self.context_id))
+    }
+}
+
+static NEXT_GPU_NATIVE_CONTEXT_ID: AtomicU64 = AtomicU64::new(1);
+static NEXT_GPU_NATIVE_WEIGHT_ID: AtomicU64 = AtomicU64::new(1);
+static NEXT_GPU_NATIVE_SCRATCH_ID: AtomicU64 = AtomicU64::new(1);
+
+fn next_nonzero_id(counter: &AtomicU64, label: &str) -> u64 {
+    let id = counter.fetch_add(1, Ordering::Relaxed);
+    assert_ne!(id, 0, "GPU-native {label} id space exhausted");
+    id
 }
 
 /// Checked byte layout for one request's initial device-resident token state.
@@ -143,6 +610,82 @@ impl GpuNativeTokenStateLayout {
     }
 }
 
+/// Checked request-scoped F32 device scratch for variable-width GEMV output.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct GpuNativeScratchLayout {
+    elements: usize,
+    bytes: u64,
+}
+
+impl GpuNativeScratchLayout {
+    pub(crate) fn try_new(elements: usize) -> Result<Self, GpuNativeBootstrapError> {
+        if elements == 0 {
+            return Err(GpuNativeBootstrapError::InvalidScratchElements);
+        }
+        if u32::try_from(elements).is_err() {
+            return Err(GpuNativeBootstrapError::ScratchSizeOverflow { elements });
+        }
+        let bytes = elements
+            .checked_mul(std::mem::size_of::<f32>())
+            .and_then(|bytes| u64::try_from(bytes).ok())
+            .ok_or(GpuNativeBootstrapError::ScratchSizeOverflow { elements })?;
+        Ok(Self { elements, bytes })
+    }
+
+    pub(crate) const fn elements(self) -> usize {
+        self.elements
+    }
+
+    pub(crate) const fn bytes(self) -> u64 {
+        self.bytes
+    }
+
+    fn usage() -> wgpu::BufferUsages {
+        wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST
+    }
+
+    fn validate_for_limits(self, limits: &wgpu::Limits) -> Result<(), GpuNativeBootstrapError> {
+        super::validate_startup_buffer("gpu_native_scratch", self.bytes, Self::usage(), limits)?;
+        Ok(())
+    }
+}
+
+pub(crate) struct GpuNativeScratch<B = wgpu::Buffer> {
+    context_id: u64,
+    scratch_id: u64,
+    layout: GpuNativeScratchLayout,
+    buffer: B,
+}
+
+impl<B> GpuNativeScratch<B> {
+    fn from_buffer(
+        context_id: u64,
+        scratch_id: u64,
+        layout: GpuNativeScratchLayout,
+        buffer: B,
+    ) -> Self {
+        Self {
+            context_id,
+            scratch_id,
+            layout,
+            buffer,
+        }
+    }
+
+    pub(crate) const fn layout(&self) -> GpuNativeScratchLayout {
+        self.layout
+    }
+}
+
+impl<B> fmt::Debug for GpuNativeScratch<B> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GpuNativeScratch")
+            .field("scratch_id", &self.scratch_id)
+            .field("layout", &self.layout)
+            .finish_non_exhaustive()
+    }
+}
+
 static NEXT_GPU_NATIVE_TOKEN_STATE_ID: AtomicU64 = AtomicU64::new(1);
 
 fn next_gpu_native_token_state_id() -> u64 {
@@ -157,6 +700,7 @@ fn next_gpu_native_token_state_id() -> u64 {
 /// lets hardware-independent tests exercise ownership and drop behavior
 /// without introducing a mock WGPU device.
 pub(crate) struct GpuNativeTokenState<B = wgpu::Buffer> {
+    context_id: u64,
     state_id: u64,
     layout: GpuNativeTokenStateLayout,
     hidden: B,
@@ -166,6 +710,7 @@ pub(crate) struct GpuNativeTokenState<B = wgpu::Buffer> {
 
 impl<B> GpuNativeTokenState<B> {
     fn from_buffers(
+        context_id: u64,
         state_id: u64,
         layout: GpuNativeTokenStateLayout,
         hidden: B,
@@ -173,6 +718,7 @@ impl<B> GpuNativeTokenState<B> {
         status: B,
     ) -> Self {
         Self {
+            context_id,
             state_id,
             layout,
             hidden,
@@ -202,6 +748,12 @@ impl<B> fmt::Debug for GpuNativeTokenState<B> {
 /// Immutable, serializable evidence for GPU-native execution boundaries.
 #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub(crate) struct GpuNativeExecutionSnapshot {
+    pub(crate) dense_weights_registered: u64,
+    pub(crate) dense_weight_uploads: u64,
+    pub(crate) dense_weight_upload_bytes: u64,
+    pub(crate) dense_weight_resident_bytes: u64,
+    pub(crate) dense_gemv_dispatches: u64,
+    pub(crate) embedding_dispatches: u64,
     pub(crate) tokens_submitted: u64,
     pub(crate) tokens_completed: u64,
     pub(crate) layers_encoded: u64,
@@ -222,6 +774,12 @@ pub(crate) struct GpuNativeExecutionSnapshot {
 
 #[derive(Debug, Default)]
 struct GpuNativeExecutionCounters {
+    dense_weights_registered: AtomicU64,
+    dense_weight_uploads: AtomicU64,
+    dense_weight_upload_bytes: AtomicU64,
+    dense_weight_resident_bytes: AtomicU64,
+    dense_gemv_dispatches: AtomicU64,
+    embedding_dispatches: AtomicU64,
     tokens_submitted: AtomicU64,
     tokens_completed: AtomicU64,
     layers_encoded: AtomicU64,
@@ -243,6 +801,12 @@ struct GpuNativeExecutionCounters {
 impl GpuNativeExecutionCounters {
     fn snapshot(&self) -> GpuNativeExecutionSnapshot {
         GpuNativeExecutionSnapshot {
+            dense_weights_registered: self.dense_weights_registered.load(Ordering::Relaxed),
+            dense_weight_uploads: self.dense_weight_uploads.load(Ordering::Relaxed),
+            dense_weight_upload_bytes: self.dense_weight_upload_bytes.load(Ordering::Relaxed),
+            dense_weight_resident_bytes: self.dense_weight_resident_bytes.load(Ordering::Relaxed),
+            dense_gemv_dispatches: self.dense_gemv_dispatches.load(Ordering::Relaxed),
+            embedding_dispatches: self.embedding_dispatches.load(Ordering::Relaxed),
             tokens_submitted: self.tokens_submitted.load(Ordering::Relaxed),
             tokens_completed: self.tokens_completed.load(Ordering::Relaxed),
             layers_encoded: self.layers_encoded.load(Ordering::Relaxed),
@@ -262,6 +826,24 @@ impl GpuNativeExecutionCounters {
         }
     }
 
+    fn record_dense_weight_registration(&self, allocation_bytes: u64) {
+        self.dense_weights_registered
+            .fetch_add(1, Ordering::Relaxed);
+        self.dense_weight_uploads.fetch_add(1, Ordering::Relaxed);
+        self.dense_weight_upload_bytes
+            .fetch_add(allocation_bytes, Ordering::Relaxed);
+        self.dense_weight_resident_bytes
+            .fetch_add(allocation_bytes, Ordering::Relaxed);
+    }
+
+    fn record_dense_gemv_dispatch(&self) {
+        self.dense_gemv_dispatches.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_embedding_dispatch(&self) {
+        self.embedding_dispatches.fetch_add(1, Ordering::Relaxed);
+    }
+
     #[cfg(test)]
     fn record_token_boundary_readback(&self) {
         self.token_boundary_readbacks
@@ -274,15 +856,171 @@ impl GpuNativeExecutionCounters {
     }
 }
 
+#[repr(C)]
+#[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+struct GpuNativeGemvPushConstants {
+    rows: u32,
+    cols: u32,
+    _pad0: u32,
+    _pad1: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+struct GpuNativeEmbeddingPushConstants {
+    token_id: u32,
+    rows: u32,
+    cols: u32,
+    _pad: u32,
+}
+
+struct GpuNativeDensePipelines {
+    gemv_bind_group_layout: wgpu::BindGroupLayout,
+    embedding_bind_group_layout: wgpu::BindGroupLayout,
+    f32_gemv: wgpu::ComputePipeline,
+    q8_0_gemv: wgpu::ComputePipeline,
+    f32_embedding: wgpu::ComputePipeline,
+    q8_0_embedding: wgpu::ComputePipeline,
+}
+
+impl GpuNativeDensePipelines {
+    fn new(device: &wgpu::Device) -> Self {
+        let read_only_storage = wgpu::BindingType::Buffer {
+            ty: wgpu::BufferBindingType::Storage { read_only: true },
+            has_dynamic_offset: false,
+            min_binding_size: None,
+        };
+        let read_write_storage = wgpu::BindingType::Buffer {
+            ty: wgpu::BufferBindingType::Storage { read_only: false },
+            has_dynamic_offset: false,
+            min_binding_size: None,
+        };
+        let gemv_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("gpu_native_dense_gemv_bind_group_layout"),
+                entries: &[
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: wgpu::ShaderStages::COMPUTE,
+                        ty: read_only_storage,
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 1,
+                        visibility: wgpu::ShaderStages::COMPUTE,
+                        ty: read_only_storage,
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 2,
+                        visibility: wgpu::ShaderStages::COMPUTE,
+                        ty: read_write_storage,
+                        count: None,
+                    },
+                ],
+            });
+        let embedding_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("gpu_native_embedding_bind_group_layout"),
+                entries: &[
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: wgpu::ShaderStages::COMPUTE,
+                        ty: read_only_storage,
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 1,
+                        visibility: wgpu::ShaderStages::COMPUTE,
+                        ty: read_write_storage,
+                        count: None,
+                    },
+                ],
+            });
+        let gemv_pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("gpu_native_dense_gemv_pipeline_layout"),
+            bind_group_layouts: &[&gemv_bind_group_layout],
+            push_constant_ranges: &[wgpu::PushConstantRange {
+                stages: wgpu::ShaderStages::COMPUTE,
+                range: 0..16,
+            }],
+        });
+        let embedding_pipeline_layout =
+            device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("gpu_native_embedding_pipeline_layout"),
+                bind_group_layouts: &[&embedding_bind_group_layout],
+                push_constant_ranges: &[wgpu::PushConstantRange {
+                    stages: wgpu::ShaderStages::COMPUTE,
+                    range: 0..16,
+                }],
+            });
+        let gemv_module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("gpu_native_dense_gemv_shader"),
+            source: wgpu::ShaderSource::Wgsl(GPU_NATIVE_DENSE_GEMV_SHADER.into()),
+        });
+        let embedding_module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("gpu_native_embedding_shader"),
+            source: wgpu::ShaderSource::Wgsl(GPU_NATIVE_EMBEDDING_SHADER.into()),
+        });
+        let pipeline = |label: &'static str,
+                        layout: &wgpu::PipelineLayout,
+                        module: &wgpu::ShaderModule,
+                        entry_point: &'static str| {
+            device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                label: Some(label),
+                layout: Some(layout),
+                module,
+                entry_point,
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            })
+        };
+        let f32_gemv = pipeline(
+            "gpu_native_f32_gemv_pipeline",
+            &gemv_pipeline_layout,
+            &gemv_module,
+            "f32_gemv_main",
+        );
+        let q8_0_gemv = pipeline(
+            "gpu_native_q8_0_gemv_pipeline",
+            &gemv_pipeline_layout,
+            &gemv_module,
+            "q8_0_gemv_main",
+        );
+        let f32_embedding = pipeline(
+            "gpu_native_f32_embedding_pipeline",
+            &embedding_pipeline_layout,
+            &embedding_module,
+            "f32_embedding_main",
+        );
+        let q8_0_embedding = pipeline(
+            "gpu_native_q8_0_embedding_pipeline",
+            &embedding_pipeline_layout,
+            &embedding_module,
+            "q8_0_embedding_main",
+        );
+        Self {
+            gemv_bind_group_layout,
+            embedding_bind_group_layout,
+            f32_gemv,
+            q8_0_gemv,
+            f32_embedding,
+            q8_0_embedding,
+        }
+    }
+}
+
 /// Internal bootstrap for future GPU-owned token execution.
 ///
 /// Retaining the exact `Arc<BackendBox>` keeps the authoritative non-cloneable
 /// WGPU `Device` and `Queue` alive. It does not request or select hardware and
 /// it is intentionally absent from all current execution-plan resolution.
 pub(crate) struct GpuNativeExecutorContext {
+    context_id: u64,
     authoritative_backend: Arc<BackendBox>,
     device_identity: GpuDeviceIdentity,
     layout: GpuNativeTokenStateLayout,
+    dense_weights: ParkingMutex<GpuNativeDenseWeightRegistry>,
+    dense_pipelines: GpuNativeDensePipelines,
     counters: GpuNativeExecutionCounters,
 }
 
@@ -306,11 +1044,16 @@ impl GpuNativeExecutorContext {
         let layout = GpuNativeTokenStateLayout::try_new(d_model)?;
         layout.validate_for_limits(&gpu.device.limits())?;
         let device_identity = gpu.gpu_device_identity();
+        let context_id = next_nonzero_id(&NEXT_GPU_NATIVE_CONTEXT_ID, "context");
+        let dense_pipelines = GpuNativeDensePipelines::new(&gpu.device);
 
         Ok(Self {
+            context_id,
             authoritative_backend,
             device_identity,
             layout,
+            dense_weights: ParkingMutex::new(GpuNativeDenseWeightRegistry::new(context_id)),
+            dense_pipelines,
             counters: GpuNativeExecutionCounters::default(),
         })
     }
@@ -351,12 +1094,339 @@ impl GpuNativeExecutorContext {
         )?;
 
         Ok(GpuNativeTokenState::from_buffers(
+            self.context_id,
             state_id,
             self.layout,
             hidden,
             residual,
             status,
         ))
+    }
+
+    /// Register one immutable model-scoped dense tensor and upload its payload
+    /// exactly once. This is the only dense-weight upload path in the
+    /// GPU-native plane; encoded GEMV and embedding calls only bind this
+    /// persistent buffer.
+    pub(crate) fn register_dense_weight(
+        &self,
+        key: GpuNativeDenseWeightKey,
+        weight: &DenseWeight,
+    ) -> Result<GpuNativeDenseWeightHandle, GpuNativeBootstrapError> {
+        let gpu = self.authoritative_gpu()?;
+        let layout = GpuNativeDenseWeightLayout::from_weight(weight)?;
+        let label = format!("gpu_native_dense_weight_{}", key.as_str());
+        layout.validate_for_limits(&label, &gpu.device.limits())?;
+
+        // Serialize the duplicate check through insertion so two startup
+        // registrars cannot both upload the same stable key.
+        let mut registry = self.dense_weights.lock();
+        if registry.weights.contains_key(&key) {
+            return Err(GpuNativeBootstrapError::DuplicateDenseWeight {
+                key: key.as_str().to_string(),
+            });
+        }
+        let buffer = create_startup_buffer(
+            &gpu.device,
+            &label,
+            layout.allocation_bytes,
+            GpuNativeDenseWeightLayout::usage(),
+        )?;
+        match weight {
+            DenseWeight::F32 { values, .. } => {
+                gpu.queue
+                    .write_buffer(&buffer, 0, bytemuck::cast_slice(values));
+            }
+            DenseWeight::Q8_0 { bytes, .. } if bytes.len() as u64 == layout.allocation_bytes => {
+                gpu.queue.write_buffer(&buffer, 0, bytes);
+            }
+            DenseWeight::Q8_0 { bytes, .. } => {
+                let mut upload = Vec::with_capacity(layout.allocation_bytes as usize);
+                upload.extend_from_slice(bytes);
+                upload.resize(layout.allocation_bytes as usize, 0);
+                gpu.queue.write_buffer(&buffer, 0, &upload);
+            }
+        }
+        let registered = GpuNativeDenseWeight {
+            weight_id: next_nonzero_id(&NEXT_GPU_NATIVE_WEIGHT_ID, "dense weight"),
+            key,
+            layout,
+            buffer,
+        };
+        let handle = registry.insert(registered)?;
+        self.counters
+            .record_dense_weight_registration(layout.allocation_bytes);
+        Ok(handle)
+    }
+
+    pub(crate) fn dense_weight_handle(
+        &self,
+        key: &GpuNativeDenseWeightKey,
+        expected_kind: GpuNativeDenseWeightKind,
+        expected_rows: usize,
+        expected_cols: usize,
+    ) -> Result<GpuNativeDenseWeightHandle, GpuNativeBootstrapError> {
+        self.dense_weights
+            .lock()
+            .handle_for(key, expected_kind, expected_rows, expected_cols)
+    }
+
+    pub(crate) fn create_scratch(
+        &self,
+        elements: usize,
+    ) -> Result<GpuNativeScratch, GpuNativeBootstrapError> {
+        let gpu = self.authoritative_gpu()?;
+        let layout = GpuNativeScratchLayout::try_new(elements)?;
+        layout.validate_for_limits(&gpu.device.limits())?;
+        let scratch_id = next_nonzero_id(&NEXT_GPU_NATIVE_SCRATCH_ID, "scratch");
+        let buffer = create_startup_buffer(
+            &gpu.device,
+            &format!("gpu_native_scratch_{scratch_id}"),
+            layout.bytes,
+            GpuNativeScratchLayout::usage(),
+        )?;
+        Ok(GpuNativeScratch::from_buffer(
+            self.context_id,
+            scratch_id,
+            layout,
+            buffer,
+        ))
+    }
+
+    /// Encode `weight[rows, cols] * state.hidden[cols] -> output[rows]`.
+    pub(crate) fn encode_dense_gemv_hidden_to_scratch(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        handle: &GpuNativeDenseWeightHandle,
+        state: &GpuNativeTokenState,
+        output: &GpuNativeScratch,
+    ) -> Result<(), GpuNativeBootstrapError> {
+        if state.context_id != self.context_id {
+            return Err(GpuNativeBootstrapError::ForeignTokenState);
+        }
+        if output.context_id != self.context_id {
+            return Err(GpuNativeBootstrapError::ForeignScratch);
+        }
+        self.encode_dense_gemv_buffers(
+            encoder,
+            handle,
+            &state.hidden,
+            state.layout.d_model,
+            &output.buffer,
+            output.layout.elements,
+        )
+    }
+
+    /// Encode `weight * input -> output` between distinct request scratch
+    /// buffers without exposing either raw WGPU buffer outside this module.
+    pub(crate) fn encode_dense_gemv_scratch_to_scratch(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        handle: &GpuNativeDenseWeightHandle,
+        input: &GpuNativeScratch,
+        output: &GpuNativeScratch,
+    ) -> Result<(), GpuNativeBootstrapError> {
+        if input.context_id != self.context_id || output.context_id != self.context_id {
+            return Err(GpuNativeBootstrapError::ForeignScratch);
+        }
+        if input.scratch_id == output.scratch_id {
+            return Err(GpuNativeBootstrapError::AliasedInputOutput);
+        }
+        self.encode_dense_gemv_buffers(
+            encoder,
+            handle,
+            &input.buffer,
+            input.layout.elements,
+            &output.buffer,
+            output.layout.elements,
+        )
+    }
+
+    /// Encode `weight * input -> state.hidden` for a matrix whose row count is
+    /// exactly d_model.
+    pub(crate) fn encode_dense_gemv_scratch_to_hidden(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        handle: &GpuNativeDenseWeightHandle,
+        input: &GpuNativeScratch,
+        state: &GpuNativeTokenState,
+    ) -> Result<(), GpuNativeBootstrapError> {
+        if input.context_id != self.context_id {
+            return Err(GpuNativeBootstrapError::ForeignScratch);
+        }
+        if state.context_id != self.context_id {
+            return Err(GpuNativeBootstrapError::ForeignTokenState);
+        }
+        self.encode_dense_gemv_buffers(
+            encoder,
+            handle,
+            &input.buffer,
+            input.layout.elements,
+            &state.hidden,
+            state.layout.d_model,
+        )
+    }
+
+    fn encode_dense_gemv_buffers(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        handle: &GpuNativeDenseWeightHandle,
+        input: &wgpu::Buffer,
+        input_elements: usize,
+        output: &wgpu::Buffer,
+        output_elements: usize,
+    ) -> Result<(), GpuNativeBootstrapError> {
+        let gpu = self.authoritative_gpu()?;
+        let weight = self.dense_weights.lock().resolve(handle)?;
+        if input_elements != weight.layout.cols {
+            return Err(GpuNativeBootstrapError::GemvInputLength {
+                expected: weight.layout.cols,
+                actual: input_elements,
+            });
+        }
+        if output_elements != weight.layout.rows {
+            return Err(GpuNativeBootstrapError::GemvOutputLength {
+                expected: weight.layout.rows,
+                actual: output_elements,
+            });
+        }
+        let workgroups = self.checked_workgroups(weight.layout.rows, &gpu.device.limits())?;
+        let bind_group = gpu.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("gpu_native_dense_gemv_bind_group"),
+            layout: &self.dense_pipelines.gemv_bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: weight.buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: input.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: output.as_entire_binding(),
+                },
+            ],
+        });
+        let pipeline = match weight.layout.kind {
+            GpuNativeDenseWeightKind::F32 => &self.dense_pipelines.f32_gemv,
+            GpuNativeDenseWeightKind::Q8_0 => &self.dense_pipelines.q8_0_gemv,
+        };
+        let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+            label: Some("gpu_native_dense_gemv_pass"),
+            timestamp_writes: None,
+        });
+        pass.set_pipeline(pipeline);
+        pass.set_bind_group(0, &bind_group, &[]);
+        pass.set_push_constants(
+            0,
+            bytemuck::bytes_of(&GpuNativeGemvPushConstants {
+                rows: weight.layout.rows as u32,
+                cols: weight.layout.cols as u32,
+                _pad0: 0,
+                _pad1: 0,
+            }),
+        );
+        pass.dispatch_workgroups(workgroups, 1, 1);
+        drop(pass);
+        self.counters.record_dense_gemv_dispatch();
+        Ok(())
+    }
+
+    /// Encode one embedding row directly into request-local hidden state.
+    pub(crate) fn encode_embedding_lookup(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        handle: &GpuNativeDenseWeightHandle,
+        token_id: u32,
+        state: &GpuNativeTokenState,
+    ) -> Result<(), GpuNativeBootstrapError> {
+        let gpu = self.authoritative_gpu()?;
+        if state.context_id != self.context_id {
+            return Err(GpuNativeBootstrapError::ForeignTokenState);
+        }
+        let weight = self.dense_weights.lock().resolve(handle)?;
+        weight.layout.validate_embedding_token(token_id)?;
+        if weight.layout.cols != state.layout.d_model {
+            return Err(GpuNativeBootstrapError::EmbeddingWidth {
+                expected: state.layout.d_model,
+                actual: weight.layout.cols,
+            });
+        }
+        let workgroups = self.checked_workgroups(weight.layout.cols, &gpu.device.limits())?;
+        let bind_group = gpu.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("gpu_native_embedding_bind_group"),
+            layout: &self.dense_pipelines.embedding_bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: weight.buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: state.hidden.as_entire_binding(),
+                },
+            ],
+        });
+        let pipeline = match weight.layout.kind {
+            GpuNativeDenseWeightKind::F32 => &self.dense_pipelines.f32_embedding,
+            GpuNativeDenseWeightKind::Q8_0 => &self.dense_pipelines.q8_0_embedding,
+        };
+        let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+            label: Some("gpu_native_embedding_pass"),
+            timestamp_writes: None,
+        });
+        pass.set_pipeline(pipeline);
+        pass.set_bind_group(0, &bind_group, &[]);
+        pass.set_push_constants(
+            0,
+            bytemuck::bytes_of(&GpuNativeEmbeddingPushConstants {
+                token_id,
+                rows: weight.layout.rows as u32,
+                cols: weight.layout.cols as u32,
+                _pad: 0,
+            }),
+        );
+        pass.dispatch_workgroups(workgroups, 1, 1);
+        drop(pass);
+        self.counters.record_embedding_dispatch();
+        Ok(())
+    }
+
+    fn authoritative_gpu(&self) -> Result<&super::GpuBackend, GpuNativeBootstrapError> {
+        let gpu = match self.authoritative_backend.as_ref() {
+            BackendBox::Gpu(gpu) => gpu,
+            BackendBox::Cpu(_) => return Err(GpuNativeBootstrapError::GpuBackendUnavailable),
+            #[cfg(test)]
+            BackendBox::TestGpu(_) => {
+                return Err(GpuNativeBootstrapError::GpuBackendUnavailable);
+            }
+        };
+        if let Some(detail) = gpu.device_loss.detail() {
+            return Err(GpuNativeBootstrapError::DeviceLost { detail });
+        }
+        Ok(gpu)
+    }
+
+    fn checked_workgroups(
+        &self,
+        elements: usize,
+        limits: &wgpu::Limits,
+    ) -> Result<u32, GpuNativeBootstrapError> {
+        let elements = u64::try_from(elements).map_err(|_| {
+            GpuNativeBootstrapError::DispatchGeometryUnsupported {
+                workgroups: u64::MAX,
+                maximum: limits.max_compute_workgroups_per_dimension,
+            }
+        })?;
+        let workgroups = elements.div_ceil(GPU_NATIVE_WORKGROUP_SIZE as u64);
+        if workgroups > limits.max_compute_workgroups_per_dimension as u64 {
+            return Err(GpuNativeBootstrapError::DispatchGeometryUnsupported {
+                workgroups,
+                maximum: limits.max_compute_workgroups_per_dimension,
+            });
+        }
+        Ok(workgroups as u32)
     }
 
     pub(crate) fn device_identity(&self) -> &GpuDeviceIdentity {
@@ -385,7 +1455,311 @@ impl fmt::Debug for GpuNativeExecutorContext {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::inference::{dequantize_q8_0_block, quantize_q8_0_block};
     use std::sync::atomic::AtomicUsize;
+
+    fn q8_bytes(values: &[f32]) -> Vec<u8> {
+        let mut bytes = vec![0; values.len().div_ceil(Q8_0_BLOCK_ELEMS) * Q8_0_BLOCK_BYTES];
+        for (block, chunk) in values.chunks(Q8_0_BLOCK_ELEMS).enumerate() {
+            quantize_q8_0_block(
+                chunk,
+                &mut bytes[block * Q8_0_BLOCK_BYTES..(block + 1) * Q8_0_BLOCK_BYTES],
+            );
+        }
+        bytes
+    }
+
+    fn read_q8_mirror(bytes: &[u8], flat_index: usize) -> f32 {
+        let block = flat_index / Q8_0_BLOCK_ELEMS;
+        let in_block = flat_index % Q8_0_BLOCK_ELEMS;
+        let offset = block * Q8_0_BLOCK_BYTES;
+        let scale = half::f16::from_le_bytes([bytes[offset], bytes[offset + 1]]).to_f32();
+        scale * (bytes[offset + 2 + in_block] as i8 as f32)
+    }
+
+    fn q8_gemv_mirror(bytes: &[u8], rows: usize, cols: usize, input: &[f32]) -> Vec<f32> {
+        (0..rows)
+            .map(|row| {
+                let mut sum = 0.0;
+                for col in 0..cols {
+                    sum += read_q8_mirror(bytes, row * cols + col) * input[col];
+                }
+                sum
+            })
+            .collect()
+    }
+
+    fn assert_close(actual: &[f32], expected: &[f32], tolerance: f32) {
+        assert_eq!(actual.len(), expected.len());
+        for (index, (&actual, &expected)) in actual.iter().zip(expected).enumerate() {
+            assert!(
+                (actual - expected).abs() <= tolerance,
+                "index {index}: actual={actual}, expected={expected}, tolerance={tolerance}"
+            );
+        }
+    }
+
+    fn test_weight<B>(
+        weight_id: u64,
+        key: &str,
+        layout: GpuNativeDenseWeightLayout,
+        buffer: B,
+    ) -> GpuNativeDenseWeight<B> {
+        GpuNativeDenseWeight {
+            weight_id,
+            key: GpuNativeDenseWeightKey::try_new(key).unwrap(),
+            layout,
+            buffer,
+        }
+    }
+
+    #[test]
+    fn f32_persistent_weight_layout_charges_exact_bytes() {
+        let weight = DenseWeight::from_f32(vec![0.0; 15], 3, 5);
+        let layout = GpuNativeDenseWeightLayout::from_weight(&weight).unwrap();
+        assert_eq!(layout.kind(), GpuNativeDenseWeightKind::F32);
+        assert_eq!((layout.rows(), layout.cols()), (3, 5));
+        assert_eq!(layout.payload_bytes(), 60);
+        assert_eq!(layout.allocation_bytes(), 60);
+    }
+
+    #[test]
+    fn q8_persistent_weight_layout_preserves_flat_blocks_and_wgpu_padding() {
+        // 3x35 deliberately makes rows cross block boundaries and leaves a
+        // final partial block: ceil(105/32) * 34 = 136 bytes.
+        let values = (0..105).map(|i| i as f32 - 52.0).collect::<Vec<_>>();
+        let weight = DenseWeight::from_q8_0_bytes(q8_bytes(&values), 3, 35).unwrap();
+        let layout = GpuNativeDenseWeightLayout::from_weight(&weight).unwrap();
+        assert_eq!(layout.kind(), GpuNativeDenseWeightKind::Q8_0);
+        assert_eq!((layout.rows(), layout.cols()), (3, 35));
+        assert_eq!(layout.payload_bytes(), 136);
+        assert_eq!(layout.allocation_bytes(), 136);
+
+        let one_block = GpuNativeDenseWeightLayout::try_new(
+            GpuNativeDenseWeightKind::Q8_0,
+            1,
+            32,
+            Q8_0_BLOCK_BYTES,
+        )
+        .unwrap();
+        assert_eq!(one_block.payload_bytes(), 34);
+        assert_eq!(one_block.allocation_bytes(), 36);
+    }
+
+    #[test]
+    fn dense_weight_layout_rejects_empty_malformed_and_overflowing_shapes() {
+        assert_eq!(
+            GpuNativeDenseWeightLayout::try_new(GpuNativeDenseWeightKind::F32, 0, 4, 0),
+            Err(GpuNativeBootstrapError::InvalidDenseWeightShape { rows: 0, cols: 4 })
+        );
+        assert_eq!(
+            GpuNativeDenseWeightLayout::try_new(GpuNativeDenseWeightKind::Q8_0, 1, 32, 33),
+            Err(GpuNativeBootstrapError::DenseWeightByteLength {
+                kind: GpuNativeDenseWeightKind::Q8_0,
+                rows: 1,
+                cols: 32,
+                expected: 34,
+                actual: 33,
+            })
+        );
+        assert_eq!(
+            GpuNativeDenseWeightLayout::try_new(GpuNativeDenseWeightKind::F32, usize::MAX, 2, 0,),
+            Err(GpuNativeBootstrapError::DenseWeightShapeOverflow {
+                rows: usize::MAX,
+                cols: 2,
+            })
+        );
+        if usize::BITS > u32::BITS {
+            let rows = u32::MAX as usize + 1;
+            assert_eq!(
+                GpuNativeDenseWeightLayout::try_new(
+                    GpuNativeDenseWeightKind::F32,
+                    rows,
+                    1,
+                    rows * std::mem::size_of::<f32>(),
+                ),
+                Err(GpuNativeBootstrapError::DenseWeightDimensionTooLarge { rows, cols: 1 })
+            );
+        }
+    }
+
+    #[test]
+    fn registry_missing_duplicate_kind_shape_and_context_checks_fail_closed() {
+        let f32_layout =
+            GpuNativeDenseWeightLayout::try_new(GpuNativeDenseWeightKind::F32, 3, 5, 60).unwrap();
+        let key = GpuNativeDenseWeightKey::try_new("embedding").unwrap();
+        let mut registry = GpuNativeDenseWeightRegistry::new(41);
+        assert_eq!(
+            registry.handle_for(&key, GpuNativeDenseWeightKind::F32, 3, 5),
+            Err(GpuNativeBootstrapError::MissingDenseWeight {
+                key: "embedding".to_string(),
+            })
+        );
+
+        let handle = registry
+            .insert(test_weight(7, "embedding", f32_layout, ()))
+            .unwrap();
+        assert_eq!(handle.layout().kind(), GpuNativeDenseWeightKind::F32);
+        assert_eq!(
+            registry.insert(test_weight(8, "embedding", f32_layout, ())),
+            Err(GpuNativeBootstrapError::DuplicateDenseWeight {
+                key: "embedding".to_string(),
+            })
+        );
+        assert_eq!(
+            registry.handle_for(&key, GpuNativeDenseWeightKind::Q8_0, 3, 5),
+            Err(GpuNativeBootstrapError::DenseWeightKindMismatch {
+                key: "embedding".to_string(),
+                expected: GpuNativeDenseWeightKind::Q8_0,
+                actual: GpuNativeDenseWeightKind::F32,
+            })
+        );
+        assert_eq!(
+            registry.handle_for(&key, GpuNativeDenseWeightKind::F32, 4, 5),
+            Err(GpuNativeBootstrapError::DenseWeightShapeMismatch {
+                key: "embedding".to_string(),
+                expected_rows: 4,
+                expected_cols: 5,
+                actual_rows: 3,
+                actual_cols: 5,
+            })
+        );
+
+        let other_registry = GpuNativeDenseWeightRegistry::<()>::new(42);
+        assert!(matches!(
+            other_registry.resolve(&handle),
+            Err(GpuNativeBootstrapError::ForeignDenseWeightHandle)
+        ));
+        let mut stale = handle;
+        stale.weight_id += 1;
+        assert!(matches!(
+            registry.resolve(&stale),
+            Err(GpuNativeBootstrapError::StaleDenseWeightHandle { .. })
+        ));
+    }
+
+    #[test]
+    fn q8_shader_mirror_matches_repository_dequant_and_signed_scale_semantics() {
+        let mut bytes = vec![0u8; 2 * Q8_0_BLOCK_BYTES];
+        for (block, scale) in [-0.5f32, 0.25f32].into_iter().enumerate() {
+            let offset = block * Q8_0_BLOCK_BYTES;
+            bytes[offset..offset + 2].copy_from_slice(&half::f16::from_f32(scale).to_le_bytes());
+            for i in 0..Q8_0_BLOCK_ELEMS {
+                bytes[offset + 2 + i] = (i as i8 - 16) as u8;
+            }
+            let mut expected = [0.0; Q8_0_BLOCK_ELEMS];
+            dequantize_q8_0_block(&bytes[offset..offset + Q8_0_BLOCK_BYTES], &mut expected);
+            for (i, &expected) in expected.iter().enumerate() {
+                assert_eq!(
+                    read_q8_mirror(&bytes, block * Q8_0_BLOCK_ELEMS + i),
+                    expected
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn f32_and_q8_host_mirrors_match_dense_weight_cpu_matvec() {
+        let rows = 3;
+        let cols = 35;
+        let values = (0..rows * cols)
+            .map(|i| ((i * 17 % 43) as f32 - 21.0) / 7.0)
+            .collect::<Vec<_>>();
+        let input = (0..cols)
+            .map(|i| ((i * 11 % 19) as f32 - 9.0) / 5.0)
+            .collect::<Vec<_>>();
+
+        let f32_weight = DenseWeight::from_f32(values.clone(), rows, cols);
+        let mut f32_mirror = vec![0.0; rows];
+        for row in 0..rows {
+            for col in 0..cols {
+                f32_mirror[row] += values[row * cols + col] * input[col];
+            }
+        }
+        assert_close(&f32_mirror, &f32_weight.matvec(&input), 1e-5);
+
+        let bytes = q8_bytes(&values);
+        let q8_weight = DenseWeight::from_q8_0_bytes(bytes.clone(), rows, cols).unwrap();
+        let q8_mirror = q8_gemv_mirror(&bytes, rows, cols, &input);
+        assert_close(&q8_mirror, &q8_weight.matvec(&input), 1e-5);
+    }
+
+    #[test]
+    fn embedding_bounds_and_row_mirror_cover_first_middle_last_and_invalid() {
+        let rows = 5;
+        let cols = 7;
+        let values = (0..rows * cols)
+            .map(|i| i as f32 - 10.0)
+            .collect::<Vec<_>>();
+        let bytes = q8_bytes(&values);
+        let weight = DenseWeight::from_q8_0_bytes(bytes.clone(), rows, cols).unwrap();
+        let layout = GpuNativeDenseWeightLayout::from_weight(&weight).unwrap();
+        for token in [0u32, 2, 4] {
+            layout.validate_embedding_token(token).unwrap();
+            let mut expected = Vec::new();
+            weight.row_dequant_into(token as usize, &mut expected);
+            let actual = (0..cols)
+                .map(|col| read_q8_mirror(&bytes, token as usize * cols + col))
+                .collect::<Vec<_>>();
+            assert_eq!(actual, expected);
+        }
+        assert_eq!(
+            layout.validate_embedding_token(5),
+            Err(GpuNativeBootstrapError::InvalidEmbeddingToken {
+                token_id: 5,
+                vocab_size: 5,
+            })
+        );
+    }
+
+    #[test]
+    fn registration_and_dispatch_counters_keep_uploads_distinct() {
+        let counters = GpuNativeExecutionCounters::default();
+        counters.record_dense_weight_registration(36);
+        let after_registration = counters.snapshot();
+        assert_eq!(after_registration.dense_weights_registered, 1);
+        assert_eq!(after_registration.dense_weight_uploads, 1);
+        assert_eq!(after_registration.dense_weight_upload_bytes, 36);
+        assert_eq!(after_registration.dense_weight_resident_bytes, 36);
+        assert_eq!(after_registration.dense_gemv_dispatches, 0);
+
+        counters.record_dense_gemv_dispatch();
+        counters.record_dense_gemv_dispatch();
+        counters.record_embedding_dispatch();
+        let after_dispatch = counters.snapshot();
+        assert_eq!(after_dispatch.dense_weight_uploads, 1);
+        assert_eq!(after_dispatch.dense_weight_upload_bytes, 36);
+        assert_eq!(after_dispatch.dense_gemv_dispatches, 2);
+        assert_eq!(after_dispatch.embedding_dispatches, 1);
+    }
+
+    #[test]
+    fn gpu_native_dense_shaders_parse_and_validate_without_hardware() {
+        for (source, entry_points) in [
+            (
+                GPU_NATIVE_DENSE_GEMV_SHADER,
+                &["f32_gemv_main", "q8_0_gemv_main"][..],
+            ),
+            (
+                GPU_NATIVE_EMBEDDING_SHADER,
+                &["f32_embedding_main", "q8_0_embedding_main"][..],
+            ),
+        ] {
+            let module = naga::front::wgsl::parse_str(source).expect("GPU-native WGSL must parse");
+            naga::valid::Validator::new(
+                naga::valid::ValidationFlags::all(),
+                naga::valid::Capabilities::all(),
+            )
+            .validate(&module)
+            .expect("GPU-native WGSL must validate");
+            for entry_point in entry_points {
+                assert!(module
+                    .entry_points
+                    .iter()
+                    .any(|entry| entry.name == *entry_point));
+            }
+        }
+    }
 
     #[test]
     fn checked_layout_derives_qwen_vector_bytes() {
@@ -449,6 +1823,29 @@ mod tests {
         let status = GpuNativeTokenStateLayout::status_usage();
         assert!(status.contains(wgpu::BufferUsages::COPY_SRC));
         assert!(!status.intersects(wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::MAP_WRITE));
+
+        for usage in [
+            GpuNativeScratchLayout::usage(),
+            GpuNativeDenseWeightLayout::usage(),
+        ] {
+            assert!(usage.contains(wgpu::BufferUsages::STORAGE));
+            assert!(!usage.contains(wgpu::BufferUsages::COPY_SRC));
+            assert!(!usage.intersects(wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::MAP_WRITE));
+        }
+    }
+
+    #[test]
+    fn scratch_layout_is_checked_and_variable_width() {
+        let q = GpuNativeScratchLayout::try_new(4096).unwrap();
+        let kv = GpuNativeScratchLayout::try_new(512).unwrap();
+        let router = GpuNativeScratchLayout::try_new(128).unwrap();
+        assert_eq!((q.elements(), q.bytes()), (4096, 16_384));
+        assert_eq!((kv.elements(), kv.bytes()), (512, 2048));
+        assert_eq!((router.elements(), router.bytes()), (128, 512));
+        assert_eq!(
+            GpuNativeScratchLayout::try_new(0),
+            Err(GpuNativeBootstrapError::InvalidScratchElements)
+        );
     }
 
     #[derive(Debug)]
@@ -469,6 +1866,7 @@ mod tests {
         drops: Arc<AtomicUsize>,
     ) -> GpuNativeTokenState<DropProbe> {
         GpuNativeTokenState::from_buffers(
+            1,
             next_gpu_native_token_state_id(),
             layout,
             DropProbe {
@@ -512,6 +1910,34 @@ mod tests {
         assert_eq!(drops.load(Ordering::Relaxed), 0);
         drop(state);
         assert_eq!(drops.load(Ordering::Relaxed), 3);
+    }
+
+    #[test]
+    fn request_state_ownership_is_separate_from_model_weight_registry() {
+        let layout = GpuNativeTokenStateLayout::try_new(32).unwrap();
+        let state_drops = Arc::new(AtomicUsize::new(0));
+        let weight_drops = Arc::new(AtomicUsize::new(0));
+        let state = test_state(layout, 1, state_drops.clone());
+        let weight_layout =
+            GpuNativeDenseWeightLayout::try_new(GpuNativeDenseWeightKind::F32, 2, 2, 16).unwrap();
+        let mut registry = GpuNativeDenseWeightRegistry::new(1);
+        registry
+            .insert(test_weight(
+                1,
+                "model.weight",
+                weight_layout,
+                DropProbe {
+                    allocation_id: 100,
+                    drops: weight_drops.clone(),
+                },
+            ))
+            .unwrap();
+
+        drop(state);
+        assert_eq!(state_drops.load(Ordering::Relaxed), 3);
+        assert_eq!(weight_drops.load(Ordering::Relaxed), 0);
+        drop(registry);
+        assert_eq!(weight_drops.load(Ordering::Relaxed), 1);
     }
 
     #[test]

--- a/rust-engine/src/backend/wgpu_shaders/gpu_native_dense_gemv.wgsl
+++ b/rust-engine/src/backend/wgpu_shaders/gpu_native_dense_gemv.wgsl
@@ -1,0 +1,64 @@
+// GPU-native row-major GEMV over persistent F32 or repository Q8_0 weights.
+//
+// Matrix convention: W is [rows, cols], X is [cols], OUT is [rows]. Q8_0
+// is one flat tensor stream, so a matrix row may begin/end inside a block.
+// Each 34-byte block stores an f16-LE scale followed by 32 signed i8 values.
+
+struct PushConstants {
+    rows: u32,
+    cols: u32,
+    _pad0: u32,
+    _pad1: u32,
+};
+var<push_constant> pc: PushConstants;
+
+@group(0) @binding(0) var<storage, read> W: array<u32>;
+@group(0) @binding(1) var<storage, read> X: array<f32>;
+@group(0) @binding(2) var<storage, read_write> OUT: array<f32>;
+
+const Q8_0_BLOCK_BYTES: u32 = 34u;
+const Q8_0_BLOCK_ELEMS: u32 = 32u;
+
+fn read_weight_byte(byte_offset: u32) -> u32 {
+    return (W[byte_offset >> 2u] >> ((byte_offset & 3u) * 8u)) & 0xffu;
+}
+
+fn q8_0_value(flat_index: u32) -> f32 {
+    let block = flat_index / Q8_0_BLOCK_ELEMS;
+    let in_block = flat_index % Q8_0_BLOCK_ELEMS;
+    let block_offset = block * Q8_0_BLOCK_BYTES;
+    let scale_bits = read_weight_byte(block_offset)
+        | (read_weight_byte(block_offset + 1u) << 8u);
+    let scale = unpack2x16float(scale_bits).x;
+    let quantized = read_weight_byte(block_offset + 2u + in_block);
+    let signed_value = select(i32(quantized), i32(quantized) - 256, quantized >= 128u);
+    return scale * f32(signed_value);
+}
+
+@compute @workgroup_size(64, 1, 1)
+fn f32_gemv_main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let row = gid.x;
+    if (row >= pc.rows) {
+        return;
+    }
+    let row_start = row * pc.cols;
+    var sum = 0.0;
+    for (var col = 0u; col < pc.cols; col = col + 1u) {
+        sum = sum + bitcast<f32>(W[row_start + col]) * X[col];
+    }
+    OUT[row] = sum;
+}
+
+@compute @workgroup_size(64, 1, 1)
+fn q8_0_gemv_main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let row = gid.x;
+    if (row >= pc.rows) {
+        return;
+    }
+    let row_start = row * pc.cols;
+    var sum = 0.0;
+    for (var col = 0u; col < pc.cols; col = col + 1u) {
+        sum = sum + q8_0_value(row_start + col) * X[col];
+    }
+    OUT[row] = sum;
+}

--- a/rust-engine/src/backend/wgpu_shaders/gpu_native_dense_gemv.wgsl
+++ b/rust-engine/src/backend/wgpu_shaders/gpu_native_dense_gemv.wgsl
@@ -7,8 +7,8 @@
 struct PushConstants {
     rows: u32,
     cols: u32,
-    _pad0: u32,
-    _pad1: u32,
+    global_row_base: u32,
+    q8_first_block: u32,
 };
 var<push_constant> pc: PushConstants;
 
@@ -24,7 +24,7 @@ fn read_weight_byte(byte_offset: u32) -> u32 {
 }
 
 fn q8_0_value(flat_index: u32) -> f32 {
-    let block = flat_index / Q8_0_BLOCK_ELEMS;
+    let block = flat_index / Q8_0_BLOCK_ELEMS - pc.q8_first_block;
     let in_block = flat_index % Q8_0_BLOCK_ELEMS;
     let block_offset = block * Q8_0_BLOCK_BYTES;
     let scale_bits = read_weight_byte(block_offset)
@@ -37,28 +37,29 @@ fn q8_0_value(flat_index: u32) -> f32 {
 
 @compute @workgroup_size(64, 1, 1)
 fn f32_gemv_main(@builtin(global_invocation_id) gid: vec3<u32>) {
-    let row = gid.x;
-    if (row >= pc.rows) {
+    let local_row = gid.x;
+    if (local_row >= pc.rows) {
         return;
     }
-    let row_start = row * pc.cols;
+    let row_start = local_row * pc.cols;
     var sum = 0.0;
     for (var col = 0u; col < pc.cols; col = col + 1u) {
         sum = sum + bitcast<f32>(W[row_start + col]) * X[col];
     }
-    OUT[row] = sum;
+    OUT[pc.global_row_base + local_row] = sum;
 }
 
 @compute @workgroup_size(64, 1, 1)
 fn q8_0_gemv_main(@builtin(global_invocation_id) gid: vec3<u32>) {
-    let row = gid.x;
-    if (row >= pc.rows) {
+    let local_row = gid.x;
+    if (local_row >= pc.rows) {
         return;
     }
-    let row_start = row * pc.cols;
+    let global_row = pc.global_row_base + local_row;
+    let row_start = global_row * pc.cols;
     var sum = 0.0;
     for (var col = 0u; col < pc.cols; col = col + 1u) {
         sum = sum + q8_0_value(row_start + col) * X[col];
     }
-    OUT[row] = sum;
+    OUT[global_row] = sum;
 }

--- a/rust-engine/src/backend/wgpu_shaders/gpu_native_embedding.wgsl
+++ b/rust-engine/src/backend/wgpu_shaders/gpu_native_embedding.wgsl
@@ -1,0 +1,51 @@
+// Copy/dequantize one row of a persistent [vocab_size, d_model] embedding
+// directly into GPU-native hidden state. Token ID is a push-constant control
+// scalar; the weight and destination never cross the host boundary here.
+
+struct PushConstants {
+    token_id: u32,
+    rows: u32,
+    cols: u32,
+    _pad: u32,
+};
+var<push_constant> pc: PushConstants;
+
+@group(0) @binding(0) var<storage, read> W: array<u32>;
+@group(0) @binding(1) var<storage, read_write> HIDDEN: array<f32>;
+
+const Q8_0_BLOCK_BYTES: u32 = 34u;
+const Q8_0_BLOCK_ELEMS: u32 = 32u;
+
+fn read_weight_byte(byte_offset: u32) -> u32 {
+    return (W[byte_offset >> 2u] >> ((byte_offset & 3u) * 8u)) & 0xffu;
+}
+
+fn q8_0_value(flat_index: u32) -> f32 {
+    let block = flat_index / Q8_0_BLOCK_ELEMS;
+    let in_block = flat_index % Q8_0_BLOCK_ELEMS;
+    let block_offset = block * Q8_0_BLOCK_BYTES;
+    let scale_bits = read_weight_byte(block_offset)
+        | (read_weight_byte(block_offset + 1u) << 8u);
+    let scale = unpack2x16float(scale_bits).x;
+    let quantized = read_weight_byte(block_offset + 2u + in_block);
+    let signed_value = select(i32(quantized), i32(quantized) - 256, quantized >= 128u);
+    return scale * f32(signed_value);
+}
+
+@compute @workgroup_size(64, 1, 1)
+fn f32_embedding_main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let col = gid.x;
+    if (col >= pc.cols) {
+        return;
+    }
+    HIDDEN[col] = bitcast<f32>(W[pc.token_id * pc.cols + col]);
+}
+
+@compute @workgroup_size(64, 1, 1)
+fn q8_0_embedding_main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let col = gid.x;
+    if (col >= pc.cols) {
+        return;
+    }
+    HIDDEN[col] = q8_0_value(pc.token_id * pc.cols + col);
+}

--- a/rust-engine/src/backend/wgpu_shaders/gpu_native_embedding.wgsl
+++ b/rust-engine/src/backend/wgpu_shaders/gpu_native_embedding.wgsl
@@ -3,10 +3,10 @@
 // scalar; the weight and destination never cross the host boundary here.
 
 struct PushConstants {
-    token_id: u32,
-    rows: u32,
+    local_row: u32,
+    global_row: u32,
     cols: u32,
-    _pad: u32,
+    q8_first_block: u32,
 };
 var<push_constant> pc: PushConstants;
 
@@ -21,7 +21,7 @@ fn read_weight_byte(byte_offset: u32) -> u32 {
 }
 
 fn q8_0_value(flat_index: u32) -> f32 {
-    let block = flat_index / Q8_0_BLOCK_ELEMS;
+    let block = flat_index / Q8_0_BLOCK_ELEMS - pc.q8_first_block;
     let in_block = flat_index % Q8_0_BLOCK_ELEMS;
     let block_offset = block * Q8_0_BLOCK_BYTES;
     let scale_bits = read_weight_byte(block_offset)
@@ -38,7 +38,7 @@ fn f32_embedding_main(@builtin(global_invocation_id) gid: vec3<u32>) {
     if (col >= pc.cols) {
         return;
     }
-    HIDDEN[col] = bitcast<f32>(W[pc.token_id * pc.cols + col]);
+    HIDDEN[col] = bitcast<f32>(W[pc.local_row * pc.cols + col]);
 }
 
 @compute @workgroup_size(64, 1, 1)
@@ -47,5 +47,5 @@ fn q8_0_embedding_main(@builtin(global_invocation_id) gid: vec3<u32>) {
     if (col >= pc.cols) {
         return;
     }
-    HIDDEN[col] = q8_0_value(pc.token_id * pc.cols + col);
+    HIDDEN[col] = q8_0_value(pc.global_row * pc.cols + col);
 }


### PR DESCRIPTION
## Summary

Adds Slice 2 of the GPU-native executor foundation on top of the merged bootstrap:

- persistent model-scoped dense-weight residency on the authoritative WGPU device
- F32 and native Q8_0 device GEMV encoded into caller-owned command encoders
- F32 and Q8_0 embedding lookup directly into GPU-native hidden state
- request-scoped variable-width scratch buffers
- chunked physical dense-weight storage derived from enabled WGPU buffer/storage-binding limits
- logical vs physical dispatch/upload accounting
- an ignored live hardware validation seam that compares results on-device and maps only a four-byte aggregate status

The existing CPU/Hybrid paths, PR7 routed-expert batching, execution-plan resolution, MER residency/cache, and SSD behavior are unchanged. This PR does not expose a production GPU-native execution mode or implement a transformer token loop.

## Large-weight residency

The initial single-buffer implementation was corrected before hardware qualification. Large logical tensors now split into independently bindable row chunks using `min(max_buffer_size, max_storage_buffer_binding_size)`.

For Q8_0, chunking preserves MER's flat 32-element / 34-byte block stream. Adjacent chunks may duplicate a boundary block, while shader push constants translate global flat-block indices to chunk-local blocks without requantization or persistent F32 dequantization.

A pure regression test covers Qwen geometry `151936 x 2048` under 128 MiB storage / 256 MiB buffer limits:

- F32 logical bytes: 1,244,659,712; 10 chunks; largest 134,217,728 bytes
- Q8_0 logical bytes: 330,612,736; 3 chunks; largest 134,215,680 bytes

## Validation

### Mac / hardware-independent

- `git diff --check`: passed
- targeted changed-file rustfmt check: passed
- repository-wide `cargo fmt --check`: only pre-existing unrelated formatting drift
- GPU-native tests: 25 passed, 1 ignored
- Naga/WGSL validation: passed
- backend tests: 77 passed
- full suite: library 53 passed; main 964 passed, 3 ignored; concurrency 4 passed; doc tests passed
- no failures

### NVIDIA L4 live WGPU gate

Frozen candidate: `2e7940299d3e2b4f19884828580af12b9a0a133f`

Hardware:
- NVIDIA L4, 23034 MiB
- driver 580.173.02
- Vulkan via NVIDIA ICD `/usr/share/vulkan/icd.d/nvidia_icd.json`
- no software renderer

Ignored test executed explicitly:

`backend::gpu_native::tests::live_l4_gpu_native_dense_gemv_embedding_persistence`

Result: **PASS** (1 passed, 0 failed)

Validated on-device:
- F32 GEMV
- Q8_0 GEMV
- F32 embedding
- Q8_0 embedding
- repeated-dispatch persistence

Evidence:
- final aggregate validation status: 0 / PASS
- 4 dense weights registered
- startup chunk/uploads: 4
- upload count before/after repeated execution: 4 / 4
- upload bytes before/after: 1392 / 1392
- GEMV logical dispatches: 4
- GEMV chunk dispatches: 4
- embedding dispatches: 6
- intermediate maps: 0
- intermediate readbacks: 0
- primitives submit no work internally; validation harness submits one encoder
- only the final four-byte aggregate status is mapped
- no WGPU validation errors, uncaptured errors, device loss, reset, or panic

## Non-goals

This PR intentionally does not add RMSNorm, RoPE, attention/KV, GPU router/top-k, routed-expert integration, weighted combine, LM-head sampling, model-wide Qwen loading, benchmarks, or any operator-facing GPU-native mode.