### PR TITLE
Connect tiered GPU-native expert residency

### DIFF
--- a/rust-engine/src/backend/gpu_native.rs
+++ b/rust-engine/src/backend/gpu_native.rs
@@ -13131,8 +13131,7 @@ fn compare_main(@builtin(global_invocation_id) gid: vec3<u32>) {
         const NUM_EXPERTS: usize = 128;
         const TOP_K: usize = 2;
         const NUM_LAYERS: usize = 2;
-        const STATUS_AND_HIDDEN_BYTES: u64 =
-            GPU_NATIVE_STATUS_BYTES + (D_MODEL * std::mem::size_of::<f32>()) as u64;
+        const READBACK_BYTES: u64 = GPU_NATIVE_STATUS_BYTES + GPU_NATIVE_STATUS_BYTES;
 
         let geometry =
             GpuNativeQ4ExpertGeometry::try_new(D_MODEL, D_FF, NUM_EXPERTS, TOP_K).unwrap();
@@ -13268,19 +13267,35 @@ fn compare_main(@builtin(global_invocation_id) gid: vec3<u32>) {
         let router_plan = executor
             .create_router_plan(0, router_geometry, gate_handle)
             .unwrap();
+        let (compare_layout, compare_pipeline) = create_test_compare_pipeline(&gpu.device);
         let state = executor.create_token_state().unwrap();
         let router_scratch = executor.create_router_scratch(router_geometry).unwrap();
         let expert_scratch = executor.create_q4_expert_scratch(geometry).unwrap();
         let hidden = vec![1.0; D_MODEL];
         let residual = vec![0.25; D_MODEL];
-        let run = |label: &str, clear_retryable: bool| {
+        let run = |label: &str, clear_retryable: bool, expected_hidden: &[f32], tolerance: f32| {
             gpu.queue
                 .write_buffer(&state.hidden, 0, bytemuck::cast_slice(&hidden));
             gpu.queue
                 .write_buffer(&state.residual, 0, bytemuck::cast_slice(&residual));
+            let expected_buffer = create_test_expected_buffer(
+                &gpu.device,
+                &gpu.queue,
+                &format!("{label}_expected_hidden"),
+                expected_hidden,
+            );
+            let comparison_status = gpu.device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some(&format!("{label}_comparison_status")),
+                size: GPU_NATIVE_STATUS_BYTES,
+                usage: wgpu::BufferUsages::STORAGE
+                    | wgpu::BufferUsages::COPY_DST
+                    | wgpu::BufferUsages::COPY_SRC,
+                mapped_at_creation: false,
+            });
+            gpu.queue.write_buffer(&comparison_status, 0, &[0; 4]);
             let staging = gpu.device.create_buffer(&wgpu::BufferDescriptor {
                 label: Some(label),
-                size: STATUS_AND_HIDDEN_BYTES,
+                size: READBACK_BYTES,
                 usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
                 mapped_at_creation: false,
             });
@@ -13305,13 +13320,24 @@ fn compare_main(@builtin(global_invocation_id) gid: vec3<u32>) {
                     &expert_scratch,
                 )
                 .unwrap();
+            encode_test_compare(
+                &gpu.device,
+                &mut encoder,
+                &compare_layout,
+                &compare_pipeline,
+                &state.hidden,
+                &expected_buffer,
+                &comparison_status,
+                D_MODEL,
+                tolerance,
+            );
             encoder.copy_buffer_to_buffer(&state.status, 0, &staging, 0, GPU_NATIVE_STATUS_BYTES);
             encoder.copy_buffer_to_buffer(
-                &state.hidden,
+                &comparison_status,
                 0,
                 &staging,
                 GPU_NATIVE_STATUS_BYTES,
-                (D_MODEL * std::mem::size_of::<f32>()) as u64,
+                GPU_NATIVE_STATUS_BYTES,
             );
             gpu.queue.submit(Some(encoder.finish()));
             let slice = staging.slice(..);
@@ -13324,24 +13350,31 @@ fn compare_main(@builtin(global_invocation_id) gid: vec3<u32>) {
                 .expect("tiered residency map callback must be drained")
                 .expect("tiered residency staging must map");
             let mapped = slice.get_mapped_range();
-            let status = u32::from_le_bytes(mapped[..4].try_into().unwrap());
-            let output = mapped[4..]
-                .chunks_exact(4)
-                .map(|bytes| f32::from_le_bytes(bytes.try_into().unwrap()))
-                .collect::<Vec<_>>();
+            let request_status = u32::from_le_bytes(
+                mapped[..GPU_NATIVE_STATUS_BYTES as usize]
+                    .try_into()
+                    .unwrap(),
+            );
+            let comparison_status = u32::from_le_bytes(
+                mapped[GPU_NATIVE_STATUS_BYTES as usize
+                    ..GPU_NATIVE_STATUS_BYTES as usize + GPU_NATIVE_STATUS_BYTES as usize]
+                    .try_into()
+                    .unwrap(),
+            );
             drop(mapped);
             staging.unmap();
-            (status, output)
+            (request_status, comparison_status)
         };
 
         gpu.queue.write_buffer(&state.status, 0, &[0; 4]);
-        let miss = run("gpu_native_tiered_residency_miss", false);
+        let (miss_request_status, miss_comparison_status) =
+            run("gpu_native_tiered_residency_miss", false, &residual, 0.0);
+        assert_eq!(miss_comparison_status, 0);
         assert_eq!(
-            miss.0 & GPU_NATIVE_STATUS_RETRYABLE_MASK,
+            miss_request_status & GPU_NATIVE_STATUS_RETRYABLE_MASK,
             GPU_NATIVE_STATUS_RETRYABLE_MASK
         );
-        assert_eq!(miss.0 & GPU_NATIVE_STATUS_FATAL_MASK, 0);
-        assert_close(&miss.1, &residual, 0.0);
+        assert_eq!(miss_request_status & GPU_NATIVE_STATUS_FATAL_MASK, 0);
 
         let payload_a = q4_uniform_expert(geometry, 0.01, 0.02, 0.005);
         let payload_b = q4_uniform_expert(geometry, -0.012, 0.018, 0.004);
@@ -13369,8 +13402,6 @@ fn compare_main(@builtin(global_invocation_id) gid: vec3<u32>) {
         assert!(manager.has_current_for_demand(128).unwrap());
         assert!(manager.has_current_for_demand(129).unwrap());
 
-        let replay = run("gpu_native_tiered_residency_replay", true);
-        assert_eq!(replay.0, 0);
         let logits = gate.matvec(&hidden);
         let (selected_ids, selected_weights, failed) = router_topk_mirror(&logits, TOP_K);
         assert!(!failed);
@@ -13383,8 +13414,16 @@ fn compare_main(@builtin(global_invocation_id) gid: vec3<u32>) {
             &residual,
             &weighted_expert_combine_mirror(&expert_outputs, &selected_weights),
         );
-        assert!(replay.1.iter().all(|value| value.is_finite()));
-        assert_close(&replay.1, &expected, 5e-4);
+        assert!(expected.iter().all(|value| value.is_finite()));
+        assert!(expected
+            .iter()
+            .zip(&residual)
+            .any(|(expected, residual)| expected != residual));
+
+        let (replay_request_status, replay_comparison_status) =
+            run("gpu_native_tiered_residency_replay", true, &expected, 5e-4);
+        assert_eq!(replay_request_status, 0);
+        assert_eq!(replay_comparison_status, 0);
 
         // Evict and re-admit logical id 2 to obtain a strictly newer real
         // generation, then prove the saved stale requester cannot disturb it.

--- a/rust-engine/src/backend/gpu_native.rs
+++ b/rust-engine/src/backend/gpu_native.rs
@@ -34,6 +34,11 @@ pub(crate) const GPU_NATIVE_STATUS_FATAL_MASK: u32 = GPU_NATIVE_STATUS_ATTENTION
     | GPU_NATIVE_STATUS_ROUTER_NUMERICAL_FAILURE
     | GPU_NATIVE_STATUS_EXPERT_NUMERICAL_FAILURE;
 pub(crate) const GPU_NATIVE_STATUS_RETRYABLE_MASK: u32 = GPU_NATIVE_STATUS_EXPERT_RESIDENCY_MISS;
+
+#[inline]
+pub(crate) const fn status_after_retryable_clear(status: u32) -> u32 {
+    status & !GPU_NATIVE_STATUS_RETRYABLE_MASK
+}
 const GPU_NATIVE_DENSE_GEMV_SHADER: &str = include_str!("wgpu_shaders/gpu_native_dense_gemv.wgsl");
 const GPU_NATIVE_EMBEDDING_SHADER: &str = include_str!("wgpu_shaders/gpu_native_embedding.wgsl");
 const GPU_NATIVE_RMSNORM_SHADER: &str = include_str!("wgpu_shaders/gpu_native_rmsnorm.wgsl");
@@ -44,6 +49,8 @@ const GPU_NATIVE_ROUTER_SHADER: &str = include_str!("wgpu_shaders/gpu_native_rou
 const GPU_NATIVE_Q4_EXPERT_SHADER: &str = include_str!("wgpu_shaders/gpu_native_q4_expert.wgsl");
 const GPU_NATIVE_EXPERT_CONTROL_SHADER: &str =
     include_str!("wgpu_shaders/gpu_native_expert_control.wgsl");
+const GPU_NATIVE_STATUS_CONTROL_SHADER: &str =
+    include_str!("wgpu_shaders/gpu_native_status_control.wgsl");
 const GPU_NATIVE_WORKGROUP_SIZE: u32 = 64;
 const GPU_NATIVE_ATTENTION_WORKGROUP_SIZE: u32 = 32;
 const GPU_NATIVE_ROUTER_WORKGROUP_SIZE: u32 = 64;
@@ -1966,6 +1973,38 @@ pub(crate) struct GpuNativeQ4ExpertVramPlan {
 }
 
 impl GpuNativeQ4ExpertVramPlan {
+    /// Construct the exact fixed allocation for a requested physical slot
+    /// count. Model-wide planning uses this helper so Slice 8 remains the
+    /// single owner of bank, dummy-binding, mapping, and device-limit
+    /// arithmetic.
+    pub(crate) fn try_for_slot_capacity(
+        geometry: GpuNativeQ4ExpertGeometry,
+        slot_capacity: usize,
+        limits: &wgpu::Limits,
+    ) -> Result<Self, GpuNativeBootstrapError> {
+        validate_q4_expert_pipeline_limits(limits)?;
+        if slot_capacity > geometry.num_experts {
+            return Err(
+                GpuNativeBootstrapError::ExpertResidentCountExceedsCapacity {
+                    residents: slot_capacity,
+                    capacity: geometry.num_experts,
+                },
+            );
+        }
+        let layout = GpuNativeQ4ExpertArenaLayout::try_new(geometry, slot_capacity, limits)?;
+        let active_bank_allocation_bytes = layout.active_bank_allocation_bytes()?;
+        let physical_bank_allocation_bytes = layout.physical_bank_allocation_bytes()?;
+        let total_arena_allocation_bytes = layout.total_allocation_bytes()?;
+        Ok(Self {
+            geometry,
+            requested_expert_budget_bytes: total_arena_allocation_bytes,
+            layout,
+            active_bank_allocation_bytes,
+            physical_bank_allocation_bytes,
+            total_arena_allocation_bytes,
+        })
+    }
+
     pub(crate) fn try_new(
         geometry: GpuNativeQ4ExpertGeometry,
         expert_budget_bytes: u64,
@@ -5422,6 +5461,49 @@ struct GpuNativeQ4ExpertPipelines {
     contain: wgpu::ComputePipeline,
 }
 
+struct GpuNativeStatusControlPipeline {
+    bind_group_layout: wgpu::BindGroupLayout,
+    clear_retryable: wgpu::ComputePipeline,
+}
+
+impl GpuNativeStatusControlPipeline {
+    fn new(device: &wgpu::Device) -> Self {
+        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("gpu_native_status_control_bind_group_layout"),
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::COMPUTE,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Storage { read_only: false },
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            }],
+        });
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("gpu_native_status_control_pipeline_layout"),
+            bind_group_layouts: &[&bind_group_layout],
+            push_constant_ranges: &[],
+        });
+        let module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("gpu_native_status_control_shader"),
+            source: wgpu::ShaderSource::Wgsl(GPU_NATIVE_STATUS_CONTROL_SHADER.into()),
+        });
+        let clear_retryable = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: Some("gpu_native_clear_retryable_status_pipeline"),
+            layout: Some(&pipeline_layout),
+            module: &module,
+            entry_point: "clear_retryable_expert_residency_main",
+            compilation_options: wgpu::PipelineCompilationOptions::default(),
+        });
+        Self {
+            bind_group_layout,
+            clear_retryable,
+        }
+    }
+}
+
 impl GpuNativeQ4ExpertPipelines {
     fn try_new(device: &wgpu::Device) -> Result<Self, GpuNativeBootstrapError> {
         validate_q4_expert_pipeline_limits(&device.limits())?;
@@ -5586,6 +5668,7 @@ pub(crate) struct GpuNativeExecutorContext {
     attention_pipelines: GpuNativeAttentionPipelines,
     router_pipeline: GpuNativeRouterPipeline,
     q4_expert_pipelines: GpuNativeQ4ExpertPipelines,
+    status_control_pipeline: GpuNativeStatusControlPipeline,
     counters: GpuNativeExecutionCounters,
 }
 
@@ -5615,6 +5698,7 @@ impl GpuNativeExecutorContext {
         let attention_pipelines = GpuNativeAttentionPipelines::new(&gpu.device);
         let router_pipeline = GpuNativeRouterPipeline::new(&gpu.device);
         let q4_expert_pipelines = GpuNativeQ4ExpertPipelines::try_new(&gpu.device)?;
+        let status_control_pipeline = GpuNativeStatusControlPipeline::new(&gpu.device);
 
         Ok(Self {
             context_id,
@@ -5627,6 +5711,7 @@ impl GpuNativeExecutorContext {
             attention_pipelines,
             router_pipeline,
             q4_expert_pipelines,
+            status_control_pipeline,
             counters: GpuNativeExecutionCounters::default(),
         })
     }
@@ -5674,6 +5759,39 @@ impl GpuNativeExecutorContext {
             residual,
             status,
         ))
+    }
+
+    /// Record the future replay boundary into the caller-owned encoder.
+    /// Only the expert-residency retry bit is cleared; fatal and unknown bits
+    /// remain latched. This method never submits, polls, maps, or reads back.
+    pub(crate) fn encode_clear_retryable_status(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        state: &GpuNativeTokenState,
+    ) -> Result<(), GpuNativeBootstrapError> {
+        let gpu = self.authoritative_gpu()?;
+        validate_token_state_owner(self.context_id, state.context_id)?;
+        state.layout.validate_for_limits(&gpu.device.limits())?;
+        let bind_group = gpu.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("gpu_native_clear_retryable_status_bind_group"),
+            layout: &self.status_control_pipeline.bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: state.status.as_entire_binding(),
+            }],
+        });
+        let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+            label: Some("gpu_native_clear_retryable_status_pass"),
+            timestamp_writes: None,
+        });
+        pass.set_pipeline(&self.status_control_pipeline.clear_retryable);
+        pass.set_bind_group(0, &bind_group, &[]);
+        pass.dispatch_workgroups(1, 1, 1);
+        Ok(())
+    }
+
+    pub(crate) fn device_limits(&self) -> Result<wgpu::Limits, GpuNativeBootstrapError> {
+        Ok(self.authoritative_gpu()?.device.limits())
     }
 
     /// Register one immutable model-scoped dense tensor and upload its payload
