### PR TITLE
Add GPU-native full token loop with demand residency replay

### DIFF
--- a/rust-engine/src/backend/gpu_native.rs
+++ b/rust-engine/src/backend/gpu_native.rs
@@ -3639,12 +3639,29 @@ impl GpuNativeScratchLayout {
         self.bytes
     }
 
-    fn usage() -> wgpu::BufferUsages {
+    pub(crate) fn usage() -> wgpu::BufferUsages {
         wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST
+    }
+
+    pub(crate) fn boundary_result_usage() -> wgpu::BufferUsages {
+        wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC
     }
 
     fn validate_for_limits(self, limits: &wgpu::Limits) -> Result<(), GpuNativeBootstrapError> {
         super::validate_startup_buffer("gpu_native_scratch", self.bytes, Self::usage(), limits)?;
+        Ok(())
+    }
+
+    fn validate_for_boundary_result_limits(
+        self,
+        limits: &wgpu::Limits,
+    ) -> Result<(), GpuNativeBootstrapError> {
+        super::validate_startup_buffer(
+            "gpu_native_boundary_result_scratch",
+            self.bytes,
+            Self::boundary_result_usage(),
+            limits,
+        )?;
         Ok(())
     }
 }
@@ -3740,11 +3757,11 @@ impl GpuNativeRouterScratchLayout {
         })
     }
 