@@ -10703,6 +10821,29 @@ mod tests {
     }
 
     #[test]
+    fn retryable_status_clear_preserves_fatal_and_unknown_bits() {
+        assert_eq!(
+            status_after_retryable_clear(GPU_NATIVE_STATUS_RETRYABLE_MASK),
+            0
+        );
+        assert_eq!(
+            status_after_retryable_clear(GPU_NATIVE_STATUS_FATAL_MASK),
+            GPU_NATIVE_STATUS_FATAL_MASK
+        );
+        assert_eq!(
+            status_after_retryable_clear(
+                GPU_NATIVE_STATUS_FATAL_MASK | GPU_NATIVE_STATUS_RETRYABLE_MASK
+            ),
+            GPU_NATIVE_STATUS_FATAL_MASK
+        );
+        let unknown = 1 << 17;
+        assert_eq!(status_after_retryable_clear(unknown), unknown);
+        assert!(GPU_NATIVE_STATUS_CONTROL_SHADER
+            .contains("atomicAnd(&STATUS.bits, ~EXPERT_RESIDENCY_RETRYABLE)"));
+        assert!(!GPU_NATIVE_STATUS_CONTROL_SHADER.contains("atomicStore"));
+    }
+
+    #[test]
     fn gpu_native_shaders_parse_and_validate_without_hardware() {
         for (source, entry_points) in [
             (
@@ -10737,6 +10878,10 @@ mod tests {
                     "expert_combine_main",
                     "expert_contain_main",
                 ][..],
+            ),
+            (
+                GPU_NATIVE_STATUS_CONTROL_SHADER,
+                &["clear_retryable_expert_residency_main"][..],
             ),
             (GPU_NATIVE_TEST_COMPARE_SHADER, &["compare_main"][..]),
         ] {
@@ -12960,6 +13105,336 @@ fn compare_main(@builtin(global_invocation_id) gid: vec3<u32>) {
         assert_eq!(completed.queue_submissions, 0);
         assert_eq!(completed.intermediate_maps, 0);
         assert_eq!(completed.intermediate_readbacks, 0);
+    }
+
+    /// Requires an actual NVIDIA L4. Exercises one model-wide two-layer
+    /// budget, real logical generations, per-layer replacement, retryable
+    /// miss containment, encoder-only retry clearing, and replay against the
+    /// new slot epochs. Test-owned submissions and final readbacks are the
+    /// only submit/map operations in this fixture.
+    #[test]
+    #[ignore = "requires authoritative NVIDIA L4 WGPU validation hardware"]
+    fn live_l4_gpu_native_tiered_residency_retry() {
+        use super::super::{
+            resolve_execution_context, ComputeOffload, GpuBackendGeometry, RoutedExpertGpuSpec,
+        };
+        use crate::buffer_pool::BufferPool;
+        use crate::expert_cache::{ExpertResident, GpuResident};
+        use crate::gpu_native_residency::{
+            GpuNativeDemandExpert, GpuNativeModelExpertVramPlan, GpuNativeResidencyPriority,
+            GpuNativeTieredResidencyError, GpuNativeTieredResidencyManager,
+        };
+        use crate::inference::WeightDtype;
+
+        const D_MODEL: usize = 32;
+        const D_FF: usize = 32;
+        const NUM_EXPERTS: usize = 128;
+        const TOP_K: usize = 2;
+        const NUM_LAYERS: usize = 2;
+        const STATUS_AND_HIDDEN_BYTES: u64 =
+            GPU_NATIVE_STATUS_BYTES + (D_MODEL * std::mem::size_of::<f32>()) as u64;
+
+        let geometry =
+            GpuNativeQ4ExpertGeometry::try_new(D_MODEL, D_FF, NUM_EXPERTS, TOP_K).unwrap();
+        let payload_template = q4_uniform_expert(geometry, 0.01, 0.02, 0.005);
+        let payload_bytes = payload_template.len();
+        let gpu_cache = Arc::new(crate::expert_cache::GpuExpertCache::new(
+            payload_bytes * 8,
+            0.0,
+            u64::MAX,
+        ));
+        let execution = resolve_execution_context(
+            ComputeOffload::Gpu,
+            false,
+            GpuBackendGeometry {
+                num_layers: NUM_LAYERS,
+                max_seq_len: 8,
+                num_heads: 1,
+                num_kv_heads: 1,
+                head_dim: D_MODEL,
+                v_head_dim: D_MODEL,
+                q4_truncation_tolerance: 0,
+            },
+            RoutedExpertGpuSpec {
+                dtype: WeightDtype::Q4_0,
+                d_model: D_MODEL,
+                d_ff: D_FF,
+            },
+            gpu_cache.clone(),
+        )
+        .expect("L4 must construct the authoritative production GPU backend");
+        let executor = Arc::new(
+            execution
+                .create_gpu_native_executor_context(D_MODEL)
+                .expect("GPU-native executor must retain the authoritative backend"),
+        );
+        assert_eq!(executor.device_identity().vendor_id, 0x10de);
+        assert!(
+            executor.device_identity().name.contains("L4"),
+            "ignored tiered residency test must run only on an NVIDIA L4, got {}",
+            executor.device_identity().name
+        );
+        let gpu = executor.authoritative_gpu().unwrap();
+        let one_layer_min =
+            GpuNativeQ4ExpertVramPlan::try_for_slot_capacity(geometry, TOP_K, &gpu.device.limits())
+                .unwrap();
+        let total_budget = one_layer_min.total_arena_allocation_bytes() * NUM_LAYERS as u64;
+        let model_plan = GpuNativeModelExpertVramPlan::try_new(
+            NUM_LAYERS,
+            geometry,
+            total_budget,
+            &gpu.device.limits(),
+        )
+        .unwrap();
+        assert_eq!(model_plan.total_arena_allocation_bytes(), total_budget);
+        assert!(model_plan
+            .layer_plans()
+            .iter()
+            .all(|plan| plan.slot_capacity() == TOP_K));
+        assert!(model_plan
+            .layer_plans()
+            .iter()
+            .all(|plan| plan.total_arena_allocation_bytes() < total_budget));
+
+        let manager = GpuNativeTieredResidencyManager::try_new(
+            executor.clone(),
+            gpu_cache.clone(),
+            NUM_LAYERS,
+            geometry,
+            total_budget,
+        )
+        .unwrap();
+        let pool = BufferPool::new(16, payload_bytes, 4);
+        let make_source = |global_id: u32, payload: &[u8]| {
+            let mut buffer = pool.try_acquire().expect("synthetic RAM slot");
+            buffer.as_mut_slice().copy_from_slice(payload);
+            let resident = Arc::new(ExpertResident::new_with_block_align(global_id, buffer, 4));
+            gpu_cache
+                .demand_admit_lru(Arc::new(GpuResident::new_with_dtype(
+                    global_id,
+                    payload.to_vec(),
+                    WeightDtype::Q4_0,
+                )))
+                .unwrap();
+            let admission = gpu_cache.current_admission(global_id).unwrap();
+            (resident, admission)
+        };
+
+        let layer1_payload_a = q4_uniform_expert(geometry, 0.004, 0.006, 0.002);
+        let layer1_payload_b = q4_uniform_expert(geometry, -0.003, 0.005, 0.001);
+        let (l1_a, l1_a_admission) = make_source(128, &layer1_payload_a);
+        let (l1_b, l1_b_admission) = make_source(129, &layer1_payload_b);
+        manager
+            .ensure_demand_set(
+                GpuNativeResidencyPriority::Demand,
+                1,
+                &[
+                    GpuNativeDemandExpert::install(128, l1_a, l1_a_admission),
+                    GpuNativeDemandExpert::install(129, l1_b, l1_b_admission),
+                ],
+            )
+            .unwrap();
+
+        let old_payload_a = q4_uniform_expert(geometry, 0.002, 0.003, 0.001);
+        let old_payload_b = q4_uniform_expert(geometry, -0.002, 0.004, 0.001);
+        let (old_a, old_a_admission) = make_source(0, &old_payload_a);
+        let (old_b, old_b_admission) = make_source(1, &old_payload_b);
+        let old_residencies = manager
+            .ensure_demand_set(
+                GpuNativeResidencyPriority::Demand,
+                0,
+                &[
+                    GpuNativeDemandExpert::install(0, old_a, old_a_admission),
+                    GpuNativeDemandExpert::install(1, old_b, old_b_admission),
+                ],
+            )
+            .unwrap();
+        let before_replace = manager.snapshot();
+        assert_eq!(before_replace.layers[0].resident_slots, TOP_K);
+        assert_eq!(before_replace.layers[1].resident_slots, TOP_K);
+
+        let mut gate_values = vec![0.0; NUM_EXPERTS * D_MODEL];
+        gate_values[2 * D_MODEL] = 4.0;
+        gate_values[3 * D_MODEL + 1] = 3.0;
+        let gate = DenseWeight::from_f32(gate_values, NUM_EXPERTS, D_MODEL);
+        let gate_handle = executor
+            .register_dense_weight(
+                GpuNativeDenseWeightKey::try_new("test.tiered_residency.router").unwrap(),
+                &gate,
+            )
+            .unwrap();
+        let router_geometry =
+            GpuNativeRouterGeometry::try_new(D_MODEL, NUM_EXPERTS, TOP_K).unwrap();
+        let router_plan = executor
+            .create_router_plan(0, router_geometry, gate_handle)
+            .unwrap();
+        let state = executor.create_token_state().unwrap();
+        let router_scratch = executor.create_router_scratch(router_geometry).unwrap();
+        let expert_scratch = executor.create_q4_expert_scratch(geometry).unwrap();
+        let hidden = vec![1.0; D_MODEL];
+        let residual = vec![0.25; D_MODEL];
+        let run = |label: &str, clear_retryable: bool| {
+            gpu.queue
+                .write_buffer(&state.hidden, 0, bytemuck::cast_slice(&hidden));
+            gpu.queue
+                .write_buffer(&state.residual, 0, bytemuck::cast_slice(&residual));
+            let staging = gpu.device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some(label),
+                size: STATUS_AND_HIDDEN_BYTES,
+                usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            });
+            let mut encoder = gpu
+                .device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: Some(label) });
+            if clear_retryable {
+                executor
+                    .encode_clear_retryable_status(&mut encoder, &state)
+                    .unwrap();
+            }
+            executor
+                .encode_router(&mut encoder, &router_plan, &state, &router_scratch)
+                .unwrap();
+            executor
+                .encode_q4_expert_arena_combine(
+                    &mut encoder,
+                    &router_plan,
+                    &router_scratch,
+                    manager.arena(0).unwrap(),
+                    &state,
+                    &expert_scratch,
+                )
+                .unwrap();
+            encoder.copy_buffer_to_buffer(&state.status, 0, &staging, 0, GPU_NATIVE_STATUS_BYTES);
+            encoder.copy_buffer_to_buffer(
+                &state.hidden,
+                0,
+                &staging,
+                GPU_NATIVE_STATUS_BYTES,
+                (D_MODEL * std::mem::size_of::<f32>()) as u64,
+            );
+            gpu.queue.submit(Some(encoder.finish()));
+            let slice = staging.slice(..);
+            let (tx, rx) = std::sync::mpsc::sync_channel(1);
+            slice.map_async(wgpu::MapMode::Read, move |result| {
+                let _ = tx.send(result);
+            });
+            gpu.device.poll(wgpu::Maintain::Wait);
+            rx.recv()
+                .expect("tiered residency map callback must be drained")
+                .expect("tiered residency staging must map");
+            let mapped = slice.get_mapped_range();
+            let status = u32::from_le_bytes(mapped[..4].try_into().unwrap());
+            let output = mapped[4..]
+                .chunks_exact(4)
+                .map(|bytes| f32::from_le_bytes(bytes.try_into().unwrap()))
+                .collect::<Vec<_>>();
+            drop(mapped);
+            staging.unmap();
+            (status, output)
+        };
+
+        gpu.queue.write_buffer(&state.status, 0, &[0; 4]);
+        let miss = run("gpu_native_tiered_residency_miss", false);
+        assert_eq!(
+            miss.0 & GPU_NATIVE_STATUS_RETRYABLE_MASK,
+            GPU_NATIVE_STATUS_RETRYABLE_MASK
+        );
+        assert_eq!(miss.0 & GPU_NATIVE_STATUS_FATAL_MASK, 0);
+        assert_close(&miss.1, &residual, 0.0);
+
+        let payload_a = q4_uniform_expert(geometry, 0.01, 0.02, 0.005);
+        let payload_b = q4_uniform_expert(geometry, -0.012, 0.018, 0.004);
+        let (resident_a, admission_a) = make_source(2, &payload_a);
+        let stale_admission_a = admission_a.clone();
+        let stale_resident_a = resident_a.clone();
+        let (resident_b, admission_b) = make_source(3, &payload_b);
+        let new_residencies = manager
+            .ensure_demand_set(
+                GpuNativeResidencyPriority::Demand,
+                0,
+                &[
+                    GpuNativeDemandExpert::install(2, resident_a, admission_a),
+                    GpuNativeDemandExpert::install(3, resident_b, admission_b),
+                ],
+            )
+            .unwrap();
+        assert!(new_residencies.iter().all(|new| old_residencies
+            .iter()
+            .filter(|old| old.location() == new.location())
+            .all(|old| old.slot_epoch() != new.slot_epoch())));
+        let after_replace = manager.snapshot();
+        assert_eq!(after_replace.layers[0].physical_evictions, 2);
+        assert_eq!(after_replace.layers[1].resident_slots, TOP_K);
+        assert!(manager.has_current_for_demand(128).unwrap());
+        assert!(manager.has_current_for_demand(129).unwrap());
+
+        let replay = run("gpu_native_tiered_residency_replay", true);
+        assert_eq!(replay.0, 0);
+        let logits = gate.matvec(&hidden);
+        let (selected_ids, selected_weights, failed) = router_topk_mirror(&logits, TOP_K);
+        assert!(!failed);
+        assert_eq!(selected_ids, vec![2, 3]);
+        let expert_outputs = [
+            q4_expert_mirror(&payload_a, geometry, &hidden),
+            q4_expert_mirror(&payload_b, geometry, &hidden),
+        ];
+        let expected = residual_add_mirror(
+            &residual,
+            &weighted_expert_combine_mirror(&expert_outputs, &selected_weights),
+        );
+        assert!(replay.1.iter().all(|value| value.is_finite()));
+        assert_close(&replay.1, &expected, 5e-4);
+
+        // Evict and re-admit logical id 2 to obtain a strictly newer real
+        // generation, then prove the saved stale requester cannot disturb it.
+        for id in 4..11u32 {
+            let payload = q4_uniform_expert(geometry, 0.001 * id as f32, 0.002, 0.001);
+            let _ = make_source(id, &payload);
+        }
+        let (newer_resident_a, newer_admission_a) = make_source(2, &payload_a);
+        assert!(newer_admission_a.generation() > stale_admission_a.generation());
+        let newest = manager
+            .ensure_demand_set(
+                GpuNativeResidencyPriority::Demand,
+                0,
+                &[GpuNativeDemandExpert::install(
+                    2,
+                    newer_resident_a,
+                    newer_admission_a,
+                )],
+            )
+            .unwrap()[0];
+        let before_stale = manager.snapshot();
+        assert!(matches!(
+            manager.ensure_demand_set(
+                GpuNativeResidencyPriority::Demand,
+                0,
+                &[GpuNativeDemandExpert::install(
+                    2,
+                    stale_resident_a,
+                    stale_admission_a,
+                )],
+            ),
+            Err(GpuNativeTieredResidencyError::LogicalAdmissionStale { .. })
+        ));
+        let after_stale = manager.snapshot();
+        assert_eq!(after_stale.layers, before_stale.layers);
+        assert_eq!(
+            after_stale.stale_generation_rejections,
+            before_stale.stale_generation_rejections + 1
+        );
+        assert!(manager.has_current_for_demand(2).unwrap());
+        assert_eq!(
+            manager
+                .ensure_demand_set(
+                    GpuNativeResidencyPriority::Demand,
+                    0,
+                    &[GpuNativeDemandExpert::current(2)],
+                )
+                .unwrap()[0],
+            newest
+        );
     }
 
     /// Requires an actual NVIDIA L4. Three isolated requests prove a finite

--- a/rust-engine/src/backend/wgpu_shaders/gpu_native_status_control.wgsl
+++ b/rust-engine/src/backend/wgpu_shaders/gpu_native_status_control.wgsl
@@ -1,0 +1,14 @@
+// Encoder-only request-status control for the future GPU-native replay seam.
+
+struct RequestStatus {
+    bits: atomic<u32>,
+};
+
+@group(0) @binding(0) var<storage, read_write> STATUS: RequestStatus;
+
+const EXPERT_RESIDENCY_RETRYABLE: u32 = 4u;
+
+@compute @workgroup_size(1, 1, 1)
+fn clear_retryable_expert_residency_main() {
+    atomicAnd(&STATUS.bits, ~EXPERT_RESIDENCY_RETRYABLE);
+}

--- a/rust-engine/src/engine.rs
+++ b/rust-engine/src/engine.rs
@@ -20,6 +20,12 @@ use crate::expert_cache::{
     ExpertResident, GpuExpertCache, GpuHotPromotionOutcome, GpuResident,
 };
 use crate::gating::Router;
+use crate::gpu_native_residency::{
+    global_to_layer_local as gpu_native_global_to_layer_local, GpuNativeDemandExpert,
+    GpuNativeResidencyPriority, GpuNativeSpeculativeInstall, GpuNativeSpeculativeProbe,
+    GpuNativeTieredResidencyError, GpuNativeTieredResidencyManager,
+    GpuNativeTieredResidencySnapshot,
+};
 use crate::inference::{
     combine_outputs, run_inference_bf16, run_inference_f16, run_inference_int8,
     run_inference_mixed_quant, run_inference_mxfp4, run_inference_q4_0, run_inference_q4_0_qmm,
@@ -368,6 +374,68 @@ impl std::fmt::Display for ExpertReadError {
 }
 
 impl std::error::Error for ExpertReadError {}
+
+#[derive(Debug)]
+pub(crate) enum GpuNativeDemandResidencyError {
+    ManagerNotInstalled,
+    ExpertRead(ExpertReadError),
+    LogicalAdmission(crate::backend::GpuExpertDispatchError),
+    Tiered(GpuNativeTieredResidencyError),
+}
+
+impl std::fmt::Display for GpuNativeDemandResidencyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ManagerNotInstalled => {
+                f.write_str("GPU-native tiered residency manager is not installed")
+            }
+            Self::ExpertRead(error) => write!(f, "tiered residency fetch failed: {error}"),
+            Self::LogicalAdmission(error) => {
+                write!(f, "tiered residency logical admission failed: {error}")
+            }
+            Self::Tiered(error) => error.fmt(f),
+        }
+    }
+}
+
+impl std::error::Error for GpuNativeDemandResidencyError {}
+
+impl From<ExpertReadError> for GpuNativeDemandResidencyError {
+    fn from(value: ExpertReadError) -> Self {
+        Self::ExpertRead(value)
+    }
+}
+
+impl From<GpuNativeTieredResidencyError> for GpuNativeDemandResidencyError {
+    fn from(value: GpuNativeTieredResidencyError) -> Self {
+        Self::Tiered(value)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum GpuNativeResidencyInstallError {
+    LegacyPhysicalExpertPlaneActive,
+    LogicalCacheMismatch,
+    AlreadyInstalled,
+}
+
+impl std::fmt::Display for GpuNativeResidencyInstallError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::LegacyPhysicalExpertPlaneActive => f.write_str(
+                "GPU-native residency cannot be installed while the legacy routed-expert GPU plane is active",
+            ),
+            Self::LogicalCacheMismatch => f.write_str(
+                "GPU-native residency manager does not share the execution context's logical GpuExpertCache",
+            ),
+            Self::AlreadyInstalled => {
+                f.write_str("GPU-native tiered residency manager is already installed")
+            }
+        }
+    }
+}
+
+impl std::error::Error for GpuNativeResidencyInstallError {}
 
 /// RAII guard that ensures the in-flight singleflight slot for an
 /// expert id is freed (and any waiters notified) when the leader's