-    fn logits_usage() -> wgpu::BufferUsages {
+    pub(crate) fn logits_usage() -> wgpu::BufferUsages {
         wgpu::BufferUsages::STORAGE
     }
 
-    fn result_usage() -> wgpu::BufferUsages {
+    pub(crate) fn result_usage() -> wgpu::BufferUsages {
         wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC
     }
 
@@ -6111,6 +6128,28 @@ impl GpuNativeExecutorContext {
             &format!("gpu_native_scratch_{scratch_id}"),
             layout.bytes,
             GpuNativeScratchLayout::usage(),
+        )?;
+        Ok(GpuNativeScratch::from_buffer(
+            self.context_id,
+            scratch_id,
+            layout,
+            buffer,
+        ))
+    }
+
+    pub(crate) fn create_boundary_result_scratch(
+        &self,
+        elements: usize,
+    ) -> Result<GpuNativeScratch, GpuNativeBootstrapError> {
+        let gpu = self.authoritative_gpu()?;
+        let layout = GpuNativeScratchLayout::try_new(elements)?;
+        layout.validate_for_boundary_result_limits(&gpu.device.limits())?;
+        let scratch_id = next_nonzero_id(&NEXT_GPU_NATIVE_SCRATCH_ID, "boundary result scratch");
+        let buffer = create_startup_buffer(
+            &gpu.device,
+            &format!("gpu_native_boundary_result_scratch_{scratch_id}"),
+            layout.bytes,
+            GpuNativeScratchLayout::boundary_result_usage(),
         )?;
         Ok(GpuNativeScratch::from_buffer(
             self.context_id,
@@ -14099,8 +14138,28 @@ fn compare_main(@builtin(global_invocation_id) gid: vec3<u32>) {
         assert!(status.contains(wgpu::BufferUsages::COPY_SRC));
         assert!(!status.intersects(wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::MAP_WRITE));
 
+        let generic_scratch = GpuNativeScratchLayout::usage();
+        assert!(generic_scratch.contains(wgpu::BufferUsages::STORAGE));
+        assert!(generic_scratch.contains(wgpu::BufferUsages::COPY_DST));
+        assert!(!generic_scratch.contains(wgpu::BufferUsages::COPY_SRC));
+        assert!(!generic_scratch
+            .intersects(wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::MAP_WRITE));
+
+        let boundary_result = GpuNativeScratchLayout::boundary_result_usage();
+        assert!(boundary_result.contains(wgpu::BufferUsages::STORAGE));
+        assert!(boundary_result.contains(wgpu::BufferUsages::COPY_SRC));
+        assert!(!boundary_result.contains(wgpu::BufferUsages::COPY_DST));
+        assert!(!boundary_result
+            .intersects(wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::MAP_WRITE));
+
+        let router_result = GpuNativeRouterScratchLayout::result_usage();
+        assert!(router_result.contains(wgpu::BufferUsages::STORAGE));
+        assert!(router_result.contains(wgpu::BufferUsages::COPY_SRC));
+        assert!(
+            !router_result.intersects(wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::MAP_WRITE)
+        );
+
         for usage in [
-            GpuNativeScratchLayout::usage(),
             GpuNativeDenseWeightLayout::usage(),
             GpuNativeKvLayout::usage(),
         ] {

--- a/rust-engine/src/backend/gpu_native.rs
+++ b/rust-engine/src/backend/gpu_native.rs
@@ -26,13 +26,15 @@ const GPU_NATIVE_STATUS_BYTES: u64 = std::mem::size_of::<u32>() as u64;
 // scheduler handles it; production encoding never clears these bits. Fatal
 // numerical failures retire the request. A residency miss is retryable after
 // residency service and must not be classified as a numerical failure.
-const GPU_NATIVE_STATUS_ATTENTION_NUMERICAL_FAILURE: u32 = 1 << 0;
-const GPU_NATIVE_STATUS_ROUTER_NUMERICAL_FAILURE: u32 = 1 << 1;
-const GPU_NATIVE_STATUS_EXPERT_RESIDENCY_MISS: u32 = 1 << 2;
-const GPU_NATIVE_STATUS_EXPERT_NUMERICAL_FAILURE: u32 = 1 << 3;
+pub(crate) const GPU_NATIVE_STATUS_ATTENTION_NUMERICAL_FAILURE: u32 = 1 << 0;
+pub(crate) const GPU_NATIVE_STATUS_ROUTER_NUMERICAL_FAILURE: u32 = 1 << 1;
+pub(crate) const GPU_NATIVE_STATUS_EXPERT_RESIDENCY_MISS: u32 = 1 << 2;
+pub(crate) const GPU_NATIVE_STATUS_EXPERT_NUMERICAL_FAILURE: u32 = 1 << 3;
+pub(crate) const GPU_NATIVE_STATUS_LM_HEAD_NUMERICAL_FAILURE: u32 = 1 << 4;
 pub(crate) const GPU_NATIVE_STATUS_FATAL_MASK: u32 = GPU_NATIVE_STATUS_ATTENTION_NUMERICAL_FAILURE
     | GPU_NATIVE_STATUS_ROUTER_NUMERICAL_FAILURE
-    | GPU_NATIVE_STATUS_EXPERT_NUMERICAL_FAILURE;
+    | GPU_NATIVE_STATUS_EXPERT_NUMERICAL_FAILURE
+    | GPU_NATIVE_STATUS_LM_HEAD_NUMERICAL_FAILURE;
 pub(crate) const GPU_NATIVE_STATUS_RETRYABLE_MASK: u32 = GPU_NATIVE_STATUS_EXPERT_RESIDENCY_MISS;
 
 #[inline]
@@ -51,6 +53,8 @@ const GPU_NATIVE_EXPERT_CONTROL_SHADER: &str =
     include_str!("wgpu_shaders/gpu_native_expert_control.wgsl");
 const GPU_NATIVE_STATUS_CONTROL_SHADER: &str =
     include_str!("wgpu_shaders/gpu_native_status_control.wgsl");
+const GPU_NATIVE_GREEDY_ARGMAX_SHADER: &str =
+    include_str!("wgpu_shaders/gpu_native_greedy_argmax.wgsl");
 const GPU_NATIVE_WORKGROUP_SIZE: u32 = 64;
 const GPU_NATIVE_ATTENTION_WORKGROUP_SIZE: u32 = 32;
 const GPU_NATIVE_ROUTER_WORKGROUP_SIZE: u32 = 64;
@@ -3574,11 +3578,11 @@ impl GpuNativeTokenStateLayout {
         self.total_buffer_bytes
     }
 
-    fn tensor_usage() -> wgpu::BufferUsages {
+    pub(crate) fn tensor_usage() -> wgpu::BufferUsages {
         wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST
     }
 
-    fn status_usage() -> wgpu::BufferUsages {
+    pub(crate) fn status_usage() -> wgpu::BufferUsages {
         wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::COPY_SRC
     }
 
@@ -3669,6 +3673,10 @@ impl<B> GpuNativeScratch<B> {
 
     pub(crate) const fn layout(&self) -> GpuNativeScratchLayout {
         self.layout
+    }
+
+    pub(crate) fn buffer(&self) -> &B {
+        &self.buffer
     }
 }
 
@@ -3814,6 +3822,10 @@ impl<B> GpuNativeRouterScratch<B> {
 
     pub(crate) const fn layout(&self) -> GpuNativeRouterScratchLayout {
         self.layout
+    }
+
+    pub(crate) fn selected_ids_buffer(&self) -> &B {
+        &self.selected_ids
     }
 }
 
@@ -4127,6 +4139,10 @@ impl<B> GpuNativeTokenState<B> {
 
     pub(crate) const fn layout(&self) -> GpuNativeTokenStateLayout {
         self.layout
+    }
+
+    pub(crate) fn status_buffer(&self) -> &B {
+        &self.status
     }
 }
 
@@ -5504,6 +5520,83 @@ impl GpuNativeStatusControlPipeline {
     }
 }
 
+#[repr(C)]
+#[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+struct GpuNativeGreedyArgmaxPushConstants {
+    vocab_size: u32,
+    _reserved_0: u32,
+    _reserved_1: u32,
+    _reserved_2: u32,
+}
+
+struct GpuNativeGreedyArgmaxPipeline {
+    bind_group_layout: wgpu::BindGroupLayout,
+    compute_pipeline: wgpu::ComputePipeline,
+}
+
+impl GpuNativeGreedyArgmaxPipeline {
+    fn new(device: &wgpu::Device) -> Self {
+        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("gpu_native_greedy_argmax_bind_group_layout"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: true },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: false },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 2,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: false },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+            ],
+        });
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("gpu_native_greedy_argmax_pipeline_layout"),
+            bind_group_layouts: &[&bind_group_layout],
+            push_constant_ranges: &[wgpu::PushConstantRange {
+                stages: wgpu::ShaderStages::COMPUTE,
+                range: 0..16,
+            }],
+        });
+        let module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("gpu_native_greedy_argmax_shader"),
+            source: wgpu::ShaderSource::Wgsl(GPU_NATIVE_GREEDY_ARGMAX_SHADER.into()),
+        });
+        let compute_pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: Some("gpu_native_greedy_argmax_pipeline"),
+            layout: Some(&pipeline_layout),
+            module: &module,
+            entry_point: "greedy_argmax_main",
+            compilation_options: wgpu::PipelineCompilationOptions::default(),
+        });
+        Self {
+            bind_group_layout,
+            compute_pipeline,
+        }
+    }
+}
+
 impl GpuNativeQ4ExpertPipelines {
     fn try_new(device: &wgpu::Device) -> Result<Self, GpuNativeBootstrapError> {
         validate_q4_expert_pipeline_limits(&device.limits())?;
@@ -5669,6 +5762,7 @@ pub(crate) struct GpuNativeExecutorContext {
     router_pipeline: GpuNativeRouterPipeline,
     q4_expert_pipelines: GpuNativeQ4ExpertPipelines,
     status_control_pipeline: GpuNativeStatusControlPipeline,
+    greedy_argmax_pipeline: GpuNativeGreedyArgmaxPipeline,
     counters: GpuNativeExecutionCounters,
 }
 
@@ -5699,6 +5793,7 @@ impl GpuNativeExecutorContext {
         let router_pipeline = GpuNativeRouterPipeline::new(&gpu.device);
         let q4_expert_pipelines = GpuNativeQ4ExpertPipelines::try_new(&gpu.device)?;
         let status_control_pipeline = GpuNativeStatusControlPipeline::new(&gpu.device);
+        let greedy_argmax_pipeline = GpuNativeGreedyArgmaxPipeline::new(&gpu.device);
 
         Ok(Self {
             context_id,
@@ -5712,6 +5807,7 @@ impl GpuNativeExecutorContext {
             router_pipeline,
             q4_expert_pipelines,
             status_control_pipeline,
+            greedy_argmax_pipeline,
             counters: GpuNativeExecutionCounters::default(),
         })
     }
@@ -6959,6 +7055,71 @@ impl GpuNativeExecutorContext {
         )
     }
 
+    /// Perform GPU greedy argmax over logits and write the selected token to `sampled_token_buf`.
+    /// On numerical failure or prior non-zero status, latches status and writes u32::MAX.
+    pub(crate) fn encode_greedy_argmax(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        logits: &GpuNativeScratch,
+        sampled_token_buf: &GpuNativeScratch,
+        state: &GpuNativeTokenState,
+        vocab_size: usize,
+    ) -> Result<(), GpuNativeBootstrapError> {
+        let gpu = self.authoritative_gpu()?;
+        if logits.context_id != self.context_id || sampled_token_buf.context_id != self.context_id {
+            return Err(GpuNativeBootstrapError::ForeignScratch);
+        }
+        if state.context_id != self.context_id {
+            return Err(GpuNativeBootstrapError::ForeignTokenState);
+        }
+        if logits.layout.elements() < vocab_size {
+            return Err(GpuNativeBootstrapError::GemvInputLength {
+                expected: vocab_size,
+                actual: logits.layout.elements(),
+            });
+        }
+        if sampled_token_buf.layout.elements() < 1 {
+            return Err(GpuNativeBootstrapError::GemvOutputLength {
+                expected: 1,
+                actual: sampled_token_buf.layout.elements(),
+            });
+        }
+        let bind_group = gpu.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("gpu_native_greedy_argmax_bind_group"),
+            layout: &self.greedy_argmax_pipeline.bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: logits.buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: sampled_token_buf.buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: state.status.as_entire_binding(),
+                },
+            ],
+        });
+        let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+            label: Some("gpu_native_greedy_argmax_pass"),
+            timestamp_writes: None,
+        });
+        pass.set_pipeline(&self.greedy_argmax_pipeline.compute_pipeline);
+        pass.set_bind_group(0, &bind_group, &[]);
+        let pc = GpuNativeGreedyArgmaxPushConstants {
+            vocab_size: vocab_size as u32,
+            _reserved_0: 0,
+            _reserved_1: 0,
+            _reserved_2: 0,
+        };
+        pass.set_push_constants(0, bytemuck::bytes_of(&pc));
+        pass.dispatch_workgroups(1, 1, 1);
+        drop(pass);
+        Ok(())
+    }
+
     /// RMS-normalise each logical scratch group independently using a shared
     /// `group_width`-element gain vector.
     pub(crate) fn encode_rms_norm_scratch_in_place(
@@ -7557,7 +7718,7 @@ impl GpuNativeExecutorContext {
         self.counters.record_residual_add_dispatch();
     }
 
-    fn authoritative_gpu(&self) -> Result<&super::GpuBackend, GpuNativeBootstrapError> {
+    pub(crate) fn authoritative_gpu(&self) -> Result<&super::GpuBackend, GpuNativeBootstrapError> {
         let gpu = match self.authoritative_backend.as_ref() {
             BackendBox::Gpu(gpu) => gpu,
             BackendBox::Cpu(_) => return Err(GpuNativeBootstrapError::GpuBackendUnavailable),
@@ -7617,7 +7778,7 @@ impl fmt::Debug for GpuNativeExecutorContext {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use crate::inference::{dequantize_q8_0_block, quantize_q8_0_block};
     use std::sync::atomic::AtomicUsize;
@@ -7751,7 +7912,7 @@ mod tests {
         block.repeat(rows * cols / Q4_0_BLOCK_ELEMS).to_vec()
     }
 
-    fn q4_uniform_expert(
+    pub(crate) fn q4_uniform_expert(
         geometry: GpuNativeQ4ExpertGeometry,
         gate_weight: f32,
         up_weight: f32,
@@ -10783,7 +10944,8 @@ mod tests {
         assert_eq!(GPU_NATIVE_STATUS_ROUTER_NUMERICAL_FAILURE, 2);
         assert_eq!(GPU_NATIVE_STATUS_EXPERT_RESIDENCY_MISS, 4);
         assert_eq!(GPU_NATIVE_STATUS_EXPERT_NUMERICAL_FAILURE, 8);
-        assert_eq!(GPU_NATIVE_STATUS_FATAL_MASK, 11);
+        assert_eq!(GPU_NATIVE_STATUS_LM_HEAD_NUMERICAL_FAILURE, 16);
+        assert_eq!(GPU_NATIVE_STATUS_FATAL_MASK, 27);
         assert_eq!(GPU_NATIVE_STATUS_RETRYABLE_MASK, 4);
         assert_eq!(
             GPU_NATIVE_STATUS_FATAL_MASK & GPU_NATIVE_STATUS_EXPERT_RESIDENCY_MISS,
@@ -10798,6 +10960,7 @@ mod tests {
             GPU_NATIVE_STATUS_ROUTER_NUMERICAL_FAILURE,
             GPU_NATIVE_STATUS_EXPERT_RESIDENCY_MISS,
             GPU_NATIVE_STATUS_EXPERT_NUMERICAL_FAILURE,
+            GPU_NATIVE_STATUS_LM_HEAD_NUMERICAL_FAILURE,
         ];
         assert!(bits.iter().all(|bit| bit.is_power_of_two()));
         for (index, bit) in bits.iter().enumerate() {
@@ -10883,6 +11046,7 @@ mod tests {
                 GPU_NATIVE_STATUS_CONTROL_SHADER,
                 &["clear_retryable_expert_residency_main"][..],
             ),
+            (GPU_NATIVE_GREEDY_ARGMAX_SHADER, &["greedy_argmax_main"][..]),
             (GPU_NATIVE_TEST_COMPARE_SHADER, &["compare_main"][..]),
         ] {
             let module = naga::front::wgsl::parse_str(source).expect("GPU-native WGSL must parse");

--- a/rust-engine/src/backend/mod.rs
+++ b/rust-engine/src/backend/mod.rs
@@ -1716,8 +1716,8 @@ fn create_startup_buffer(
 }
 
 pub struct GpuBackend {
-    device: wgpu::Device,
-    queue: wgpu::Queue,
+    pub(crate) device: wgpu::Device,
+    pub(crate) queue: wgpu::Queue,
     /// `wgpu` 0.20 has no synchronous device-loss return from submit, so
     /// dispatch checks this per-device callback state at entry and after poll.
     device_loss: Arc<DeviceLossState>,
@@ -4848,6 +4848,7 @@ impl ResolvedExecutionPlan {
         gpu_expert_cache_available: bool,
         routed_expert_gpu_spec: RoutedExpertGpuSpec,
         routed_expert_gpu_compatible: bool,
+        legacy_routed_experts_enabled: bool,
     ) -> Self {
         let cpu = ExecutionPlane::Cpu;
         let (attention, kv, routed_experts) = match resolution.resolved {
@@ -4855,7 +4856,10 @@ impl ResolvedExecutionPlan {
             ResolvedBackend::Gpu => (
                 ExecutionPlane::Gpu,
                 ExecutionPlane::Gpu,
-                if gpu_expert_cache_available && routed_expert_gpu_compatible {
+                if gpu_expert_cache_available
+                    && routed_expert_gpu_compatible
+                    && legacy_routed_experts_enabled
+                {
                     ExecutionPlane::Gpu
                 } else {
                     cpu
@@ -4864,7 +4868,10 @@ impl ResolvedExecutionPlan {
             ResolvedBackend::HybridCpuAttentionGpuExperts => (
                 cpu,
                 cpu,
-                if gpu_expert_cache_available && routed_expert_gpu_compatible {
+                if gpu_expert_cache_available
+                    && routed_expert_gpu_compatible
+                    && legacy_routed_experts_enabled
+                {
                     ExecutionPlane::Gpu
                 } else {
                     cpu
@@ -5511,10 +5518,53 @@ pub fn resolve_execution_context(
     routed_expert_gpu_spec: RoutedExpertGpuSpec,
     gpu_expert_cache: Arc<crate::expert_cache::GpuExpertCache>,
 ) -> std::result::Result<Arc<ExecutionContext>, BackendResolutionError> {
+    resolve_execution_context_custom(
+        requested,
+        strict_attention,
+        true,
+        geometry,
+        routed_expert_gpu_spec,
+        gpu_expert_cache,
+    )
+}
+
+/// Specialized resolution boundary for the GPU-native runtime.
+/// It constructs the authoritative full GPU backend for device ownership
+/// while disabling the legacy physical routed-expert registry so the
+/// model-wide expert VRAM budget remains exclusively owned by Slice 9's
+/// tiered residency manager.
+pub fn resolve_execution_context_for_gpu_native(
+    geometry: GpuBackendGeometry,
+    gpu_expert_cache: Arc<crate::expert_cache::GpuExpertCache>,
+) -> std::result::Result<Arc<ExecutionContext>, BackendResolutionError> {
+    let d_model = geometry.head_dim * geometry.num_heads;
+    resolve_execution_context_custom(
+        ComputeOffload::Gpu,
+        false,
+        false,
+        geometry,
+        RoutedExpertGpuSpec {
+            dtype: crate::inference::WeightDtype::Q4_0,
+            d_model,
+            d_ff: d_model,
+        },
+        gpu_expert_cache,
+    )
+}
+
+pub fn resolve_execution_context_custom(
+    requested: ComputeOffload,
+    strict_attention: bool,
+    legacy_routed_experts_enabled: bool,
+    geometry: GpuBackendGeometry,
+    routed_expert_gpu_spec: RoutedExpertGpuSpec,
+    gpu_expert_cache: Arc<crate::expert_cache::GpuExpertCache>,
+) -> std::result::Result<Arc<ExecutionContext>, BackendResolutionError> {
     let context_gpu_expert_cache = gpu_expert_cache.clone();
     resolve_execution_context_with_resource_plan(
         requested,
         strict_attention,
+        legacy_routed_experts_enabled,
         geometry,
         routed_expert_gpu_spec,
         context_gpu_expert_cache,
@@ -5581,6 +5631,7 @@ pub(crate) fn test_gpu_execution_context_unchecked(
         true,
         routed_expert_gpu_spec,
         true,
+        true,
     );
     Arc::new(ExecutionContext::new(
         plan,
@@ -5606,6 +5657,7 @@ where
     resolve_execution_context_with_resource_plan(
         requested,
         strict_attention,
+        true,
         geometry,
         routed_expert_gpu_spec,
         gpu_expert_cache,
@@ -5621,6 +5673,7 @@ where
 fn resolve_execution_context_with_resource_plan<F>(
     requested: ComputeOffload,
     strict_attention: bool,
+    legacy_routed_experts_enabled: bool,
     geometry: GpuBackendGeometry,
     routed_expert_gpu_spec: RoutedExpertGpuSpec,
     gpu_expert_cache: Arc<crate::expert_cache::GpuExpertCache>,
@@ -5659,6 +5712,7 @@ where
             gpu_expert_cache_available,
             routed_expert_gpu_spec,
             expert_compatibility.is_ok(),
+            legacy_routed_experts_enabled,
         );
         Some(GpuResourcePlan::from_execution_plan(
             &successful_plan,
@@ -5710,6 +5764,7 @@ where
         gpu_expert_cache_available,
         routed_expert_gpu_spec,
         routed_expert_gpu_compatible,
+        legacy_routed_experts_enabled,
     );
     Ok(Arc::new(ExecutionContext::new(
         plan,
@@ -5738,6 +5793,7 @@ pub fn cpu_execution_context() -> Arc<ExecutionContext> {
             d_ff: 0,
         },
         true,
+        false,
     );
     Arc::new(ExecutionContext::new(
         plan,
@@ -6449,6 +6505,7 @@ mod tests {
             true,
             test_routed_expert_gpu_spec(dtype),
             true,
+            true,
         )
     }
 
@@ -6675,6 +6732,7 @@ mod tests {
         let mut observed = None;
         let context = resolve_execution_context_with_resource_plan(
             ComputeOffload::Hybrid,
+            true,
             true,
             qwen3_coder_geometry(),
             test_routed_expert_gpu_spec(crate::inference::WeightDtype::Q4_0),
@@ -7103,6 +7161,7 @@ mod tests {
             true,
             test_routed_expert_gpu_spec(crate::inference::WeightDtype::F32),
             true,
+            true,
         );
         let _ = ExecutionContext::new(plan, None, test_gpu_expert_cache(1024));
     }
@@ -7120,6 +7179,7 @@ mod tests {
             next_execution_context_id(),
             true,
             test_routed_expert_gpu_spec(crate::inference::WeightDtype::F32),
+            true,
             true,
         );
         let _ = ExecutionContext::new(plan, Some(test_gpu_backend()), test_gpu_expert_cache(0));
@@ -7204,6 +7264,7 @@ mod tests {
         geometry.v_head_dim = 0;
         let context = resolve_execution_context_with_resource_plan(
             ComputeOffload::Hybrid,
+            true,
             true,
             geometry,
             test_routed_expert_gpu_spec(crate::inference::WeightDtype::Q4_0),

--- a/rust-engine/src/backend/wgpu_shaders/gpu_native_expert_control.wgsl
+++ b/rust-engine/src/backend/wgpu_shaders/gpu_native_expert_control.wgsl
@@ -28,7 +28,7 @@ const LOCATION_BANK_SHIFT: u32 = 30u;
 const LOCATION_SLOT_MASK: u32 = 0x3fffffffu;
 const UNMAPPED: u32 = 0xffffffffu;
 const EXPERT_RESIDENCY_MISS: u32 = 4u;
-const FATAL_STATUS_MASK: u32 = 11u;
+const FATAL_STATUS_MASK: u32 = 27u;
 const RETRYABLE_STATUS_MASK: u32 = EXPERT_RESIDENCY_MISS;
 
 fn bank_capacity(bank: u32) -> u32 {

--- a/rust-engine/src/backend/wgpu_shaders/gpu_native_greedy_argmax.wgsl
+++ b/rust-engine/src/backend/wgpu_shaders/gpu_native_greedy_argmax.wgsl
@@ -1,0 +1,102 @@
+// GPU-native greedy argmax sampler for one token.
+//
+// One 64-lane workgroup strides over the vocabulary logits. Per-lane candidates
+// are reduced deterministically in shared workgroup memory with an exact
+// lower-token-id tie-break. Any non-finite logit latches the LM-head numerical
+// failure status bit and writes u32::MAX.
+
+struct PushConstants {
+    vocab_size: u32,
+    _reserved_0: u32,
+    _reserved_1: u32,
+    _reserved_2: u32,
+};
+var<push_constant> pc: PushConstants;
+
+@group(0) @binding(0) var<storage, read> LOGITS: array<f32>;
+@group(0) @binding(1) var<storage, read_write> SAMPLED_TOKEN: array<u32>;
+struct Status {
+    bits: atomic<u32>,
+};
+@group(0) @binding(2) var<storage, read_write> STATUS: Status;
+
+const WG: u32 = 64u;
+const MAX_FINITE_F32: f32 = 3.402823e+38;
+const FINITE_NEGATIVE_SENTINEL: f32 = -3.402823e+38;
+const INVALID_TOKEN_SENTINEL: u32 = 0xffffffffu;
+const GPU_NATIVE_STATUS_LM_HEAD_NUMERICAL_FAILURE: u32 = 16u;
+
+var<workgroup> candidate_vals: array<f32, 64u>;
+var<workgroup> candidate_idxs: array<u32, 64u>;
+var<workgroup> numerical_failure: atomic<u32>;
+
+fn is_finite(value: f32) -> bool {
+    return value == value && abs(value) <= MAX_FINITE_F32;
+}
+
+fn latch_numerical_failure() {
+    atomicOr(&STATUS.bits, GPU_NATIVE_STATUS_LM_HEAD_NUMERICAL_FAILURE);
+    atomicOr(&numerical_failure, GPU_NATIVE_STATUS_LM_HEAD_NUMERICAL_FAILURE);
+}
+
+@compute @workgroup_size(64, 1, 1)
+fn greedy_argmax_main(@builtin(local_invocation_id) local_id: vec3<u32>) {
+    let lane = local_id.x;
+    if (lane == 0u) {
+        atomicStore(&numerical_failure, 0u);
+        SAMPLED_TOKEN[0] = INVALID_TOKEN_SENTINEL;
+    }
+    workgroupBarrier();
+
+    let prior_status = atomicLoad(&STATUS.bits);
+    if (prior_status != 0u) {
+        return;
+    }
+
+    var best_val = FINITE_NEGATIVE_SENTINEL;
+    var best_idx = INVALID_TOKEN_SENTINEL;
+
+    for (var idx = lane; idx < pc.vocab_size; idx = idx + WG) {
+        let val = LOGITS[idx];
+        if (!is_finite(val)) {
+            latch_numerical_failure();
+        } else if (best_idx == INVALID_TOKEN_SENTINEL || val > best_val || (val == best_val && idx < best_idx)) {
+            best_val = val;
+            best_idx = idx;
+        }
+    }
+
+    candidate_vals[lane] = best_val;
+    candidate_idxs[lane] = best_idx;
+    workgroupBarrier();
+
+    for (var offset = WG / 2u; offset > 0u; offset = offset / 2u) {
+        if (lane < offset) {
+            let other_val = candidate_vals[lane + offset];
+            let other_idx = candidate_idxs[lane + offset];
+            let cur_val = candidate_vals[lane];
+            let cur_idx = candidate_idxs[lane];
+
+            if (cur_idx == INVALID_TOKEN_SENTINEL) {
+                candidate_vals[lane] = other_val;
+                candidate_idxs[lane] = other_idx;
+            } else if (other_idx != INVALID_TOKEN_SENTINEL) {
+                if (other_val > cur_val || (other_val == cur_val && other_idx < cur_idx)) {
+                    candidate_vals[lane] = other_val;
+                    candidate_idxs[lane] = other_idx;
+                }
+            }
+        }
+        workgroupBarrier();
+    }
+
+    if (lane == 0u) {
+        let failure = atomicLoad(&numerical_failure);
+        let final_status = atomicLoad(&STATUS.bits);
+        if (failure != 0u || final_status != 0u || candidate_idxs[0] == INVALID_TOKEN_SENTINEL) {
+            SAMPLED_TOKEN[0] = INVALID_TOKEN_SENTINEL;
+        } else {
+            SAMPLED_TOKEN[0] = candidate_idxs[0];
+        }
+    }
+}

--- a/rust-engine/src/config.rs
+++ b/rust-engine/src/config.rs
@@ -451,6 +451,16 @@ pub struct RealTransformerConfig {
     #[serde(default)]
     pub window_size: usize,
 
+    /// Explicit opt-in to the GPU-native, GPU-owned token loop.
+    /// Default: `false`. When false, all existing behavior is unchanged.
+    #[serde(default)]
+    pub gpu_native: bool,
+
+    /// Maximum sequence length for the GPU-native request KV allocation.
+    /// Default: 4096. Must be > 0 when `gpu_native = true`.
+    #[serde(default = "default_gpu_native_max_seq_len")]
+    pub gpu_native_max_seq_len: usize,
+
     /// **Pool back-pressure: "high" threshold** (gist Part 1, fix #4).
     /// Fraction of [`block_pool::BlockPool`] primary capacity at or
     /// above which the scheduler classifies the pool as
@@ -658,6 +668,9 @@ fn default_idle_eviction_threshold_ms() -> u64 {
 }
 fn default_speculation_base_depth() -> usize {
     1
+}
+fn default_gpu_native_max_seq_len() -> usize {
+    4096
 }
 
 /// Configuration for the predictive architecture (`[predictive]` block).
@@ -1228,6 +1241,93 @@ impl Config {
             if rt.max_fetch_yields == 0 {
                 return Err(ConfigError::Invalid(
                     "real_transformer.max_fetch_yields must be > 0".into(),
+                ));
+            }
+        }
+        if self.real_transformer.gpu_native {
+            if !self.real_transformer.enabled {
+                return Err(ConfigError::Invalid(
+                    "real_transformer.gpu_native requires real_transformer.enabled = true".into(),
+                ));
+            }
+            if self.real_transformer.compute_offload != crate::backend::ComputeOffload::Gpu {
+                return Err(ConfigError::Invalid(
+                    "real_transformer.gpu_native requires real_transformer.compute_offload = \"gpu\"".into(),
+                ));
+            }
+            if !self.gpu_cache.enabled {
+                return Err(ConfigError::Invalid(
+                    "real_transformer.gpu_native requires gpu_cache.enabled = true".into(),
+                ));
+            }
+            if self.gpu_cache.vram_capacity_mb == 0 {
+                return Err(ConfigError::Invalid(
+                    "real_transformer.gpu_native requires gpu_cache.vram_capacity_mb > 0".into(),
+                ));
+            }
+            if self.model.dtype != crate::inference::WeightDtype::Q4_0 {
+                return Err(ConfigError::Invalid(
+                    "real_transformer.gpu_native requires model.dtype = \"q4_0\"".into(),
+                ));
+            }
+            if !self.real_transformer.strict_weights {
+                return Err(ConfigError::Invalid(
+                    "real_transformer.gpu_native requires real_transformer.strict_weights = true".into(),
+                ));
+            }
+            if self.real_transformer.allow_seeded_fallback {
+                return Err(ConfigError::Invalid(
+                    "real_transformer.gpu_native rejects real_transformer.allow_seeded_fallback = true".into(),
+                ));
+            }
+            if self.real_transformer.allow_degraded_experts {
+                return Err(ConfigError::Invalid(
+                    "real_transformer.gpu_native rejects real_transformer.allow_degraded_experts = true".into(),
+                ));
+            }
+            if self.real_transformer.allow_nonfinite_attention_fallback {
+                return Err(ConfigError::Invalid(
+                    "real_transformer.gpu_native rejects real_transformer.allow_nonfinite_attention_fallback = true".into(),
+                ));
+            }
+            if self.real_transformer.allow_truncated_expert_payloads {
+                return Err(ConfigError::Invalid(
+                    "real_transformer.gpu_native rejects real_transformer.allow_truncated_expert_payloads = true".into(),
+                ));
+            }
+            if self.distributed.enabled {
+                return Err(ConfigError::Invalid(
+                    "real_transformer.gpu_native rejects distributed.enabled = true".into(),
+                ));
+            }
+            if self.server.session_ttl_secs != 0 {
+                return Err(ConfigError::Invalid(
+                    "real_transformer.gpu_native requires server.session_ttl_secs = 0".into(),
+                ));
+            }
+            if self.server.max_concurrent_requests != 1 {
+                return Err(ConfigError::Invalid(
+                    "real_transformer.gpu_native requires server.max_concurrent_requests = 1".into(),
+                ));
+            }
+            if self.real_transformer.max_batch_size != 1 {
+                return Err(ConfigError::Invalid(
+                    "real_transformer.gpu_native requires real_transformer.max_batch_size = 1".into(),
+                ));
+            }
+            if self.real_transformer.gpu_native_max_seq_len == 0 {
+                return Err(ConfigError::Invalid(
+                    "real_transformer.gpu_native_max_seq_len must be > 0".into(),
+                ));
+            }
+            if self.predictive.speculator_enabled {
+                return Err(ConfigError::Invalid(
+                    "real_transformer.gpu_native rejects predictive.speculator_enabled = true (neural speculation requires CPU hidden state readback)".into(),
+                ));
+            }
+            if self.real_transformer.speculation_base_depth > 1 {
+                return Err(ConfigError::Invalid(
+                    "real_transformer.gpu_native rejects speculative token decoding (speculation_base_depth > 1)".into(),
                 ));
             }
         }

--- a/rust-engine/src/engine.rs
+++ b/rust-engine/src/engine.rs
@@ -340,7 +340,7 @@ enum FetchOnceError {
 /// `fetch_with_retry` (via [`Engine::moe_step`]) so a single corrupt
 /// expert downgrades gracefully into a missing top-K member rather
 /// than killing the server.
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum ExpertReadError {
     /// Storage returned a (possibly transient) I/O error every attempt.
     Io {
@@ -375,7 +375,7 @@ impl std::fmt::Display for ExpertReadError {
 
 impl std::error::Error for ExpertReadError {}
 
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub(crate) enum GpuNativeDemandResidencyError {
     ManagerNotInstalled,
     ExpertRead(ExpertReadError),
@@ -2531,6 +2531,84 @@ impl Engine {
             .gpu_native_residency
             .as_ref()
             .map(|manager| manager.snapshot())
+    }
+
+    /// Record actual GPU-native route selections across layers into the engine's
+    /// route observation and prefetch infrastructure without requiring CPU hidden state.
+    pub(crate) fn record_gpu_native_actual_routes(
+        self: &Arc<Self>,
+        selected_ids_by_layer: &[Vec<u32>],
+    ) {
+        self.core.governor.refresh();
+        let per_layer_opt = self.core.storage.config().num_experts_per_layer;
+
+        for (layer_idx, local_ids) in selected_ids_by_layer.iter().enumerate() {
+            if local_ids.is_empty() {
+                continue;
+            }
+            let per_layer = per_layer_opt.unwrap_or(0);
+            let target: Vec<u32> = if per_layer > 0 {
+                local_ids
+                    .iter()
+                    .map(|&loc| self.resolve_alias(layer_idx as u32 * per_layer + loc))
+                    .collect()
+            } else {
+                local_ids.iter().map(|&id| self.resolve_alias(id)).collect()
+            };
+
+            self.metrics
+                .counters
+                .selected_routed_experts
+                .fetch_add(target.len() as u64, Ordering::Relaxed);
+
+            self.locality_observe_and_reconcile(&target);
+
+            if let Some(affinity) = self.speculation.affinity.as_ref() {
+                affinity.observe_layer(layer_idx, local_ids);
+            }
+
+            if self.core.options.pin_after_observations > 0
+                || self.core.options.collect_route_profile
+                || self.static_residency_needs_counts()
+            {
+                self.bump_route_observations(&target);
+            }
+            self.maybe_apply_static_residency();
+
+            if let Some(&seed) = target.last() {
+                let ring = self.speculation.markov_ring.lock();
+                let contiguous = self.markov_layers_contiguous(ring.last.layer, Some(layer_idx as u32));
+                let s_markov = match ring.last.ids.last() {
+                    Some(&pp) if contiguous => self.core.predictor.predict_next2(pp, seed),
+                    _ => self.core.predictor.predict_next(seed),
+                };
+                drop(ring);
+                let in_flight: HashSet<u32> = target.iter().copied().collect();
+                self.union_prefetch(&s_markov, &[], &in_flight, Some(layer_idx as u32));
+            }
+
+            if !target.is_empty() {
+                let mut ring = self.speculation.markov_ring.lock();
+                if !ring.last.ids.is_empty()
+                    && self.markov_layers_contiguous(ring.last.layer, Some(layer_idx as u32))
+                {
+                    let pp: &[u32] =
+                        if self.markov_layers_contiguous(ring.last_last.layer, ring.last.layer) {
+                            &ring.last_last.ids
+                        } else {
+                            &[]
+                        };
+                    self.core
+                        .predictor
+                        .observe_step2(pp, &ring.last.ids, &target);
+                }
+                ring.last_last = ring.last.clone();
+                ring.last = MarkovHistory {
+                    ids: target.clone(),
+                    layer: Some(layer_idx as u32),
+                };
+            }
+        }
     }
 
     /// Attach the logical GPU-admission cache — Phase 2 hierarchy policy.

--- a/rust-engine/src/gpu_native_token_loop.rs
+++ b/rust-engine/src/gpu_native_token_loop.rs
@@ -926,6 +926,27 @@ impl GpuNativeTokenLoop {
         })
     }
 
+    /// Calculate the required context capacity for a prompt of length `prompt_len`
+    /// and `max_tokens` completion tokens, starting from `committed_position`.
+    ///
+    /// For `max_tokens == 0`, zero completion tokens are generated and zero additional positions are consumed.
+    /// For `max_tokens > 0`, the full autoregressive forward count (and final committed position) is:
+    /// `committed_position + prompt_len + max_tokens - 1`
+    /// because the forward evaluation of the final prompt token produces completion token 0.
+    pub fn calculate_required_context_len(
+        committed_position: usize,
+        prompt_len: usize,
+        max_tokens: usize,
+    ) -> Option<usize> {
+        if max_tokens == 0 {
+            return Some(committed_position);
+        }
+        committed_position
+            .checked_add(prompt_len)
+            .and_then(|sum| sum.checked_add(max_tokens))
+            .and_then(|sum| sum.checked_sub(1))
+    }
+
     /// Ingest a multi-token prompt, commit KV positions, and generate up to `max_tokens` completion tokens.
     pub async fn ingest_prompt_and_generate(
         self: &Arc<Self>,
@@ -945,12 +966,20 @@ impl GpuNativeTokenLoop {
                 reason: "only greedy sampling (temperature=0.0) is supported in gpu_native mode in this slice".into(),
             });
         }
-        let total_required_len = prompt_ids.len().checked_add(max_tokens).ok_or_else(|| {
-            GpuNativeTokenLoopError::ContextLimitExceeded {
-                requested_position: usize::MAX,
-                max_seq_len: request.max_seq_len,
-            }
+        if max_tokens == 0 {
+            return Ok(Vec::new());
+        }
+
+        let total_required_len = Self::calculate_required_context_len(
+            request.committed_position,
+            prompt_ids.len(),
+            max_tokens,
+        )
+        .ok_or_else(|| GpuNativeTokenLoopError::ContextLimitExceeded {
+            requested_position: usize::MAX,
+            max_seq_len: request.max_seq_len,
         })?;
+
         if total_required_len > request.max_seq_len {
             return Err(GpuNativeTokenLoopError::ContextLimitExceeded {
                 requested_position: total_required_len,
@@ -1162,13 +1191,6 @@ impl GpuNativeTokenLoop {
         }
 
         self.counters.token_attempts.fetch_add(1, Ordering::Relaxed);
-        self.counters
-            .queue_submissions
-            .fetch_add(1, Ordering::Relaxed);
-        self.counters.boundary_maps.fetch_add(1, Ordering::Relaxed);
-        self.counters
-            .boundary_readbacks
-            .fetch_add(1, Ordering::Relaxed);
         if replay {
             self.counters
                 .replay_attempts
@@ -1336,6 +1358,9 @@ impl GpuNativeTokenLoop {
 
         // ONE submission
         gpu.queue.submit(Some(encoder.finish()));
+        self.counters
+            .queue_submissions
+            .fetch_add(1, Ordering::Relaxed);
 
         // ONE map/readback
         let slice = request
@@ -1345,6 +1370,8 @@ impl GpuNativeTokenLoop {
         slice.map_async(wgpu::MapMode::Read, move |res| {
             let _ = tx.send(res);
         });
+        self.counters.boundary_maps.fetch_add(1, Ordering::Relaxed);
+
         gpu.device.poll(wgpu::Maintain::Wait);
         rx.recv()
             .map_err(|e| GpuNativeTokenLoopError::MapFailed(e.to_string()))?
@@ -1354,6 +1381,10 @@ impl GpuNativeTokenLoop {
         let report = self.report_layout.parse(&mapped)?;
         drop(mapped);
         request.staging_buffer.unmap();
+
+        self.counters
+            .boundary_readbacks
+            .fetch_add(1, Ordering::Relaxed);
 
         Ok(report)
     }
@@ -1854,6 +1885,90 @@ pub(crate) mod tests {
             .map(|&loc| 1 * num_experts + loc)
             .collect();
         assert_eq!(layer_1_globals, vec![4, 7]);
+    }
+
+    #[test]
+    fn context_capacity_accounting_boundary_and_overflow() {
+        let max_seq_len = 8usize;
+
+        // 1. P + C - 1 == max_seq_len -> accepted by preflight
+        // Prompt of 4 tokens + 5 completion tokens -> 4 + 5 - 1 = 8 evaluations (positions 0..=7)
+        let req_len = GpuNativeTokenLoop::calculate_required_context_len(0, 4, 5);
+        assert_eq!(req_len, Some(8));
+        assert!(req_len.unwrap() <= max_seq_len);
+
+        // 2. P + C - 1 > max_seq_len -> rejected
+        // Prompt of 4 tokens + 6 completion tokens -> 4 + 6 - 1 = 9 evaluations
+        let req_len_overflow = GpuNativeTokenLoop::calculate_required_context_len(0, 4, 6);
+        assert_eq!(req_len_overflow, Some(9));
+        assert!(req_len_overflow.unwrap() > max_seq_len);
+
+        // 3. Arithmetic overflow -> returns None (fail-closed)
+        let req_overflow = GpuNativeTokenLoop::calculate_required_context_len(0, usize::MAX, 2);
+        assert_eq!(req_overflow, None);
+        let req_overflow2 =
+            GpuNativeTokenLoop::calculate_required_context_len(usize::MAX - 1, 2, 2);
+        assert_eq!(req_overflow2, None);
+
+        // 4. Ordinary shorter request -> unchanged / accepted
+        let req_len_short = GpuNativeTokenLoop::calculate_required_context_len(0, 2, 2);
+        assert_eq!(req_len_short, Some(3));
+        assert!(req_len_short.unwrap() <= max_seq_len);
+
+        // 5. max_tokens == 0 -> zero completion tokens, consumes zero additional capacity
+        let req_zero = GpuNativeTokenLoop::calculate_required_context_len(0, 5, 0);
+        assert_eq!(req_zero, Some(0));
+
+        // 6. Non-zero starting committed position
+        let req_with_offset = GpuNativeTokenLoop::calculate_required_context_len(2, 3, 4);
+        assert_eq!(req_with_offset, Some(8)); // 2 + 3 + 4 - 1 = 8
+    }
+
+    #[test]
+    fn token_loop_counters_track_actual_operations_only() {
+        let counters = GpuNativeTokenLoopCounters::default();
+        let snap0 = counters.snapshot();
+        assert_eq!(snap0.token_attempts, 0);
+        assert_eq!(snap0.queue_submissions, 0);
+        assert_eq!(snap0.boundary_maps, 0);
+        assert_eq!(snap0.boundary_readbacks, 0);
+        assert_eq!(snap0.replay_attempts, 0);
+
+        // Simulate an attempt starting: token_attempts is incremented
+        counters.token_attempts.fetch_add(1, Ordering::Relaxed);
+        let snap1 = counters.snapshot();
+        assert_eq!(snap1.token_attempts, 1);
+        // An encode-time failure before submission leaves queue_submissions, boundary_maps,
+        // and boundary_readbacks at 0
+        assert_eq!(snap1.queue_submissions, 0);
+        assert_eq!(snap1.boundary_maps, 0);
+        assert_eq!(snap1.boundary_readbacks, 0);
+
+        // When queue.submit actually occurs:
+        counters.queue_submissions.fetch_add(1, Ordering::Relaxed);
+        let snap2 = counters.snapshot();
+        assert_eq!(snap2.queue_submissions, 1);
+        assert_eq!(snap2.boundary_maps, 0);
+        assert_eq!(snap2.boundary_readbacks, 0);
+
+        // When map_async actually initiates:
+        counters.boundary_maps.fetch_add(1, Ordering::Relaxed);
+        let snap3 = counters.snapshot();
+        assert_eq!(snap3.boundary_maps, 1);
+        assert_eq!(snap3.boundary_readbacks, 0);
+
+        // When map succeeds and report is parsed:
+        counters.boundary_readbacks.fetch_add(1, Ordering::Relaxed);
+        let snap4 = counters.snapshot();
+        assert_eq!(snap4.boundary_readbacks, 1);
+
+        // Replay attempt increments replay_attempts and token_attempts
+        counters.token_attempts.fetch_add(1, Ordering::Relaxed);
+        counters.replay_attempts.fetch_add(1, Ordering::Relaxed);
+        let snap5 = counters.snapshot();
+        assert_eq!(snap5.token_attempts, 2);
+        assert_eq!(snap5.replay_attempts, 1);
+        assert_eq!(snap5.queue_submissions, 1);
     }
 
     #[test]

--- a/rust-engine/src/gpu_native_token_loop.rs
+++ b/rust-engine/src/gpu_native_token_loop.rs
@@ -948,7 +948,7 @@ impl GpuNativeTokenLoop {
         let logits_scratch = self
             .executor
             .create_scratch(self.model_geometry.vocab_size)?;
-        let sampled_token_buf = self.executor.create_scratch(1)?;
+        let sampled_token_buf = self.executor.create_boundary_result_scratch(1)?;
 
         let gpu = self.executor.authoritative_gpu()?;
         let staging_buffer = gpu.device.create_buffer(&wgpu::BufferDescriptor {
@@ -1867,6 +1867,48 @@ pub(crate) mod tests {
         assert!(!usage.contains(wgpu::BufferUsages::COPY_SRC));
         assert!(!usage.contains(wgpu::BufferUsages::MAP_READ));
         assert!(!usage.contains(wgpu::BufferUsages::MAP_WRITE));
+    }
+
+    #[test]
+    fn buffer_usage_boundary_isolation_contract() {
+        use crate::backend::gpu_native::{
+            GpuNativeRouterScratchLayout, GpuNativeScratchLayout, GpuNativeTokenStateLayout,
+        };
+
+        // 1. Generic scratch (hidden, residual, logits, attention/expert scratch):
+        // STORAGE | COPY_DST, strictly no COPY_SRC, no MAP_READ, no MAP_WRITE
+        let generic_scratch = GpuNativeScratchLayout::usage();
+        assert!(generic_scratch.contains(wgpu::BufferUsages::STORAGE));
+        assert!(generic_scratch.contains(wgpu::BufferUsages::COPY_DST));
+        assert!(!generic_scratch.contains(wgpu::BufferUsages::COPY_SRC));
+        assert!(!generic_scratch
+            .intersects(wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::MAP_WRITE));
+
+        // 2. Specialized boundary result scratch (sampled_token_buf):
+        // STORAGE | COPY_SRC, strictly no MAP_READ, no MAP_WRITE
+        let boundary_scratch = GpuNativeScratchLayout::boundary_result_usage();
+        assert!(boundary_scratch.contains(wgpu::BufferUsages::STORAGE));
+        assert!(boundary_scratch.contains(wgpu::BufferUsages::COPY_SRC));
+        assert!(!boundary_scratch.contains(wgpu::BufferUsages::COPY_DST));
+        assert!(!boundary_scratch
+            .intersects(wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::MAP_WRITE));
+
+        // 3. Status buffer:
+        // STORAGE | COPY_DST | COPY_SRC, strictly no MAP_READ, no MAP_WRITE
+        let status = GpuNativeTokenStateLayout::status_usage();
+        assert!(status.contains(wgpu::BufferUsages::STORAGE));
+        assert!(status.contains(wgpu::BufferUsages::COPY_DST));
+        assert!(status.contains(wgpu::BufferUsages::COPY_SRC));
+        assert!(!status.intersects(wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::MAP_WRITE));
+
+        // 4. Router selected-ids result:
+        // STORAGE | COPY_SRC, strictly no MAP_READ, no MAP_WRITE
+        let router_result = GpuNativeRouterScratchLayout::result_usage();
+        assert!(router_result.contains(wgpu::BufferUsages::STORAGE));
+        assert!(router_result.contains(wgpu::BufferUsages::COPY_SRC));
+        assert!(
+            !router_result.intersects(wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::MAP_WRITE)
+        );
     }
 
     #[test]

--- a/rust-engine/src/gpu_native_token_loop.rs
+++ b/rust-engine/src/gpu_native_token_loop.rs
@@ -1,0 +1,2131 @@
+//! GPU-native, GPU-owned autoregressive token loop.
+//!
+//! Owns the execution of the entire forward transformer pass on GPU:
+//! Embedding lookup -> Layer (Attention RMSNorm -> QKV/RoPE/KV -> Causal Attention/O -> MoE RMSNorm -> Router -> Q4 Expert Combine) -> Final RMSNorm -> LM Head -> GPU Greedy Argmax.
+
+use std::collections::HashSet;
+use std::fmt;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use tokio::sync::Mutex as TokioMutex;
+
+use crate::architecture::Architecture;
+use crate::backend::gpu_native::{
+    GpuNativeAttentionGeometry, GpuNativeAttentionNorm, GpuNativeAttentionPlan,
+    GpuNativeAttentionScratch, GpuNativeBootstrapError, GpuNativeDenseWeightHandle,
+    GpuNativeDenseWeightKey, GpuNativeExecutorContext, GpuNativeKvState, GpuNativeQ4ExpertGeometry,
+    GpuNativeQ4ExpertScratch, GpuNativeRmsNormHandle, GpuNativeRouterGeometry, GpuNativeRouterPlan,
+    GpuNativeRouterScratch, GpuNativeScratch, GpuNativeTokenState, GPU_NATIVE_STATUS_FATAL_MASK,
+    GPU_NATIVE_STATUS_RETRYABLE_MASK, MAX_GPU_NATIVE_ROUTER_EXPERTS, MAX_GPU_NATIVE_ROUTER_TOP_K,
+};
+use crate::dense_tensor::DenseDType;
+use crate::engine::{Engine, GpuNativeDemandResidencyError};
+use crate::gating::ScoringFunc;
+use crate::gpu_native_residency::GpuNativeTieredResidencyManager;
+use crate::model::RealModel;
+use crate::sampling::SamplingParams;
+
+/// Structured summary of runtime counters across the GPU-native token loop.
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
+pub struct GpuNativeTokenLoopSnapshot {
+    pub token_attempts: u64,
+    pub tokens_completed: u64,
+    pub warm_tokens_completed: u64,
+    pub residency_miss_attempts: u64,
+    pub replay_attempts: u64,
+    pub residency_services: u64,
+    pub fatal_failures: u64,
+    pub no_progress_failures: u64,
+    pub queue_submissions: u64,
+    pub boundary_maps: u64,
+    pub boundary_readbacks: u64,
+}
+
+#[derive(Default)]
+struct GpuNativeTokenLoopCounters {
+    token_attempts: AtomicU64,
+    tokens_completed: AtomicU64,
+    warm_tokens_completed: AtomicU64,
+    residency_miss_attempts: AtomicU64,
+    replay_attempts: AtomicU64,
+    residency_services: AtomicU64,
+    fatal_failures: AtomicU64,
+    no_progress_failures: AtomicU64,
+    queue_submissions: AtomicU64,
+    boundary_maps: AtomicU64,
+    boundary_readbacks: AtomicU64,
+}
+
+impl GpuNativeTokenLoopCounters {
+    fn snapshot(&self) -> GpuNativeTokenLoopSnapshot {
+        GpuNativeTokenLoopSnapshot {
+            token_attempts: self.token_attempts.load(Ordering::Relaxed),
+            tokens_completed: self.tokens_completed.load(Ordering::Relaxed),
+            warm_tokens_completed: self.warm_tokens_completed.load(Ordering::Relaxed),
+            residency_miss_attempts: self.residency_miss_attempts.load(Ordering::Relaxed),
+            replay_attempts: self.replay_attempts.load(Ordering::Relaxed),
+            residency_services: self.residency_services.load(Ordering::Relaxed),
+            fatal_failures: self.fatal_failures.load(Ordering::Relaxed),
+            no_progress_failures: self.no_progress_failures.load(Ordering::Relaxed),
+            queue_submissions: self.queue_submissions.load(Ordering::Relaxed),
+            boundary_maps: self.boundary_maps.load(Ordering::Relaxed),
+            boundary_readbacks: self.boundary_readbacks.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// Errors originating in the GPU-native token loop.
+#[derive(Debug, Clone, PartialEq)]
+pub enum GpuNativeTokenLoopError {
+    IncompatibleModel(GpuNativeModelCompatibilityError),
+    ContextLimitExceeded {
+        requested_position: usize,
+        max_seq_len: usize,
+    },
+    AttemptBoundExceeded {
+        attempts: usize,
+        max_attempts: usize,
+    },
+    NoProgress {
+        layer_index: usize,
+        selected_ids: Vec<u32>,
+    },
+    FatalNumericalFailure {
+        layer_index: Option<usize>,
+        status_bits: u32,
+    },
+    ResidencyServiceFailed(GpuNativeDemandResidencyError),
+    UnsupportedSampling {
+        reason: String,
+    },
+    Bootstrap(GpuNativeBootstrapError),
+    InvalidBoundaryReport {
+        detail: String,
+    },
+    InvalidSelectedExpertId {
+        layer_index: usize,
+        expert_id: u32,
+    },
+    DuplicateSelectedExpertId {
+        layer_index: usize,
+        expert_id: u32,
+    },
+    InvalidTopKCount {
+        expected: usize,
+        actual: usize,
+    },
+    MapFailed(String),
+}
+
+impl fmt::Display for GpuNativeTokenLoopError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::IncompatibleModel(err) => write!(f, "incompatible model: {err}"),
+            Self::ContextLimitExceeded {
+                requested_position,
+                max_seq_len,
+            } => write!(
+                f,
+                "requested position {requested_position} exceeds gpu_native_max_seq_len {max_seq_len}"
+            ),
+            Self::AttemptBoundExceeded {
+                attempts,
+                max_attempts,
+            } => write!(
+                f,
+                "token attempt bound exceeded: {attempts} attempts >= {max_attempts}"
+            ),
+            Self::NoProgress {
+                layer_index,
+                selected_ids,
+            } => write!(
+                f,
+                "no progress after residency service on layer {layer_index} with experts {selected_ids:?}"
+            ),
+            Self::FatalNumericalFailure {
+                layer_index,
+                status_bits,
+            } => write!(
+                f,
+                "fatal numerical failure on {:?} with status bits 0x{status_bits:08x}",
+                layer_index
+            ),
+            Self::ResidencyServiceFailed(err) => write!(f, "residency service failed: {err}"),
+            Self::UnsupportedSampling { reason } => write!(f, "unsupported sampling: {reason}"),
+            Self::Bootstrap(err) => write!(f, "GPU-native bootstrap error: {err}"),
+            Self::InvalidBoundaryReport { detail } => {
+                write!(f, "invalid boundary report: {detail}")
+            }
+            Self::InvalidSelectedExpertId {
+                layer_index,
+                expert_id,
+            } => write!(
+                f,
+                "invalid selected expert id {expert_id} on layer {layer_index}"
+            ),
+            Self::DuplicateSelectedExpertId {
+                layer_index,
+                expert_id,
+            } => write!(
+                f,
+                "duplicate selected expert id {expert_id} on layer {layer_index}"
+            ),
+            Self::InvalidTopKCount { expected, actual } => write!(
+                f,
+                "selected expert count mismatch: expected {expected}, got {actual}"
+            ),
+            Self::MapFailed(detail) => write!(f, "staging buffer map failed: {detail}"),
+        }
+    }
+}
+
+impl std::error::Error for GpuNativeTokenLoopError {}
+
+impl From<GpuNativeModelCompatibilityError> for GpuNativeTokenLoopError {
+    fn from(err: GpuNativeModelCompatibilityError) -> Self {
+        Self::IncompatibleModel(err)
+    }
+}
+
+impl From<GpuNativeBootstrapError> for GpuNativeTokenLoopError {
+    fn from(err: GpuNativeBootstrapError) -> Self {
+        Self::Bootstrap(err)
+    }
+}
+
+/// Errors raised when a model checkpoint violates the supported GPU-native model contract.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GpuNativeModelCompatibilityError {
+    UnsupportedArchitecture {
+        architecture: String,
+    },
+    DenseLayerUnsupported {
+        layer_index: usize,
+    },
+    SharedExpertUnsupported {
+        layer_index: usize,
+    },
+    MlaUnsupported {
+        layer_index: usize,
+    },
+    NonQ4ExpertDtype {
+        dtype: String,
+    },
+    TooManyExperts {
+        num_experts: usize,
+        max: usize,
+    },
+    InvalidTopK {
+        top_k: usize,
+        max: usize,
+    },
+    IncompatibleGeometry {
+        detail: String,
+    },
+    AsymmetricVHeadDim {
+        head_dim: usize,
+        v_head_dim: usize,
+    },
+    AttentionSinkUnsupported {
+        layer_index: usize,
+    },
+    AttentionBiasesUnsupported {
+        layer_index: usize,
+    },
+    ValueScaleUnsupported {
+        layer_index: usize,
+    },
+    SlidingWindowUnsupported {
+        layer_index: usize,
+    },
+    GroupedRoutingUnsupported {
+        layer_index: usize,
+    },
+    NonSoftmaxRouter {
+        layer_index: usize,
+    },
+    RouterCorrectionBiasUnsupported {
+        layer_index: usize,
+    },
+    RoutedScalingFactorUnsupported {
+        layer_index: usize,
+        factor_bits: u32,
+    },
+    NonNormalisedTopK {
+        layer_index: usize,
+    },
+    UnsupportedDenseDtype {
+        tensor: String,
+        dtype: String,
+    },
+}
+
+impl fmt::Display for GpuNativeModelCompatibilityError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedArchitecture { architecture } => write!(
+                f,
+                "GPU-native execution supports only Qwen3Moe in this slice, got {architecture}"
+            ),
+            Self::DenseLayerUnsupported { layer_index } => write!(
+                f,
+                "layer {layer_index} contains a dense FFN; all layers must be sparse MoE"
+            ),
+            Self::SharedExpertUnsupported { layer_index } => write!(
+                f,
+                "layer {layer_index} contains a shared expert; shared experts are unsupported"
+            ),
+            Self::MlaUnsupported { layer_index } => write!(
+                f,
+                "layer {layer_index} contains MLA; MLA is unsupported"
+            ),
+            Self::NonQ4ExpertDtype { dtype } => write!(
+                f,
+                "routed expert dtype must be Q4_0, got {dtype}"
+            ),
+            Self::TooManyExperts { num_experts, max } => write!(
+                f,
+                "num_experts ({num_experts}) exceeds GPU router maximum ({max})"
+            ),
+            Self::InvalidTopK { top_k, max } => write!(
+                f,
+                "top_k ({top_k}) must be in 1..={max}"
+            ),
+            Self::IncompatibleGeometry { detail } => write!(
+                f,
+                "incompatible model geometry: {detail}"
+            ),
+            Self::AsymmetricVHeadDim { head_dim, v_head_dim } => write!(
+                f,
+                "asymmetric V head dimension unsupported: head_dim={head_dim}, v_head_dim={v_head_dim}"
+            ),
+            Self::AttentionSinkUnsupported { layer_index } => write!(
+                f,
+                "layer {layer_index} uses attention sink bias; sinks are unsupported"
+            ),
+            Self::AttentionBiasesUnsupported { layer_index } => write!(
+                f,
+                "layer {layer_index} uses attention projection biases; biases are unsupported"
+            ),
+            Self::ValueScaleUnsupported { layer_index } => write!(
+                f,
+                "layer {layer_index} uses attention value scaling; value scaling is unsupported"
+            ),
+            Self::SlidingWindowUnsupported { layer_index } => write!(
+                f,
+                "layer {layer_index} uses sliding-window attention; sliding window is unsupported"
+            ),
+            Self::GroupedRoutingUnsupported { layer_index } => write!(
+                f,
+                "layer {layer_index} uses grouped expert routing; grouped routing is unsupported"
+            ),
+            Self::NonSoftmaxRouter { layer_index } => write!(
+                f,
+                "layer {layer_index} uses non-softmax router scoring; only Softmax is supported"
+            ),
+            Self::RouterCorrectionBiasUnsupported { layer_index } => write!(
+                f,
+                "layer {layer_index} uses router correction bias; correction bias is unsupported"
+            ),
+            Self::RoutedScalingFactorUnsupported { layer_index, factor_bits } => write!(
+                f,
+                "layer {layer_index} uses routed scaling factor 0x{factor_bits:08x} != 1.0"
+            ),
+            Self::NonNormalisedTopK { layer_index } => write!(
+                f,
+                "layer {layer_index} does not normalise top-K weights; top-K normalisation is required"
+            ),
+            Self::UnsupportedDenseDtype { tensor, dtype } => write!(
+                f,
+                "tensor {tensor} has unsupported dense dtype {dtype}; only F32 and Q8_0 are supported"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for GpuNativeModelCompatibilityError {}
+
+/// Fixed byte layout for one token-boundary compact report staging buffer.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct GpuNativeBoundaryReportLayout {
+    pub num_layers: usize,
+    pub top_k: usize,
+    pub layer_status_offset: usize,
+    pub layer_status_bytes: usize,
+    pub selected_ids_offset: usize,
+    pub selected_ids_bytes: usize,
+    pub final_status_offset: usize,
+    pub sampled_token_offset: usize,
+    pub total_bytes: u64,
+}
+
+impl GpuNativeBoundaryReportLayout {
+    pub fn try_new(num_layers: usize, top_k: usize) -> Result<Self, GpuNativeTokenLoopError> {
+        if num_layers == 0 {
+            return Err(GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "num_layers must be > 0".into(),
+            });
+        }
+        if top_k == 0 || top_k > MAX_GPU_NATIVE_ROUTER_TOP_K {
+            return Err(GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: format!("top_k must be in 1..={MAX_GPU_NATIVE_ROUTER_TOP_K}"),
+            });
+        }
+        let u32_bytes = std::mem::size_of::<u32>();
+
+        let layer_status_offset = 0usize;
+        let layer_status_bytes = num_layers.checked_mul(u32_bytes).ok_or_else(|| {
+            GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "layer status bytes overflow".into(),
+            }
+        })?;
+
+        let selected_ids_offset = layer_status_bytes;
+        let selected_ids_per_layer = top_k.checked_mul(u32_bytes).ok_or_else(|| {
+            GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "selected ids per layer overflow".into(),
+            }
+        })?;
+        let selected_ids_bytes =
+            num_layers
+                .checked_mul(selected_ids_per_layer)
+                .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
+                    detail: "total selected ids bytes overflow".into(),
+                })?;
+
+        let final_status_offset = selected_ids_offset
+            .checked_add(selected_ids_bytes)
+            .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "final status offset overflow".into(),
+            })?;
+
+        let sampled_token_offset = final_status_offset.checked_add(u32_bytes).ok_or_else(|| {
+            GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "sampled token offset overflow".into(),
+            }
+        })?;
+
+        let total_size = sampled_token_offset.checked_add(u32_bytes).ok_or_else(|| {
+            GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "total report bytes overflow".into(),
+            }
+        })?;
+
+        let total_bytes = u64::try_from(total_size).map_err(|_| {
+            GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "total report bytes exceed u64".into(),
+            }
+        })?;
+
+        Ok(Self {
+            num_layers,
+            top_k,
+            layer_status_offset,
+            layer_status_bytes,
+            selected_ids_offset,
+            selected_ids_bytes,
+            final_status_offset,
+            sampled_token_offset,
+            total_bytes,
+        })
+    }
+
+    pub fn parse(&self, bytes: &[u8]) -> Result<GpuNativeBoundaryReport, GpuNativeTokenLoopError> {
+        if (bytes.len() as u64) < self.total_bytes {
+            return Err(GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: format!(
+                    "readback bytes length {} less than required {}",
+                    bytes.len(),
+                    self.total_bytes
+                ),
+            });
+        }
+
+        let mut layer_statuses = Vec::with_capacity(self.num_layers);
+        for l in 0..self.num_layers {
+            let start = self.layer_status_offset + l * 4;
+            let status = u32::from_le_bytes(bytes[start..start + 4].try_into().map_err(|_| {
+                GpuNativeTokenLoopError::InvalidBoundaryReport {
+                    detail: "failed to decode layer status".into(),
+                }
+            })?);
+            layer_statuses.push(status);
+        }
+
+        let mut selected_ids = Vec::with_capacity(self.num_layers);
+        for l in 0..self.num_layers {
+            let mut layer_ids = Vec::with_capacity(self.top_k);
+            let layer_start = self.selected_ids_offset + l * self.top_k * 4;
+            for k in 0..self.top_k {
+                let start = layer_start + k * 4;
+                let id = u32::from_le_bytes(bytes[start..start + 4].try_into().map_err(|_| {
+                    GpuNativeTokenLoopError::InvalidBoundaryReport {
+                        detail: "failed to decode selected id".into(),
+                    }
+                })?);
+                layer_ids.push(id);
+            }
+            selected_ids.push(layer_ids);
+        }
+
+        let final_status = u32::from_le_bytes(
+            bytes[self.final_status_offset..self.final_status_offset + 4]
+                .try_into()
+                .map_err(|_| GpuNativeTokenLoopError::InvalidBoundaryReport {
+                    detail: "failed to decode final status".into(),
+                })?,
+        );
+
+        let sampled_token = u32::from_le_bytes(
+            bytes[self.sampled_token_offset..self.sampled_token_offset + 4]
+                .try_into()
+                .map_err(|_| GpuNativeTokenLoopError::InvalidBoundaryReport {
+                    detail: "failed to decode sampled token".into(),
+                })?,
+        );
+
+        Ok(GpuNativeBoundaryReport {
+            layer_statuses,
+            selected_ids,
+            final_status,
+            sampled_token,
+        })
+    }
+}
+
+/// Parsed results of one token attempt's boundary readback.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GpuNativeBoundaryReport {
+    pub layer_statuses: Vec<u32>,
+    pub selected_ids: Vec<Vec<u32>>,
+    pub final_status: u32,
+    pub sampled_token: u32,
+}
+
+impl GpuNativeBoundaryReport {
+    /// Returns the index of the first layer whose latched status transitioned to non-zero.
+    pub fn first_failure_layer(&self) -> Option<usize> {
+        self.layer_statuses.iter().position(|&status| status != 0)
+    }
+}
+
+/// Persistent per-layer plans and handles for one Qwen3-MoE transformer layer.
+pub struct GpuNativeLayerPlan {
+    pub layer_index: usize,
+    pub rms_attn_handle: GpuNativeRmsNormHandle,
+    pub rms_moe_handle: GpuNativeRmsNormHandle,
+    pub attn_plan: GpuNativeAttentionPlan,
+    pub router_plan: GpuNativeRouterPlan,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct GpuNativeModelGeometry {
+    pub num_layers: usize,
+    pub d_model: usize,
+    pub d_ff: usize,
+    pub num_experts: usize,
+    pub top_k: usize,
+    pub num_heads: usize,
+    pub num_kv_heads: usize,
+    pub head_dim: usize,
+    pub vocab_size: usize,
+    pub max_seq_len: usize,
+    pub rms_eps: f32,
+    pub rope_base: f32,
+}
+
+/// Persistent, model-scoped owner of the GPU-native token loop.
+pub struct GpuNativeTokenLoop {
+    executor: Arc<GpuNativeExecutorContext>,
+    residency_manager: Arc<GpuNativeTieredResidencyManager>,
+    model_geometry: GpuNativeModelGeometry,
+    embedding_handle: GpuNativeDenseWeightHandle,
+    final_norm_handle: GpuNativeRmsNormHandle,
+    lm_head_handle: GpuNativeDenseWeightHandle,
+    layers: Vec<GpuNativeLayerPlan>,
+    report_layout: GpuNativeBoundaryReportLayout,
+    counters: GpuNativeTokenLoopCounters,
+    execution_guard: TokioMutex<()>,
+}
+
+impl GpuNativeTokenLoop {
+    /// Validate that `model` conforms strictly to the supported Qwen3Moe GPU-native contract.
+    pub fn validate_model_compatibility(
+        model: &RealModel,
+    ) -> Result<(), GpuNativeModelCompatibilityError> {
+        if model.config.architecture != Architecture::Qwen3Moe {
+            return Err(GpuNativeModelCompatibilityError::UnsupportedArchitecture {
+                architecture: format!("{:?}", model.config.architecture),
+            });
+        }
+        if model.config.top_k == 0 || model.config.top_k > MAX_GPU_NATIVE_ROUTER_TOP_K {
+            return Err(GpuNativeModelCompatibilityError::InvalidTopK {
+                top_k: model.config.top_k,
+                max: MAX_GPU_NATIVE_ROUTER_TOP_K,
+            });
+        }
+        if model.config.num_experts > MAX_GPU_NATIVE_ROUTER_EXPERTS {
+            return Err(GpuNativeModelCompatibilityError::TooManyExperts {
+                num_experts: model.config.num_experts,
+                max: MAX_GPU_NATIVE_ROUTER_EXPERTS,
+            });
+        }
+        if model.config.window_size.is_some() {
+            return Err(GpuNativeModelCompatibilityError::SlidingWindowUnsupported {
+                layer_index: 0,
+            });
+        }
+
+        let is_valid_dense_dtype =
+            |dtype: DenseDType| -> bool { matches!(dtype, DenseDType::F32 | DenseDType::Q8_0) };
+
+        if !is_valid_dense_dtype(model.embedding.dtype()) {
+            return Err(GpuNativeModelCompatibilityError::UnsupportedDenseDtype {
+                tensor: "embed.weight".into(),
+                dtype: model.embedding.dtype_name().into(),
+            });
+        }
+        if !is_valid_dense_dtype(model.lm_head.weights.dtype()) {
+            return Err(GpuNativeModelCompatibilityError::UnsupportedDenseDtype {
+                tensor: "lm_head.weight".into(),
+                dtype: model.lm_head.weights.dtype_name().into(),
+            });
+        }
+        for (layer_idx, layer) in model.layers.iter().enumerate() {
+            if layer.dense_ffn.is_some() {
+                return Err(GpuNativeModelCompatibilityError::DenseLayerUnsupported {
+                    layer_index: layer_idx,
+                });
+            }
+            if layer.shared_expert.is_some() {
+                return Err(GpuNativeModelCompatibilityError::SharedExpertUnsupported {
+                    layer_index: layer_idx,
+                });
+            }
+            if layer.mla.is_some() {
+                return Err(GpuNativeModelCompatibilityError::MlaUnsupported {
+                    layer_index: layer_idx,
+                });
+            }
+            if layer.attn.v_head_dim != layer.attn.head_dim {
+                return Err(GpuNativeModelCompatibilityError::AsymmetricVHeadDim {
+                    head_dim: layer.attn.head_dim,
+                    v_head_dim: layer.attn.v_head_dim,
+                });
+            }
+            if layer.attn.sink_bias.is_some() {
+                return Err(GpuNativeModelCompatibilityError::AttentionSinkUnsupported {
+                    layer_index: layer_idx,
+                });
+            }
+            if layer.attn.bq.is_some()
+                || layer.attn.bk.is_some()
+                || layer.attn.bv.is_some()
+                || layer.attn.bo.is_some()
+            {
+                return Err(
+                    GpuNativeModelCompatibilityError::AttentionBiasesUnsupported {
+                        layer_index: layer_idx,
+                    },
+                );
+            }
+            if layer.attn.attention_value_scale.is_some() {
+                return Err(GpuNativeModelCompatibilityError::ValueScaleUnsupported {
+                    layer_index: layer_idx,
+                });
+            }
+            if layer.attn.window_size.is_some() {
+                return Err(GpuNativeModelCompatibilityError::SlidingWindowUnsupported {
+                    layer_index: layer_idx,
+                });
+            }
+            if layer.gate.scoring_func != ScoringFunc::Softmax {
+                return Err(GpuNativeModelCompatibilityError::NonSoftmaxRouter {
+                    layer_index: layer_idx,
+                });
+            }
+            if layer.gate.correction_bias.is_some() {
+                return Err(
+                    GpuNativeModelCompatibilityError::RouterCorrectionBiasUnsupported {
+                        layer_index: layer_idx,
+                    },
+                );
+            }
+            if layer.gate.n_group > 1 || layer.gate.topk_group > 1 {
+                return Err(
+                    GpuNativeModelCompatibilityError::GroupedRoutingUnsupported {
+                        layer_index: layer_idx,
+                    },
+                );
+            }
+            if (layer.gate.routed_scaling_factor - 1.0).abs() > 1e-5 {
+                return Err(
+                    GpuNativeModelCompatibilityError::RoutedScalingFactorUnsupported {
+                        layer_index: layer_idx,
+                        factor_bits: layer.gate.routed_scaling_factor.to_bits(),
+                    },
+                );
+            }
+            if !layer.gate.normalise_topk {
+                return Err(GpuNativeModelCompatibilityError::NonNormalisedTopK {
+                    layer_index: layer_idx,
+                });
+            }
+
+            for (name, weight) in [
+                ("wq", &layer.attn.wq),
+                ("wk", &layer.attn.wk),
+                ("wv", &layer.attn.wv),
+                ("wo", &layer.attn.wo),
+                ("gate", &layer.gate.weights),
+            ] {
+                if !is_valid_dense_dtype(weight.dtype()) {
+                    return Err(GpuNativeModelCompatibilityError::UnsupportedDenseDtype {
+                        tensor: format!("layer_{layer_idx}_{name}"),
+                        dtype: weight.dtype_name().into(),
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Construct and initialize the persistent GPU-native token loop.
+    pub fn try_new(
+        executor: Arc<GpuNativeExecutorContext>,
+        residency_manager: Arc<GpuNativeTieredResidencyManager>,
+        model: &RealModel,
+        max_seq_len: usize,
+    ) -> Result<Arc<Self>, GpuNativeTokenLoopError> {
+        Self::validate_model_compatibility(model)?;
+
+        let num_layers = model.layers.len();
+        let top_k = model.config.top_k;
+        let d_model = model.config.d_model;
+        let d_ff = model.config.d_ff;
+        let num_experts = model.config.num_experts;
+        let num_heads = model.config.num_heads;
+        let num_kv_heads = model.config.num_kv_heads;
+        let head_dim = model.config.head_dim;
+        let vocab_size = model.config.vocab_size;
+        let rms_eps = model.config.rms_eps;
+        let rope_base = model.config.rope_base;
+
+        if max_seq_len == 0 {
+            return Err(GpuNativeTokenLoopError::ContextLimitExceeded {
+                requested_position: 0,
+                max_seq_len,
+            });
+        }
+
+        let model_geometry = GpuNativeModelGeometry {
+            num_layers,
+            d_model,
+            d_ff,
+            num_experts,
+            top_k,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            vocab_size,
+            max_seq_len,
+            rms_eps,
+            rope_base,
+        };
+
+        let report_layout = GpuNativeBoundaryReportLayout::try_new(num_layers, top_k)?;
+
+        let embedding_handle = executor.register_dense_weight(
+            GpuNativeDenseWeightKey::try_new("model.embed")?,
+            &model.embedding,
+        )?;
+
+        let mut layers = Vec::with_capacity(num_layers);
+        let router_geometry = GpuNativeRouterGeometry::try_new(d_model, num_experts, top_k)?;
+        let attention_geometry = GpuNativeAttentionGeometry::try_new(
+            d_model,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            max_seq_len,
+        )?;
+
+        for (l, layer) in model.layers.iter().enumerate() {
+            let rms_attn_handle = executor.register_rms_norm(
+                GpuNativeDenseWeightKey::try_new(format!("model.layers.{l}.rms_attn"))?,
+                layer.rms_attn.weight.as_slice(),
+            )?;
+            let rms_moe_handle = executor.register_rms_norm(
+                GpuNativeDenseWeightKey::try_new(format!("model.layers.{l}.rms_moe"))?,
+                layer.rms_moe.weight.as_slice(),
+            )?;
+
+            let q_handle = executor.register_dense_weight(
+                GpuNativeDenseWeightKey::try_new(format!("model.layers.{l}.attn.q"))?,
+                &layer.attn.wq,
+            )?;
+            let k_handle = executor.register_dense_weight(
+                GpuNativeDenseWeightKey::try_new(format!("model.layers.{l}.attn.k"))?,
+                &layer.attn.wk,
+            )?;
+            let v_handle = executor.register_dense_weight(
+                GpuNativeDenseWeightKey::try_new(format!("model.layers.{l}.attn.v"))?,
+                &layer.attn.wv,
+            )?;
+            let o_handle = executor.register_dense_weight(
+                GpuNativeDenseWeightKey::try_new(format!("model.layers.{l}.attn.o"))?,
+                &layer.attn.wo,
+            )?;
+
+            let q_norm_handle = if let Some(ref q_norm) = layer.attn.q_norm {
+                let handle = executor.register_rms_norm(
+                    GpuNativeDenseWeightKey::try_new(format!("model.layers.{l}.attn.q_norm"))?,
+                    q_norm.weight.as_slice(),
+                )?;
+                Some(GpuNativeAttentionNorm::try_new(handle, q_norm.eps)?)
+            } else {
+                None
+            };
+
+            let k_norm_handle = if let Some(ref k_norm) = layer.attn.k_norm {
+                let handle = executor.register_rms_norm(
+                    GpuNativeDenseWeightKey::try_new(format!("model.layers.{l}.attn.k_norm"))?,
+                    k_norm.weight.as_slice(),
+                )?;
+                Some(GpuNativeAttentionNorm::try_new(handle, k_norm.eps)?)
+            } else {
+                None
+            };
+
+            let rope_handle = executor.register_standard_rope(
+                GpuNativeDenseWeightKey::try_new(format!("model.layers.{l}.attn.rope"))?,
+                layer.attn.rope_dim,
+                layer.attn.rope_base,
+            )?;
+
+            let attn_plan = executor.create_attention_plan(
+                l,
+                attention_geometry,
+                q_handle,
+                k_handle,
+                v_handle,
+                o_handle,
+                q_norm_handle,
+                k_norm_handle,
+                rope_handle,
+            )?;
+
+            let gate_handle = executor.register_dense_weight(
+                GpuNativeDenseWeightKey::try_new(format!("model.layers.{l}.router"))?,
+                &layer.gate.weights,
+            )?;
+            let router_plan = executor.create_router_plan(l, router_geometry, gate_handle)?;
+
+            layers.push(GpuNativeLayerPlan {
+                layer_index: l,
+                rms_attn_handle,
+                rms_moe_handle,
+                attn_plan,
+                router_plan,
+            });
+        }
+
+        let final_norm_handle = executor.register_rms_norm(
+            GpuNativeDenseWeightKey::try_new("model.final_norm")?,
+            model.final_rms.weight.as_slice(),
+        )?;
+        let lm_head_handle = executor.register_dense_weight(
+            GpuNativeDenseWeightKey::try_new("model.lm_head")?,
+            &model.lm_head.weights,
+        )?;
+
+        Ok(Arc::new(Self {
+            executor,
+            residency_manager,
+            model_geometry,
+            embedding_handle,
+            final_norm_handle,
+            lm_head_handle,
+            layers,
+            report_layout,
+            counters: GpuNativeTokenLoopCounters::default(),
+            execution_guard: TokioMutex::new(()),
+        }))
+    }
+
+    pub fn model_geometry(&self) -> GpuNativeModelGeometry {
+        self.model_geometry
+    }
+
+    pub fn max_seq_len(&self) -> usize {
+        self.model_geometry.max_seq_len
+    }
+
+    pub fn snapshot(&self) -> GpuNativeTokenLoopSnapshot {
+        self.counters.snapshot()
+    }
+
+    /// Allocate request-local device resources for one GPU-native sequence.
+    pub fn create_request_state(&self) -> Result<GpuNativeRequestState, GpuNativeTokenLoopError> {
+        let token_state = self.executor.create_token_state()?;
+        let kv_width = self.model_geometry.num_kv_heads * self.model_geometry.head_dim;
+        let kv_state = self.executor.create_kv_state(
+            self.model_geometry.num_layers,
+            self.model_geometry.max_seq_len,
+            kv_width,
+        )?;
+
+        let attn_geom = GpuNativeAttentionGeometry::try_new(
+            self.model_geometry.d_model,
+            self.model_geometry.num_heads,
+            self.model_geometry.num_kv_heads,
+            self.model_geometry.head_dim,
+            self.model_geometry.max_seq_len,
+        )?;
+        let attn_scratch = self.executor.create_attention_scratch(attn_geom)?;
+
+        let router_geom = GpuNativeRouterGeometry::try_new(
+            self.model_geometry.d_model,
+            self.model_geometry.num_experts,
+            self.model_geometry.top_k,
+        )?;
+        let router_scratch = self.executor.create_router_scratch(router_geom)?;
+
+        let expert_geom = GpuNativeQ4ExpertGeometry::try_new(
+            self.model_geometry.d_model,
+            self.model_geometry.d_ff,
+            self.model_geometry.num_experts,
+            self.model_geometry.top_k,
+        )?;
+        let expert_scratch = self.executor.create_q4_expert_scratch(expert_geom)?;
+
+        let logits_scratch = self
+            .executor
+            .create_scratch(self.model_geometry.vocab_size)?;
+        let sampled_token_buf = self.executor.create_scratch(1)?;
+
+        let gpu = self.executor.authoritative_gpu()?;
+        let staging_buffer = gpu.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("gpu_native_boundary_staging"),
+            size: self.report_layout.total_bytes,
+            usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        Ok(GpuNativeRequestState {
+            token_state,
+            kv_state,
+            attn_scratch,
+            router_scratch,
+            expert_scratch,
+            logits_scratch,
+            sampled_token_buf,
+            staging_buffer,
+            committed_position: 0,
+            max_seq_len: self.model_geometry.max_seq_len,
+        })
+    }
+
+    /// Ingest a multi-token prompt, commit KV positions, and generate up to `max_tokens` completion tokens.
+    pub async fn ingest_prompt_and_generate(
+        self: &Arc<Self>,
+        engine: &Arc<Engine>,
+        request: &mut GpuNativeRequestState,
+        prompt_ids: &[u32],
+        max_tokens: usize,
+        params: &SamplingParams,
+    ) -> Result<Vec<u32>, GpuNativeTokenLoopError> {
+        if prompt_ids.is_empty() {
+            return Err(GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "prompt_ids must be non-empty".into(),
+            });
+        }
+        if !params.is_greedy() {
+            return Err(GpuNativeTokenLoopError::UnsupportedSampling {
+                reason: "only greedy sampling (temperature=0.0) is supported in gpu_native mode in this slice".into(),
+            });
+        }
+        let total_required_len = prompt_ids.len().checked_add(max_tokens).ok_or_else(|| {
+            GpuNativeTokenLoopError::ContextLimitExceeded {
+                requested_position: usize::MAX,
+                max_seq_len: request.max_seq_len,
+            }
+        })?;
+        if total_required_len > request.max_seq_len {
+            return Err(GpuNativeTokenLoopError::ContextLimitExceeded {
+                requested_position: total_required_len,
+                max_seq_len: request.max_seq_len,
+            });
+        }
+
+        let _guard = self.execution_guard.lock().await;
+
+        // Ingest prefix prompt tokens without evaluating LM-head
+        let prefix_count = prompt_ids.len().saturating_sub(1);
+        for &token_id in &prompt_ids[..prefix_count] {
+            let pos = request.committed_position;
+            self.step_token(engine, request, token_id, pos, false)
+                .await?;
+        }
+
+        // Final prompt token: evaluate LM-head and sample first completion token
+        let final_prompt = *prompt_ids.last().expect("checked non-empty");
+        let final_prompt_pos = request.committed_position;
+        let first_completion = self
+            .step_token(engine, request, final_prompt, final_prompt_pos, true)
+            .await?
+            .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "final prompt step produced no sampled token".into(),
+            })?;
+
+        let mut completion_ids = Vec::with_capacity(max_tokens);
+        completion_ids.push(first_completion);
+
+        let mut last_token = first_completion;
+        while completion_ids.len() < max_tokens {
+            let pos = request.committed_position;
+            if pos >= request.max_seq_len {
+                break;
+            }
+            let next_token = self
+                .step_token(engine, request, last_token, pos, true)
+                .await?
+                .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
+                    detail: "decode step produced no sampled token".into(),
+                })?;
+            completion_ids.push(next_token);
+            last_token = next_token;
+        }
+
+        Ok(completion_ids)
+    }
+
+    /// Execute one single token step with bounded retries and residency demand service.
+    pub async fn step_token(
+        &self,
+        engine: &Arc<Engine>,
+        request: &mut GpuNativeRequestState,
+        token_id: u32,
+        position: usize,
+        sample: bool,
+    ) -> Result<Option<u32>, GpuNativeTokenLoopError> {
+        let mut attempt = 0;
+        let mut last_miss_sig: Option<(usize, Vec<u32>)> = None;
+        let max_attempts = self.layers.len() + 1;
+        let mut is_warm = true;
+
+        loop {
+            if attempt >= max_attempts {
+                return Err(GpuNativeTokenLoopError::AttemptBoundExceeded {
+                    attempts: attempt,
+                    max_attempts,
+                });
+            }
+
+            let replay = attempt > 0;
+            let report = self.execute_token_attempt(request, token_id, position, sample, replay)?;
+
+            if let Some(fail_layer) = report.first_failure_layer() {
+                let layer_status = report.layer_statuses[fail_layer];
+                if (layer_status & GPU_NATIVE_STATUS_FATAL_MASK) != 0 {
+                    self.counters.fatal_failures.fetch_add(1, Ordering::Relaxed);
+                    return Err(GpuNativeTokenLoopError::FatalNumericalFailure {
+                        layer_index: Some(fail_layer),
+                        status_bits: layer_status,
+                    });
+                }
+                if (layer_status & GPU_NATIVE_STATUS_RETRYABLE_MASK)
+                    == GPU_NATIVE_STATUS_RETRYABLE_MASK
+                {
+                    is_warm = false;
+                    self.counters
+                        .residency_miss_attempts
+                        .fetch_add(1, Ordering::Relaxed);
+                    let local_ids = &report.selected_ids[fail_layer];
+
+                    for &id in local_ids {
+                        if id as usize >= self.model_geometry.num_experts {
+                            return Err(GpuNativeTokenLoopError::InvalidSelectedExpertId {
+                                layer_index: fail_layer,
+                                expert_id: id,
+                            });
+                        }
+                    }
+                    let mut seen = HashSet::with_capacity(local_ids.len());
+                    for &id in local_ids {
+                        if !seen.insert(id) {
+                            return Err(GpuNativeTokenLoopError::DuplicateSelectedExpertId {
+                                layer_index: fail_layer,
+                                expert_id: id,
+                            });
+                        }
+                    }
+                    if local_ids.len() != self.model_geometry.top_k {
+                        return Err(GpuNativeTokenLoopError::InvalidTopKCount {
+                            expected: self.model_geometry.top_k,
+                            actual: local_ids.len(),
+                        });
+                    }
+
+                    if let Some((prev_layer, ref prev_ids)) = last_miss_sig {
+                        if prev_layer == fail_layer && prev_ids == local_ids {
+                            self.counters
+                                .no_progress_failures
+                                .fetch_add(1, Ordering::Relaxed);
+                            return Err(GpuNativeTokenLoopError::NoProgress {
+                                layer_index: fail_layer,
+                                selected_ids: local_ids.clone(),
+                            });
+                        }
+                    }
+
+                    let global_ids: Vec<u32> = local_ids
+                        .iter()
+                        .map(|&loc| {
+                            fail_layer as u32 * self.model_geometry.num_experts as u32 + loc
+                        })
+                        .collect();
+
+                    engine
+                        .ensure_gpu_native_demand_residency(fail_layer, &global_ids)
+                        .await
+                        .map_err(GpuNativeTokenLoopError::ResidencyServiceFailed)?;
+
+                    self.counters
+                        .residency_services
+                        .fetch_add(1, Ordering::Relaxed);
+                    last_miss_sig = Some((fail_layer, local_ids.clone()));
+                    attempt += 1;
+                    continue;
+                }
+
+                return Err(GpuNativeTokenLoopError::FatalNumericalFailure {
+                    layer_index: Some(fail_layer),
+                    status_bits: layer_status,
+                });
+            }
+
+            if (report.final_status & GPU_NATIVE_STATUS_FATAL_MASK) != 0 {
+                self.counters.fatal_failures.fetch_add(1, Ordering::Relaxed);
+                return Err(GpuNativeTokenLoopError::FatalNumericalFailure {
+                    layer_index: None,
+                    status_bits: report.final_status,
+                });
+            }
+            if report.final_status != 0 {
+                return Err(GpuNativeTokenLoopError::FatalNumericalFailure {
+                    layer_index: None,
+                    status_bits: report.final_status,
+                });
+            }
+
+            request.committed_position += 1;
+            self.counters
+                .tokens_completed
+                .fetch_add(1, Ordering::Relaxed);
+            if is_warm {
+                self.counters
+                    .warm_tokens_completed
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+
+            engine.record_gpu_native_actual_routes(&report.selected_ids);
+
+            if sample {
+                return Ok(Some(report.sampled_token));
+            } else {
+                return Ok(None);
+            }
+        }
+    }
+
+    /// Encode and execute one single attempt on device and read back the compact boundary report.
+    pub fn execute_token_attempt(
+        &self,
+        request: &mut GpuNativeRequestState,
+        token_id: u32,
+        position: usize,
+        sample: bool,
+        replay: bool,
+    ) -> Result<GpuNativeBoundaryReport, GpuNativeTokenLoopError> {
+        if position != request.committed_position {
+            return Err(GpuNativeTokenLoopError::ContextLimitExceeded {
+                requested_position: position,
+                max_seq_len: request.committed_position,
+            });
+        }
+        if position >= request.max_seq_len {
+            return Err(GpuNativeTokenLoopError::ContextLimitExceeded {
+                requested_position: position,
+                max_seq_len: request.max_seq_len,
+            });
+        }
+
+        self.counters.token_attempts.fetch_add(1, Ordering::Relaxed);
+        self.counters
+            .queue_submissions
+            .fetch_add(1, Ordering::Relaxed);
+        self.counters.boundary_maps.fetch_add(1, Ordering::Relaxed);
+        self.counters
+            .boundary_readbacks
+            .fetch_add(1, Ordering::Relaxed);
+        if replay {
+            self.counters
+                .replay_attempts
+                .fetch_add(1, Ordering::Relaxed);
+        }
+
+        let gpu = self.executor.authoritative_gpu()?;
+        let mut encoder = gpu
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("gpu_native_token_attempt"),
+            });
+
+        if replay {
+            self.executor
+                .encode_clear_retryable_status(&mut encoder, &request.token_state)?;
+        }
+
+        self.executor.encode_embedding_lookup(
+            &mut encoder,
+            &self.embedding_handle,
+            token_id,
+            &request.token_state,
+        )?;
+
+        let num_layers = self.layers.len();
+        let top_k = self.model_geometry.top_k;
+        let rms_eps = self.model_geometry.rms_eps;
+
+        for (layer_idx, layer_plan) in self.layers.iter().enumerate() {
+            // 1. Attention Pre-Norm
+            self.executor.encode_rms_norm_state_in_place(
+                &mut encoder,
+                &layer_plan.rms_attn_handle,
+                rms_eps,
+                &request.token_state,
+            )?;
+
+            // 2. Attention Prepare
+            self.executor.encode_attention_prepare(
+                &mut encoder,
+                &layer_plan.attn_plan,
+                &request.token_state,
+                &request.attn_scratch,
+                &request.kv_state,
+                position,
+            )?;
+
+            // 3. Attention Complete
+            self.executor.encode_attention_complete(
+                &mut encoder,
+                &layer_plan.attn_plan,
+                &request.token_state,
+                &request.attn_scratch,
+                &request.kv_state,
+                position + 1,
+            )?;
+
+            // 4. MoE Pre-Norm
+            self.executor.encode_rms_norm_state_in_place(
+                &mut encoder,
+                &layer_plan.rms_moe_handle,
+                rms_eps,
+                &request.token_state,
+            )?;
+
+            // 5. Router
+            self.executor.encode_router(
+                &mut encoder,
+                &layer_plan.router_plan,
+                &request.token_state,
+                &request.router_scratch,
+            )?;
+
+            // 6. Expert Combine
+            let arena = self.residency_manager.arena(layer_idx).ok_or_else(|| {
+                GpuNativeTokenLoopError::InvalidBoundaryReport {
+                    detail: format!("missing expert arena for layer {layer_idx}"),
+                }
+            })?;
+            self.executor.encode_q4_expert_arena_combine(
+                &mut encoder,
+                &layer_plan.router_plan,
+                &request.router_scratch,
+                arena,
+                &request.token_state,
+                &request.expert_scratch,
+            )?;
+
+            // Copy layer status to staging
+            let status_offset = (layer_idx * 4) as u64;
+            encoder.copy_buffer_to_buffer(
+                request.token_state.status_buffer(),
+                0,
+                &request.staging_buffer,
+                status_offset,
+                4,
+            );
+
+            // Copy selected ids to staging before scratch reuse
+            let ids_offset = (num_layers * 4 + layer_idx * top_k * 4) as u64;
+            encoder.copy_buffer_to_buffer(
+                request.router_scratch.selected_ids_buffer(),
+                0,
+                &request.staging_buffer,
+                ids_offset,
+                (top_k * 4) as u64,
+            );
+        }
+
+        if sample {
+            // Final RMSNorm
+            self.executor.encode_rms_norm_hidden_in_place(
+                &mut encoder,
+                &self.final_norm_handle,
+                rms_eps,
+                &request.token_state,
+            )?;
+
+            // LM Head GEMV
+            self.executor.encode_dense_gemv_hidden_to_scratch(
+                &mut encoder,
+                &self.lm_head_handle,
+                &request.token_state,
+                &request.logits_scratch,
+            )?;
+
+            // GPU Greedy Argmax
+            self.executor.encode_greedy_argmax(
+                &mut encoder,
+                &request.logits_scratch,
+                &request.sampled_token_buf,
+                &request.token_state,
+                self.model_geometry.vocab_size,
+            )?;
+
+            // Copy final status and sampled token
+            let final_status_offset = (num_layers * 4 + num_layers * top_k * 4) as u64;
+            encoder.copy_buffer_to_buffer(
+                request.token_state.status_buffer(),
+                0,
+                &request.staging_buffer,
+                final_status_offset,
+                4,
+            );
+            let token_offset = final_status_offset + 4;
+            encoder.copy_buffer_to_buffer(
+                request.sampled_token_buf.buffer(),
+                0,
+                &request.staging_buffer,
+                token_offset,
+                4,
+            );
+        } else {
+            // Ingest-only: copy final status to staging
+            let final_status_offset = (num_layers * 4 + num_layers * top_k * 4) as u64;
+            encoder.copy_buffer_to_buffer(
+                request.token_state.status_buffer(),
+                0,
+                &request.staging_buffer,
+                final_status_offset,
+                4,
+            );
+        }
+
+        // ONE submission
+        gpu.queue.submit(Some(encoder.finish()));
+
+        // ONE map/readback
+        let slice = request
+            .staging_buffer
+            .slice(..self.report_layout.total_bytes);
+        let (tx, rx) = std::sync::mpsc::sync_channel(1);
+        slice.map_async(wgpu::MapMode::Read, move |res| {
+            let _ = tx.send(res);
+        });
+        gpu.device.poll(wgpu::Maintain::Wait);
+        rx.recv()
+            .map_err(|e| GpuNativeTokenLoopError::MapFailed(e.to_string()))?
+            .map_err(|e| GpuNativeTokenLoopError::MapFailed(format!("{e:?}")))?;
+
+        let mapped = slice.get_mapped_range();
+        let report = self.report_layout.parse(&mapped)?;
+        drop(mapped);
+        request.staging_buffer.unmap();
+
+        Ok(report)
+    }
+}
+
+/// Request-local device resources for one GPU-native generation sequence.
+pub struct GpuNativeRequestState {
+    pub token_state: GpuNativeTokenState,
+    pub kv_state: GpuNativeKvState,
+    pub attn_scratch: GpuNativeAttentionScratch,
+    pub router_scratch: GpuNativeRouterScratch,
+    pub expert_scratch: GpuNativeQ4ExpertScratch,
+    pub logits_scratch: GpuNativeScratch,
+    pub sampled_token_buf: GpuNativeScratch,
+    pub staging_buffer: wgpu::Buffer,
+    pub committed_position: usize,
+    pub max_seq_len: usize,
+}
+
+impl GpuNativeRequestState {
+    pub fn committed_position(&self) -> usize {
+        self.committed_position
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use crate::architecture::Architecture;
+    use crate::backend::gpu_native::{
+        GPU_NATIVE_STATUS_ATTENTION_NUMERICAL_FAILURE, GPU_NATIVE_STATUS_EXPERT_NUMERICAL_FAILURE,
+        GPU_NATIVE_STATUS_LM_HEAD_NUMERICAL_FAILURE, GPU_NATIVE_STATUS_ROUTER_NUMERICAL_FAILURE,
+    };
+    use crate::config::Config;
+    use crate::dense_tensor::DenseWeight;
+    use crate::gating::{LinearGate, ScoringFunc};
+    use crate::model::RealModelConfig;
+    use crate::transformer::{LMHead, MultiHeadSelfAttention, RmsNorm, TransformerLayer};
+
+    pub(crate) fn make_test_qwen3_moe_config() -> RealModelConfig {
+        RealModelConfig {
+            d_model: 32,
+            d_ff: 32,
+            num_heads: 2,
+            num_kv_heads: 2,
+            head_dim: 16,
+            vocab_size: 32,
+            num_layers: 2,
+            num_experts: 4,
+            top_k: 2,
+            rope_base: 10_000.0,
+            rms_eps: 1e-5,
+            window_size: None,
+            architecture: Architecture::Qwen3Moe,
+            first_k_dense_replace: 0,
+            advanced: Default::default(),
+        }
+    }
+
+    pub(crate) fn make_test_qwen3_moe_model(cfg: RealModelConfig) -> RealModel {
+        let embedding = DenseWeight::from_f32(
+            vec![0.1; cfg.vocab_size * cfg.d_model],
+            cfg.vocab_size,
+            cfg.d_model,
+        );
+        let lm_head = LMHead::new(
+            vec![0.1; cfg.vocab_size * cfg.d_model],
+            cfg.vocab_size,
+            cfg.d_model,
+        );
+        let final_rms = RmsNorm::new(vec![1.0; cfg.d_model], cfg.rms_eps);
+
+        let mut layers = Vec::with_capacity(cfg.num_layers);
+        for _ in 0..cfg.num_layers {
+            let attn = MultiHeadSelfAttention {
+                d_model: cfg.d_model,
+                num_heads: cfg.num_heads,
+                num_kv_heads: cfg.num_kv_heads,
+                head_dim: cfg.head_dim,
+                rope_dim: cfg.head_dim,
+                v_head_dim: cfg.head_dim,
+                attention_value_scale: None,
+                rope_base: cfg.rope_base,
+                wq: DenseWeight::from_f32(
+                    vec![0.01; cfg.num_heads * cfg.head_dim * cfg.d_model],
+                    cfg.num_heads * cfg.head_dim,
+                    cfg.d_model,
+                ),
+                wk: DenseWeight::from_f32(
+                    vec![0.01; cfg.num_kv_heads * cfg.head_dim * cfg.d_model],
+                    cfg.num_kv_heads * cfg.head_dim,
+                    cfg.d_model,
+                ),
+                wv: DenseWeight::from_f32(
+                    vec![0.01; cfg.num_kv_heads * cfg.head_dim * cfg.d_model],
+                    cfg.num_kv_heads * cfg.head_dim,
+                    cfg.d_model,
+                ),
+                wo: DenseWeight::from_f32(
+                    vec![0.01; cfg.d_model * cfg.num_heads * cfg.head_dim],
+                    cfg.d_model,
+                    cfg.num_heads * cfg.head_dim,
+                ),
+                window_size: None,
+                q_norm: Some(RmsNorm::new(vec![1.0; cfg.head_dim], cfg.rms_eps)),
+                k_norm: Some(RmsNorm::new(vec![1.0; cfg.head_dim], cfg.rms_eps)),
+                rope_yarn: None,
+                rope_cache: None,
+                bq: None,
+                bk: None,
+                bv: None,
+                bo: None,
+                sink_bias: None,
+            };
+            let gate = LinearGate::new(
+                vec![0.1; cfg.num_experts * cfg.d_model],
+                cfg.num_experts,
+                cfg.d_model,
+                cfg.top_k,
+            );
+            let layer = TransformerLayer {
+                rms_attn: RmsNorm::new(vec![1.0; cfg.d_model], cfg.rms_eps),
+                attn,
+                mla: None,
+                rms_moe: RmsNorm::new(vec![1.0; cfg.d_model], cfg.rms_eps),
+                gate,
+                shared_expert: None,
+                dense_ffn: None,
+            };
+            layers.push(layer);
+        }
+
+        RealModel {
+            config: cfg,
+            embedding,
+            layers,
+            final_rms,
+            lm_head,
+            load_status: crate::model::WeightLoadStatus::default(),
+        }
+    }
+
+    #[test]
+    fn compatibility_validation_accepts_supported_qwen3_moe() {
+        let cfg = make_test_qwen3_moe_config();
+        let model = make_test_qwen3_moe_model(cfg);
+        assert!(GpuNativeTokenLoop::validate_model_compatibility(&model).is_ok());
+    }
+
+    #[test]
+    fn compatibility_validation_rejects_wrong_architecture() {
+        let mut cfg = make_test_qwen3_moe_config();
+        cfg.architecture = Architecture::Mixtral;
+        let model = make_test_qwen3_moe_model(cfg);
+        assert!(matches!(
+            GpuNativeTokenLoop::validate_model_compatibility(&model),
+            Err(GpuNativeModelCompatibilityError::UnsupportedArchitecture { .. })
+        ));
+    }
+
+    #[test]
+    fn compatibility_validation_rejects_dense_and_shared_experts() {
+        let cfg = make_test_qwen3_moe_config();
+        let mut model = make_test_qwen3_moe_model(cfg);
+        model.layers[0].dense_ffn = Some(
+            crate::transformer::SharedExpert::from_projections(
+                32,
+                32,
+                &vec![0.1; 32 * 32],
+                &vec![0.1; 32 * 32],
+                &vec![0.1; 32 * 32],
+                None,
+            )
+            .unwrap(),
+        );
+        assert!(matches!(
+            GpuNativeTokenLoop::validate_model_compatibility(&model),
+            Err(GpuNativeModelCompatibilityError::DenseLayerUnsupported { .. })
+        ));
+
+        let cfg2 = make_test_qwen3_moe_config();
+        let mut model2 = make_test_qwen3_moe_model(cfg2);
+        model2.layers[0].shared_expert = Some(
+            crate::transformer::SharedExpert::from_projections(
+                32,
+                32,
+                &vec![0.1; 32 * 32],
+                &vec![0.1; 32 * 32],
+                &vec![0.1; 32 * 32],
+                None,
+            )
+            .unwrap(),
+        );
+        assert!(matches!(
+            GpuNativeTokenLoop::validate_model_compatibility(&model2),
+            Err(GpuNativeModelCompatibilityError::SharedExpertUnsupported { .. })
+        ));
+    }
+
+    #[test]
+    fn compatibility_validation_rejects_asymmetric_v_and_sinks() {
+        let cfg = make_test_qwen3_moe_config();
+        let mut model = make_test_qwen3_moe_model(cfg);
+        model.layers[0].attn.v_head_dim = 32;
+        assert!(matches!(
+            GpuNativeTokenLoop::validate_model_compatibility(&model),
+            Err(GpuNativeModelCompatibilityError::AsymmetricVHeadDim { .. })
+        ));
+
+        let cfg2 = make_test_qwen3_moe_config();
+        let mut model2 = make_test_qwen3_moe_model(cfg2);
+        model2.layers[0].attn.sink_bias = Some(vec![0.0; 2]);
+        assert!(matches!(
+            GpuNativeTokenLoop::validate_model_compatibility(&model2),
+            Err(GpuNativeModelCompatibilityError::AttentionSinkUnsupported { .. })
+        ));
+    }
+
+    #[test]
+    fn compatibility_validation_rejects_biases_and_sliding_window() {
+        let cfg = make_test_qwen3_moe_config();
+        let mut model = make_test_qwen3_moe_model(cfg);
+        model.layers[0].attn.bq = Some(vec![0.0; 32]);
+        assert!(matches!(
+            GpuNativeTokenLoop::validate_model_compatibility(&model),
+            Err(GpuNativeModelCompatibilityError::AttentionBiasesUnsupported { .. })
+        ));
+
+        let mut cfg2 = make_test_qwen3_moe_config();
+        cfg2.window_size = Some(4096);
+        let model2 = make_test_qwen3_moe_model(cfg2);
+        assert!(matches!(
+            GpuNativeTokenLoop::validate_model_compatibility(&model2),
+            Err(GpuNativeModelCompatibilityError::SlidingWindowUnsupported { .. })
+        ));
+    }
+
+    #[test]
+    fn compatibility_validation_rejects_non_softmax_and_router_features() {
+        let cfg = make_test_qwen3_moe_config();
+        let mut model = make_test_qwen3_moe_model(cfg);
+        model.layers[0].gate.scoring_func = ScoringFunc::Sigmoid;
+        assert!(matches!(
+            GpuNativeTokenLoop::validate_model_compatibility(&model),
+            Err(GpuNativeModelCompatibilityError::NonSoftmaxRouter { .. })
+        ));
+
+        let cfg2 = make_test_qwen3_moe_config();
+        let mut model2 = make_test_qwen3_moe_model(cfg2);
+        model2.layers[0].gate.correction_bias = Some(vec![0.0; 4]);
+        assert!(matches!(
+            GpuNativeTokenLoop::validate_model_compatibility(&model2),
+            Err(GpuNativeModelCompatibilityError::RouterCorrectionBiasUnsupported { .. })
+        ));
+
+        let cfg3 = make_test_qwen3_moe_config();
+        let mut model3 = make_test_qwen3_moe_model(cfg3);
+        model3.layers[0].gate.n_group = 2;
+        assert!(matches!(
+            GpuNativeTokenLoop::validate_model_compatibility(&model3),
+            Err(GpuNativeModelCompatibilityError::GroupedRoutingUnsupported { .. })
+        ));
+
+        let cfg4 = make_test_qwen3_moe_config();
+        let mut model4 = make_test_qwen3_moe_model(cfg4);
+        model4.layers[0].gate.routed_scaling_factor = 2.0;
+        assert!(matches!(
+            GpuNativeTokenLoop::validate_model_compatibility(&model4),
+            Err(GpuNativeModelCompatibilityError::RoutedScalingFactorUnsupported { .. })
+        ));
+    }
+
+    #[test]
+    fn boundary_report_layout_and_parser_work_correctly() {
+        let layout = GpuNativeBoundaryReportLayout::try_new(2, 2).unwrap();
+        assert_eq!(layout.total_bytes, 32);
+        assert_eq!(layout.layer_status_offset, 0);
+        assert_eq!(layout.layer_status_bytes, 8);
+        assert_eq!(layout.selected_ids_offset, 8);
+        assert_eq!(layout.selected_ids_bytes, 16);
+        assert_eq!(layout.final_status_offset, 24);
+        assert_eq!(layout.sampled_token_offset, 28);
+
+        let mut bytes = vec![0u8; 32];
+        bytes[8..12].copy_from_slice(&2u32.to_le_bytes());
+        bytes[12..16].copy_from_slice(&3u32.to_le_bytes());
+        bytes[16..20].copy_from_slice(&0u32.to_le_bytes());
+        bytes[20..24].copy_from_slice(&1u32.to_le_bytes());
+        bytes[24..28].copy_from_slice(&0u32.to_le_bytes());
+        bytes[28..32].copy_from_slice(&17u32.to_le_bytes());
+
+        let report = layout.parse(&bytes).unwrap();
+        assert_eq!(report.layer_statuses, vec![0, 0]);
+        assert_eq!(report.selected_ids, vec![vec![2, 3], vec![0, 1]]);
+        assert_eq!(report.final_status, 0);
+        assert_eq!(report.sampled_token, 17);
+        assert_eq!(report.first_failure_layer(), None);
+    }
+
+    #[test]
+    fn first_failure_layer_detects_first_nonzero_transition() {
+        let layout = GpuNativeBoundaryReportLayout::try_new(4, 2).unwrap();
+        let mut bytes = vec![0u8; layout.total_bytes as usize];
+        bytes[8..12].copy_from_slice(&4u32.to_le_bytes());
+        bytes[12..16].copy_from_slice(&4u32.to_le_bytes());
+
+        let report = layout.parse(&bytes).unwrap();
+        assert_eq!(report.first_failure_layer(), Some(2));
+    }
+
+    #[test]
+    fn greedy_argmax_reference_semantics() {
+        let reference_argmax = |logits: &[f32]| -> Result<u32, &'static str> {
+            if logits.is_empty() {
+                return Err("empty logits");
+            }
+            let mut best_val = -f32::MAX;
+            let mut best_idx = None;
+            for (idx, &val) in logits.iter().enumerate() {
+                if !val.is_finite() {
+                    return Err("non-finite logit");
+                }
+                if best_idx.is_none() || val > best_val {
+                    best_val = val;
+                    best_idx = Some(idx as u32);
+                }
+            }
+            best_idx.ok_or("no candidate")
+        };
+
+        // Unique max
+        assert_eq!(reference_argmax(&[1.0, 5.0, 2.0, 3.0]).unwrap(), 1);
+
+        // Tied max selects lower token id
+        assert_eq!(reference_argmax(&[1.0, 5.0, 2.0, 5.0, 3.0]).unwrap(), 1);
+
+        // All negative finite logits
+        assert_eq!(reference_argmax(&[-10.0, -2.0, -5.0]).unwrap(), 1);
+
+        // Non-finite logits fail
+        assert!(reference_argmax(&[1.0, f32::NAN, 2.0]).is_err());
+        assert!(reference_argmax(&[1.0, f32::INFINITY, 2.0]).is_err());
+        assert!(reference_argmax(&[1.0, f32::NEG_INFINITY, 2.0]).is_err());
+    }
+
+    #[test]
+    fn fatal_status_mask_and_retry_clear_invariants() {
+        assert_eq!(
+            GPU_NATIVE_STATUS_FATAL_MASK & GPU_NATIVE_STATUS_RETRYABLE_MASK,
+            0
+        );
+        assert_eq!(
+            crate::backend::gpu_native::status_after_retryable_clear(
+                GPU_NATIVE_STATUS_RETRYABLE_MASK
+            ),
+            0
+        );
+        assert_eq!(
+            crate::backend::gpu_native::status_after_retryable_clear(
+                GPU_NATIVE_STATUS_FATAL_MASK | GPU_NATIVE_STATUS_RETRYABLE_MASK
+            ),
+            GPU_NATIVE_STATUS_FATAL_MASK
+        );
+    }
+
+    #[test]
+    fn gpu_native_token_state_hidden_and_residual_have_no_copy_src() {
+        let usage = crate::backend::gpu_native::GpuNativeTokenStateLayout::tensor_usage();
+        assert!(!usage.contains(wgpu::BufferUsages::COPY_SRC));
+        assert!(!usage.contains(wgpu::BufferUsages::MAP_READ));
+        assert!(!usage.contains(wgpu::BufferUsages::MAP_WRITE));
+    }
+
+    #[test]
+    fn gpu_native_config_defaults_and_validation() {
+        let toml_str = r#"
+            [model]
+            data_dir = "."
+            num_layers = 2
+            num_experts = 4
+            top_k = 2
+            expert_size = 4096
+            d_model = 32
+            d_ff = 32
+            dtype = "q4_0"
+
+            [server]
+            bind = "127.0.0.1:8080"
+            max_concurrent_requests = 1
+            session_ttl_secs = 0
+
+            [storage]
+            block_align = 4096
+            cache_slots = 16
+
+            [gpu_cache]
+            enabled = true
+            vram_capacity_mb = 128
+
+            [real_transformer]
+            enabled = true
+            compute_offload = "gpu"
+            gpu_native = true
+            strict_weights = true
+            max_batch_size = 1
+        "#;
+        let cfg: Config = toml::from_str(toml_str).unwrap();
+        assert!(cfg.real_transformer.gpu_native);
+        assert_eq!(cfg.real_transformer.gpu_native_max_seq_len, 4096);
+        assert!(cfg.validate().is_ok());
+
+        let mut invalid_cfg = cfg.clone();
+        invalid_cfg.server.max_concurrent_requests = 2;
+        assert!(invalid_cfg.validate().is_err());
+
+        let mut invalid_cfg2 = cfg.clone();
+        invalid_cfg2.real_transformer.max_batch_size = 2;
+        assert!(invalid_cfg2.validate().is_err());
+    }
+
+    #[test]
+    fn compatibility_validation_rejects_mla_and_oversized() {
+        let mut cfg = make_test_qwen3_moe_config();
+        cfg.num_experts = 16;
+        cfg.top_k = 9;
+        let model = make_test_qwen3_moe_model(cfg);
+        assert!(matches!(
+            GpuNativeTokenLoop::validate_model_compatibility(&model),
+            Err(GpuNativeModelCompatibilityError::InvalidTopK { .. })
+        ));
+
+        let mut cfg2 = make_test_qwen3_moe_config();
+        cfg2.num_experts = 129;
+        let model2 = make_test_qwen3_moe_model(cfg2);
+        assert!(matches!(
+            GpuNativeTokenLoop::validate_model_compatibility(&model2),
+            Err(GpuNativeModelCompatibilityError::TooManyExperts { .. })
+        ));
+    }
+
+    #[test]
+    fn boundary_report_parser_identifies_failure_modes() {
+        let layout = GpuNativeBoundaryReportLayout::try_new(2, 2).unwrap();
+        let mut bytes = vec![0u8; 32];
+
+        // Fatal attention
+        bytes[0..4].copy_from_slice(&GPU_NATIVE_STATUS_ATTENTION_NUMERICAL_FAILURE.to_le_bytes());
+        let report = layout.parse(&bytes).unwrap();
+        assert_eq!(report.first_failure_layer(), Some(0));
+        assert_eq!(
+            report.layer_statuses[0] & GPU_NATIVE_STATUS_FATAL_MASK,
+            GPU_NATIVE_STATUS_ATTENTION_NUMERICAL_FAILURE
+        );
+
+        // Fatal router
+        bytes[0..4].copy_from_slice(&0u32.to_le_bytes());
+        bytes[4..8].copy_from_slice(&GPU_NATIVE_STATUS_ROUTER_NUMERICAL_FAILURE.to_le_bytes());
+        let report2 = layout.parse(&bytes).unwrap();
+        assert_eq!(report2.first_failure_layer(), Some(1));
+        assert_eq!(
+            report2.layer_statuses[1] & GPU_NATIVE_STATUS_FATAL_MASK,
+            GPU_NATIVE_STATUS_ROUTER_NUMERICAL_FAILURE
+        );
+
+        // Fatal expert
+        bytes[4..8].copy_from_slice(&GPU_NATIVE_STATUS_EXPERT_NUMERICAL_FAILURE.to_le_bytes());
+        let report3 = layout.parse(&bytes).unwrap();
+        assert_eq!(report3.first_failure_layer(), Some(1));
+        assert_eq!(
+            report3.layer_statuses[1] & GPU_NATIVE_STATUS_FATAL_MASK,
+            GPU_NATIVE_STATUS_EXPERT_NUMERICAL_FAILURE
+        );
+
+        // Fatal LM head
+        bytes[4..8].copy_from_slice(&0u32.to_le_bytes());
+        bytes[24..28].copy_from_slice(&GPU_NATIVE_STATUS_LM_HEAD_NUMERICAL_FAILURE.to_le_bytes());
+        let report4 = layout.parse(&bytes).unwrap();
+        assert_eq!(report4.first_failure_layer(), None);
+        assert_eq!(
+            report4.final_status & GPU_NATIVE_STATUS_FATAL_MASK,
+            GPU_NATIVE_STATUS_LM_HEAD_NUMERICAL_FAILURE
+        );
+    }
+
+    #[test]
+    fn local_to_global_conversion_and_validation() {
+        let num_experts = 4u32;
+        let layer_0_locals = vec![1u32, 2];
+        let layer_0_globals: Vec<u32> = layer_0_locals
+            .iter()
+            .map(|&loc| 0 * num_experts + loc)
+            .collect();
+        assert_eq!(layer_0_globals, vec![1, 2]);
+
+        let layer_1_locals = vec![0u32, 3];
+        let layer_1_globals: Vec<u32> = layer_1_locals
+            .iter()
+            .map(|&loc| 1 * num_experts + loc)
+            .collect();
+        assert_eq!(layer_1_globals, vec![4, 7]);
+    }
+
+    #[test]
+    fn disabled_mode_preserves_legacy_state() {
+        let toml_str = r#"
+            [model]
+            data_dir = "."
+            num_layers = 2
+            num_experts = 4
+            top_k = 2
+            expert_size = 4096
+            d_model = 32
+            d_ff = 32
+            dtype = "q4_0"
+
+            [server]
+            bind = "127.0.0.1:8080"
+            max_concurrent_requests = 4
+            session_ttl_secs = 0
+
+            [storage]
+            block_align = 4096
+            cache_slots = 16
+
+            [gpu_cache]
+            enabled = false
+            vram_capacity_mb = 0
+
+            [real_transformer]
+            enabled = false
+            gpu_native = false
+        "#;
+        let cfg: Config = toml::from_str(toml_str).unwrap();
+        assert!(!cfg.real_transformer.gpu_native);
+        assert!(cfg.validate().is_ok());
+    }
+
+    struct TempDir {
+        path: std::path::PathBuf,
+    }
+
+    impl TempDir {
+        fn new(tag: &str) -> Self {
+            static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+            let id = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            let path =
+                std::env::temp_dir().join(format!("mer-test-{tag}-{id}-{}", std::process::id()));
+            let _ = std::fs::remove_dir_all(&path);
+            std::fs::create_dir_all(&path).unwrap();
+            Self { path }
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+
+    #[test]
+    #[ignore = "requires authoritative NVIDIA L4 WGPU validation hardware"]
+    fn live_l4_gpu_native_full_token_loop_retry() {
+        use crate::backend::{resolve_execution_context_for_gpu_native, GpuBackendGeometry};
+        use crate::buffer_pool::BufferPool;
+        use crate::expert_cache::{ExpertResident, GpuExpertCache, GpuResident};
+
+        const D_MODEL: usize = 32;
+        const D_FF: usize = 32;
+        const NUM_EXPERTS: usize = 4;
+        const TOP_K: usize = 2;
+        const NUM_LAYERS: usize = 2;
+        const VOCAB_SIZE: usize = 32;
+        const MAX_SEQ_LEN: usize = 8;
+
+        let geometry =
+            GpuNativeQ4ExpertGeometry::try_new(D_MODEL, D_FF, NUM_EXPERTS, TOP_K).unwrap();
+        let payload_template =
+            crate::backend::gpu_native::tests::q4_uniform_expert(geometry, 0.01, 0.02, 0.005);
+        let payload_bytes = payload_template.len();
+
+        let gpu_cache = Arc::new(GpuExpertCache::new(payload_bytes * 16, 0.0, u64::MAX));
+
+        let execution = resolve_execution_context_for_gpu_native(
+            GpuBackendGeometry {
+                num_layers: NUM_LAYERS,
+                max_seq_len: MAX_SEQ_LEN,
+                num_heads: 2,
+                num_kv_heads: 2,
+                head_dim: 16,
+                v_head_dim: 16,
+                q4_truncation_tolerance: 0,
+            },
+            gpu_cache.clone(),
+        )
+        .expect("L4 must construct the authoritative production GPU backend");
+
+        let executor = Arc::new(
+            execution
+                .create_gpu_native_executor_context(D_MODEL)
+                .expect("GPU-native executor must retain the authoritative backend"),
+        );
+        assert_eq!(executor.device_identity().vendor_id, 0x10de);
+        assert!(
+            executor.device_identity().name.contains("L4"),
+            "ignored full token loop test must run only on an NVIDIA L4, got {}",
+            executor.device_identity().name
+        );
+
+        let total_budget = (payload_bytes as u64) * (TOP_K as u64) * (NUM_LAYERS as u64) * 2;
+        let residency_manager = Arc::new(
+            GpuNativeTieredResidencyManager::try_new(
+                executor.clone(),
+                gpu_cache.clone(),
+                NUM_LAYERS,
+                geometry,
+                total_budget,
+            )
+            .unwrap(),
+        );
+
+        let temp_dir = TempDir::new("full_token_loop");
+        let storage = Arc::new(
+            crate::io_provider::NvmeStorage::new(crate::io_provider::StorageConfig {
+                base_path: temp_dir.path.clone(),
+                expert_size: payload_bytes,
+                block_align: 4,
+                use_direct_io: false,
+                num_experts_per_layer: Some(NUM_EXPERTS as u32),
+            })
+            .unwrap(),
+        );
+
+        let router = crate::gating::Router::Markov(Arc::new(crate::router::TopKRouter::new(
+            (NUM_EXPERTS * NUM_LAYERS) as u32,
+            TOP_K,
+            0xC0FFEE,
+        )));
+        let predictor = Arc::new(crate::router::PredictiveLoader::new(
+            (NUM_EXPERTS * NUM_LAYERS) as u32,
+            TOP_K,
+            0.0,
+            42,
+        ));
+
+        let mut engine_builder = Engine::with_options_and_execution_context(
+            Arc::new(
+                crate::multi_layer_cache::MultiLayerExpertCache::with_uniform_capacity(
+                    NUM_LAYERS,
+                    16,
+                    NUM_EXPERTS as u32,
+                ),
+            ),
+            BufferPool::new(16, payload_bytes, 4),
+            storage,
+            router,
+            predictor,
+            crate::engine::ModelShape {
+                d_model: D_MODEL,
+                d_ff: D_FF,
+                hidden_seed: 0xC0FFEE,
+            },
+            crate::engine::EngineOptions {
+                io_only: false,
+                dtype: crate::inference::WeightDtype::Q4_0,
+                partial_load_fraction: 1.0,
+                pin_after_observations: 0,
+                use_qmm_for_q4: true,
+                expert_execution_policy: crate::engine::ExpertExecutionPolicy::Auto,
+                max_concurrent_prefetches: 64,
+                max_fetch_yields: 128,
+                prefetch_governor: false,
+                prefetch_precision_floor: 0.0,
+                prefetch_contention_weight: 0.0,
+                cost_aware_eviction: false,
+                pregate_enabled: false,
+                collect_route_profile: false,
+                policy: crate::inference::RealInferencePolicy::default(),
+            },
+            execution.clone(),
+        );
+        engine_builder
+            .install_gpu_native_residency_manager(residency_manager.clone())
+            .unwrap();
+        let engine = Arc::new(engine_builder);
+
+        let cfg = RealModelConfig {
+            d_model: D_MODEL,
+            d_ff: D_FF,
+            num_heads: 2,
+            num_kv_heads: 2,
+            head_dim: 16,
+            vocab_size: VOCAB_SIZE,
+            num_layers: NUM_LAYERS,
+            num_experts: NUM_EXPERTS,
+            top_k: TOP_K,
+            rope_base: 10_000.0,
+            rms_eps: 1e-5,
+            window_size: None,
+            architecture: Architecture::Qwen3Moe,
+            first_k_dense_replace: 0,
+            advanced: Default::default(),
+        };
+        let model = make_test_qwen3_moe_model(cfg);
+
+        let token_loop = GpuNativeTokenLoop::try_new(
+            executor.clone(),
+            residency_manager.clone(),
+            &model,
+            MAX_SEQ_LEN,
+        )
+        .unwrap();
+
+        let mut request_state = token_loop.create_request_state().unwrap();
+
+        let pool = BufferPool::new(16, payload_bytes, 4);
+        for layer_idx in 0..NUM_LAYERS {
+            for local_id in 0..NUM_EXPERTS as u32 {
+                let global_id = layer_idx as u32 * NUM_EXPERTS as u32 + local_id;
+                let payload = crate::backend::gpu_native::tests::q4_uniform_expert(
+                    geometry,
+                    0.01 * (global_id + 1) as f32,
+                    0.02,
+                    0.005,
+                );
+                let mut buffer = pool.try_acquire().expect("synthetic RAM slot");
+                buffer.as_mut_slice().copy_from_slice(&payload);
+                let resident = Arc::new(ExpertResident::new_with_block_align(global_id, buffer, 4));
+                gpu_cache
+                    .demand_admit_lru(Arc::new(GpuResident::new_with_dtype(
+                        global_id,
+                        payload.clone(),
+                        crate::inference::WeightDtype::Q4_0,
+                    )))
+                    .unwrap();
+                let admission = gpu_cache.current_admission(global_id).unwrap();
+                let _ = (resident, admission);
+            }
+        }
+
+        let first_token =
+            pollster::block_on(token_loop.step_token(&engine, &mut request_state, 1, 0, true))
+                .unwrap()
+                .expect("cold token 0 must succeed after retries");
+
+        assert_eq!(request_state.committed_position, 1);
+        let snap1 = token_loop.snapshot();
+        assert_eq!(snap1.tokens_completed, 1);
+        assert_eq!(snap1.token_attempts, 3);
+        assert_eq!(snap1.residency_miss_attempts, 2);
+        assert_eq!(snap1.replay_attempts, 2);
+        assert_eq!(snap1.residency_services, 2);
+        assert_eq!(snap1.fatal_failures, 0);
+
+        let _second_token = pollster::block_on(token_loop.step_token(
+            &engine,
+            &mut request_state,
+            first_token,
+            1,
+            true,
+        ))
+        .unwrap()
+        .expect("warm token 1 must succeed directly");
+
+        assert_eq!(request_state.committed_position, 2);
+        let snap2 = token_loop.snapshot();
+        assert_eq!(snap2.tokens_completed, 2);
+        assert_eq!(snap2.warm_tokens_completed, 1);
+        assert_eq!(snap2.token_attempts, 4);
+        assert_eq!(snap2.queue_submissions, 4);
+        assert_eq!(snap2.boundary_maps, 4);
+        assert_eq!(snap2.boundary_readbacks, 4);
+        assert_eq!(snap2.residency_services, 2);
+        assert_eq!(snap2.fatal_failures, 0);
+    }
+}

--- a/rust-engine/src/gpu_native_token_loop.rs
+++ b/rust-engine/src/gpu_native_token_loop.rs
@@ -269,6 +269,11 @@ pub enum GpuNativeModelCompatibilityError {
         tensor: String,
         dtype: String,
     },
+    InconsistentRopeDimension {
+        layer_index: usize,
+        expected: usize,
+        actual: usize,
+    },
 }
 
 impl fmt::Display for GpuNativeModelCompatibilityError {
@@ -349,6 +354,14 @@ impl fmt::Display for GpuNativeModelCompatibilityError {
             Self::UnsupportedDenseDtype { tensor, dtype } => write!(
                 f,
                 "tensor {tensor} has unsupported dense dtype {dtype}; only F32 and Q8_0 are supported"
+            ),
+            Self::InconsistentRopeDimension {
+                layer_index,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "layer {layer_index} has rope_dim {actual}, expected uniform rope_dim {expected}"
             ),
         }
     }
@@ -539,6 +552,7 @@ pub struct GpuNativeModelGeometry {
     pub num_heads: usize,
     pub num_kv_heads: usize,
     pub head_dim: usize,
+    pub rope_dim: usize,
     pub vocab_size: usize,
     pub max_seq_len: usize,
     pub rms_eps: f32,
@@ -602,7 +616,18 @@ impl GpuNativeTokenLoop {
                 dtype: model.lm_head.weights.dtype_name().into(),
             });
         }
+        let expected_rope_dim = model.layers.first().map(|l| l.attn.rope_dim).unwrap_or(0);
+
         for (layer_idx, layer) in model.layers.iter().enumerate() {
+            if layer.attn.rope_dim != expected_rope_dim {
+                return Err(
+                    GpuNativeModelCompatibilityError::InconsistentRopeDimension {
+                        layer_index: layer_idx,
+                        expected: expected_rope_dim,
+                        actual: layer.attn.rope_dim,
+                    },
+                );
+            }
             if layer.dense_ffn.is_some() {
                 return Err(GpuNativeModelCompatibilityError::DenseLayerUnsupported {
                     layer_index: layer_idx,
@@ -718,6 +743,11 @@ impl GpuNativeTokenLoop {
         let num_heads = model.config.num_heads;
         let num_kv_heads = model.config.num_kv_heads;
         let head_dim = model.config.head_dim;
+        let rope_dim = model
+            .layers
+            .first()
+            .map(|l| l.attn.rope_dim)
+            .unwrap_or(head_dim);
         let vocab_size = model.config.vocab_size;
         let rms_eps = model.config.rms_eps;
         let rope_base = model.config.rope_base;
@@ -738,6 +768,7 @@ impl GpuNativeTokenLoop {
             num_heads,
             num_kv_heads,
             head_dim,
+            rope_dim,
             vocab_size,
             max_seq_len,
             rms_eps,
@@ -758,7 +789,7 @@ impl GpuNativeTokenLoop {
             num_heads,
             num_kv_heads,
             head_dim,
-            max_seq_len,
+            rope_dim,
         )?;
 
         for (l, layer) in model.layers.iter().enumerate() {
@@ -868,6 +899,10 @@ impl GpuNativeTokenLoop {
         self.model_geometry
     }
 
+    pub fn rope_dim(&self) -> usize {
+        self.model_geometry.rope_dim
+    }
+
     pub fn max_seq_len(&self) -> usize {
         self.model_geometry.max_seq_len
     }
@@ -891,7 +926,7 @@ impl GpuNativeTokenLoop {
             self.model_geometry.num_heads,
             self.model_geometry.num_kv_heads,
             self.model_geometry.head_dim,
-            self.model_geometry.max_seq_len,
+            self.model_geometry.rope_dim,
         )?;
         let attn_scratch = self.executor.create_attention_scratch(attn_geom)?;
 
@@ -1666,6 +1701,71 @@ pub(crate) mod tests {
             GpuNativeTokenLoop::validate_model_compatibility(&model4),
             Err(GpuNativeModelCompatibilityError::RoutedScalingFactorUnsupported { .. })
         ));
+    }
+
+    #[test]
+    fn compatibility_validation_validates_rope_dim_uniformity() {
+        let cfg = make_test_qwen3_moe_config();
+        let mut model = make_test_qwen3_moe_model(cfg);
+        // Valid uniform rope_dim
+        assert_eq!(model.layers[0].attn.rope_dim, 16);
+        assert_eq!(model.layers[1].attn.rope_dim, 16);
+        assert!(GpuNativeTokenLoop::validate_model_compatibility(&model).is_ok());
+
+        // Inconsistent rope_dim across layers fails closed
+        model.layers[1].attn.rope_dim = 8;
+        let err = GpuNativeTokenLoop::validate_model_compatibility(&model).unwrap_err();
+        assert_eq!(
+            err,
+            GpuNativeModelCompatibilityError::InconsistentRopeDimension {
+                layer_index: 1,
+                expected: 16,
+                actual: 8,
+            }
+        );
+        let msg = err.to_string();
+        assert!(msg.contains("layer 1 has rope_dim 8, expected uniform rope_dim 16"));
+    }
+
+    #[test]
+    fn model_rope_dim_is_derived_independently_from_max_seq_len() {
+        let cfg = make_test_qwen3_moe_config();
+        let model = make_test_qwen3_moe_model(cfg);
+        assert_eq!(model.layers[0].attn.rope_dim, 16);
+
+        // max_seq_len (e.g. 8) and rope_dim (16) must remain distinct and independent
+        let max_seq_len = 8usize;
+        let rope_dim = model.layers[0].attn.rope_dim;
+        assert_ne!(rope_dim, max_seq_len);
+
+        let geom = GpuNativeModelGeometry {
+            num_layers: model.config.num_layers,
+            d_model: model.config.d_model,
+            d_ff: model.config.d_ff,
+            num_experts: model.config.num_experts,
+            top_k: model.config.top_k,
+            num_heads: model.config.num_heads,
+            num_kv_heads: model.config.num_kv_heads,
+            head_dim: model.config.head_dim,
+            rope_dim,
+            vocab_size: model.config.vocab_size,
+            max_seq_len,
+            rms_eps: model.config.rms_eps,
+            rope_base: model.config.rope_base,
+        };
+        assert_eq!(geom.rope_dim, 16);
+        assert_eq!(geom.max_seq_len, 8);
+
+        // Attention geometry construction must accept rope_dim=16, not max_seq_len=8
+        let attn_geom = GpuNativeAttentionGeometry::try_new(
+            geom.d_model,
+            geom.num_heads,
+            geom.num_kv_heads,
+            geom.head_dim,
+            geom.rope_dim,
+        )
+        .unwrap();
+        assert_eq!(attn_geom.rope_dim(), 16);
     }
 
     #[test]

--- a/rust-engine/src/gpu_native_token_loop.rs
+++ b/rust-engine/src/gpu_native_token_loop.rs
@@ -82,6 +82,10 @@ pub enum GpuNativeTokenLoopError {
         requested_position: usize,
         max_seq_len: usize,
     },
+    PositionMismatch {
+        requested_position: usize,
+        committed_position: usize,
+    },
     AttemptBoundExceeded {
         attempts: usize,
         max_attempts: usize,
@@ -127,6 +131,13 @@ impl fmt::Display for GpuNativeTokenLoopError {
             } => write!(
                 f,
                 "requested position {requested_position} exceeds gpu_native_max_seq_len {max_seq_len}"
+            ),
+            Self::PositionMismatch {
+                requested_position,
+                committed_position,
+            } => write!(
+                f,
+                "position mismatch: requested position {requested_position} does not match committed position {committed_position}"
             ),
             Self::AttemptBoundExceeded {
                 attempts,
@@ -1178,9 +1189,9 @@ impl GpuNativeTokenLoop {
         replay: bool,
     ) -> Result<GpuNativeBoundaryReport, GpuNativeTokenLoopError> {
         if position != request.committed_position {
-            return Err(GpuNativeTokenLoopError::ContextLimitExceeded {
+            return Err(GpuNativeTokenLoopError::PositionMismatch {
                 requested_position: position,
-                max_seq_len: request.committed_position,
+                committed_position: request.committed_position,
             });
         }
         if position >= request.max_seq_len {
@@ -1925,7 +1936,22 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn token_loop_counters_track_actual_operations_only() {
+    fn position_mismatch_error_behavior() {
+        let err = GpuNativeTokenLoopError::PositionMismatch {
+            requested_position: 3,
+            committed_position: 2,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("position mismatch"));
+        assert!(msg.contains("requested position 3"));
+        assert!(msg.contains("committed position 2"));
+    }
+
+    #[test]
+    fn token_loop_counters_snapshot_and_accounting_semantics() {
+        // Unit-tests the internal snapshotting, atomic counter representations,
+        // and stage-by-stage accounting invariants of GpuNativeTokenLoopCounters.
+        // (End-to-end WGPU hardware execution is validated under the ignored L4 test fixture).
         let counters = GpuNativeTokenLoopCounters::default();
         let snap0 = counters.snapshot();
         assert_eq!(snap0.token_attempts, 0);
@@ -1934,12 +1960,11 @@ pub(crate) mod tests {
         assert_eq!(snap0.boundary_readbacks, 0);
         assert_eq!(snap0.replay_attempts, 0);
 
-        // Simulate an attempt starting: token_attempts is incremented
+        // In GpuNativeTokenLoop::execute_token_attempt, token_attempts is incremented
+        // when a valid attempt starts (after position validation).
         counters.token_attempts.fetch_add(1, Ordering::Relaxed);
         let snap1 = counters.snapshot();
         assert_eq!(snap1.token_attempts, 1);
-        // An encode-time failure before submission leaves queue_submissions, boundary_maps,
-        // and boundary_readbacks at 0
         assert_eq!(snap1.queue_submissions, 0);
         assert_eq!(snap1.boundary_maps, 0);
         assert_eq!(snap1.boundary_readbacks, 0);

--- a/rust-engine/src/gpu_native_token_loop.rs
+++ b/rust-engine/src/gpu_native_token_loop.rs
@@ -2173,6 +2173,49 @@ pub(crate) mod tests {
         assert!(cfg.validate().is_ok());
     }
 
+    #[test]
+    fn multi_layer_ram_cache_seeding_and_lookup() {
+        use crate::buffer_pool::BufferPool;
+        use crate::expert_cache::ExpertResident;
+        use crate::multi_layer_cache::MultiLayerExpertCache;
+
+        const NUM_LAYERS: usize = 2;
+        const NUM_EXPERTS: u32 = 4;
+        const EXPERT_SIZE: usize = 64;
+
+        let ram_cache = Arc::new(MultiLayerExpertCache::with_uniform_capacity(
+            NUM_LAYERS,
+            16,
+            NUM_EXPERTS,
+        ));
+        let pool = BufferPool::new(16, EXPERT_SIZE, 4);
+
+        for layer_idx in 0..NUM_LAYERS {
+            for local_id in 0..NUM_EXPERTS {
+                let global_id = layer_idx as u32 * NUM_EXPERTS + local_id;
+                let mut buffer = pool.try_acquire().expect("buffer slot");
+                buffer.as_mut_slice().fill((global_id + 1) as u8);
+                let resident = Arc::new(ExpertResident::new_with_block_align(global_id, buffer, 4));
+                assert!(
+                    ram_cache.insert(resident).is_ok(),
+                    "RAM cache insert must succeed for global_id {global_id}"
+                );
+            }
+        }
+
+        for layer_idx in 0..NUM_LAYERS {
+            for local_id in 0..NUM_EXPERTS {
+                let global_id = layer_idx as u32 * NUM_EXPERTS + local_id;
+                assert!(ram_cache.contains(global_id));
+                let resident = ram_cache
+                    .get(global_id)
+                    .expect("must retrieve seeded resident");
+                assert_eq!(resident.id, global_id);
+                assert_eq!(resident.data()[0], (global_id + 1) as u8);
+            }
+        }
+    }
+
     struct TempDir {
         path: std::path::PathBuf,
     }
@@ -2280,14 +2323,16 @@ pub(crate) mod tests {
             42,
         ));
 
-        let mut engine_builder = Engine::with_options_and_execution_context(
-            Arc::new(
-                crate::multi_layer_cache::MultiLayerExpertCache::with_uniform_capacity(
-                    NUM_LAYERS,
-                    16,
-                    NUM_EXPERTS as u32,
-                ),
+        let ram_cache = Arc::new(
+            crate::multi_layer_cache::MultiLayerExpertCache::with_uniform_capacity(
+                NUM_LAYERS,
+                16,
+                NUM_EXPERTS as u32,
             ),
+        );
+
+        let mut engine_builder = Engine::with_options_and_execution_context(
+            ram_cache.clone(),
             BufferPool::new(16, payload_bytes, 4),
             storage,
             router,
@@ -2363,6 +2408,10 @@ pub(crate) mod tests {
                 let mut buffer = pool.try_acquire().expect("synthetic RAM slot");
                 buffer.as_mut_slice().copy_from_slice(&payload);
                 let resident = Arc::new(ExpertResident::new_with_block_align(global_id, buffer, 4));
+                assert!(
+                    ram_cache.insert(resident).is_ok(),
+                    "synthetic RAM expert must be admitted"
+                );
                 gpu_cache
                     .demand_admit_lru(Arc::new(GpuResident::new_with_dtype(
                         global_id,
@@ -2371,7 +2420,27 @@ pub(crate) mod tests {
                     )))
                     .unwrap();
                 let admission = gpu_cache.current_admission(global_id).unwrap();
-                let _ = (resident, admission);
+                let _ = admission;
+            }
+        }
+
+        // Precondition assertions: RAM warm, logical GPU admissions present, physical VRAM cold.
+        for layer_idx in 0..NUM_LAYERS {
+            for local_id in 0..NUM_EXPERTS as u32 {
+                let global_id = layer_idx as u32 * NUM_EXPERTS as u32 + local_id;
+                assert!(
+                    ram_cache.contains(global_id),
+                    "RAM cache must contain global_id {global_id}"
+                );
+                assert!(
+                    gpu_cache.current_admission(global_id).is_some(),
+                    "gpu_cache must contain logical admission for global_id {global_id}"
+                );
+                assert_eq!(
+                    residency_manager.has_current_for_demand(global_id).unwrap(),
+                    false,
+                    "physical residency manager must initially be cold for global_id {global_id}"
+                );
             }
         }
 
@@ -2409,5 +2478,11 @@ pub(crate) mod tests {
         assert_eq!(snap2.boundary_readbacks, 4);
         assert_eq!(snap2.residency_services, 2);
         assert_eq!(snap2.fatal_failures, 0);
+
+        assert_eq!(
+            engine.report().bytes_read,
+            0,
+            "pure RAM->VRAM qualification must not fall back to storage reads"
+        );
     }
 }

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -140,6 +140,7 @@ mod gating;
 mod gguf;
 mod gguf_loader;
 mod gpu_native_residency;
+pub(crate) mod gpu_native_token_loop;
 #[cfg(feature = "grpc")]
 mod grpc;
 #[cfg(feature = "grpc")]
@@ -8159,34 +8160,44 @@ async fn cmd_serve(config_path: PathBuf) -> Result<(), Box<dyn std::error::Error
     } else {
         cfg.real_transformer.head_dim
     };
-    let execution_context = crate::backend::resolve_execution_context(
-        cfg.real_transformer.compute_offload,
-        strict_attention,
-        crate::backend::GpuBackendGeometry {
-            num_layers: cfg.model.num_layers,
-            max_seq_len: if cfg.real_transformer.window_size == 0 {
-                4096
-            } else {
-                cfg.real_transformer.window_size
+    let gpu_geometry = crate::backend::GpuBackendGeometry {
+        num_layers: cfg.model.num_layers,
+        max_seq_len: if cfg.real_transformer.gpu_native {
+            cfg.real_transformer.gpu_native_max_seq_len
+        } else if cfg.real_transformer.window_size == 0 {
+            4096
+        } else {
+            cfg.real_transformer.window_size
+        },
+        num_heads,
+        num_kv_heads: cfg.real_transformer.num_kv_heads,
+        head_dim,
+        // Finding 12: asymmetric-V models keep the CPU attention path;
+        // zero retains the existing symmetric GPU sizing contract.
+        v_head_dim: 0,
+        q4_truncation_tolerance: cfg
+            .real_transformer
+            .inference_policy()
+            .expert_size_tolerance(),
+    };
+    let execution_context = if cfg.real_transformer.gpu_native {
+        crate::backend::resolve_execution_context_for_gpu_native(
+            gpu_geometry,
+            gpu_expert_cache.clone(),
+        )?
+    } else {
+        crate::backend::resolve_execution_context(
+            cfg.real_transformer.compute_offload,
+            strict_attention,
+            gpu_geometry,
+            crate::backend::RoutedExpertGpuSpec {
+                dtype: cfg.model.dtype,
+                d_model: cfg.model.d_model,
+                d_ff: cfg.model.d_ff,
             },
-            num_heads,
-            num_kv_heads: cfg.real_transformer.num_kv_heads,
-            head_dim,
-            // Finding 12: asymmetric-V models keep the CPU attention path;
-            // zero retains the existing symmetric GPU sizing contract.
-            v_head_dim: 0,
-            q4_truncation_tolerance: cfg
-                .real_transformer
-                .inference_policy()
-                .expert_size_tolerance(),
-        },
-        crate::backend::RoutedExpertGpuSpec {
-            dtype: cfg.model.dtype,
-            d_model: cfg.model.d_model,
-            d_ff: cfg.model.d_ff,
-        },
-        gpu_expert_cache.clone(),
-    )?;
+            gpu_expert_cache.clone(),
+        )?
+    };
     crate::backend::set_execution_context(execution_context.clone())
         .map_err(|e| format!("failed to install resolved execution context: {e}"))?;
     {
@@ -8673,23 +8684,55 @@ async fn cmd_serve(config_path: PathBuf) -> Result<(), Box<dyn std::error::Error
         );
         engine_builder.install_gpu_cache();
     }
-    let engine = Arc::new(engine_builder.with_metrics(metrics.clone()));
 
-    let tokenizer = resolve_serving_tokenizer(
-        cfg.real_transformer.enabled,
-        cfg.tokenizer.path.as_deref(),
-        real_model.as_ref().map(|m| m.config.vocab_size),
-    )?;
-
-    // Optional real-transformer pipeline. When enabled, every request
-    // runs `embedding -> stacked layers (each with SSD-streamed MoE) ->
-    // LM head -> argmax`; when disabled, the legacy benchmark generator
-    // is used (the engine still streams expert FFN compute either way).
-    // Note: `real_model` was constructed above so its per-layer gate
-    // could be wired into the engine; here we just spawn the
-    // continuous-batching scheduler against the already-built model.
-    let (real_model, batch_scheduler) = if let Some(model_arc) = real_model {
-        let rt = &cfg.real_transformer;
+    let (real_model, batch_scheduler, gpu_native_token_loop, engine) = if let Some(model_arc) = real_model {
+        if cfg.real_transformer.gpu_native {
+            let executor = Arc::new(
+                execution_context
+                    .create_gpu_native_executor_context(cfg.model.d_model)
+                    .map_err(|e| format!("failed to create GPU-native executor context: {e}"))?,
+            );
+            let total_expert_budget = (cfg.gpu_cache.vram_capacity_mb as u64) * 1024 * 1024;
+            let expert_geom = crate::backend::gpu_native::GpuNativeQ4ExpertGeometry::try_new(
+                cfg.model.d_model,
+                cfg.model.d_ff,
+                cfg.model.num_experts as usize,
+                cfg.model.top_k,
+            )
+            .map_err(|e| format!("invalid GPU-native Q4 expert geometry: {e}"))?;
+            let residency_manager = Arc::new(
+                crate::gpu_native_residency::GpuNativeTieredResidencyManager::try_new(
+                    executor.clone(),
+                    gpu_expert_cache.clone(),
+                    cfg.model.num_layers,
+                    expert_geom,
+                    total_expert_budget,
+                )
+                .map_err(|e| format!("failed to construct tiered residency manager: {e}"))?,
+            );
+            engine_builder
+                .install_gpu_native_residency_manager(residency_manager.clone())
+                .map_err(|e| format!("failed to install tiered residency manager on engine: {e}"))?;
+            let token_loop = crate::gpu_native_token_loop::GpuNativeTokenLoop::try_new(
+                executor,
+                residency_manager,
+                &model_arc,
+                cfg.real_transformer.gpu_native_max_seq_len,
+            )
+            .map_err(|e| format!("failed to initialize GPU-native token loop: {e}"))?;
+            let engine = Arc::new(engine_builder.with_metrics(metrics.clone()));
+            info!(
+                num_layers = cfg.model.num_layers,
+                d_model = cfg.model.d_model,
+                num_experts = cfg.model.num_experts,
+                top_k = cfg.model.top_k,
+                max_seq_len = cfg.real_transformer.gpu_native_max_seq_len,
+                "GPU-native token loop initialized (authoritative GPU-owned execution)"
+            );
+            (Some(model_arc), None, Some(token_loop), engine)
+        } else {
+            let engine = Arc::new(engine_builder.with_metrics(metrics.clone()));
+            let rt = &cfg.real_transformer;
         let head_dim = if rt.head_dim == 0 {
             cfg.model.d_model / rt.num_heads
         } else {
@@ -8758,11 +8801,19 @@ async fn cmd_serve(config_path: PathBuf) -> Result<(), Box<dyn std::error::Error
             speculation_base_depth = rt.speculation_base_depth,
             "real transformer pipeline enabled (with continuous batching)"
         );
-        (Some(model_arc), Some(Arc::new(scheduler)))
-    } else {
-        info!("real_transformer disabled; using legacy benchmark generator");
-        (None, None)
-    };
+        (Some(model_arc), Some(Arc::new(scheduler)), None, engine)
+    }
+} else {
+    let engine = Arc::new(engine_builder.with_metrics(metrics.clone()));
+    info!("real_transformer disabled; using legacy benchmark generator");
+    (None, None, None, engine)
+};
+
+let tokenizer = resolve_serving_tokenizer(
+    cfg.real_transformer.enabled,
+    cfg.tokenizer.path.as_deref(),
+    real_model.as_ref().map(|m| m.config.vocab_size),
+)?;
 
     let sessions = if cfg.server.session_ttl_secs > 0 {
         let store = crate::session::SessionStore::new(std::time::Duration::from_secs(
@@ -8842,6 +8893,7 @@ async fn cmd_serve(config_path: PathBuf) -> Result<(), Box<dyn std::error::Error
         real_model,
         batch_scheduler,
         draft_engine,
+        gpu_native_token_loop,
         speculation_k,
         runtime: runtime.clone(),
         sessions,

--- a/rust-engine/src/server.rs
+++ b/rust-engine/src/server.rs
@@ -545,6 +545,29 @@ pub enum GenerateError {
     KvStateLost(String),
 }
 
+pub(crate) fn map_gpu_native_token_loop_error(
+    err: crate::gpu_native_token_loop::GpuNativeTokenLoopError,
+) -> GenerateError {
+    use crate::gpu_native_token_loop::GpuNativeTokenLoopError;
+    match err {
+        GpuNativeTokenLoopError::ContextLimitExceeded { .. }
+        | GpuNativeTokenLoopError::UnsupportedSampling { .. } => {
+            GenerateError::InvalidRequest(err.to_string())
+        }
+        GpuNativeTokenLoopError::IncompatibleModel(_)
+        | GpuNativeTokenLoopError::AttemptBoundExceeded { .. }
+        | GpuNativeTokenLoopError::NoProgress { .. }
+        | GpuNativeTokenLoopError::FatalNumericalFailure { .. }
+        | GpuNativeTokenLoopError::ResidencyServiceFailed(_)
+        | GpuNativeTokenLoopError::Bootstrap(_)
+        | GpuNativeTokenLoopError::InvalidBoundaryReport { .. }
+        | GpuNativeTokenLoopError::InvalidSelectedExpertId { .. }
+        | GpuNativeTokenLoopError::DuplicateSelectedExpertId { .. }
+        | GpuNativeTokenLoopError::InvalidTopKCount { .. }
+        | GpuNativeTokenLoopError::MapFailed(_) => GenerateError::Inference(err.to_string()),
+    }
+}
+
 impl std::fmt::Display for GenerateError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -762,7 +785,7 @@ async fn generate(
         }
         let mut req_state = gpu_native_loop
             .create_request_state()
-            .map_err(|e| GenerateError::Inference(e.to_string()))?;
+            .map_err(map_gpu_native_token_loop_error)?;
         let pre_hits = state.engine.report().hits;
         let pre_misses = state.engine.report().misses;
         completion_ids = gpu_native_loop
@@ -774,7 +797,7 @@ async fn generate(
                 &params,
             )
             .await
-            .map_err(|e| GenerateError::Inference(e.to_string()))?;
+            .map_err(map_gpu_native_token_loop_error)?;
         hits_total = state.engine.report().hits.saturating_sub(pre_hits);
         misses_total = state.engine.report().misses.saturating_sub(pre_misses);
     } else if let Some(model) = state.real_model.as_ref() {
@@ -3781,5 +3804,63 @@ mod tests {
                 "chat={chat}: metrics must count only successfully emitted tokens"
             );
         }
+    }
+
+    #[test]
+    fn gpu_native_error_mapping_to_http_status_codes() {
+        use crate::gpu_native_token_loop::GpuNativeTokenLoopError;
+        use axum::http::StatusCode;
+
+        // 1. Client/Request errors map to GenerateError::InvalidRequest -> HTTP 400 (invalid_request_error)
+        let context_limit_err = GpuNativeTokenLoopError::ContextLimitExceeded {
+            requested_position: 9,
+            max_seq_len: 8,
+        };
+        let gen_err1 = map_gpu_native_token_loop_error(context_limit_err);
+        assert!(matches!(gen_err1, GenerateError::InvalidRequest(_)));
+        let resp1 = error_response(gen_err1);
+        assert_eq!(resp1.status(), StatusCode::BAD_REQUEST);
+
+        let unsupported_sampling_err = GpuNativeTokenLoopError::UnsupportedSampling {
+            reason: "temperature must be 0.0".into(),
+        };
+        let gen_err2 = map_gpu_native_token_loop_error(unsupported_sampling_err);
+        assert!(matches!(gen_err2, GenerateError::InvalidRequest(_)));
+        let resp2 = error_response(gen_err2);
+        assert_eq!(resp2.status(), StatusCode::BAD_REQUEST);
+
+        // 2. Runtime / GPU execution errors map to GenerateError::Inference -> HTTP 500 (server_error)
+        let fatal_err = GpuNativeTokenLoopError::FatalNumericalFailure {
+            layer_index: Some(0),
+            status_bits: 0x1,
+        };
+        let gen_err3 = map_gpu_native_token_loop_error(fatal_err);
+        assert!(matches!(gen_err3, GenerateError::Inference(_)));
+        let resp3 = error_response(gen_err3);
+        assert_eq!(resp3.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+        let map_failed_err = GpuNativeTokenLoopError::MapFailed("device lost".into());
+        let gen_err4 = map_gpu_native_token_loop_error(map_failed_err);
+        assert!(matches!(gen_err4, GenerateError::Inference(_)));
+        let resp4 = error_response(gen_err4);
+        assert_eq!(resp4.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+        let no_progress_err = GpuNativeTokenLoopError::NoProgress {
+            layer_index: 1,
+            selected_ids: vec![0, 1],
+        };
+        let gen_err5 = map_gpu_native_token_loop_error(no_progress_err);
+        assert!(matches!(gen_err5, GenerateError::Inference(_)));
+        let resp5 = error_response(gen_err5);
+        assert_eq!(resp5.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+        let attempt_bound_err = GpuNativeTokenLoopError::AttemptBoundExceeded {
+            attempts: 4,
+            max_attempts: 3,
+        };
+        let gen_err6 = map_gpu_native_token_loop_error(attempt_bound_err);
+        assert!(matches!(gen_err6, GenerateError::Inference(_)));
+        let resp6 = error_response(gen_err6);
+        assert_eq!(resp6.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
 }

--- a/rust-engine/src/server.rs
+++ b/rust-engine/src/server.rs
@@ -554,7 +554,8 @@ pub(crate) fn map_gpu_native_token_loop_error(
         | GpuNativeTokenLoopError::UnsupportedSampling { .. } => {
             GenerateError::InvalidRequest(err.to_string())
         }
-        GpuNativeTokenLoopError::IncompatibleModel(_)
+        GpuNativeTokenLoopError::PositionMismatch { .. }
+        | GpuNativeTokenLoopError::IncompatibleModel(_)
         | GpuNativeTokenLoopError::AttemptBoundExceeded { .. }
         | GpuNativeTokenLoopError::NoProgress { .. }
         | GpuNativeTokenLoopError::FatalNumericalFailure { .. }
@@ -3830,6 +3831,15 @@ mod tests {
         assert_eq!(resp2.status(), StatusCode::BAD_REQUEST);
 
         // 2. Runtime / GPU execution errors map to GenerateError::Inference -> HTTP 500 (server_error)
+        let position_mismatch_err = GpuNativeTokenLoopError::PositionMismatch {
+            requested_position: 3,
+            committed_position: 2,
+        };
+        let gen_err_pos = map_gpu_native_token_loop_error(position_mismatch_err);
+        assert!(matches!(gen_err_pos, GenerateError::Inference(_)));
+        let resp_pos = error_response(gen_err_pos);
+        assert_eq!(resp_pos.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
         let fatal_err = GpuNativeTokenLoopError::FatalNumericalFailure {
             layer_index: Some(0),
             status_bits: 0x1,

--- a/rust-engine/src/server.rs
+++ b/rust-engine/src/server.rs
@@ -83,6 +83,9 @@ pub struct AppState {
     /// when `cfg.predictive.speculator_enabled = true`.
     pub draft_engine: Option<Arc<crate::draft::DraftEngine>>,
 
+    /// Optional persistent GPU-native token loop for GPU-owned execution.
+    pub gpu_native_token_loop: Option<Arc<crate::gpu_native_token_loop::GpuNativeTokenLoop>>,
+
     /// Number of draft tokens to attempt per speculative step.
     /// Populated from `cfg.real_transformer.speculation_base_depth`.
     /// `0` or `1` disables speculation (falls back to sequential).
@@ -309,6 +312,14 @@ async fn completions(
     let params = resolve_params(&state, req.temperature, req.top_p, req.top_k, req.seed);
     let session_id = req.session_id.clone();
     if req.stream.unwrap_or(false) {
+        if state.gpu_native_token_loop.is_some() {
+            state
+                .metrics
+                .record_request("/v1/completions", started.elapsed().as_secs_f64());
+            return error_response(GenerateError::InvalidRequest(
+                "streaming is unsupported in gpu_native mode in this slice".into(),
+            ));
+        }
         // Server-Sent Events streaming path: emit one OpenAI-style chunk
         // per generated token, terminated with `data: [DONE]`. The whole
         // SSD-streaming substrate is exercised inside the generator
@@ -422,6 +433,14 @@ async fn chat_completions(
     let params = resolve_params(&state, req.temperature, req.top_p, req.top_k, req.seed);
     let session_id = req.session_id.clone();
     if req.stream.unwrap_or(false) {
+        if state.gpu_native_token_loop.is_some() {
+            state
+                .metrics
+                .record_request("/v1/chat/completions", started.elapsed().as_secs_f64());
+            return error_response(GenerateError::InvalidRequest(
+                "streaming is unsupported in gpu_native mode in this slice".into(),
+            ));
+        }
         match build_chat_stream(
             &state,
             &prompt,
@@ -730,7 +749,35 @@ async fn generate(
     let mut misses_total = 0u64;
     let mut completion_ids: Vec<u32> = Vec::with_capacity(max_tokens);
 
-    if let Some(model) = state.real_model.as_ref() {
+    if let Some(ref gpu_native_loop) = state.gpu_native_token_loop {
+        if session_id.is_some() {
+            return Err(GenerateError::InvalidRequest(
+                "session persistence is unsupported in gpu_native mode in this slice".into(),
+            ));
+        }
+        if !params.is_greedy() {
+            return Err(GenerateError::InvalidRequest(
+                "only greedy sampling (temperature=0.0) is supported in gpu_native mode in this slice".into(),
+            ));
+        }
+        let mut req_state = gpu_native_loop
+            .create_request_state()
+            .map_err(|e| GenerateError::Inference(e.to_string()))?;
+        let pre_hits = state.engine.report().hits;
+        let pre_misses = state.engine.report().misses;
+        completion_ids = gpu_native_loop
+            .ingest_prompt_and_generate(
+                &state.engine,
+                &mut req_state,
+                &prompt_ids,
+                max_tokens,
+                &params,
+            )
+            .await
+            .map_err(|e| GenerateError::Inference(e.to_string()))?;
+        hits_total = state.engine.report().hits.saturating_sub(pre_hits);
+        misses_total = state.engine.report().misses.saturating_sub(pre_misses);
+    } else if let Some(model) = state.real_model.as_ref() {
         // Resolve session: take any existing KV state, then put it
         // back at the end. When no session is configured the request
         // is fully stateless (legacy behaviour).
@@ -2315,6 +2362,7 @@ mod tests {
             real_model: None,
             batch_scheduler: None,
             draft_engine: None,
+            gpu_native_token_loop: None,
             speculation_k: 0,
             runtime: crate::config::LiveConfig::from_config(&{
                 let mut c = test_minimal_cfg();
@@ -2749,6 +2797,7 @@ mod tests {
             real_model: Some(model),
             batch_scheduler: Some(scheduler),
             draft_engine: None,
+            gpu_native_token_loop: None,
             speculation_k: 0,
             runtime: crate::config::LiveConfig::from_config(&{
                 let mut c = test_minimal_cfg();


### PR DESCRIPTION
## Summary

Compose the GPU-native transformer path into a full per-token execution loop on the authoritative WGPU device:

- embedding lookup
- attention pre-norm
- Q/K/V projection, Q/K norm, RoPE, KV append
- causal attention, output projection, residual
- MoE pre-norm
- router/top-k
- Q4 expert execution/combine with tiered demand residency
- final RMSNorm
- LM head
- GPU greedy argmax
- one compact token-boundary staging readback per submitted attempt

On a retryable expert-residency miss, the token loop reads back only the failing layer's selected expert IDs, services demand residency through the existing tiered residency manager, clears retryable status while preserving fatal status, and replays the full token attempt. Requests fail closed on no-progress, attempt exhaustion, fatal numerical status, unsupported sampling, context overflow, and internal position mismatch.

The operator-facing path remains gated behind the GPU-native real-transformer configuration and preserves legacy behavior when disabled.

## Review fixes included

The branch includes follow-up fixes found during software review and L4 qualification:

- exact context-capacity accounting (`P + C - 1`) and zero-token handling
- queue/map/readback counters moved to actual operation sites
- HTTP 400 vs 500 error classification separation
- dedicated internal `PositionMismatch` runtime error
- model `rope_dim` carried independently from `max_seq_len`, with uniform per-layer validation
- sampled-token buffer uses a dedicated GPU boundary-result allocation with `COPY_SRC` without broadening generic scratch readback capabilities
- L4 fixture explicitly seeds RAM residents, proves physical VRAM starts cold, and asserts zero storage reads for the RAM -> VRAM qualification path

## Validation

Portable validation on the final branch head passed:

- `cargo check --bin micro-expert-router`
- focused GPU-native token-loop tests
- `backend::` tests
- `engine::` tests
- `server::` tests
- `gpu_native_residency` tests
- full Mac-safe suite: 1036 passed, 11 ignored hardware tests

### NVIDIA L4 qualification

Final qualified head:

`7b7f819dc9e37907c79e2c74ade0b2069a1aed18`

Hardware:

- NVIDIA L4
- 23034 MiB VRAM
- driver 580.173.02

Exact ignored fixture:

`gpu_native_token_loop::tests::live_l4_gpu_native_full_token_loop_retry`

Result:

- 1 passed
- 0 failed
- `TEST_EXIT=0`

The fixture asserts the intended cold path (two layer-local residency misses serviced from pre-seeded RAM with full-token replay) followed by a warm direct token, with expected attempt/submission/map/readback accounting, zero fatal failures, and zero storage reads.

Earlier single-run qualification failures were preserved and fixed rather than rerun around:

- `df93cb1853eaa16b444fc064a7079d8ebd66e2d9`: RoPE dimension incorrectly wired to context length
- `98d3318dc919a9d1b333c59bf2a9caf59e2d7560`: sampled-token source lacked `COPY_SRC`
- `5bbd4422f3bb44c3affe2b2494e421d3ae89f7ff`: qualification fixture discarded synthetic RAM residents and fell into the storage retry path

## Claim boundary

This PR qualifies Slice 10 full-token composition and RAM -> VRAM demand-residency/replay behavior on NVIDIA L4.

It does **not** claim:

- real Qwen3-Coder checkpoint generation parity
- CPU/Hybrid vs GPU generated-token parity
- real autoregressive generated-token TPS
- the >=10 generated TPS commercial gate
- oversized Qwen3-235B operation
- predictive-prefetch benefit or final hierarchy value