@@ -1126,6 +1194,10 @@ pub(crate) struct EngineCore {
     /// first probes logical admission; misses fall through to the RAM
     /// `MultiLayerExpertCache` and then to NVMe.
     pub(super) gpu_cache: Option<Arc<GpuExpertCache>>,
+    /// Optional future-token-loop physical residency plane. It is never
+    /// installed from the legacy GPU mode. When absent, every existing
+    /// demand and speculative path remains unchanged.
+    pub(super) gpu_native_residency: Option<Arc<GpuNativeTieredResidencyManager>>,
     /// One-shot sender that feeds background RAM → logical-GPU-admission
     /// promotion task. The receiver lives on a dedicated Tokio task
     /// spawned by [`Engine::install_gpu_cache`]; the inference hot
@@ -1446,6 +1518,7 @@ impl EngineCore {
             shape,
             options,
             gpu_cache: None,
+            gpu_native_residency: None,
             gpu_promotion_tx: None,
             in_flight: Arc::new(DashMap::new()),
             prefetch_semaphore: Arc::new(tokio::sync::Semaphore::new(prefetch_permits)),
@@ -2390,6 +2463,74 @@ impl Engine {
             }
         }
         outcome
+    }
+
+    /// Apply the existing non-evicting speculative logical-admission policy
+    /// and return its current generation. The historical `GpuResident`
+    /// payload copy remains compatibility debt; physical upload still reads
+    /// directly from `ExpertResident::data()` and this helper adds no further
+    /// persistent host copy.
+    fn ensure_speculative_gpu_admission(
+        &self,
+        resident: &Arc<ExpertResident>,
+    ) -> Option<crate::expert_cache::GpuAdmission> {
+        let gpu = self.core.execution_context.gpu_expert_cache();
+        if let Some(admission) = gpu.current_admission(resident.id) {
+            return Some(admission);
+        }
+        let bytes = resident.data().len();
+        if (gpu.used_bytes() as usize).saturating_add(bytes) > gpu.capacity_bytes() {
+            return None;
+        }
+        let gpu_resident = Arc::new(GpuResident::new_with_dtype(
+            resident.id,
+            resident.data().to_vec(),
+            self.core.options.dtype,
+        ));
+        if gpu.try_promote_lru_no_evict(gpu_resident) {
+            if let Some(prom) = self.metrics.prom.as_ref() {
+                prom.record_promotions(1);
+                prom.set_vram_used_bytes(gpu.used_bytes());
+            }
+        }
+        gpu.current_admission(resident.id)
+    }
+
+    /// Explicit future bootstrap seam for the GPU-native physical plane.
+    ///
+    /// The manager must retain the exact logical cache owned by this engine's
+    /// authoritative execution context. Slice 9 also rejects simultaneous
+    /// activation of the legacy routed-expert GPU registry: Slice 10 may
+    /// compose the GPU-native token loop, but it must never double-consume one
+    /// request's configured expert capacity across both physical planes.
+    pub(crate) fn install_gpu_native_residency_manager(
+        &mut self,
+        manager: Arc<GpuNativeTieredResidencyManager>,
+    ) -> Result<(), GpuNativeResidencyInstallError> {
+        if self.core.gpu_native_residency.is_some() {
+            return Err(GpuNativeResidencyInstallError::AlreadyInstalled);
+        }
+        if self.core.execution_context.plan().routed_experts()
+            == crate::backend::ExecutionPlane::Gpu
+        {
+            return Err(GpuNativeResidencyInstallError::LegacyPhysicalExpertPlaneActive);
+        }
+        if !Arc::ptr_eq(
+            manager.gpu_cache(),
+            self.core.execution_context.gpu_expert_cache(),
+        ) {
+            return Err(GpuNativeResidencyInstallError::LogicalCacheMismatch);
+        }
+        self.core.gpu_cache = Some(manager.gpu_cache().clone());
+        self.core.gpu_native_residency = Some(manager);
+        Ok(())
+    }
+
+    pub(crate) fn gpu_native_residency_snapshot(&self) -> Option<GpuNativeTieredResidencySnapshot> {
+        self.core
+            .gpu_native_residency
+            .as_ref()
+            .map(|manager| manager.snapshot())
     }
 
     /// Attach the logical GPU-admission cache — Phase 2 hierarchy policy.
@@ -3379,6 +3520,77 @@ impl Engine {
         })
     }
 
+    /// Future GPU-native retry service. Physical hits never touch RAM or
+    /// storage. RAM misses use the exact existing `fetch_with_retry`
+    /// singleflight path, then the existing logical demand-admission policy,
+    /// before Slice 8 receives `ExpertResident::data()` for physical upload.
+    /// Demand never consults the speculative governor or semaphore.
+    pub(crate) async fn ensure_gpu_native_demand_residency(
+        self: &Arc<Self>,
+        layer_index: usize,
+        global_ids: &[u32],
+    ) -> Result<
+        Vec<crate::backend::gpu_native::GpuNativeQ4ExpertResidency>,
+        GpuNativeDemandResidencyError,
+    > {
+        let manager = self
+            .core
+            .gpu_native_residency
+            .as_ref()
+            .cloned()
+            .ok_or(GpuNativeDemandResidencyError::ManagerNotInstalled)?;
+        let num_layers = manager.plan().num_layers();
+        let experts_per_layer = manager.plan().geometry().num_experts() as u32;
+        let mut seen = HashSet::with_capacity(global_ids.len());
+        for &global_id in global_ids {
+            if !seen.insert(global_id) {
+                return Err(
+                    GpuNativeTieredResidencyError::DuplicateDemandExpert { global_id }.into(),
+                );
+            }
+            let identity =
+                gpu_native_global_to_layer_local(global_id, num_layers, experts_per_layer)?;
+            if identity.layer_index != layer_index {
+                return Err(GpuNativeTieredResidencyError::DemandLayerMismatch {
+                    requested_layer: layer_index,
+                    global_id,
+                    actual_layer: identity.layer_index,
+                }
+                .into());
+            }
+        }
+
+        let mut demands = Vec::with_capacity(global_ids.len());
+        for &global_id in global_ids {
+            if manager.has_current_for_demand(global_id)? {
+                demands.push(GpuNativeDemandExpert::current(global_id));
+                continue;
+            }
+            let resident = match self.core.cache.get(global_id) {
+                Some(resident) => resident,
+                None => self.fetch_with_retry(global_id).await?,
+            };
+            self.demand_admit_resident_to_gpu(layer_index as u32, resident.as_ref())
+                .map_err(GpuNativeDemandResidencyError::LogicalAdmission)?;
+            let admission = self
+                .core
+                .execution_context
+                .gpu_expert_cache()
+                .current_admission(global_id)
+                .ok_or_else(|| {
+                    GpuNativeDemandResidencyError::Tiered(
+                        GpuNativeTieredResidencyError::DemandSourceMissing { global_id },
+                    )
+                })?;
+            demands.push(GpuNativeDemandExpert::install(
+                global_id, resident, admission,
+            ));
+        }
+        manager
+            .ensure_demand_set(GpuNativeResidencyPriority::Demand, layer_index, &demands)
+            .map_err(Into::into)
+    }
+
     /// One single fetch attempt. Acquires a buffer (yielding briefly
     /// if the pool is under pressure), issues the read, and either
     /// installs the resident in the cache or surfaces the I/O error
@@ -3463,7 +3675,84 @@ impl Engine {
         }
     }
 
+    fn spawn_gpu_native_ram_to_vram_prefetch(
+        self: &Arc<Self>,
+        manager: Arc<GpuNativeTieredResidencyManager>,
+        resident: Arc<ExpertResident>,
+        p: f64,
+    ) {
+        let id = resident.id;
+        // This is the prediction's one and only governor decision. A PCIe
+        // write does not call `record_completed`; that denominator remains
+        // tied to speculative RAM/NVMe prefetch usefulness.
+        if !self.core.governor.admit(p) {
+            self.metrics
+                .counters
+                .prefetch_dropped_governor
+                .fetch_add(1, Ordering::Relaxed);
+            return;
+        }
+        let permit = match self.core.prefetch_semaphore.clone().try_acquire_owned() {
+            Ok(permit) => permit,
+            Err(_) => {
+                self.metrics
+                    .counters
+                    .prefetch_dropped_concurrency
+                    .fetch_add(1, Ordering::Relaxed);
+                return;
+            }
+        };
+        let me = self.clone();
+        tokio::spawn(async move {
+            let _permit = permit;
+            let Some(admission) = me.ensure_speculative_gpu_admission(&resident) else {
+                return;
+            };
+            match manager.ensure_speculative_resident(
+                id,
+                &resident,
+                &admission,
+                GpuNativeResidencyPriority::Speculative { score: p },
+            ) {
+                Ok(
+                    GpuNativeSpeculativeInstall::Hit(_)
+                    | GpuNativeSpeculativeInstall::Installed(_)
+                    | GpuNativeSpeculativeInstall::DroppedCapacityOrPressure
+                    | GpuNativeSpeculativeInstall::StaleLogicalGeneration,
+                ) => {}
+                Err(error) => debug!(
+                    expert = id,
+                    error = %error,
+                    "RAM-to-VRAM speculative residency was dropped"
+                ),
+            }
+        });
+    }
+
     fn spawn_prefetch(self: &Arc<Self>, id: u32, p: f64) {
+        if let Some(manager) = self.core.gpu_native_residency.as_ref().cloned() {
+            match manager.probe_speculative(
+                id,
+                GpuNativeResidencyPriority::Speculative { score: p },
+            ) {
+                Ok(GpuNativeSpeculativeProbe::Hit(_))
+                | Ok(GpuNativeSpeculativeProbe::DroppedPressure) => return,
+                Ok(GpuNativeSpeculativeProbe::Miss) => {
+                    if let Some(resident) = self.core.cache.get(id) {
+                        self.spawn_gpu_native_ram_to_vram_prefetch(manager, resident, p);
+                        return;
+                    }
+                }
+                Err(error) => {
+                    debug!(
+                        expert = id,
+                        error = %error,
+                        "dropping invalid GPU-native speculative residency request"
+                    );
+                    return;
+                }
+            }
+        }
         // **Dedup before spending a permit.** `union_prefetch` and
         // `speculate_layer_ahead` can both nominate the same id for one
         // token; without this pre-check each duplicate consumed a
@@ -3655,16 +3944,35 @@ impl Engine {
                         );
                         return;
                     }
-                    // **Eager logical GPU admission.** A speculative prefetch is
-                    // a strong "about to be routed" signal, so try to
-                    // stage the host bytes into the admission LRU *now* instead
-                    // of waiting for `promote_after_hits` RAM hits — the
-                    // lazy path can leave a predicted expert on the CPU
-                    // fallback path for its first few activations.
-                    // Only attempt eager admission when the logical cache has room;
-                    // otherwise we would copy ~expert_size bytes into a Vec only to have the
-                    // non-evicting promotion path immediately reject it.
-                    if let Some(gpu) = me.core.gpu_cache.as_ref() {
+                    // With the optional Slice 9 plane, the same prediction and
+                    // semaphore permit continue through logical admission and
+                    // RAM -> VRAM. There is no second governor decision and no
+                    // second prefetch scheduler.
+                    if let Some(manager) = me.core.gpu_native_residency.as_ref().cloned() {
+                        if let Some(admission) = me.ensure_speculative_gpu_admission(&resident) {
+                            if let Err(error) = manager.ensure_speculative_resident(
+                                id,
+                                &resident,
+                                &admission,
+                                GpuNativeResidencyPriority::Speculative { score: p },
+                            ) {
+                                debug!(
+                                    expert = id,
+                                    error = %error,
+                                    "cold prefetch landed in RAM but GPU-native speculation was dropped"
+                                );
+                            }
+                        }
+                    } else if let Some(gpu) = me.core.gpu_cache.as_ref() {
+                        // **Eager logical GPU admission.** A speculative prefetch is
+                        // a strong "about to be routed" signal, so try to
+                        // stage the host bytes into the admission LRU *now* instead
+                        // of waiting for `promote_after_hits` RAM hits — the
+                        // lazy path can leave a predicted expert on the CPU
+                        // fallback path for its first few activations.
+                        // Only attempt eager admission when the logical cache has room;
+                        // otherwise we would copy ~expert_size bytes into a Vec only to have the
+                        // non-evicting promotion path immediately reject it.
                         let bytes = resident.data().len();
                         if (gpu.used_bytes() as usize).saturating_add(bytes) <= gpu.capacity_bytes()
                         {
@@ -6034,6 +6342,14 @@ mod tests {
                 hidden_seed: seed,
             },
         ))
+    }
+
+    #[test]
+    fn gpu_native_tiered_residency_is_strictly_opt_in() {
+        let dir = TempDir::new("gpu-native-residency-opt-in");
+        let engine = build_engine(&dir.path, 4, 8, 8, 2, 1, 1, 17);
+        assert!(engine.core.gpu_native_residency.is_none());
+        assert!(engine.gpu_native_residency_snapshot().is_none());
     }
 
     fn rebuild_with_speculator(

--- a/rust-engine/src/gpu_native_residency.rs
+++ b/rust-engine/src/gpu_native_residency.rs
@@ -1,0 +1,1151 @@
+//! Tier-aware control plane for the future GPU-native token loop.
+//!
+//! The engine remains responsible for NVMe reads, RAM-cache ownership,
+//! speculative admission, and logical [`GpuExpertCache`] generations. This
+//! module owns only the preallocated RAM -> VRAM physical plane built from
+//! Slice 8's mutable Q4 expert arenas.
+
+#![allow(dead_code)]
+
+use crate::backend::gpu_native::{
+    GpuNativeBootstrapError, GpuNativeExecutorContext, GpuNativeQ4ExpertAcquire,
+    GpuNativeQ4ExpertArena, GpuNativeQ4ExpertGeometry, GpuNativeQ4ExpertKey,
+    GpuNativeQ4ExpertResidency, GpuNativeQ4ExpertRetire, GpuNativeQ4ExpertVramPlan,
+};
+use crate::expert_cache::{ExpertResident, GpuAdmission, GpuExpertCache};
+use lru::LruCache;
+use parking_lot::{Mutex, MutexGuard};
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum GpuNativeTieredResidencyError {
+    InvalidModelLayerCount,
+    InvalidExpertsPerLayer,
+    ExpertNamespaceOverflow {
+        num_layers: usize,
+        experts_per_layer: usize,
+    },
+    GlobalExpertOutOfRange {
+        global_id: u32,
+        num_layers: usize,
+        experts_per_layer: u32,
+    },
+    LayerOutOfRange {
+        layer_index: usize,
+        num_layers: usize,
+    },
+    LocalExpertOutOfRange {
+        local_expert_id: u32,
+        experts_per_layer: u32,
+    },
+    ModelBudgetOverflow,
+    ModelBudgetTooSmall {
+        requested_bytes: u64,
+        minimum_bytes: u64,
+    },
+    DuplicateDemandExpert {
+        global_id: u32,
+    },
+    DemandLayerMismatch {
+        requested_layer: usize,
+        global_id: u32,
+        actual_layer: usize,
+    },
+    DemandSetExceedsLayerCapacity {
+        requested: usize,
+        capacity: usize,
+    },
+    DemandSourceMissing {
+        global_id: u32,
+    },
+    DemandSourceIdentityMismatch {
+        global_id: u32,
+    },
+    LogicalAdmissionStale {
+        global_id: u32,
+        generation: u64,
+    },
+    InstallInProgress {
+        global_id: u32,
+        generation: u64,
+    },
+    NoPhysicalSlot {
+        layer_index: usize,
+    },
+    NoEvictablePhysicalSlot {
+        layer_index: usize,
+    },
+    StalePhysicalRequester {
+        global_id: u32,
+        generation: u64,
+    },
+    ResidencyPriorityMismatch,
+    Backend(GpuNativeBootstrapError),
+}
+
+impl fmt::Display for GpuNativeTieredResidencyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidModelLayerCount => f.write_str("GPU-native residency requires at least one MoE layer"),
+            Self::InvalidExpertsPerLayer => f.write_str("GPU-native residency requires at least one expert per layer"),
+            Self::ExpertNamespaceOverflow { num_layers, experts_per_layer } => write!(f, "global expert namespace overflows u32: layers={num_layers} experts_per_layer={experts_per_layer}"),
+            Self::GlobalExpertOutOfRange { global_id, num_layers, experts_per_layer } => write!(f, "global expert {global_id} is outside {num_layers} layers x {experts_per_layer} experts"),
+            Self::LayerOutOfRange { layer_index, num_layers } => write!(f, "layer {layer_index} is outside {num_layers} GPU-native arenas"),
+            Self::LocalExpertOutOfRange { local_expert_id, experts_per_layer } => write!(f, "local expert {local_expert_id} is outside layer width {experts_per_layer}"),
+            Self::ModelBudgetOverflow => f.write_str("model-wide GPU-native expert budget arithmetic overflowed"),
+            Self::ModelBudgetTooSmall { requested_bytes, minimum_bytes } => write!(f, "model-wide expert budget {requested_bytes} bytes is below the executable minimum {minimum_bytes} bytes"),
+            Self::DuplicateDemandExpert { global_id } => write!(f, "demand set repeats global expert {global_id}"),
+            Self::DemandLayerMismatch { requested_layer, global_id, actual_layer } => write!(f, "demand for layer {requested_layer} contains global expert {global_id} from layer {actual_layer}"),
+            Self::DemandSetExceedsLayerCapacity { requested, capacity } => write!(f, "demand set of {requested} experts exceeds physical layer capacity {capacity}"),
+            Self::DemandSourceMissing { global_id } => write!(f, "physical miss for global expert {global_id} has no RAM/logical-admission source"),
+            Self::DemandSourceIdentityMismatch { global_id } => write!(f, "RAM resident or logical admission does not match global expert {global_id}"),
+            Self::LogicalAdmissionStale { global_id, generation } => write!(f, "logical generation {generation} for global expert {global_id} is no longer current"),
+            Self::InstallInProgress { global_id, generation } => write!(f, "physical install is already in progress for global expert {global_id} generation {generation}"),
+            Self::NoPhysicalSlot { layer_index } => write!(f, "layer {layer_index} has no free physical expert slot"),
+            Self::NoEvictablePhysicalSlot { layer_index } => write!(f, "layer {layer_index} has no physical victim outside the protected demand set"),
+            Self::StalePhysicalRequester { global_id, generation } => write!(f, "stale physical requester for global expert {global_id} generation {generation}"),
+            Self::ResidencyPriorityMismatch => f.write_str("residency request used the wrong demand/speculative priority"),
+            Self::Backend(error) => write!(f, "GPU-native residency backend error: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for GpuNativeTieredResidencyError {}
+
+impl From<GpuNativeBootstrapError> for GpuNativeTieredResidencyError {
+    fn from(value: GpuNativeBootstrapError) -> Self {
+        Self::Backend(value)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct GpuNativeLayerExpertId {
+    pub(crate) layer_index: usize,
+    pub(crate) local_expert_id: u32,
+}
+
+pub(crate) fn global_to_layer_local(
+    global_id: u32,
+    num_layers: usize,
+    experts_per_layer: u32,
+) -> Result<GpuNativeLayerExpertId, GpuNativeTieredResidencyError> {
+    validate_namespace(num_layers, experts_per_layer as usize)?;
+    let layer_index = (global_id / experts_per_layer) as usize;
+    if layer_index >= num_layers {
+        return Err(GpuNativeTieredResidencyError::GlobalExpertOutOfRange {
+            global_id,
+            num_layers,
+            experts_per_layer,
+        });
+    }
+    Ok(GpuNativeLayerExpertId {
+        layer_index,
+        local_expert_id: global_id % experts_per_layer,
+    })
+}
+
+pub(crate) fn layer_local_to_global(
+    layer_index: usize,
+    local_expert_id: u32,
+    num_layers: usize,
+    experts_per_layer: u32,
+) -> Result<u32, GpuNativeTieredResidencyError> {
+    validate_namespace(num_layers, experts_per_layer as usize)?;
+    if layer_index >= num_layers {
+        return Err(GpuNativeTieredResidencyError::LayerOutOfRange {
+            layer_index,
+            num_layers,
+        });
+    }
+    if local_expert_id >= experts_per_layer {
+        return Err(GpuNativeTieredResidencyError::LocalExpertOutOfRange {
+            local_expert_id,
+            experts_per_layer,
+        });
+    }
+    let global = (layer_index as u64)
+        .checked_mul(experts_per_layer as u64)
+        .and_then(|base| base.checked_add(local_expert_id as u64))
+        .and_then(|id| u32::try_from(id).ok())
+        .ok_or(GpuNativeTieredResidencyError::ExpertNamespaceOverflow {
+            num_layers,
+            experts_per_layer: experts_per_layer as usize,
+        })?;
+    Ok(global)
+}
+
+pub(crate) fn global_to_q4_expert_key(
+    global_id: u32,
+    logical_generation: u64,
+    num_layers: usize,
+    experts_per_layer: u32,
+) -> Result<GpuNativeQ4ExpertKey, GpuNativeTieredResidencyError> {
+    let identity = global_to_layer_local(global_id, num_layers, experts_per_layer)?;
+    Ok(GpuNativeQ4ExpertKey::new(
+        identity.layer_index,
+        identity.local_expert_id,
+        logical_generation,
+    ))
+}
+
+fn validate_namespace(
+    num_layers: usize,
+    experts_per_layer: usize,
+) -> Result<(), GpuNativeTieredResidencyError> {
+    if num_layers == 0 {
+        return Err(GpuNativeTieredResidencyError::InvalidModelLayerCount);
+    }
+    if experts_per_layer == 0 {
+        return Err(GpuNativeTieredResidencyError::InvalidExpertsPerLayer);
+    }
+    let count = (num_layers as u128)
+        .checked_mul(experts_per_layer as u128)
+        .ok_or(GpuNativeTieredResidencyError::ExpertNamespaceOverflow {
+            num_layers,
+            experts_per_layer,
+        })?;
+    if count > u32::MAX as u128 + 1 {
+        return Err(GpuNativeTieredResidencyError::ExpertNamespaceOverflow {
+            num_layers,
+            experts_per_layer,
+        });
+    }
+    Ok(())
+}
+
+/// One deterministic model-wide post-headroom expert-VRAM plan.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct GpuNativeModelExpertVramPlan {
+    geometry: GpuNativeQ4ExpertGeometry,
+    total_expert_budget_bytes: u64,
+    minimum_executable_budget_bytes: u64,
+    layer_plans: Vec<GpuNativeQ4ExpertVramPlan>,
+    total_arena_allocation_bytes: u64,
+}
+
+impl GpuNativeModelExpertVramPlan {
+    pub(crate) fn try_new(
+        num_layers: usize,
+        geometry: GpuNativeQ4ExpertGeometry,
+        total_expert_budget_bytes: u64,
+        limits: &wgpu::Limits,
+    ) -> Result<Self, GpuNativeTieredResidencyError> {
+        validate_namespace(num_layers, geometry.num_experts())?;
+        let minimum_layer =
+            GpuNativeQ4ExpertVramPlan::try_for_slot_capacity(geometry, geometry.top_k(), limits)?;
+        let minimum_executable_budget_bytes = minimum_layer
+            .total_arena_allocation_bytes()
+            .checked_mul(num_layers as u64)
+            .ok_or(GpuNativeTieredResidencyError::ModelBudgetOverflow)?;
+        if total_expert_budget_bytes < minimum_executable_budget_bytes {
+            return Err(GpuNativeTieredResidencyError::ModelBudgetTooSmall {
+                requested_bytes: total_expert_budget_bytes,
+                minimum_bytes: minimum_executable_budget_bytes,
+            });
+        }
+
+        let mut layer_plans = vec![minimum_layer; num_layers];
+        let mut total_arena_allocation_bytes = minimum_executable_budget_bytes;
+        loop {
+            let remaining = total_expert_budget_bytes - total_arena_allocation_bytes;
+            let mut best: Option<(u64, usize, GpuNativeQ4ExpertVramPlan)> = None;
+            for (layer_index, current) in layer_plans.iter().copied().enumerate() {
+                if current.slot_capacity() >= geometry.num_experts() {
+                    continue;
+                }
+                let candidate = GpuNativeQ4ExpertVramPlan::try_for_slot_capacity(
+                    geometry,
+                    current.slot_capacity() + 1,
+                    limits,
+                )?;
+                let increment = candidate
+                    .total_arena_allocation_bytes()
+                    .checked_sub(current.total_arena_allocation_bytes())
+                    .ok_or(GpuNativeTieredResidencyError::ModelBudgetOverflow)?;
+                if increment > remaining {
+                    continue;
+                }
+                if best.as_ref().is_none_or(|(best_increment, best_layer, _)| {
+                    (increment, layer_index) < (*best_increment, *best_layer)
+                }) {
+                    best = Some((increment, layer_index, candidate));
+                }
+            }
+            let Some((increment, layer_index, candidate)) = best else {
+                break;
+            };
+            layer_plans[layer_index] = candidate;
+            total_arena_allocation_bytes = total_arena_allocation_bytes
+                .checked_add(increment)
+                .ok_or(GpuNativeTieredResidencyError::ModelBudgetOverflow)?;
+        }
+
+        debug_assert!(total_arena_allocation_bytes <= total_expert_budget_bytes);
+        Ok(Self {
+            geometry,
+            total_expert_budget_bytes,
+            minimum_executable_budget_bytes,
+            layer_plans,
+            total_arena_allocation_bytes,
+        })
+    }
+
+    pub(crate) const fn geometry(&self) -> GpuNativeQ4ExpertGeometry {
+        self.geometry
+    }
+
+    pub(crate) const fn total_expert_budget_bytes(&self) -> u64 {
+        self.total_expert_budget_bytes
+    }
+
+    pub(crate) const fn minimum_executable_budget_bytes(&self) -> u64 {
+        self.minimum_executable_budget_bytes
+    }
+
+    pub(crate) fn num_layers(&self) -> usize {
+        self.layer_plans.len()
+    }
+
+    pub(crate) fn layer_plans(&self) -> &[GpuNativeQ4ExpertVramPlan] {
+        &self.layer_plans
+    }
+
+    pub(crate) const fn total_arena_allocation_bytes(&self) -> u64 {
+        self.total_arena_allocation_bytes
+    }
+
+    pub(crate) const fn unused_remainder_bytes(&self) -> u64 {
+        self.total_expert_budget_bytes - self.total_arena_allocation_bytes
+    }
+
+    pub(crate) fn model_slot_capacity(&self) -> usize {
+        self.layer_plans
+            .iter()
+            .map(|plan| plan.slot_capacity())
+            .sum()
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) enum GpuNativeResidencyPriority {
+    Demand,
+    Speculative { score: f64 },
+}
+
+#[derive(Clone)]
+pub(crate) enum GpuNativeDemandExpert {
+    Current {
+        global_id: u32,
+    },
+    Install {
+        global_id: u32,
+        resident: Arc<ExpertResident>,
+        admission: GpuAdmission,
+    },
+}
+
+impl GpuNativeDemandExpert {
+    pub(crate) const fn current(global_id: u32) -> Self {
+        Self::Current { global_id }
+    }
+
+    pub(crate) fn install(
+        global_id: u32,
+        resident: Arc<ExpertResident>,
+        admission: GpuAdmission,
+    ) -> Self {
+        Self::Install {
+            global_id,
+            resident,
+            admission,
+        }
+    }
+
+    const fn global_id(&self) -> u32 {
+        match self {
+            Self::Current { global_id } | Self::Install { global_id, .. } => *global_id,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum GpuNativeSpeculativeProbe {
+    Hit(GpuNativeQ4ExpertResidency),
+    Miss,
+    DroppedPressure,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum GpuNativeSpeculativeInstall {
+    Hit(GpuNativeQ4ExpertResidency),
+    Installed(GpuNativeQ4ExpertResidency),
+    DroppedCapacityOrPressure,
+    StaleLogicalGeneration,
+}
+
+#[derive(Clone, Copy)]
+struct PhysicalRecord {
+    key: GpuNativeQ4ExpertKey,
+    residency: GpuNativeQ4ExpertResidency,
+}
+
+struct LayerResidencyState {
+    residents: LruCache<u32, PhysicalRecord>,
+    last_installed_generations: HashMap<u32, u64>,
+    physical_evictions: u64,
+}
+
+impl Default for LayerResidencyState {
+    fn default() -> Self {
+        Self {
+            residents: LruCache::unbounded(),
+            last_installed_generations: HashMap::new(),
+            physical_evictions: 0,
+        }
+    }
+}
+
+struct LayerResidency {
+    arena: Arc<GpuNativeQ4ExpertArena>,
+    state: Mutex<LayerResidencyState>,
+}
+
+#[derive(Default)]
+struct TieredResidencyCounters {
+    vram_hits: AtomicU64,
+    vram_misses: AtomicU64,
+    ram_to_vram_installs: AtomicU64,
+    physical_evictions: AtomicU64,
+    physical_reinstalls: AtomicU64,
+    stale_generation_rejections: AtomicU64,
+    demand_requests: AtomicU64,
+    speculative_requests: AtomicU64,
+    speculative_vram_hits: AtomicU64,
+    speculative_ram_to_vram_installs: AtomicU64,
+    speculative_dropped_capacity_or_pressure: AtomicU64,
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub(crate) struct GpuNativeTieredLayerSnapshot {
+    pub(crate) slot_capacity: usize,
+    pub(crate) resident_slots: usize,
+    pub(crate) free_slots: usize,
+    pub(crate) physical_evictions: u64,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub(crate) struct GpuNativeTieredResidencySnapshot {
+    pub(crate) model_expert_budget_bytes: u64,
+    pub(crate) model_arena_allocation_bytes: u64,
+    pub(crate) model_slot_capacity: usize,
+    pub(crate) resident_physical_slots: usize,
+    pub(crate) free_physical_slots: usize,
+    pub(crate) vram_hits: u64,
+    pub(crate) vram_misses: u64,
+    pub(crate) ram_to_vram_installs: u64,
+    pub(crate) physical_evictions: u64,
+    pub(crate) physical_reinstalls: u64,
+    pub(crate) stale_generation_rejections: u64,
+    pub(crate) demand_requests: u64,
+    pub(crate) speculative_requests: u64,
+    pub(crate) speculative_vram_hits: u64,
+    pub(crate) speculative_ram_to_vram_installs: u64,
+    pub(crate) speculative_dropped_capacity_or_pressure: u64,
+    pub(crate) layers: Vec<GpuNativeTieredLayerSnapshot>,
+}
+
+/// Model-scoped owner of the preallocated per-layer Q4 expert arenas.
+pub(crate) struct GpuNativeTieredResidencyManager {
+    executor: Arc<GpuNativeExecutorContext>,
+    gpu_cache: Arc<GpuExpertCache>,
+    plan: GpuNativeModelExpertVramPlan,
+    layers: Vec<LayerResidency>,
+    counters: TieredResidencyCounters,
+}
+
+impl GpuNativeTieredResidencyManager {
+    pub(crate) fn try_new(
+        executor: Arc<GpuNativeExecutorContext>,
+        gpu_cache: Arc<GpuExpertCache>,
+        num_layers: usize,
+        geometry: GpuNativeQ4ExpertGeometry,
+        total_expert_budget_bytes: u64,
+    ) -> Result<Self, GpuNativeTieredResidencyError> {
+        let limits = executor.device_limits()?;
+        let plan = GpuNativeModelExpertVramPlan::try_new(
+            num_layers,
+            geometry,
+            total_expert_budget_bytes,
+            &limits,
+        )?;
+        let mut layers = Vec::with_capacity(num_layers);
+        for (layer_index, layer_plan) in plan.layer_plans().iter().copied().enumerate() {
+            let arena = executor.create_q4_expert_arena(layer_index, layer_plan, &[])?;
+            layers.push(LayerResidency {
+                arena: Arc::new(arena),
+                state: Mutex::new(LayerResidencyState::default()),
+            });
+        }
+        Ok(Self {
+            executor,
+            gpu_cache,
+            plan,
+            layers,
+            counters: TieredResidencyCounters::default(),
+        })
+    }
+
+    pub(crate) fn executor(&self) -> &Arc<GpuNativeExecutorContext> {
+        &self.executor
+    }
+
+    pub(crate) fn gpu_cache(&self) -> &Arc<GpuExpertCache> {
+        &self.gpu_cache
+    }
+
+    pub(crate) fn plan(&self) -> &GpuNativeModelExpertVramPlan {
+        &self.plan
+    }
+
+    pub(crate) fn arena(&self, layer_index: usize) -> Option<&Arc<GpuNativeQ4ExpertArena>> {
+        self.layers.get(layer_index).map(|layer| &layer.arena)
+    }
+
+    fn identity(
+        &self,
+        global_id: u32,
+    ) -> Result<GpuNativeLayerExpertId, GpuNativeTieredResidencyError> {
+        global_to_layer_local(
+            global_id,
+            self.plan.num_layers(),
+            self.plan.geometry().num_experts() as u32,
+        )
+    }
+
+    /// Read-only tier selection probe for the engine's async demand path.
+    /// A stale logical identity is retired before returning `false`.
+    pub(crate) fn has_current_for_demand(
+        &self,
+        global_id: u32,
+    ) -> Result<bool, GpuNativeTieredResidencyError> {
+        let identity = self.identity(global_id)?;
+        let layer = &self.layers[identity.layer_index];
+        let mut state = layer.state.lock();
+        Ok(self
+            .current_record_locked(global_id, layer, &mut state, false)?
+            .is_some())
+    }
+
+    /// VRAM-first speculative probe. It never waits behind a demand mutation;
+    /// contention is an immediate best-effort drop.
+    pub(crate) fn probe_speculative(
+        &self,
+        global_id: u32,
+        priority: GpuNativeResidencyPriority,
+    ) -> Result<GpuNativeSpeculativeProbe, GpuNativeTieredResidencyError> {
+        let GpuNativeResidencyPriority::Speculative { score: _ } = priority else {
+            return Err(GpuNativeTieredResidencyError::ResidencyPriorityMismatch);
+        };
+        self.counters
+            .speculative_requests
+            .fetch_add(1, Ordering::Relaxed);
+        let identity = self.identity(global_id)?;
+        let layer = &self.layers[identity.layer_index];
+        let Some(mut state) = layer.state.try_lock() else {
+            self.record_speculative_drop();
+            return Ok(GpuNativeSpeculativeProbe::DroppedPressure);
+        };
+        if let Some(record) = self.current_record_locked(global_id, layer, &mut state, true)? {
+            self.counters.vram_hits.fetch_add(1, Ordering::Relaxed);
+            self.counters
+                .speculative_vram_hits
+                .fetch_add(1, Ordering::Relaxed);
+            Ok(GpuNativeSpeculativeProbe::Hit(record.residency))
+        } else {
+            self.counters.vram_misses.fetch_add(1, Ordering::Relaxed);
+            Ok(GpuNativeSpeculativeProbe::Miss)
+        }
+    }
+
+    pub(crate) fn ensure_demand_set(
+        &self,
+        priority: GpuNativeResidencyPriority,
+        layer_index: usize,
+        demands: &[GpuNativeDemandExpert],
+    ) -> Result<Vec<GpuNativeQ4ExpertResidency>, GpuNativeTieredResidencyError> {
+        if !matches!(priority, GpuNativeResidencyPriority::Demand) {
+            return Err(GpuNativeTieredResidencyError::ResidencyPriorityMismatch);
+        }
+        let layer =
+            self.layers
+                .get(layer_index)
+                .ok_or(GpuNativeTieredResidencyError::LayerOutOfRange {
+                    layer_index,
+                    num_layers: self.layers.len(),
+                })?;
+        if demands.len() > layer.arena.slot_capacity() {
+            return Err(
+                GpuNativeTieredResidencyError::DemandSetExceedsLayerCapacity {
+                    requested: demands.len(),
+                    capacity: layer.arena.slot_capacity(),
+                },
+            );
+        }
+        let mut protected = HashSet::with_capacity(demands.len());
+        for demand in demands {
+            let global_id = demand.global_id();
+            if !protected.insert(global_id) {
+                return Err(GpuNativeTieredResidencyError::DuplicateDemandExpert { global_id });
+            }
+            let identity = self.identity(global_id)?;
+            if identity.layer_index != layer_index {
+                return Err(GpuNativeTieredResidencyError::DemandLayerMismatch {
+                    requested_layer: layer_index,
+                    global_id,
+                    actual_layer: identity.layer_index,
+                });
+            }
+            if let GpuNativeDemandExpert::Install {
+                resident,
+                admission,
+                ..
+            } = demand
+            {
+                self.validate_source(global_id, resident, admission)?;
+            }
+        }
+
+        self.counters
+            .demand_requests
+            .fetch_add(demands.len() as u64, Ordering::Relaxed);
+        let mut state = layer.state.lock();
+        let mut resolved = vec![None; demands.len()];
+        let mut misses = Vec::new();
+        for (index, demand) in demands.iter().enumerate() {
+            let global_id = demand.global_id();
+            if let Some(record) = self.current_record_locked(global_id, layer, &mut state, true)? {
+                self.counters.vram_hits.fetch_add(1, Ordering::Relaxed);
+                resolved[index] = Some(record.residency);
+            } else {
+                self.counters.vram_misses.fetch_add(1, Ordering::Relaxed);
+                match demand {
+                    GpuNativeDemandExpert::Install { .. } => misses.push(index),
+                    GpuNativeDemandExpert::Current { .. } => {
+                        return Err(GpuNativeTieredResidencyError::DemandSourceMissing {
+                            global_id,
+                        });
+                    }
+                }
+            }
+        }
+
+        while state.residents.len().saturating_add(misses.len()) > layer.arena.slot_capacity() {
+            let victim = oldest_unprotected(&state.residents, &protected)
+                .ok_or(GpuNativeTieredResidencyError::NoEvictablePhysicalSlot { layer_index })?;
+            self.retire_metadata_record_locked(victim, layer, &mut state, true)?;
+        }
+
+        for index in misses {
+            let GpuNativeDemandExpert::Install {
+                global_id,
+                resident,
+                admission,
+            } = &demands[index]
+            else {
+                unreachable!("miss list contains only install sources")
+            };
+            let residency =
+                self.install_locked(*global_id, resident, admission, layer, &mut state, false)?;
+            resolved[index] = Some(residency);
+        }
+        resolved
+            .into_iter()
+            .enumerate()
+            .map(|(index, residency)| {
+                residency.ok_or(GpuNativeTieredResidencyError::DemandSourceMissing {
+                    global_id: demands[index].global_id(),
+                })
+            })
+            .collect()
+    }
+
+    pub(crate) fn ensure_speculative_resident(
+        &self,
+        global_id: u32,
+        resident: &Arc<ExpertResident>,
+        admission: &GpuAdmission,
+        priority: GpuNativeResidencyPriority,
+    ) -> Result<GpuNativeSpeculativeInstall, GpuNativeTieredResidencyError> {
+        let GpuNativeResidencyPriority::Speculative { score: _ } = priority else {
+            return Err(GpuNativeTieredResidencyError::ResidencyPriorityMismatch);
+        };
+        if let Err(error) = self.validate_source(global_id, resident, admission) {
+            if matches!(
+                error,
+                GpuNativeTieredResidencyError::LogicalAdmissionStale { .. }
+            ) {
+                return Ok(GpuNativeSpeculativeInstall::StaleLogicalGeneration);
+            }
+            return Err(error);
+        }
+        let identity = self.identity(global_id)?;
+        let layer = &self.layers[identity.layer_index];
+        let Some(mut state) = layer.state.try_lock() else {
+            self.record_speculative_drop();
+            return Ok(GpuNativeSpeculativeInstall::DroppedCapacityOrPressure);
+        };
+        if let Some(record) = self.current_record_locked(global_id, layer, &mut state, true)? {
+            self.counters.vram_hits.fetch_add(1, Ordering::Relaxed);
+            self.counters
+                .speculative_vram_hits
+                .fetch_add(1, Ordering::Relaxed);
+            return Ok(GpuNativeSpeculativeInstall::Hit(record.residency));
+        }
+        if !self
+            .gpu_cache
+            .contains_generation(global_id, admission.generation())
+        {
+            self.counters
+                .stale_generation_rejections
+                .fetch_add(1, Ordering::Relaxed);
+            return Ok(GpuNativeSpeculativeInstall::StaleLogicalGeneration);
+        }
+        if state.residents.len() >= layer.arena.slot_capacity() {
+            self.record_speculative_drop();
+            return Ok(GpuNativeSpeculativeInstall::DroppedCapacityOrPressure);
+        }
+        let residency =
+            match self.install_locked(global_id, resident, admission, layer, &mut state, true) {
+                Ok(residency) => residency,
+                Err(GpuNativeTieredResidencyError::NoPhysicalSlot { .. }) => {
+                    return Ok(GpuNativeSpeculativeInstall::DroppedCapacityOrPressure);
+                }
+                Err(error) => return Err(error),
+            };
+        Ok(GpuNativeSpeculativeInstall::Installed(residency))
+    }
+
+    pub(crate) fn snapshot(&self) -> GpuNativeTieredResidencySnapshot {
+        let layers = self
+            .layers
+            .iter()
+            .map(|layer| {
+                let arena = layer.arena.residency_snapshot();
+                let state = layer.state.lock();
+                GpuNativeTieredLayerSnapshot {
+                    slot_capacity: arena.slot_capacity,
+                    resident_slots: arena.resident_slots,
+                    free_slots: arena.free_slots,
+                    physical_evictions: state.physical_evictions,
+                }
+            })
+            .collect::<Vec<_>>();
+        GpuNativeTieredResidencySnapshot {
+            model_expert_budget_bytes: self.plan.total_expert_budget_bytes(),
+            model_arena_allocation_bytes: self.plan.total_arena_allocation_bytes(),
+            model_slot_capacity: self.plan.model_slot_capacity(),
+            resident_physical_slots: layers.iter().map(|layer| layer.resident_slots).sum(),
+            free_physical_slots: layers.iter().map(|layer| layer.free_slots).sum(),
+            vram_hits: self.counters.vram_hits.load(Ordering::Relaxed),
+            vram_misses: self.counters.vram_misses.load(Ordering::Relaxed),
+            ram_to_vram_installs: self.counters.ram_to_vram_installs.load(Ordering::Relaxed),
+            physical_evictions: self.counters.physical_evictions.load(Ordering::Relaxed),
+            physical_reinstalls: self.counters.physical_reinstalls.load(Ordering::Relaxed),
+            stale_generation_rejections: self
+                .counters
+                .stale_generation_rejections
+                .load(Ordering::Relaxed),
+            demand_requests: self.counters.demand_requests.load(Ordering::Relaxed),
+            speculative_requests: self.counters.speculative_requests.load(Ordering::Relaxed),
+            speculative_vram_hits: self.counters.speculative_vram_hits.load(Ordering::Relaxed),
+            speculative_ram_to_vram_installs: self
+                .counters
+                .speculative_ram_to_vram_installs
+                .load(Ordering::Relaxed),
+            speculative_dropped_capacity_or_pressure: self
+                .counters
+                .speculative_dropped_capacity_or_pressure
+                .load(Ordering::Relaxed),
+            layers,
+        }
+    }
+
+    fn validate_source(
+        &self,
+        global_id: u32,
+        resident: &Arc<ExpertResident>,
+        admission: &GpuAdmission,
+    ) -> Result<(), GpuNativeTieredResidencyError> {
+        if resident.id != global_id || admission.resident().id != global_id {
+            return Err(GpuNativeTieredResidencyError::DemandSourceIdentityMismatch { global_id });
+        }
+        if !self
+            .gpu_cache
+            .contains_generation(global_id, admission.generation())
+        {
+            self.counters
+                .stale_generation_rejections
+                .fetch_add(1, Ordering::Relaxed);
+            return Err(GpuNativeTieredResidencyError::LogicalAdmissionStale {
+                global_id,
+                generation: admission.generation(),
+            });
+        }
+        Ok(())
+    }
+
+    fn current_record_locked(
+        &self,
+        global_id: u32,
+        layer: &LayerResidency,
+        state: &mut MutexGuard<'_, LayerResidencyState>,
+        touch: bool,
+    ) -> Result<Option<PhysicalRecord>, GpuNativeTieredResidencyError> {
+        let Some(record) = state.residents.peek(&global_id).copied() else {
+            return Ok(None);
+        };
+        if !self
+            .gpu_cache
+            .contains_generation(global_id, record.key.logical_generation())
+        {
+            self.retire_metadata_record_locked(global_id, layer, state, false)?;
+            self.counters
+                .stale_generation_rejections
+                .fetch_add(1, Ordering::Relaxed);
+            return Ok(None);
+        }
+        if touch {
+            let record = state
+                .residents
+                .get(&global_id)
+                .copied()
+                .expect("peeked current physical record remains under layer lock");
+            Ok(Some(record))
+        } else {
+            Ok(Some(record))
+        }
+    }
+
+    fn retire_metadata_record_locked(
+        &self,
+        global_id: u32,
+        layer: &LayerResidency,
+        state: &mut MutexGuard<'_, LayerResidencyState>,
+        capacity_eviction: bool,
+    ) -> Result<(), GpuNativeTieredResidencyError> {
+        let Some(record) = state.residents.peek(&global_id).copied() else {
+            return Ok(());
+        };
+        match self
+            .executor
+            .retire_q4_expert_residency(&layer.arena, record.key)?
+        {
+            GpuNativeQ4ExpertRetire::Retired
+            | GpuNativeQ4ExpertRetire::CancelledInstall
+            | GpuNativeQ4ExpertRetire::NotResident
+            | GpuNativeQ4ExpertRetire::StaleRequester => {}
+        }
+        state.residents.pop(&global_id);
+        if capacity_eviction {
+            state.physical_evictions = state.physical_evictions.saturating_add(1);
+            self.counters
+                .physical_evictions
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        Ok(())
+    }
+
+    fn install_locked(
+        &self,
+        global_id: u32,
+        resident: &Arc<ExpertResident>,
+        admission: &GpuAdmission,
+        layer: &LayerResidency,
+        state: &mut MutexGuard<'_, LayerResidencyState>,
+        speculative: bool,
+    ) -> Result<GpuNativeQ4ExpertResidency, GpuNativeTieredResidencyError> {
+        let identity = self.identity(global_id)?;
+        let key = global_to_q4_expert_key(
+            global_id,
+            admission.generation(),
+            self.plan.num_layers(),
+            self.plan.geometry().num_experts() as u32,
+        )?;
+        let (residency, installed) = match self
+            .executor
+            .acquire_q4_expert_residency(&layer.arena, key)?
+        {
+            GpuNativeQ4ExpertAcquire::Hit(hit) => (hit, false),
+            GpuNativeQ4ExpertAcquire::Install(permit) => (
+                self.executor
+                    .install_q4_expert_residency(permit, resident.data())?,
+                true,
+            ),
+            GpuNativeQ4ExpertAcquire::InstallInProgress => {
+                return Err(GpuNativeTieredResidencyError::InstallInProgress {
+                    global_id,
+                    generation: admission.generation(),
+                });
+            }
+            GpuNativeQ4ExpertAcquire::StaleRequester => {
+                self.counters
+                    .stale_generation_rejections
+                    .fetch_add(1, Ordering::Relaxed);
+                return Err(GpuNativeTieredResidencyError::StalePhysicalRequester {
+                    global_id,
+                    generation: admission.generation(),
+                });
+            }
+            GpuNativeQ4ExpertAcquire::NoPhysicalSlot => {
+                if speculative {
+                    self.record_speculative_drop();
+                }
+                return Err(GpuNativeTieredResidencyError::NoPhysicalSlot {
+                    layer_index: identity.layer_index,
+                });
+            }
+        };
+        if !self
+            .gpu_cache
+            .contains_generation(global_id, admission.generation())
+        {
+            let _ = self
+                .executor
+                .retire_q4_expert_residency(&layer.arena, key)?;
+            self.counters
+                .stale_generation_rejections
+                .fetch_add(1, Ordering::Relaxed);
+            return Err(GpuNativeTieredResidencyError::LogicalAdmissionStale {
+                global_id,
+                generation: admission.generation(),
+            });
+        }
+        let reinstall = installed
+            && state
+                .last_installed_generations
+                .insert(global_id, admission.generation())
+                == Some(admission.generation());
+        state
+            .residents
+            .put(global_id, PhysicalRecord { key, residency });
+        if installed {
+            self.counters
+                .ram_to_vram_installs
+                .fetch_add(1, Ordering::Relaxed);
+            if reinstall {
+                self.counters
+                    .physical_reinstalls
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+            if speculative {
+                self.counters
+                    .speculative_ram_to_vram_installs
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+        }
+        Ok(residency)
+    }
+
+    fn record_speculative_drop(&self) {
+        self.counters
+            .speculative_dropped_capacity_or_pressure
+            .fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+fn oldest_unprotected<T>(cache: &LruCache<u32, T>, protected: &HashSet<u32>) -> Option<u32> {
+    cache
+        .iter()
+        .rev()
+        .find_map(|(&global_id, _)| (!protected.contains(&global_id)).then_some(global_id))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::expert_cache::GpuResident;
+
+    fn geometry() -> GpuNativeQ4ExpertGeometry {
+        GpuNativeQ4ExpertGeometry::try_new(32, 32, 128, 2).unwrap()
+    }
+
+    fn limits() -> wgpu::Limits {
+        wgpu::Limits {
+            max_push_constant_size: 32,
+            max_storage_buffers_per_shader_stage: 8,
+            max_compute_workgroup_size_x: 64,
+            max_compute_invocations_per_workgroup: 64,
+            ..wgpu::Limits::default()
+        }
+    }
+
+    #[test]
+    fn global_layer_local_identity_is_checked_without_clamping() {
+        assert_eq!(
+            global_to_layer_local(0, 2, 128).unwrap(),
+            GpuNativeLayerExpertId {
+                layer_index: 0,
+                local_expert_id: 0,
+            }
+        );
+        assert_eq!(global_to_layer_local(127, 2, 128).unwrap().layer_index, 0);
+        assert_eq!(
+            global_to_layer_local(128, 2, 128).unwrap(),
+            GpuNativeLayerExpertId {
+                layer_index: 1,
+                local_expert_id: 0,
+            }
+        );
+        assert_eq!(layer_local_to_global(1, 127, 2, 128).unwrap(), 255);
+        assert!(matches!(
+            global_to_layer_local(256, 2, 128),
+            Err(GpuNativeTieredResidencyError::GlobalExpertOutOfRange { .. })
+        ));
+        assert!(layer_local_to_global(2, 0, 2, 128).is_err());
+        assert!(layer_local_to_global(1, 128, 2, 128).is_err());
+        let generation = 0xfedc_ba98_7654_3210;
+        let key = global_to_q4_expert_key(129, generation, 2, 128).unwrap();
+        assert_eq!(key.layer_index(), 1);
+        assert_eq!(key.expert_id(), 1);
+        assert_eq!(key.logical_generation(), generation);
+    }
+
+    #[test]
+    fn logical_admission_generation_reaches_physical_key_unchanged() {
+        let cache = GpuExpertCache::new(8, 0.0, 0);
+        cache
+            .demand_admit_lru(Arc::new(GpuResident::new(7, vec![1; 8])))
+            .unwrap();
+        let first = cache.current_admission(7).unwrap();
+        let first_key = global_to_q4_expert_key(7, first.generation(), 2, 128).unwrap();
+        assert_eq!(first_key.logical_generation(), first.generation());
+        assert!(cache.contains_generation(7, first_key.logical_generation()));
+
+        // Fill the one-entry LRU with another identity, then readmit the same
+        // global expert. Only GpuExpertCache advances the logical generation;
+        // the physical key is a lossless consumer of that identity.
+        cache
+            .demand_admit_lru(Arc::new(GpuResident::new(8, vec![2; 8])))
+            .unwrap();
+        assert!(!cache.contains_generation(7, first.generation()));
+        cache
+            .demand_admit_lru(Arc::new(GpuResident::new(7, vec![3; 8])))
+            .unwrap();
+        let newer = cache.current_admission(7).unwrap();
+        assert!(newer.generation() > first.generation());
+        let newer_key = global_to_q4_expert_key(7, newer.generation(), 2, 128).unwrap();
+        assert_eq!(newer_key.logical_generation(), newer.generation());
+        assert!(!cache.contains_generation(7, first_key.logical_generation()));
+        assert!(cache.contains_generation(7, newer_key.logical_generation()));
+    }
+
+    #[test]
+    fn model_plan_requires_top_k_slots_per_layer_and_counts_every_arena() {
+        let limits = limits();
+        let geometry = geometry();
+        let layer_min =
+            GpuNativeQ4ExpertVramPlan::try_for_slot_capacity(geometry, geometry.top_k(), &limits)
+                .unwrap();
+        let exact = layer_min.total_arena_allocation_bytes() * 2;
+        assert!(matches!(
+            GpuNativeModelExpertVramPlan::try_new(2, geometry, exact - 1, &limits),
+            Err(GpuNativeTieredResidencyError::ModelBudgetTooSmall { .. })
+        ));
+        let plan = GpuNativeModelExpertVramPlan::try_new(2, geometry, exact, &limits).unwrap();
+        assert_eq!(plan.minimum_executable_budget_bytes(), exact);
+        assert_eq!(plan.total_arena_allocation_bytes(), exact);
+        assert_eq!(plan.layer_plans().len(), 2);
+        assert!(plan
+            .layer_plans()
+            .iter()
+            .all(|layer| layer.slot_capacity() == geometry.top_k()));
+        assert!(plan.layer_plans().iter().all(|layer| {
+            layer.total_arena_allocation_bytes()
+                >= layer.physical_bank_allocation_bytes() + layer.mapping_metadata_bytes()
+        }));
+        assert!(plan.layer_plans().iter().all(|layer| {
+            layer.physical_bank_allocation_bytes() - layer.active_bank_allocation_bytes()
+                == 3 * std::mem::size_of::<u32>() as u64
+        }));
+        assert!(plan
+            .layer_plans()
+            .iter()
+            .all(|layer| layer.total_arena_allocation_bytes() < exact));
+    }
+
+    #[test]
+    fn model_plan_is_deterministic_monotonic_bounded_and_saturating() {
+        let limits = limits();
+        let geometry = geometry();
+        let minimum = GpuNativeModelExpertVramPlan::try_new(
+            3,
+            geometry,
+            GpuNativeQ4ExpertVramPlan::try_for_slot_capacity(geometry, geometry.top_k(), &limits)
+                .unwrap()
+                .total_arena_allocation_bytes()
+                * 3,
+            &limits,
+        )
+        .unwrap();
+        let extra = geometry.slot_stride_bytes() as u64 * 7;
+        let larger = GpuNativeModelExpertVramPlan::try_new(
+            3,
+            geometry,
+            minimum.total_expert_budget_bytes() + extra,
+            &limits,
+        )
+        .unwrap();
+        let repeat = GpuNativeModelExpertVramPlan::try_new(
+            3,
+            geometry,
+            minimum.total_expert_budget_bytes() + extra,
+            &limits,
+        )
+        .unwrap();
+        assert_eq!(larger, repeat);
+        assert!(larger.total_arena_allocation_bytes() <= larger.total_expert_budget_bytes());
+        for (small, large) in minimum.layer_plans().iter().zip(larger.layer_plans()) {
+            assert!(large.slot_capacity() >= small.slot_capacity());
+            assert!(large.slot_capacity() <= geometry.num_experts());
+        }
+        for layer in larger.layer_plans() {
+            if layer.slot_capacity() < geometry.num_experts() {
+                let next = GpuNativeQ4ExpertVramPlan::try_for_slot_capacity(
+                    geometry,
+                    layer.slot_capacity() + 1,
+                    &limits,
+                )
+                .unwrap();
+                let increment =
+                    next.total_arena_allocation_bytes() - layer.total_arena_allocation_bytes();
+                assert!(increment > larger.unused_remainder_bytes());
+            }
+        }
+    }
+
+    #[test]
+    fn protected_demand_members_are_never_lru_victims() {
+        let mut lru = LruCache::unbounded();
+        for id in 0..8 {
+            lru.put(id, ());
+        }
+        let protected = HashSet::from([0, 1, 2, 3, 4, 5, 6]);
+        assert_eq!(oldest_unprotected(&lru, &protected), Some(7));
+        let all = (0..8).collect::<HashSet<_>>();
+        assert_eq!(oldest_unprotected(&lru, &all), None);
+
+        let mut other_layer = LruCache::unbounded();
+        other_layer.put(128, ());
+        other_layer.put(129, ());
+        let other_before = other_layer.iter().map(|(&id, _)| id).collect::<Vec<_>>();
+        let _ = oldest_unprotected(&lru, &protected);
+        assert_eq!(
+            other_layer.iter().map(|(&id, _)| id).collect::<Vec<_>>(),
+            other_before
+        );
+    }
+}

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -139,6 +139,7 @@ mod expert_cache;
 mod gating;
 mod gguf;
 mod gguf_loader;
+mod gpu_native_residency;
 #[cfg(feature = "grpc")]
 mod grpc;
 #[cfg(feature = "grpc")]


### PR DESCRIPTION
## Summary
- add a model-wide GPU-native expert VRAM planner with per-layer executable top-k capacity
- connect existing logical GPU admission generations and RAM `ExpertResident` payloads to Slice 8 mutable Q4 expert arenas
- reuse the existing NVMe singleflight, speculative semaphore, shadow-buffer path, predictors, and `PrefetchGovernor` for tier-aware RAM/NVMe -> VRAM residency
- add per-layer physical LRU replacement, demand-set protection, generation validation, and tiered residency observability
- add an encoder-only retryable residency-status clear that preserves fatal bits
- keep GPU-native production token-loop composition out of scope

## Validation
- `cargo check --bin micro-expert-router`: passed
- GPU-native tests: 67 passed, 8 ignored
- tier-manager tests: 5 passed
- backend tests: passed
- full Mac-safe suite: 1012 passed, 10 ignored
- concurrency integration: passed
- WGSL/Naga, targeted rustfmt, and `git diff --check`: passed
- NVIDIA L4 qualification: `backend::gpu_native::tests::live_l4_gpu_native_tiered_residency_retry` passed 1/1 at exact head `e50863a2a1bafc6ddbdbd5277696558d3f0304ef`

## Scope notes
- no `GpuExpertCache`, `PrefetchGovernor`, legacy `PhysicalGpuExpertRegistry`, or config semantic changes
- no second WGPU device/context
- no production submit/map/readback path added
- no CPU expert fallback added
- no full GPU-native token loop wired in this PR

Qualified head: `e50863a2a1bafc6ddbdbd5277696558d3f0304ef`