### PR TITLE
Integrate GPU-native Qwen qualification and residency performance improvements

### DIFF
--- a/rust-engine/src/backend/gpu_native.rs
+++ b/rust-engine/src/backend/gpu_native.rs
@@ -4013,6 +4013,14 @@ impl<B> GpuNativeQ4ExpertScratch<B> {
     pub(crate) const fn layout(&self) -> GpuNativeQ4ExpertScratchLayout {
         self.layout
     }
+
+    pub(crate) fn route_outputs_buffer(&self) -> &B {
+        &self.route_outputs.buffer
+    }
+
+    pub(crate) fn combined_buffer(&self) -> &B {
+        &self.combined.buffer
+    }
 }
 
 impl<B> fmt::Debug for GpuNativeQ4ExpertScratch<B> {
@@ -6410,6 +6418,24 @@ impl GpuNativeExecutorContext {
         &self,
         geometry: GpuNativeQ4ExpertGeometry,
     ) -> Result<GpuNativeQ4ExpertScratch, GpuNativeBootstrapError> {
+        self.create_q4_expert_scratch_inner(geometry, false)
+    }
+
+    /// Allocate request-local expert scratch whose completed route outputs and
+    /// combined vector are copyable only for the explicit semantic diagnostic.
+    /// Normal production requests continue to use storage-only expert tensors.
+    pub(crate) fn create_q4_expert_semantic_diagnostic_scratch(
+        &self,
+        geometry: GpuNativeQ4ExpertGeometry,
+    ) -> Result<GpuNativeQ4ExpertScratch, GpuNativeBootstrapError> {
+        self.create_q4_expert_scratch_inner(geometry, true)
+    }
+
+    fn create_q4_expert_scratch_inner(
+        &self,
+        geometry: GpuNativeQ4ExpertGeometry,
+        semantic_diagnostic: bool,
+    ) -> Result<GpuNativeQ4ExpertScratch, GpuNativeBootstrapError> {
         if geometry.d_model != self.layout.d_model {
             return Err(GpuNativeBootstrapError::ExpertDModelMismatch {
                 expected: self.layout.d_model,
@@ -6428,31 +6454,36 @@ impl GpuNativeExecutorContext {
             GpuNativeQ4ExpertScratchLayout::resolved_usage(),
         )?;
         let create_tensor = |label: &str,
-                             tensor_layout: GpuNativeScratchLayout|
+                             tensor_layout: GpuNativeScratchLayout,
+                             copy_src: bool|
          -> Result<GpuNativeScratch, GpuNativeBootstrapError> {
+            let usage = GpuNativeQ4ExpertScratchLayout::tensor_usage()
+                | if copy_src {
+                    wgpu::BufferUsages::COPY_SRC
+                } else {
+                    wgpu::BufferUsages::empty()
+                };
             Ok(GpuNativeScratch::from_buffer(
                 self.context_id,
                 next_nonzero_id(&NEXT_GPU_NATIVE_SCRATCH_ID, "expert tensor scratch"),
                 tensor_layout,
-                create_startup_buffer(
-                    &gpu.device,
-                    label,
-                    tensor_layout.bytes,
-                    GpuNativeQ4ExpertScratchLayout::tensor_usage(),
-                )?,
+                create_startup_buffer(&gpu.device, label, tensor_layout.bytes, usage)?,
             ))
         };
         let activation = create_tensor(
             &format!("gpu_native_expert_scratch_{scratch_id}_activation"),
             layout.activation,
+            false,
         )?;
         let route_outputs = create_tensor(
             &format!("gpu_native_expert_scratch_{scratch_id}_route_outputs"),
             layout.route_outputs,
+            semantic_diagnostic,
         )?;
         let combined = create_tensor(
             &format!("gpu_native_expert_scratch_{scratch_id}_combined"),
             layout.combined,
+            semantic_diagnostic,
         )?;
         Ok(GpuNativeQ4ExpertScratch::from_buffers(
             self.context_id,

--- a/rust-engine/src/backend/gpu_native.rs
+++ b/rust-engine/src/backend/gpu_native.rs
@@ -3844,6 +3844,14 @@ impl<B> GpuNativeRouterScratch<B> {
     pub(crate) fn selected_ids_buffer(&self) -> &B {
         &self.selected_ids
     }
+
+    pub(crate) fn selected_weights_buffer(&self) -> &B {
+        &self.selected_weights
+    }
+
+    pub(crate) fn logits_buffer(&self) -> &B {
+        &self.logits
+    }
 }
 
 impl<B> fmt::Debug for GpuNativeRouterScratch<B> {
@@ -4160,6 +4168,14 @@ impl<B> GpuNativeTokenState<B> {
 
     pub(crate) fn status_buffer(&self) -> &B {
         &self.status
+    }
+
+    pub(crate) fn hidden_buffer(&self) -> &B {
+        &self.hidden
+    }
+
+    pub(crate) fn residual_buffer(&self) -> &B {
+        &self.residual
     }
 }
 

--- a/rust-engine/src/backend/gpu_native.rs
+++ b/rust-engine/src/backend/gpu_native.rs
@@ -2985,6 +2985,35 @@ impl<B> GpuNativeQ4ExpertArena<B> {
             .count()
     }
 
+    /// Check that one manager-held residency still names the exact live arena
+    /// owner. This is deliberately independent of host logical-admission LRU
+    /// state: the arena's context, layer, logical id, install generation,
+    /// physical location, and slot epoch are the physical identity contract.
+    pub(crate) fn contains_exact_residency(
+        &self,
+        context_id: u64,
+        residency: GpuNativeQ4ExpertResidency,
+    ) -> bool {
+        if self.context_id != context_id || residency.key.layer_index != self.layer_index {
+            return false;
+        }
+        let logical_id = residency.key.expert_id as usize;
+        let state = self.state.lock();
+        let Some(flat_slot) = state.logical_slots.get(logical_id).copied().flatten() else {
+            return false;
+        };
+        state.latest_generations.get(logical_id).copied().flatten()
+            == Some(residency.key.logical_generation)
+            && state.slots.get(flat_slot).is_some_and(|slot| {
+                slot.location == residency.location
+                    && slot.last_epoch == residency.slot_epoch
+                    && matches!(
+                        slot.owner,
+                        GpuNativeQ4ExpertSlotOwner::Resident(current) if current == residency
+                    )
+            })
+    }
+
     pub(crate) const fn vram_plan(&self) -> GpuNativeQ4ExpertVramPlan {
         self.plan
     }
@@ -6220,6 +6249,10 @@ impl GpuNativeExecutorContext {
             greedy_argmax_pipeline,
             counters: GpuNativeExecutionCounters::default(),
         })
+    }
+
+    pub(crate) const fn context_id(&self) -> u64 {
+        self.context_id
     }
 
     pub(crate) fn create_token_state(
@@ -10154,6 +10187,29 @@ pub(crate) mod tests {
             7 * GPU_NATIVE_EXPERT_MAPPING_ENTRY_BYTES as u64
         );
         assert_eq!(mapping.borrow()[0].1, residency_a.mapping_entry().unwrap());
+        assert!(arena.contains_exact_residency(7, residency_a));
+        assert!(!arena.contains_exact_residency(8, residency_a));
+        assert!(!arena.contains_exact_residency(
+            7,
+            GpuNativeQ4ExpertResidency {
+                key: GpuNativeQ4ExpertKey::new(2, 7, 10),
+                ..residency_a
+            }
+        ));
+        assert!(!arena.contains_exact_residency(
+            7,
+            GpuNativeQ4ExpertResidency {
+                key: GpuNativeQ4ExpertKey::new(3, 8, 10),
+                ..residency_a
+            }
+        ));
+        assert!(!arena.contains_exact_residency(
+            7,
+            GpuNativeQ4ExpertResidency {
+                slot_epoch: residency_a.slot_epoch() + 1,
+                ..residency_a
+            }
+        ));
         assert!(matches!(
             arena.acquire_with_unpublish(key_a, |_, _| {}).unwrap(),
             GpuNativeQ4ExpertAcquire::Hit(hit) if hit == residency_a
@@ -10186,6 +10242,7 @@ pub(crate) mod tests {
                 GpuNativeQ4ExpertMappingEntry::UNMAPPED,
             )]
         );
+        assert!(!arena.contains_exact_residency(7, residency_a));
 
         let reinstall =
             expect_expert_install(arena.acquire_with_unpublish(key_a, |_, _| {}).unwrap());
@@ -10194,7 +10251,65 @@ pub(crate) mod tests {
             .install_with_writes(&payload, |_, _, _| {}, |_, _| {})
             .unwrap();
         assert_eq!(reinstalled.key().logical_generation(), 10);
+        assert_ne!(reinstalled.slot_epoch(), residency_a.slot_epoch());
+        assert!(arena.contains_exact_residency(7, reinstalled));
+        assert!(!arena.contains_exact_residency(7, residency_a));
         assert_eq!(arena.residency_snapshot().expert_slot_reuses, 1);
+    }
+
+    #[test]
+    fn gpu_native_residency_physical_arena_survives_logical_admission_eviction() {
+        use crate::expert_cache::{GpuExpertCache, GpuResident};
+        use std::cell::RefCell;
+
+        let arena = test_mutable_expert_arena(1);
+        let payload = q4_uniform_expert(arena.geometry(), 0.01, 0.02, 0.005);
+        let cache = GpuExpertCache::new(payload.len(), 0.0, 0);
+        cache
+            .demand_admit_lru(Arc::new(GpuResident::new(7, payload.clone())))
+            .unwrap();
+        let admission = cache.current_admission(7).unwrap();
+        let key = GpuNativeQ4ExpertKey::new(3, 7, admission.generation());
+        let physical_writes = RefCell::new(Vec::new());
+        let permit = expect_expert_install(arena.acquire_with_unpublish(key, |_, _| {}).unwrap());
+        let residency = permit
+            .install_with_writes(
+                &payload,
+                |bank, offset, bytes| {
+                    physical_writes
+                        .borrow_mut()
+                        .push((bank, offset, bytes.to_vec()));
+                },
+                |_, _| {},
+            )
+            .unwrap();
+        let before = arena.residency_snapshot();
+        assert!(arena.contains_exact_residency(7, residency));
+
+        cache
+            .demand_admit_lru(Arc::new(GpuResident::new(8, vec![9; payload.len()])))
+            .unwrap();
+        assert!(!cache.contains_generation(7, admission.generation()));
+        drop(admission);
+
+        let hit = match arena.acquire_with_unpublish(key, |_, _| {}).unwrap() {
+            GpuNativeQ4ExpertAcquire::Hit(hit) => hit,
+            _ => panic!("logical eviction must not invalidate exact physical residency"),
+        };
+        assert_eq!(hit, residency);
+        assert_eq!(hit.key(), key);
+        assert_eq!(hit.location(), residency.location());
+        assert_eq!(hit.slot_epoch(), residency.slot_epoch());
+        assert!(arena.contains_exact_residency(7, hit));
+        assert_eq!(arena.residency_snapshot(), before);
+
+        let physical = physical_writes.borrow();
+        assert_eq!(physical.len(), 1);
+        let payload_start = arena.geometry().payload_offset_bytes();
+        assert_eq!(
+            &physical[0].2[payload_start..payload_start + payload.len()],
+            payload.as_slice()
+        );
     }
 
     #[test]
@@ -14789,9 +14904,42 @@ fn compare_main(@builtin(global_invocation_id) gid: vec3<u32>) {
             let payload = q4_uniform_expert(geometry, 0.001 * id as f32, 0.002, 0.001);
             let _ = make_source(id, &payload);
         }
+        assert!(!gpu_cache.contains_generation(2, stale_admission_a.generation()));
+        let before_physical_only_hit = manager.snapshot();
+        assert!(manager.has_current_for_demand(2).unwrap());
+        let physical_only_hit = manager
+            .ensure_demand_set(
+                GpuNativeResidencyPriority::Demand,
+                0,
+                &[GpuNativeDemandExpert::current(2)],
+            )
+            .unwrap()[0];
+        assert_eq!(physical_only_hit, new_residencies[0]);
+        let after_physical_only_hit = manager.snapshot();
+        assert_eq!(
+            after_physical_only_hit.physical_current_hits,
+            before_physical_only_hit.physical_current_hits + 1
+        );
+        assert_eq!(
+            after_physical_only_hit.ram_to_vram_installs,
+            before_physical_only_hit.ram_to_vram_installs
+        );
+        assert_eq!(
+            after_physical_only_hit.physical_source_acquisitions,
+            before_physical_only_hit.physical_source_acquisitions
+        );
+        assert_eq!(
+            after_physical_only_hit.logical_admissions_for_physical_misses,
+            before_physical_only_hit.logical_admissions_for_physical_misses
+        );
+        assert_eq!(
+            after_physical_only_hit.layers,
+            before_physical_only_hit.layers
+        );
+
         let (newer_resident_a, newer_admission_a) = make_source(2, &payload_a);
         assert!(newer_admission_a.generation() > stale_admission_a.generation());
-        let newest = manager
+        let physical_after_newer_logical_admission = manager
             .ensure_demand_set(
                 GpuNativeResidencyPriority::Demand,
                 0,
@@ -14802,6 +14950,7 @@ fn compare_main(@builtin(global_invocation_id) gid: vec3<u32>) {
                 )],
             )
             .unwrap()[0];
+        assert_eq!(physical_after_newer_logical_admission, new_residencies[0]);
         let before_stale = manager.snapshot();
         assert!(matches!(
             manager.ensure_demand_set(
@@ -14830,7 +14979,7 @@ fn compare_main(@builtin(global_invocation_id) gid: vec3<u32>) {
                     &[GpuNativeDemandExpert::current(2)],
                 )
                 .unwrap()[0],
-            newest
+            new_residencies[0]
         );
     }
 

--- a/rust-engine/src/backend/gpu_native.rs
+++ b/rust-engine/src/backend/gpu_native.rs
@@ -4023,6 +4023,11 @@ impl<B> fmt::Debug for GpuNativeQ4ExpertScratch<B> {
 /// Request-scoped, non-mappable F32 attention intermediates with geometry
 /// attached, preventing projection, context, and output buffers from being
 /// interchanged at the composed API.
+pub struct Layer0AttentionGpuDiagnosticSink<'a> {
+    pub layout: &'a crate::gpu_native_layer0_diagnostics::Layer0AttentionDiagnosticTraceLayout,
+    pub staging_buffer: &'a wgpu::Buffer,
+}
+
 pub(crate) struct GpuNativeAttentionScratch<B = wgpu::Buffer> {
     context_id: u64,
     geometry: GpuNativeAttentionGeometry,
@@ -7502,6 +7507,42 @@ impl GpuNativeExecutorContext {
         kv: &GpuNativeKvState,
         position: usize,
     ) -> Result<(), GpuNativeBootstrapError> {
+        self.encode_attention_prepare_impl(encoder, plan, state, scratch, kv, position, None)
+    }
+
+    /// Diagnostic variant of [`Self::encode_attention_prepare`] that captures intermediate
+    /// Q/K/V activations before and after norm and RoPE into `diagnostic_sink`.
+    pub(crate) fn encode_attention_prepare_layer0_diagnostic(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        plan: &GpuNativeAttentionPlan,
+        state: &GpuNativeTokenState,
+        scratch: &GpuNativeAttentionScratch,
+        kv: &GpuNativeKvState,
+        position: usize,
+        diagnostic_sink: &Layer0AttentionGpuDiagnosticSink<'_>,
+    ) -> Result<(), GpuNativeBootstrapError> {
+        self.encode_attention_prepare_impl(
+            encoder,
+            plan,
+            state,
+            scratch,
+            kv,
+            position,
+            Some(diagnostic_sink),
+        )
+    }
+
+    fn encode_attention_prepare_impl(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        plan: &GpuNativeAttentionPlan,
+        state: &GpuNativeTokenState,
+        scratch: &GpuNativeAttentionScratch,
+        kv: &GpuNativeKvState,
+        position: usize,
+        diagnostic_sink: Option<&Layer0AttentionGpuDiagnosticSink<'_>>,
+    ) -> Result<(), GpuNativeBootstrapError> {
         let gpu = self.authoritative_gpu()?;
         self.validate_attention_plan(plan)?;
         validate_token_state_owner(self.context_id, state.context_id)?;
@@ -7522,8 +7563,35 @@ impl GpuNativeExecutorContext {
         self.validate_attention_dispatch_limits(plan, &gpu.device.limits())?;
 
         self.encode_dense_gemv_hidden_to_scratch(encoder, &plan.q_projection, state, &scratch.q)?;
+        if let Some(sink) = diagnostic_sink {
+            encoder.copy_buffer_to_buffer(
+                &scratch.q.buffer,
+                0,
+                sink.staging_buffer,
+                sink.layout.q_raw_offset as u64,
+                sink.layout.q_raw_bytes as u64,
+            );
+        }
         self.encode_dense_gemv_hidden_to_scratch(encoder, &plan.k_projection, state, &scratch.k)?;
+        if let Some(sink) = diagnostic_sink {
+            encoder.copy_buffer_to_buffer(
+                &scratch.k.buffer,
+                0,
+                sink.staging_buffer,
+                sink.layout.k_raw_offset as u64,
+                sink.layout.k_raw_bytes as u64,
+            );
+        }
         self.encode_dense_gemv_hidden_to_scratch(encoder, &plan.v_projection, state, &scratch.v)?;
+        if let Some(sink) = diagnostic_sink {
+            encoder.copy_buffer_to_buffer(
+                &scratch.v.buffer,
+                0,
+                sink.staging_buffer,
+                sink.layout.v_raw_offset as u64,
+                sink.layout.v_raw_bytes as u64,
+            );
+        }
         if let Some(norm) = &plan.q_norm {
             self.encode_rms_norm_scratch_in_place(
                 encoder,
@@ -7533,6 +7601,15 @@ impl GpuNativeExecutorContext {
                 plan.geometry.num_heads,
                 plan.geometry.head_dim,
             )?;
+        }
+        if let Some(sink) = diagnostic_sink {
+            encoder.copy_buffer_to_buffer(
+                &scratch.q.buffer,
+                0,
+                sink.staging_buffer,
+                sink.layout.q_after_norm_offset as u64,
+                sink.layout.q_after_norm_bytes as u64,
+            );
         }
         if let Some(norm) = &plan.k_norm {
             self.encode_rms_norm_scratch_in_place(
@@ -7544,6 +7621,15 @@ impl GpuNativeExecutorContext {
                 plan.geometry.head_dim,
             )?;
         }
+        if let Some(sink) = diagnostic_sink {
+            encoder.copy_buffer_to_buffer(
+                &scratch.k.buffer,
+                0,
+                sink.staging_buffer,
+                sink.layout.k_after_norm_offset as u64,
+                sink.layout.k_after_norm_bytes as u64,
+            );
+        }
         self.encode_rope_scratch_in_place(
             encoder,
             &plan.rope,
@@ -7553,6 +7639,15 @@ impl GpuNativeExecutorContext {
             plan.geometry.head_dim,
             position,
         )?;
+        if let Some(sink) = diagnostic_sink {
+            encoder.copy_buffer_to_buffer(
+                &scratch.q.buffer,
+                0,
+                sink.staging_buffer,
+                sink.layout.q_after_rope_offset as u64,
+                sink.layout.q_after_rope_bytes as u64,
+            );
+        }
         self.encode_rope_scratch_in_place(
             encoder,
             &plan.rope,
@@ -7562,6 +7657,15 @@ impl GpuNativeExecutorContext {
             plan.geometry.head_dim,
             position,
         )?;
+        if let Some(sink) = diagnostic_sink {
+            encoder.copy_buffer_to_buffer(
+                &scratch.k.buffer,
+                0,
+                sink.staging_buffer,
+                sink.layout.k_after_rope_offset as u64,
+                sink.layout.k_after_rope_bytes as u64,
+            );
+        }
         self.encode_kv_append(
             encoder,
             &scratch.k,
@@ -7643,6 +7747,42 @@ impl GpuNativeExecutorContext {
         kv: &GpuNativeKvState,
         position: usize,
     ) -> Result<(), GpuNativeBootstrapError> {
+        self.encode_attention_complete_impl(encoder, plan, state, scratch, kv, position, None)
+    }
+
+    /// Diagnostic variant of [`Self::encode_attention_complete`] that captures intermediate
+    /// causal attention context and O-projection activations into `diagnostic_sink`.
+    pub(crate) fn encode_attention_complete_layer0_diagnostic(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        plan: &GpuNativeAttentionPlan,
+        state: &GpuNativeTokenState,
+        scratch: &GpuNativeAttentionScratch,
+        kv: &GpuNativeKvState,
+        position: usize,
+        diagnostic_sink: &Layer0AttentionGpuDiagnosticSink<'_>,
+    ) -> Result<(), GpuNativeBootstrapError> {
+        self.encode_attention_complete_impl(
+            encoder,
+            plan,
+            state,
+            scratch,
+            kv,
+            position,
+            Some(diagnostic_sink),
+        )
+    }
+
+    fn encode_attention_complete_impl(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        plan: &GpuNativeAttentionPlan,
+        state: &GpuNativeTokenState,
+        scratch: &GpuNativeAttentionScratch,
+        kv: &GpuNativeKvState,
+        position: usize,
+        diagnostic_sink: Option<&Layer0AttentionGpuDiagnosticSink<'_>>,
+    ) -> Result<(), GpuNativeBootstrapError> {
         let gpu = self.authoritative_gpu()?;
         self.validate_attention_plan(plan)?;
         validate_token_state_owner(self.context_id, state.context_id)?;
@@ -7697,6 +7837,15 @@ impl GpuNativeExecutorContext {
             self.checked_workgroups(state.layout.d_model, &gpu.device.limits())?;
 
         self.encode_causal_attention_pass(gpu, encoder, plan, state, scratch, kv, seq_len);
+        if let Some(sink) = diagnostic_sink {
+            encoder.copy_buffer_to_buffer(
+                &scratch.context.buffer,
+                0,
+                sink.staging_buffer,
+                sink.layout.attention_context_offset as u64,
+                sink.layout.attention_context_bytes as u64,
+            );
+        }
         self.encode_dense_gemv_resolved(
             gpu,
             encoder,
@@ -7705,6 +7854,15 @@ impl GpuNativeExecutorContext {
             &scratch.projected.buffer,
             &o_workgroups,
         );
+        if let Some(sink) = diagnostic_sink {
+            encoder.copy_buffer_to_buffer(
+                &scratch.projected.buffer,
+                0,
+                sink.staging_buffer,
+                sink.layout.o_projection_offset as u64,
+                sink.layout.o_projection_bytes as u64,
+            );
+        }
         self.encode_residual_add_pass(gpu, encoder, state, &scratch.projected, residual_workgroups);
         self.counters.record_attention_complete_dispatch();
         Ok(())

--- a/rust-engine/src/backend/gpu_native.rs
+++ b/rust-engine/src/backend/gpu_native.rs
@@ -49,6 +49,8 @@ const GPU_NATIVE_KV_APPEND_SHADER: &str = include_str!("wgpu_shaders/gpu_native_
 const GPU_NATIVE_ATTENTION_SHADER: &str = include_str!("wgpu_shaders/gpu_native_attention.wgsl");
 const GPU_NATIVE_ROUTER_SHADER: &str = include_str!("wgpu_shaders/gpu_native_router.wgsl");
 const GPU_NATIVE_Q4_EXPERT_SHADER: &str = include_str!("wgpu_shaders/gpu_native_q4_expert.wgsl");
+const GPU_NATIVE_Q4_EXPERT_STAGE_DIAGNOSTIC_SHADER: &str =
+    include_str!("wgpu_shaders/gpu_native_q4_expert_stage_diagnostic.wgsl");
 const GPU_NATIVE_EXPERT_CONTROL_SHADER: &str =
     include_str!("wgpu_shaders/gpu_native_expert_control.wgsl");
 const GPU_NATIVE_STATUS_CONTROL_SHADER: &str =
@@ -350,6 +352,10 @@ pub(crate) enum GpuNativeBootstrapError {
     ExpertScratchGeometry {
         expected: GpuNativeQ4ExpertGeometry,
         actual: GpuNativeQ4ExpertGeometry,
+    },
+    ExpertStageScratchElements {
+        expected: usize,
+        actual: usize,
     },
     InvalidAttentionHeadCount {
         tensor: GpuNativeAttentionTensor,
@@ -865,6 +871,10 @@ impl fmt::Display for GpuNativeBootstrapError {
             Self::ExpertScratchGeometry { expected, actual } => write!(
                 f,
                 "GPU-native expert scratch geometry {actual:?} does not match {expected:?}"
+            ),
+            Self::ExpertStageScratchElements { expected, actual } => write!(
+                f,
+                "GPU-native expert stage scratch has {actual} elements, expected {expected}"
             ),
             Self::InvalidAttentionHeadCount { tensor, heads } => write!(
                 f,
@@ -1645,6 +1655,18 @@ impl GpuNativeQ4ExpertGeometry {
 
     pub(crate) const fn top_k(self) -> usize {
         self.top_k
+    }
+
+    pub(crate) fn diagnostic_stage_elements(self) -> usize {
+        self.top_k
+            .checked_mul(self.d_ff)
+            .and_then(|elements| elements.checked_mul(3))
+            .and_then(|elements| {
+                self.top_k
+                    .checked_mul(self.d_model)
+                    .and_then(|down| elements.checked_add(down))
+            })
+            .expect("validated expert geometry must fit diagnostic stage elements")
     }
 
     pub(crate) const fn blocks_per_projection(self) -> usize {
@@ -5522,6 +5544,8 @@ struct GpuNativeQ4ExpertPipelines {
     route_resolve: wgpu::ComputePipeline,
     gate_up: wgpu::ComputePipeline,
     down: wgpu::ComputePipeline,
+    diagnostic_stage_gate_up: wgpu::ComputePipeline,
+    diagnostic_stage_down: wgpu::ComputePipeline,
     validate: wgpu::ComputePipeline,
     combine: wgpu::ComputePipeline,
     contain: wgpu::ComputePipeline,
@@ -5737,6 +5761,10 @@ impl GpuNativeQ4ExpertPipelines {
             label: Some("gpu_native_q4_expert_shader"),
             source: wgpu::ShaderSource::Wgsl(GPU_NATIVE_Q4_EXPERT_SHADER.into()),
         });
+        let diagnostic_stage_module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("gpu_native_q4_expert_stage_diagnostic_shader"),
+            source: wgpu::ShaderSource::Wgsl(GPU_NATIVE_Q4_EXPERT_STAGE_DIAGNOSTIC_SHADER.into()),
+        });
         let control_module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label: Some("gpu_native_expert_control_shader"),
             source: wgpu::ShaderSource::Wgsl(GPU_NATIVE_EXPERT_CONTROL_SHADER.into()),
@@ -5772,6 +5800,18 @@ impl GpuNativeQ4ExpertPipelines {
                 &expert_pipeline_layout,
                 &expert_module,
                 "q4_expert_down_main",
+            ),
+            diagnostic_stage_gate_up: pipeline(
+                "gpu_native_q4_expert_stage_diagnostic_gate_up_pipeline",
+                &expert_pipeline_layout,
+                &diagnostic_stage_module,
+                "q4_expert_stage_gate_up_main",
+            ),
+            diagnostic_stage_down: pipeline(
+                "gpu_native_q4_expert_stage_diagnostic_down_pipeline",
+                &expert_pipeline_layout,
+                &diagnostic_stage_module,
+                "q4_expert_stage_down_main",
             ),
             validate: pipeline(
                 "gpu_native_expert_validate_pipeline",
@@ -6431,6 +6471,44 @@ impl GpuNativeExecutorContext {
         self.create_q4_expert_scratch_inner(geometry, true)
     }
 
+    /// Allocate one diagnostic-only storage vector containing raw gate, raw
+    /// up, post-SwiGLU activation, and down outputs for every selected route.
+    pub(crate) fn create_q4_expert_stage_diagnostic_scratch(
+        &self,
+        geometry: GpuNativeQ4ExpertGeometry,
+    ) -> Result<GpuNativeScratch, GpuNativeBootstrapError> {
+        if geometry.d_model != self.layout.d_model {
+            return Err(GpuNativeBootstrapError::ExpertDModelMismatch {
+                expected: self.layout.d_model,
+                actual: geometry.d_model,
+            });
+        }
+        let gpu = self.authoritative_gpu()?;
+        let layout = GpuNativeScratchLayout::try_new(geometry.diagnostic_stage_elements())?;
+        let usage = wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC;
+        super::validate_startup_buffer(
+            "gpu_native_q4_expert_stage_diagnostic_scratch",
+            layout.bytes,
+            usage,
+            &gpu.device.limits(),
+        )?;
+        let scratch_id = next_nonzero_id(
+            &NEXT_GPU_NATIVE_SCRATCH_ID,
+            "Q4 expert stage diagnostic scratch",
+        );
+        Ok(GpuNativeScratch::from_buffer(
+            self.context_id,
+            scratch_id,
+            layout,
+            create_startup_buffer(
+                &gpu.device,
+                &format!("gpu_native_q4_expert_stage_diagnostic_{scratch_id}"),
+                layout.bytes,
+                usage,
+            )?,
+        ))
+    }
+
     fn create_q4_expert_scratch_inner(
         &self,
         geometry: GpuNativeQ4ExpertGeometry,
@@ -6817,6 +6895,160 @@ impl GpuNativeExecutorContext {
         pass.dispatch_workgroups(1, 1, 1);
         drop(pass);
         self.counters.record_router_dispatch();
+        Ok(())
+    }
+
+    /// Diagnostic-only observation of raw Q4 expert stages. The method uses
+    /// the same arena, actual selected routes, push constants, byte layout,
+    /// workgroup geometry, Q4 accumulation contract, and SwiGLU expression as
+    /// production, but writes only to caller-owned diagnostic scratch.
+    pub(crate) fn encode_q4_expert_stage_diagnostic(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        router_plan: &GpuNativeRouterPlan,
+        router_scratch: &GpuNativeRouterScratch,
+        arena: &GpuNativeQ4ExpertArena,
+        state: &GpuNativeTokenState,
+        expert_scratch: &GpuNativeQ4ExpertScratch,
+        stage_scratch: &GpuNativeScratch,
+    ) -> Result<(), GpuNativeBootstrapError> {
+        let gpu = self.authoritative_gpu()?;
+        let limits = gpu.device.limits();
+        validate_token_state_owner(self.context_id, state.context_id)?;
+        let _gate = validate_router_plan_with_registry(
+            self.context_id,
+            self.layout.d_model,
+            &self.dense_weights.lock(),
+            router_plan,
+        )?;
+        validate_router_scratch(self.context_id, router_plan.geometry, router_scratch)?;
+        validate_q4_expert_arena(self.context_id, arena, &limits)?;
+        validate_q4_expert_scratch(self.context_id, arena.geometry, expert_scratch, &limits)?;
+        validate_scratch_owner(self.context_id, stage_scratch.context_id)?;
+        validate_router_expert_geometry(router_plan, arena)?;
+        if stage_scratch.layout.elements() != arena.geometry.diagnostic_stage_elements() {
+            return Err(GpuNativeBootstrapError::ExpertStageScratchElements {
+                expected: arena.geometry.diagnostic_stage_elements(),
+                actual: stage_scratch.layout.elements(),
+            });
+        }
+        validate_q4_expert_pipeline_limits(&limits)?;
+        let route_workgroups = self.checked_workgroups(arena.geometry.top_k, &limits)?;
+        let gate_up_workgroups = self.checked_workgroups(arena.geometry.d_ff, &limits)?;
+        let down_workgroups = self.checked_workgroups(arena.geometry.d_model, &limits)?;
+        let bank_slots =
+            arena.plan.layout.banks.map(|bank| {
+                u32::try_from(bank.slot_capacity).expect("validated bank slot capacity")
+            });
+        let resolve_pc = GpuNativeExpertResolvePushConstants {
+            num_experts: arena.geometry.num_experts as u32,
+            top_k: arena.geometry.top_k as u32,
+            active_banks: arena.plan.layout.active_banks as u32,
+            _reserved: 0,
+            bank_slots,
+        };
+        let route_bind_group = gpu.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("gpu_native_q4_stage_route_resolve_bind_group"),
+            layout: &self.q4_expert_pipelines.route_bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: router_scratch.selected_ids.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: arena.mapping.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: expert_scratch.resolved_locations.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 3,
+                    resource: state.status.as_entire_binding(),
+                },
+            ],
+        });
+        {
+            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                label: Some("gpu_native_q4_stage_route_resolve_pass"),
+                timestamp_writes: None,
+            });
+            pass.set_pipeline(&self.q4_expert_pipelines.route_resolve);
+            pass.set_bind_group(0, &route_bind_group, &[]);
+            pass.set_push_constants(0, bytemuck::bytes_of(&resolve_pc));
+            pass.dispatch_workgroups(route_workgroups, 1, 1);
+        }
+        let bind_group = gpu.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("gpu_native_q4_expert_stage_diagnostic_bind_group"),
+            layout: &self.q4_expert_pipelines.expert_bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: arena.banks[0].as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: arena.banks[1].as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: arena.banks[2].as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 3,
+                    resource: arena.banks[3].as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 4,
+                    resource: state.hidden.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 5,
+                    resource: expert_scratch.resolved_locations.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 6,
+                    resource: stage_scratch.buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 7,
+                    resource: state.status.as_entire_binding(),
+                },
+            ],
+        });
+        for route_slot in 0..arena.geometry.top_k {
+            let pc = GpuNativeQ4ExpertPushConstants {
+                d_model: arena.geometry.d_model as u32,
+                d_ff: arena.geometry.d_ff as u32,
+                blocks_per_projection: arena.geometry.blocks_per_projection as u32,
+                slot_stride_bytes: arena.geometry.slot_stride_bytes as u32,
+                route_slot: route_slot as u32,
+                top_k: arena.geometry.top_k as u32,
+                swiglu_limit: crate::inference::swiglu_limit().unwrap_or(f32::INFINITY),
+                _reserved: 0,
+            };
+            {
+                let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                    label: Some("gpu_native_q4_expert_stage_diagnostic_gate_up_pass"),
+                    timestamp_writes: None,
+                });
+                pass.set_pipeline(&self.q4_expert_pipelines.diagnostic_stage_gate_up);
+                pass.set_bind_group(0, &bind_group, &[]);
+                pass.set_push_constants(0, bytemuck::bytes_of(&pc));
+                pass.dispatch_workgroups(gate_up_workgroups, 1, 1);
+            }
+            {
+                let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                    label: Some("gpu_native_q4_expert_stage_diagnostic_down_pass"),
+                    timestamp_writes: None,
+                });
+                pass.set_pipeline(&self.q4_expert_pipelines.diagnostic_stage_down);
+                pass.set_bind_group(0, &bind_group, &[]);
+                pass.set_push_constants(0, bytemuck::bytes_of(&pc));
+                pass.dispatch_workgroups(down_workgroups, 1, 1);
+            }
+        }
         Ok(())
     }
 
@@ -11265,6 +11497,60 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn q4_expert_stage_shader_is_pinned_to_production_arithmetic() {
+        fn wgsl_function(source: &str, name: &str) -> String {
+            let marker = format!("fn {name}(");
+            let start = source.find(&marker).expect("WGSL function start");
+            let brace = source[start..]
+                .find('{')
+                .map(|offset| start + offset)
+                .expect("WGSL function brace");
+            let mut depth = 0usize;
+            let end = source[brace..]
+                .char_indices()
+                .find_map(|(offset, value)| {
+                    if value == '{' {
+                        depth += 1;
+                    } else if value == '}' {
+                        depth -= 1;
+                        if depth == 0 {
+                            return Some(brace + offset + 1);
+                        }
+                    }
+                    None
+                })
+                .expect("WGSL function end");
+            source[start..end].to_string()
+        }
+
+        let production = wgsl_function(GPU_NATIVE_Q4_EXPERT_SHADER, "q4_dot");
+        let diagnostic_input =
+            wgsl_function(GPU_NATIVE_Q4_EXPERT_STAGE_DIAGNOSTIC_SHADER, "q4_dot_input")
+                .replace("q4_dot_input", "q4_dot");
+        let diagnostic_gated =
+            wgsl_function(GPU_NATIVE_Q4_EXPERT_STAGE_DIAGNOSTIC_SHADER, "q4_dot_gated")
+                .replace("q4_dot_gated", "q4_dot")
+                .replace("STAGES", "INPUT");
+        assert_eq!(diagnostic_input, production);
+        assert_eq!(diagnostic_gated, production);
+        let production_activation =
+            "let activation = (clamped_gate / (1.0 + exp(-clamped_gate))) * up;";
+        assert!(GPU_NATIVE_Q4_EXPERT_SHADER.contains(production_activation));
+        assert!(GPU_NATIVE_Q4_EXPERT_STAGE_DIAGNOSTIC_SHADER.contains(production_activation));
+
+        use sha2::Digest as _;
+        assert_eq!(
+            format!(
+                "{:x}",
+                sha2::Sha256::digest(GPU_NATIVE_Q4_EXPERT_SHADER.as_bytes())
+            ),
+            "54bae352aad7f25920212f596c00b8e3bac2c0a14281b9664d219d1eea212306"
+        );
+        assert!(GPU_NATIVE_Q4_EXPERT_SHADER.contains("fn q4_expert_gate_up_main"));
+        assert!(GPU_NATIVE_Q4_EXPERT_SHADER.contains("fn q4_expert_down_main"));
+    }
+
+    #[test]
     fn retryable_status_clear_preserves_fatal_and_unknown_bits() {
         assert_eq!(
             status_after_retryable_clear(GPU_NATIVE_STATUS_RETRYABLE_MASK),
@@ -11313,6 +11599,10 @@ pub(crate) mod tests {
             (
                 GPU_NATIVE_Q4_EXPERT_SHADER,
                 &["q4_expert_gate_up_main", "q4_expert_down_main"][..],
+            ),
+            (
+                GPU_NATIVE_Q4_EXPERT_STAGE_DIAGNOSTIC_SHADER,
+                &["q4_expert_stage_gate_up_main", "q4_expert_stage_down_main"][..],
             ),
             (
                 GPU_NATIVE_EXPERT_CONTROL_SHADER,

--- a/rust-engine/src/backend/gpu_native.rs
+++ b/rust-engine/src/backend/gpu_native.rs
@@ -3761,6 +3761,10 @@ impl GpuNativeRouterScratchLayout {
         wgpu::BufferUsages::STORAGE
     }
 
+    pub(crate) fn diagnostic_logits_usage() -> wgpu::BufferUsages {
+        Self::logits_usage() | wgpu::BufferUsages::COPY_SRC
+    }
+
     pub(crate) fn result_usage() -> wgpu::BufferUsages {
         wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC
     }
@@ -6184,6 +6188,23 @@ impl GpuNativeExecutorContext {
         &self,
         geometry: GpuNativeRouterGeometry,
     ) -> Result<GpuNativeRouterScratch, GpuNativeBootstrapError> {
+        self.create_router_scratch_inner(geometry, false)
+    }
+
+    /// Router scratch whose exact GEMV logits may be copied by an explicitly
+    /// active diagnostic. Ordinary request allocation uses `create_router_scratch`.
+    pub(crate) fn create_router_diagnostic_scratch(
+        &self,
+        geometry: GpuNativeRouterGeometry,
+    ) -> Result<GpuNativeRouterScratch, GpuNativeBootstrapError> {
+        self.create_router_scratch_inner(geometry, true)
+    }
+
+    fn create_router_scratch_inner(
+        &self,
+        geometry: GpuNativeRouterGeometry,
+        diagnostic_logits_copy: bool,
+    ) -> Result<GpuNativeRouterScratch, GpuNativeBootstrapError> {
         if geometry.d_model != self.layout.d_model {
             return Err(GpuNativeBootstrapError::RouterDModelMismatch {
                 expected: self.layout.d_model,
@@ -6195,11 +6216,22 @@ impl GpuNativeExecutorContext {
         layout.validate_for_limits(&gpu.device.limits())?;
         validate_router_dispatch(&gpu.device.limits())?;
         let scratch_id = next_nonzero_id(&NEXT_GPU_NATIVE_SCRATCH_ID, "router scratch");
+        let logits_usage = if diagnostic_logits_copy {
+            GpuNativeRouterScratchLayout::diagnostic_logits_usage()
+        } else {
+            GpuNativeRouterScratchLayout::logits_usage()
+        };
+        super::validate_startup_buffer(
+            "gpu_native_router_logits",
+            layout.logits_bytes,
+            logits_usage,
+            &gpu.device.limits(),
+        )?;
         let logits = create_startup_buffer(
             &gpu.device,
             &format!("gpu_native_router_scratch_{scratch_id}_logits"),
             layout.logits_bytes,
-            GpuNativeRouterScratchLayout::logits_usage(),
+            logits_usage,
         )?;
         let selected_ids = create_startup_buffer(
             &gpu.device,
@@ -9905,6 +9937,11 @@ pub(crate) mod tests {
         assert_eq!(layout.total_bytes(), 576);
         assert!(!GpuNativeRouterScratchLayout::logits_usage()
             .intersects(wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::MAP_WRITE));
+        assert!(
+            !GpuNativeRouterScratchLayout::logits_usage().contains(wgpu::BufferUsages::COPY_SRC)
+        );
+        assert!(GpuNativeRouterScratchLayout::diagnostic_logits_usage()
+            .contains(wgpu::BufferUsages::COPY_SRC));
         assert!(!GpuNativeRouterScratchLayout::result_usage()
             .intersects(wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::MAP_WRITE));
         assert!(GpuNativeRouterScratchLayout::result_usage().contains(wgpu::BufferUsages::COPY_SRC));

--- a/rust-engine/src/backend/gpu_native.rs
+++ b/rust-engine/src/backend/gpu_native.rs
@@ -3579,7 +3579,7 @@ impl GpuNativeTokenStateLayout {
     }
 
     pub(crate) fn tensor_usage() -> wgpu::BufferUsages {
-        wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST
+        wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::COPY_SRC
     }
 
     pub(crate) fn status_usage() -> wgpu::BufferUsages {
@@ -3640,7 +3640,7 @@ impl GpuNativeScratchLayout {
     }
 
     pub(crate) fn usage() -> wgpu::BufferUsages {
-        wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST
+        wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::COPY_SRC
     }
 
     pub(crate) fn boundary_result_usage() -> wgpu::BufferUsages {
@@ -14145,7 +14145,7 @@ fn compare_main(@builtin(global_invocation_id) gid: vec3<u32>) {
         let tensor = GpuNativeTokenStateLayout::tensor_usage();
         assert!(tensor.contains(wgpu::BufferUsages::STORAGE));
         assert!(tensor.contains(wgpu::BufferUsages::COPY_DST));
-        assert!(!tensor.contains(wgpu::BufferUsages::COPY_SRC));
+        assert!(tensor.contains(wgpu::BufferUsages::COPY_SRC));
         assert!(!tensor.intersects(wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::MAP_WRITE));
 
         let status = GpuNativeTokenStateLayout::status_usage();
@@ -14157,7 +14157,7 @@ fn compare_main(@builtin(global_invocation_id) gid: vec3<u32>) {
         let generic_scratch = GpuNativeScratchLayout::usage();
         assert!(generic_scratch.contains(wgpu::BufferUsages::STORAGE));
         assert!(generic_scratch.contains(wgpu::BufferUsages::COPY_DST));
-        assert!(!generic_scratch.contains(wgpu::BufferUsages::COPY_SRC));
+        assert!(generic_scratch.contains(wgpu::BufferUsages::COPY_SRC));
         assert!(!generic_scratch
             .intersects(wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::MAP_WRITE));
 

--- a/rust-engine/src/backend/gpu_native.rs
+++ b/rust-engine/src/backend/gpu_native.rs
@@ -87,6 +87,29 @@ pub(crate) enum GpuNativeBootstrapError {
     StateSizeOverflow {
         d_model: usize,
     },
+    InvalidPreExpertCheckpointGeometry {
+        num_layers: usize,
+        d_model: usize,
+        top_k: usize,
+    },
+    PreExpertCheckpointSizeOverflow {
+        num_layers: usize,
+        d_model: usize,
+        top_k: usize,
+    },
+    PreExpertCheckpointLayerOutOfRange {
+        layer_index: usize,
+        num_layers: usize,
+    },
+    ForeignPreExpertCheckpoints,
+    PreExpertCheckpointGeometryMismatch {
+        expected_num_layers: usize,
+        expected_d_model: usize,
+        expected_top_k: usize,
+        actual_num_layers: usize,
+        actual_d_model: usize,
+        actual_top_k: usize,
+    },
     InvalidDenseWeightKey,
     InvalidDenseWeightShape {
         rows: usize,
@@ -493,6 +516,44 @@ impl fmt::Display for GpuNativeBootstrapError {
             Self::StateSizeOverflow { d_model } => write!(
                 f,
                 "GPU-native token-state size overflows for d_model={d_model}"
+            ),
+            Self::InvalidPreExpertCheckpointGeometry {
+                num_layers,
+                d_model,
+                top_k,
+            } => write!(
+                f,
+                "GPU-native pre-expert checkpoint geometry must have non-zero layers/d_model and top_k in 1..={MAX_GPU_NATIVE_ROUTER_TOP_K}, got layers={num_layers} d_model={d_model} top_k={top_k}"
+            ),
+            Self::PreExpertCheckpointSizeOverflow {
+                num_layers,
+                d_model,
+                top_k,
+            } => write!(
+                f,
+                "GPU-native pre-expert checkpoint layout overflows for layers={num_layers} d_model={d_model} top_k={top_k}"
+            ),
+            Self::PreExpertCheckpointLayerOutOfRange {
+                layer_index,
+                num_layers,
+            } => write!(
+                f,
+                "GPU-native pre-expert checkpoint layer {layer_index} is outside 0..{num_layers}"
+            ),
+            Self::ForeignPreExpertCheckpoints => write!(
+                f,
+                "GPU-native pre-expert checkpoints belong to a different executor context"
+            ),
+            Self::PreExpertCheckpointGeometryMismatch {
+                expected_num_layers,
+                expected_d_model,
+                expected_top_k,
+                actual_num_layers,
+                actual_d_model,
+                actual_top_k,
+            } => write!(
+                f,
+                "GPU-native pre-expert checkpoint geometry layers={actual_num_layers} d_model={actual_d_model} top_k={actual_top_k} does not match expected layers={expected_num_layers} d_model={expected_d_model} top_k={expected_top_k}"
             ),
             Self::InvalidDenseWeightKey => {
                 write!(f, "GPU-native dense weight key must be non-empty")
@@ -3561,6 +3622,228 @@ pub(crate) struct GpuNativeTokenStateLayout {
     total_buffer_bytes: u64,
 }
 
+/// Exact byte ranges for one layer's request-local pre-expert checkpoint.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct GpuNativePreExpertCheckpointRegions {
+    pub(crate) hidden_offset: u64,
+    pub(crate) residual_offset: u64,
+    pub(crate) selected_ids_offset: u64,
+    pub(crate) selected_weights_offset: u64,
+}
+
+/// Checked packed layout for all pre-expert checkpoints owned by one request.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct GpuNativePreExpertCheckpointLayout {
+    num_layers: usize,
+    d_model: usize,
+    top_k: usize,
+    hidden_bytes: u64,
+    residual_bytes: u64,
+    selected_ids_bytes: u64,
+    selected_weights_bytes: u64,
+    layer_bytes: u64,
+    total_bytes: u64,
+}
+
+impl GpuNativePreExpertCheckpointLayout {
+    pub(crate) fn try_new(
+        num_layers: usize,
+        d_model: usize,
+        top_k: usize,
+    ) -> Result<Self, GpuNativeBootstrapError> {
+        if num_layers == 0 || d_model == 0 || top_k == 0 || top_k > MAX_GPU_NATIVE_ROUTER_TOP_K {
+            return Err(
+                GpuNativeBootstrapError::InvalidPreExpertCheckpointGeometry {
+                    num_layers,
+                    d_model,
+                    top_k,
+                },
+            );
+        }
+
+        let checked_bytes = |elements: usize| {
+            elements
+                .checked_mul(std::mem::size_of::<u32>())
+                .and_then(|bytes| u64::try_from(bytes).ok())
+                .ok_or(GpuNativeBootstrapError::PreExpertCheckpointSizeOverflow {
+                    num_layers,
+                    d_model,
+                    top_k,
+                })
+        };
+        let hidden_bytes = checked_bytes(d_model)?;
+        let residual_bytes = checked_bytes(d_model)?;
+        let selected_ids_bytes = checked_bytes(top_k)?;
+        let selected_weights_bytes = checked_bytes(top_k)?;
+        let layer_bytes = hidden_bytes
+            .checked_add(residual_bytes)
+            .and_then(|bytes| bytes.checked_add(selected_ids_bytes))
+            .and_then(|bytes| bytes.checked_add(selected_weights_bytes))
+            .ok_or(GpuNativeBootstrapError::PreExpertCheckpointSizeOverflow {
+                num_layers,
+                d_model,
+                top_k,
+            })?;
+        let total_bytes = u64::try_from(num_layers)
+            .ok()
+            .and_then(|layers| layer_bytes.checked_mul(layers))
+            .ok_or(GpuNativeBootstrapError::PreExpertCheckpointSizeOverflow {
+                num_layers,
+                d_model,
+                top_k,
+            })?;
+
+        let layout = Self {
+            num_layers,
+            d_model,
+            top_k,
+            hidden_bytes,
+            residual_bytes,
+            selected_ids_bytes,
+            selected_weights_bytes,
+            layer_bytes,
+            total_bytes,
+        };
+        debug_assert_eq!(layout.total_bytes % wgpu::COPY_BUFFER_ALIGNMENT, 0);
+        Ok(layout)
+    }
+
+    pub(crate) const fn num_layers(self) -> usize {
+        self.num_layers
+    }
+
+    pub(crate) const fn d_model(self) -> usize {
+        self.d_model
+    }
+
+    pub(crate) const fn top_k(self) -> usize {
+        self.top_k
+    }
+
+    pub(crate) const fn hidden_bytes(self) -> u64 {
+        self.hidden_bytes
+    }
+
+    pub(crate) const fn residual_bytes(self) -> u64 {
+        self.residual_bytes
+    }
+
+    pub(crate) const fn selected_ids_bytes(self) -> u64 {
+        self.selected_ids_bytes
+    }
+
+    pub(crate) const fn selected_weights_bytes(self) -> u64 {
+        self.selected_weights_bytes
+    }
+
+    pub(crate) const fn layer_bytes(self) -> u64 {
+        self.layer_bytes
+    }
+
+    pub(crate) const fn total_bytes(self) -> u64 {
+        self.total_bytes
+    }
+
+    pub(crate) fn usage() -> wgpu::BufferUsages {
+        wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::COPY_DST
+    }
+
+    pub(crate) fn regions(
+        self,
+        layer_index: usize,
+    ) -> Result<GpuNativePreExpertCheckpointRegions, GpuNativeBootstrapError> {
+        if layer_index >= self.num_layers {
+            return Err(
+                GpuNativeBootstrapError::PreExpertCheckpointLayerOutOfRange {
+                    layer_index,
+                    num_layers: self.num_layers,
+                },
+            );
+        }
+        let overflow = || GpuNativeBootstrapError::PreExpertCheckpointSizeOverflow {
+            num_layers: self.num_layers,
+            d_model: self.d_model,
+            top_k: self.top_k,
+        };
+        let base = self
+            .layer_bytes
+            .checked_mul(layer_index as u64)
+            .ok_or_else(overflow)?;
+        let residual_offset = base.checked_add(self.hidden_bytes).ok_or_else(overflow)?;
+        let selected_ids_offset = residual_offset
+            .checked_add(self.residual_bytes)
+            .ok_or_else(overflow)?;
+        let selected_weights_offset = selected_ids_offset
+            .checked_add(self.selected_ids_bytes)
+            .ok_or_else(overflow)?;
+        let end = selected_weights_offset
+            .checked_add(self.selected_weights_bytes)
+            .ok_or_else(overflow)?;
+        if end > self.total_bytes
+            || [
+                base,
+                residual_offset,
+                selected_ids_offset,
+                selected_weights_offset,
+                end,
+            ]
+            .into_iter()
+            .any(|offset| offset % wgpu::COPY_BUFFER_ALIGNMENT != 0)
+        {
+            return Err(overflow());
+        }
+        Ok(GpuNativePreExpertCheckpointRegions {
+            hidden_offset: base,
+            residual_offset,
+            selected_ids_offset,
+            selected_weights_offset,
+        })
+    }
+
+    fn validate_for_limits(self, limits: &wgpu::Limits) -> Result<(), GpuNativeBootstrapError> {
+        super::validate_startup_buffer(
+            "gpu_native_pre_expert_checkpoints",
+            self.total_bytes,
+            Self::usage(),
+            limits,
+        )?;
+        Ok(())
+    }
+}
+
+/// Opaque request-local, GPU-resident storage for exact pre-expert state.
+pub(crate) struct GpuNativePreExpertCheckpoints<B = wgpu::Buffer> {
+    context_id: u64,
+    layout: GpuNativePreExpertCheckpointLayout,
+    buffer: B,
+}
+
+impl<B> GpuNativePreExpertCheckpoints<B> {
+    fn from_buffer(context_id: u64, layout: GpuNativePreExpertCheckpointLayout, buffer: B) -> Self {
+        Self {
+            context_id,
+            layout,
+            buffer,
+        }
+    }
+
+    pub(crate) const fn layout(&self) -> GpuNativePreExpertCheckpointLayout {
+        self.layout
+    }
+
+    pub(crate) fn buffer(&self) -> &B {
+        &self.buffer
+    }
+}
+
+impl<B> fmt::Debug for GpuNativePreExpertCheckpoints<B> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GpuNativePreExpertCheckpoints")
+            .field("layout", &self.layout)
+            .finish_non_exhaustive()
+    }
+}
+
 impl GpuNativeTokenStateLayout {
     pub(crate) fn try_new(d_model: usize) -> Result<Self, GpuNativeBootstrapError> {
         if d_model == 0 {
@@ -3788,7 +4071,7 @@ impl GpuNativeRouterScratchLayout {
     }
 
     pub(crate) fn result_usage() -> wgpu::BufferUsages {
-        wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC
+        wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::COPY_DST
     }
 
     fn validate_for_limits(self, limits: &wgpu::Limits) -> Result<(), GpuNativeBootstrapError> {
@@ -4280,6 +4563,43 @@ fn validate_router_scratch<B>(
         });
     }
     Ok(())
+}
+
+fn validate_pre_expert_checkpoint_resources<B, C>(
+    context_id: u64,
+    checkpoints: &GpuNativePreExpertCheckpoints<C>,
+    state: &GpuNativeTokenState<B>,
+    router_scratch: &GpuNativeRouterScratch<B>,
+    layer_index: usize,
+) -> Result<GpuNativePreExpertCheckpointRegions, GpuNativeBootstrapError> {
+    if checkpoints.context_id != context_id {
+        return Err(GpuNativeBootstrapError::ForeignPreExpertCheckpoints);
+    }
+    validate_token_state_owner(context_id, state.context_id)?;
+    validate_router_scratch(context_id, router_scratch.layout.geometry, router_scratch)?;
+    let expected = checkpoints.layout;
+    let actual_d_model = state.layout.d_model;
+    let router_geometry = router_scratch.layout.geometry;
+    if actual_d_model != expected.d_model
+        || router_geometry.d_model != expected.d_model
+        || router_geometry.top_k != expected.top_k
+        || state.layout.vector_bytes != expected.hidden_bytes
+        || state.layout.vector_bytes != expected.residual_bytes
+        || router_scratch.layout.selected_ids_bytes != expected.selected_ids_bytes
+        || router_scratch.layout.selected_weights_bytes != expected.selected_weights_bytes
+    {
+        return Err(
+            GpuNativeBootstrapError::PreExpertCheckpointGeometryMismatch {
+                expected_num_layers: expected.num_layers,
+                expected_d_model: expected.d_model,
+                expected_top_k: expected.top_k,
+                actual_num_layers: expected.num_layers,
+                actual_d_model,
+                actual_top_k: router_geometry.top_k,
+            },
+        );
+    }
+    expected.regions(layer_index)
 }
 
 fn validate_router_plan_with_registry<B>(
@@ -5945,6 +6265,138 @@ impl GpuNativeExecutorContext {
             residual,
             status,
         ))
+    }
+
+    /// Allocate one request's exact, GPU-only pre-expert checkpoints.
+    pub(crate) fn create_pre_expert_checkpoints(
+        &self,
+        layout: GpuNativePreExpertCheckpointLayout,
+    ) -> Result<GpuNativePreExpertCheckpoints, GpuNativeBootstrapError> {
+        if layout.d_model != self.layout.d_model {
+            return Err(
+                GpuNativeBootstrapError::PreExpertCheckpointGeometryMismatch {
+                    expected_num_layers: layout.num_layers,
+                    expected_d_model: self.layout.d_model,
+                    expected_top_k: layout.top_k,
+                    actual_num_layers: layout.num_layers,
+                    actual_d_model: layout.d_model,
+                    actual_top_k: layout.top_k,
+                },
+            );
+        }
+        let gpu = self.authoritative_gpu()?;
+        layout.validate_for_limits(&gpu.device.limits())?;
+        let buffer = create_startup_buffer(
+            &gpu.device,
+            "gpu_native_pre_expert_checkpoints",
+            layout.total_bytes,
+            GpuNativePreExpertCheckpointLayout::usage(),
+        )?;
+        Ok(GpuNativePreExpertCheckpoints::from_buffer(
+            self.context_id,
+            layout,
+            buffer,
+        ))
+    }
+
+    /// Capture exact post-router, pre-expert state for one layer.
+    pub(crate) fn encode_capture_pre_expert_checkpoint(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        checkpoints: &GpuNativePreExpertCheckpoints,
+        layer_index: usize,
+        state: &GpuNativeTokenState,
+        router_scratch: &GpuNativeRouterScratch,
+    ) -> Result<(), GpuNativeBootstrapError> {
+        self.authoritative_gpu()?;
+        let regions = validate_pre_expert_checkpoint_resources(
+            self.context_id,
+            checkpoints,
+            state,
+            router_scratch,
+            layer_index,
+        )?;
+        let layout = checkpoints.layout;
+
+        encoder.copy_buffer_to_buffer(
+            &state.hidden,
+            0,
+            &checkpoints.buffer,
+            regions.hidden_offset,
+            layout.hidden_bytes,
+        );
+        encoder.copy_buffer_to_buffer(
+            &state.residual,
+            0,
+            &checkpoints.buffer,
+            regions.residual_offset,
+            layout.residual_bytes,
+        );
+        encoder.copy_buffer_to_buffer(
+            &router_scratch.selected_ids,
+            0,
+            &checkpoints.buffer,
+            regions.selected_ids_offset,
+            layout.selected_ids_bytes,
+        );
+        encoder.copy_buffer_to_buffer(
+            &router_scratch.selected_weights,
+            0,
+            &checkpoints.buffer,
+            regions.selected_weights_offset,
+            layout.selected_weights_bytes,
+        );
+        Ok(())
+    }
+
+    /// Restore one layer's exact post-router, pre-expert state.
+    pub(crate) fn encode_restore_pre_expert_checkpoint(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        checkpoints: &GpuNativePreExpertCheckpoints,
+        layer_index: usize,
+        state: &GpuNativeTokenState,
+        router_scratch: &GpuNativeRouterScratch,
+    ) -> Result<(), GpuNativeBootstrapError> {
+        self.authoritative_gpu()?;
+        let regions = validate_pre_expert_checkpoint_resources(
+            self.context_id,
+            checkpoints,
+            state,
+            router_scratch,
+            layer_index,
+        )?;
+        let layout = checkpoints.layout;
+
+        encoder.copy_buffer_to_buffer(
+            &checkpoints.buffer,
+            regions.hidden_offset,
+            &state.hidden,
+            0,
+            layout.hidden_bytes,
+        );
+        encoder.copy_buffer_to_buffer(
+            &checkpoints.buffer,
+            regions.residual_offset,
+            &state.residual,
+            0,
+            layout.residual_bytes,
+        );
+        encoder.copy_buffer_to_buffer(
+            &checkpoints.buffer,
+            regions.selected_ids_offset,
+            &router_scratch.selected_ids,
+            0,
+            layout.selected_ids_bytes,
+        );
+        encoder.copy_buffer_to_buffer(
+            &checkpoints.buffer,
+            regions.selected_weights_offset,
+            &router_scratch.selected_weights,
+            0,
+            layout.selected_weights_bytes,
+        );
+        Ok(())
     }
 
     /// Record the future replay boundary into the caller-owned encoder.
@@ -10208,6 +10660,7 @@ pub(crate) mod tests {
         assert!(!GpuNativeRouterScratchLayout::result_usage()
             .intersects(wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::MAP_WRITE));
         assert!(GpuNativeRouterScratchLayout::result_usage().contains(wgpu::BufferUsages::COPY_SRC));
+        assert!(GpuNativeRouterScratchLayout::result_usage().contains(wgpu::BufferUsages::COPY_DST));
 
         let scratch = GpuNativeRouterScratch::from_buffers(7, 1, layout, (), (), ());
         assert_eq!(validate_router_scratch(7, geometry, &scratch), Ok(()));
@@ -10248,6 +10701,176 @@ pub(crate) mod tests {
             validate_router_scratch(7, geometry, &wrong_weights),
             Err(GpuNativeBootstrapError::RouterSelectedWeightsLength { .. })
         ));
+    }
+
+    #[test]
+    fn pre_expert_checkpoint_layout_is_exact_checked_and_aligned() {
+        let layout = GpuNativePreExpertCheckpointLayout::try_new(48, 2048, 8).unwrap();
+        assert_eq!(layout.num_layers(), 48);
+        assert_eq!(layout.d_model(), 2048);
+        assert_eq!(layout.top_k(), 8);
+        assert_eq!(layout.hidden_bytes(), 8192);
+        assert_eq!(layout.residual_bytes(), 8192);
+        assert_eq!(layout.selected_ids_bytes(), 32);
+        assert_eq!(layout.selected_weights_bytes(), 32);
+        assert_eq!(layout.layer_bytes(), 16_448);
+        assert_eq!(layout.total_bytes(), 789_504);
+
+        for layer_index in 0..layout.num_layers() {
+            let regions = layout.regions(layer_index).unwrap();
+            let offsets = [
+                regions.hidden_offset,
+                regions.residual_offset,
+                regions.selected_ids_offset,
+                regions.selected_weights_offset,
+            ];
+            assert!(offsets
+                .iter()
+                .all(|offset| offset % wgpu::COPY_BUFFER_ALIGNMENT == 0));
+            assert_eq!(regions.hidden_offset, layer_index as u64 * 16_448);
+            assert_eq!(regions.residual_offset, regions.hidden_offset + 8192);
+            assert_eq!(regions.selected_ids_offset, regions.residual_offset + 8192);
+            assert_eq!(
+                regions.selected_weights_offset,
+                regions.selected_ids_offset + 32
+            );
+            assert!(regions.selected_weights_offset + 32 <= layout.total_bytes());
+        }
+        assert_eq!(
+            layout.regions(48),
+            Err(
+                GpuNativeBootstrapError::PreExpertCheckpointLayerOutOfRange {
+                    layer_index: 48,
+                    num_layers: 48,
+                }
+            )
+        );
+
+        let usage = GpuNativePreExpertCheckpointLayout::usage();
+        assert_eq!(
+            usage,
+            wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::COPY_DST
+        );
+        assert!(!usage.intersects(
+            wgpu::BufferUsages::MAP_READ
+                | wgpu::BufferUsages::MAP_WRITE
+                | wgpu::BufferUsages::STORAGE
+        ));
+    }
+
+    #[test]
+    fn pre_expert_checkpoint_layout_rejects_invalid_or_overflowing_geometry() {
+        for (num_layers, d_model, top_k) in [(0, 2048, 8), (48, 0, 8), (48, 2048, 0), (48, 2048, 9)]
+        {
+            assert_eq!(
+                GpuNativePreExpertCheckpointLayout::try_new(num_layers, d_model, top_k),
+                Err(
+                    GpuNativeBootstrapError::InvalidPreExpertCheckpointGeometry {
+                        num_layers,
+                        d_model,
+                        top_k,
+                    }
+                )
+            );
+        }
+        assert!(matches!(
+            GpuNativePreExpertCheckpointLayout::try_new(usize::MAX, usize::MAX, 8),
+            Err(GpuNativeBootstrapError::PreExpertCheckpointSizeOverflow { .. })
+        ));
+    }
+
+    #[test]
+    fn pre_expert_checkpoint_ownership_and_geometry_fail_closed() {
+        let layout = GpuNativePreExpertCheckpointLayout::try_new(2, 16, 4).unwrap();
+        let checkpoints = GpuNativePreExpertCheckpoints::from_buffer(7, layout, ());
+        let state_layout = GpuNativeTokenStateLayout::try_new(16).unwrap();
+        let state = GpuNativeTokenState::from_buffers(7, 1, state_layout, (), (), ());
+        let router_geometry = GpuNativeRouterGeometry::try_new(16, 8, 4).unwrap();
+        let router_layout = GpuNativeRouterScratchLayout::try_new(router_geometry).unwrap();
+        let router = GpuNativeRouterScratch::from_buffers(7, 1, router_layout, (), (), ());
+
+        assert!(
+            validate_pre_expert_checkpoint_resources(7, &checkpoints, &state, &router, 1).is_ok()
+        );
+        assert_eq!(
+            validate_pre_expert_checkpoint_resources(8, &checkpoints, &state, &router, 0),
+            Err(GpuNativeBootstrapError::ForeignPreExpertCheckpoints)
+        );
+        assert_eq!(
+            validate_pre_expert_checkpoint_resources(7, &checkpoints, &state, &router, 2),
+            Err(
+                GpuNativeBootstrapError::PreExpertCheckpointLayerOutOfRange {
+                    layer_index: 2,
+                    num_layers: 2,
+                }
+            )
+        );
+
+        let wrong_state_layout = GpuNativeTokenStateLayout::try_new(8).unwrap();
+        let wrong_state = GpuNativeTokenState::from_buffers(7, 2, wrong_state_layout, (), (), ());
+        assert!(matches!(
+            validate_pre_expert_checkpoint_resources(7, &checkpoints, &wrong_state, &router, 0),
+            Err(GpuNativeBootstrapError::PreExpertCheckpointGeometryMismatch { .. })
+        ));
+
+        let wrong_router_geometry = GpuNativeRouterGeometry::try_new(16, 8, 2).unwrap();
+        let wrong_router_layout =
+            GpuNativeRouterScratchLayout::try_new(wrong_router_geometry).unwrap();
+        let wrong_router =
+            GpuNativeRouterScratch::from_buffers(7, 2, wrong_router_layout, (), (), ());
+        assert!(matches!(
+            validate_pre_expert_checkpoint_resources(7, &checkpoints, &state, &wrong_router, 0),
+            Err(GpuNativeBootstrapError::PreExpertCheckpointGeometryMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn pre_expert_checkpoint_roundtrip_preserves_exact_ordered_state_bytes() {
+        let layout = GpuNativePreExpertCheckpointLayout::try_new(3, 4, 3).unwrap();
+        let regions = layout.regions(1).unwrap();
+        let hidden = [1.0f32, -0.0, f32::from_bits(1), f32::INFINITY];
+        let residual = [-3.5f32, 7.25, f32::MIN_POSITIVE, f32::NEG_INFINITY];
+        let selected_ids = [7u32, 2, 5];
+        let selected_weights = [0.625f32, 0.25, 0.125];
+        let mut checkpoint = vec![0u8; layout.total_bytes() as usize];
+
+        let mut capture = |offset: u64, bytes: &[u8]| {
+            let start = offset as usize;
+            checkpoint[start..start + bytes.len()].copy_from_slice(bytes);
+        };
+        capture(regions.hidden_offset, bytemuck::cast_slice(&hidden));
+        capture(regions.residual_offset, bytemuck::cast_slice(&residual));
+        capture(
+            regions.selected_ids_offset,
+            bytemuck::cast_slice(&selected_ids),
+        );
+        capture(
+            regions.selected_weights_offset,
+            bytemuck::cast_slice(&selected_weights),
+        );
+
+        let restore = |offset: u64, bytes: u64| {
+            checkpoint[offset as usize..(offset + bytes) as usize].to_vec()
+        };
+        assert_eq!(
+            restore(regions.hidden_offset, layout.hidden_bytes()),
+            bytemuck::cast_slice::<f32, u8>(&hidden)
+        );
+        assert_eq!(
+            restore(regions.residual_offset, layout.residual_bytes()),
+            bytemuck::cast_slice::<f32, u8>(&residual)
+        );
+        assert_eq!(
+            restore(regions.selected_ids_offset, layout.selected_ids_bytes()),
+            bytemuck::cast_slice::<u32, u8>(&selected_ids)
+        );
+        assert_eq!(
+            restore(
+                regions.selected_weights_offset,
+                layout.selected_weights_bytes()
+            ),
+            bytemuck::cast_slice::<f32, u8>(&selected_weights)
+        );
     }
 
     #[test]
@@ -14687,6 +15310,7 @@ fn compare_main(@builtin(global_invocation_id) gid: vec3<u32>) {
         let router_result = GpuNativeRouterScratchLayout::result_usage();
         assert!(router_result.contains(wgpu::BufferUsages::STORAGE));
         assert!(router_result.contains(wgpu::BufferUsages::COPY_SRC));
+        assert!(router_result.contains(wgpu::BufferUsages::COPY_DST));
         assert!(
             !router_result.intersects(wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::MAP_WRITE)
         );

--- a/rust-engine/src/backend/wgpu_shaders/gpu_native_q4_expert_stage_diagnostic.wgsl
+++ b/rust-engine/src/backend/wgpu_shaders/gpu_native_q4_expert_stage_diagnostic.wgsl
@@ -1,0 +1,229 @@
+// Diagnostic-only raw-stage observation for the production GPU-native Q4_0
+// expert. This shader is never dispatched by ordinary token execution. Its
+// Q4 byte reads and sequential arithmetic are pinned to q4_dot in
+// gpu_native_q4_expert.wgsl by deterministic Rust source invariants.
+
+struct PushConstants {
+    d_model: u32,
+    d_ff: u32,
+    blocks_per_projection: u32,
+    slot_stride_bytes: u32,
+    route_slot: u32,
+    top_k: u32,
+    swiglu_limit: f32,
+    _reserved: u32,
+};
+var<push_constant> pc: PushConstants;
+
+@group(0) @binding(0) var<storage, read> W0: array<u32>;
+@group(0) @binding(1) var<storage, read> W1: array<u32>;
+@group(0) @binding(2) var<storage, read> W2: array<u32>;
+@group(0) @binding(3) var<storage, read> W3: array<u32>;
+@group(0) @binding(4) var<storage, read> INPUT: array<f32>;
+struct ExpertRoute {
+    location: u32,
+    slot_epoch: u32,
+};
+@group(0) @binding(5) var<storage, read> RESOLVED_LOCATIONS: array<ExpertRoute>;
+@group(0) @binding(6) var<storage, read_write> STAGES: array<f32>;
+struct Status {
+    bits: atomic<u32>,
+};
+@group(0) @binding(7) var<storage, read_write> STATUS: Status;
+
+const BLOCK_BYTES: u32 = 18u;
+const BLOCK_ELEMS: u32 = 32u;
+const LOCATION_BANK_SHIFT: u32 = 30u;
+const LOCATION_SLOT_MASK: u32 = 0x3fffffffu;
+const UNMAPPED: u32 = 0xffffffffu;
+const EXPERT_RESIDENCY_MISS: u32 = 4u;
+const EXPERT_NUMERICAL_FAILURE: u32 = 8u;
+const MAX_FINITE_F32: f32 = 3.402823e+38;
+
+fn is_finite(value: f32) -> bool {
+    return value == value && abs(value) <= MAX_FINITE_F32;
+}
+
+fn read_bank_word(bank: u32, word: u32) -> u32 {
+    switch bank {
+        case 0u: { return W0[word]; }
+        case 1u: { return W1[word]; }
+        case 2u: { return W2[word]; }
+        default: { return W3[word]; }
+    }
+}
+
+fn read_bank_byte(bank: u32, byte_offset: u32) -> u32 {
+    let word = byte_offset >> 2u;
+    let shift = (byte_offset & 3u) * 8u;
+    return (read_bank_word(bank, word) >> shift) & 0xffu;
+}
+
+fn q4_dot_input(
+    bank: u32,
+    slot_base: u32,
+    first_block: u32,
+    blocks_per_row: u32,
+    input_base: u32,
+) -> f32 {
+    var sum = 0.0;
+    for (var block = 0u; block < blocks_per_row; block += 1u) {
+        let byte_offset = slot_base + (first_block + block) * BLOCK_BYTES;
+        let scale_bits = read_bank_byte(bank, byte_offset)
+            | (read_bank_byte(bank, byte_offset + 1u) << 8u);
+        let scale = unpack2x16float(scale_bits).x;
+        var partial = 0.0;
+        let x_base = input_base + block * BLOCK_ELEMS;
+        for (var nibble = 0u; nibble < 16u; nibble += 1u) {
+            let packed = read_bank_byte(bank, byte_offset + 2u + nibble);
+            partial += (f32(packed & 0xfu) - 8.0) * INPUT[x_base + nibble];
+            partial += (f32(packed >> 4u) - 8.0) * INPUT[x_base + nibble + 16u];
+        }
+        sum += scale * partial;
+    }
+    return sum;
+}
+
+fn q4_dot_gated(
+    bank: u32,
+    slot_base: u32,
+    first_block: u32,
+    blocks_per_row: u32,
+    input_base: u32,
+) -> f32 {
+    var sum = 0.0;
+    for (var block = 0u; block < blocks_per_row; block += 1u) {
+        let byte_offset = slot_base + (first_block + block) * BLOCK_BYTES;
+        let scale_bits = read_bank_byte(bank, byte_offset)
+            | (read_bank_byte(bank, byte_offset + 1u) << 8u);
+        let scale = unpack2x16float(scale_bits).x;
+        var partial = 0.0;
+        let x_base = input_base + block * BLOCK_ELEMS;
+        for (var nibble = 0u; nibble < 16u; nibble += 1u) {
+            let packed = read_bank_byte(bank, byte_offset + 2u + nibble);
+            partial += (f32(packed & 0xfu) - 8.0) * STAGES[x_base + nibble];
+            partial += (f32(packed >> 4u) - 8.0) * STAGES[x_base + nibble + 16u];
+        }
+        sum += scale * partial;
+    }
+    return sum;
+}
+
+fn resolved_route() -> ExpertRoute {
+    if (pc.route_slot >= pc.top_k || atomicLoad(&STATUS.bits) != 0u) {
+        return ExpertRoute(UNMAPPED, 0u);
+    }
+    return RESOLVED_LOCATIONS[pc.route_slot];
+}
+
+fn gate_base() -> u32 {
+    return pc.route_slot * pc.d_ff;
+}
+
+fn up_base() -> u32 {
+    return pc.top_k * pc.d_ff + pc.route_slot * pc.d_ff;
+}
+
+fn gated_base() -> u32 {
+    return 2u * pc.top_k * pc.d_ff + pc.route_slot * pc.d_ff;
+}
+
+fn down_base() -> u32 {
+    return 3u * pc.top_k * pc.d_ff + pc.route_slot * pc.d_model;
+}
+
+@compute @workgroup_size(64, 1, 1)
+fn q4_expert_stage_gate_up_main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let row = gid.x;
+    if (row >= pc.d_ff) {
+        return;
+    }
+    let route = resolved_route();
+    let location = route.location;
+    if (location == UNMAPPED) {
+        STAGES[gate_base() + row] = 0.0;
+        STAGES[up_base() + row] = 0.0;
+        STAGES[gated_base() + row] = 0.0;
+        return;
+    }
+    let bank = location >> LOCATION_BANK_SHIFT;
+    let slot = location & LOCATION_SLOT_MASK;
+    let slot_base = slot * pc.slot_stride_bytes;
+    let current_slot_epoch = read_bank_word(bank, slot_base >> 2u);
+    if (current_slot_epoch == 0u || current_slot_epoch != route.slot_epoch) {
+        atomicOr(&STATUS.bits, EXPERT_RESIDENCY_MISS);
+        STAGES[gate_base() + row] = 0.0;
+        STAGES[up_base() + row] = 0.0;
+        STAGES[gated_base() + row] = 0.0;
+        return;
+    }
+    let payload_base = slot_base + 4u;
+    let blocks_per_row = pc.d_model / BLOCK_ELEMS;
+    let row_block = row * blocks_per_row;
+    let gate = q4_dot_input(bank, payload_base, row_block, blocks_per_row, 0u);
+    let up = q4_dot_input(
+        bank,
+        payload_base,
+        pc.blocks_per_projection + row_block,
+        blocks_per_row,
+        0u,
+    );
+    if (!is_finite(gate) || !is_finite(up)) {
+        atomicOr(&STATUS.bits, EXPERT_NUMERICAL_FAILURE);
+        STAGES[gate_base() + row] = 0.0;
+        STAGES[up_base() + row] = 0.0;
+        STAGES[gated_base() + row] = 0.0;
+        return;
+    }
+    let clamped_gate = clamp(gate, -pc.swiglu_limit, pc.swiglu_limit);
+    let activation = (clamped_gate / (1.0 + exp(-clamped_gate))) * up;
+    if (!is_finite(activation)) {
+        atomicOr(&STATUS.bits, EXPERT_NUMERICAL_FAILURE);
+        STAGES[gate_base() + row] = 0.0;
+        STAGES[up_base() + row] = 0.0;
+        STAGES[gated_base() + row] = 0.0;
+        return;
+    }
+    STAGES[gate_base() + row] = gate;
+    STAGES[up_base() + row] = up;
+    STAGES[gated_base() + row] = activation;
+}
+
+@compute @workgroup_size(64, 1, 1)
+fn q4_expert_stage_down_main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let row = gid.x;
+    if (row >= pc.d_model) {
+        return;
+    }
+    let route = resolved_route();
+    let location = route.location;
+    if (location == UNMAPPED) {
+        STAGES[down_base() + row] = 0.0;
+        return;
+    }
+    let bank = location >> LOCATION_BANK_SHIFT;
+    let slot = location & LOCATION_SLOT_MASK;
+    let slot_base = slot * pc.slot_stride_bytes;
+    let current_slot_epoch = read_bank_word(bank, slot_base >> 2u);
+    if (current_slot_epoch == 0u || current_slot_epoch != route.slot_epoch) {
+        atomicOr(&STATUS.bits, EXPERT_RESIDENCY_MISS);
+        STAGES[down_base() + row] = 0.0;
+        return;
+    }
+    let payload_base = slot_base + 4u;
+    let blocks_per_row = pc.d_ff / BLOCK_ELEMS;
+    let first_block = 2u * pc.blocks_per_projection + row * blocks_per_row;
+    let value = q4_dot_gated(
+        bank,
+        payload_base,
+        first_block,
+        blocks_per_row,
+        gated_base(),
+    );
+    if (!is_finite(value)) {
+        atomicOr(&STATUS.bits, EXPERT_NUMERICAL_FAILURE);
+        STAGES[down_base() + row] = 0.0;
+        return;
+    }
+    STAGES[down_base() + row] = value;
+}

--- a/rust-engine/src/engine.rs
+++ b/rust-engine/src/engine.rs
@@ -17,7 +17,8 @@ use crate::aligned_buffer::AlignedBuffer;
 use crate::backend::Backend as _;
 use crate::buffer_pool::BufferPool;
 use crate::expert_cache::{
-    ExpertResident, GpuExpertCache, GpuHotPromotionOutcome, GpuResident,
+    ExpertResident, GpuAdmission, GpuDemandAdmissionError, GpuDemandSetAdmission, GpuExpertCache,
+    GpuHotPromotionOutcome, GpuResident,
 };
 use crate::gating::Router;
 use crate::gpu_native_residency::{
@@ -381,6 +382,15 @@ pub(crate) enum GpuNativeDemandResidencyError {
     ManagerNotInstalled,
     ExpertRead(ExpertReadError),
     LogicalAdmission(crate::backend::GpuExpertDispatchError),
+    LogicalDemandSet(GpuDemandAdmissionError),
+    LogicalDemandSetRecoveryExhausted {
+        global_ids: Vec<u32>,
+        attempts: usize,
+    },
+    PhysicalDemandRecoveryExhausted {
+        global_id: u32,
+        recovery_attempts: usize,
+    },
     Tiered(GpuNativeTieredResidencyError),
 }
 
@@ -394,6 +404,23 @@ impl std::fmt::Display for GpuNativeDemandResidencyError {
             Self::LogicalAdmission(error) => {
                 write!(f, "tiered residency logical admission failed: {error}")
             }
+            Self::LogicalDemandSet(error) => {
+                write!(f, "tiered residency logical demand-set admission failed: {error}")
+            }
+            Self::LogicalDemandSetRecoveryExhausted {
+                global_ids,
+                attempts,
+            } => write!(
+                f,
+                "tiered residency logical demand-set source resolution remained incomplete for experts {global_ids:?} after {attempts} bounded attempts"
+            ),
+            Self::PhysicalDemandRecoveryExhausted {
+                global_id,
+                recovery_attempts,
+            } => write!(
+                f,
+                "tiered residency physical demand-set recovery remained stale/missing for expert {global_id} after {recovery_attempts} bounded recovery attempt(s)"
+            ),
             Self::Tiered(error) => error.fmt(f),
         }
     }
@@ -411,6 +438,20 @@ impl From<GpuNativeTieredResidencyError> for GpuNativeDemandResidencyError {
     fn from(value: GpuNativeTieredResidencyError) -> Self {
         Self::Tiered(value)
     }
+}
+
+impl From<GpuDemandAdmissionError> for GpuNativeDemandResidencyError {
+    fn from(value: GpuDemandAdmissionError) -> Self {
+        Self::LogicalDemandSet(value)
+    }
+}
+
+const GPU_NATIVE_LOGICAL_DEMAND_SET_ATTEMPTS: usize = 2;
+const GPU_NATIVE_PHYSICAL_DEMAND_RECOVERY_LIMIT: usize = 1;
+
+#[inline]
+const fn gpu_native_physical_demand_recovery_allowed(completed_attempts: usize) -> bool {
+    completed_attempts < GPU_NATIVE_PHYSICAL_DEMAND_RECOVERY_LIMIT
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -3753,11 +3794,77 @@ impl Engine {
         })
     }
 
-    /// Future GPU-native retry service. Physical hits never touch RAM or
-    /// storage. RAM misses use the exact existing `fetch_with_retry`
-    /// singleflight path, then the existing logical demand-admission policy,
-    /// before Slice 8 receives `ExpertResident::data()` for physical upload.
-    /// Demand never consults the speculative governor or semaphore.
+    async fn gpu_native_demand_source(
+        self: &Arc<Self>,
+        global_id: u32,
+        residents: &mut HashMap<u32, Arc<ExpertResident>>,
+    ) -> Result<Arc<ExpertResident>, GpuNativeDemandResidencyError> {
+        if let Some(resident) = residents.get(&global_id) {
+            return Ok(resident.clone());
+        }
+        let resident = match self.core.cache.get(global_id) {
+            Some(resident) => resident,
+            None => self.fetch_with_retry(global_id).await?,
+        };
+        residents.insert(global_id, resident.clone());
+        Ok(resident)
+    }
+
+    async fn ensure_gpu_native_logical_demand_set(
+        self: &Arc<Self>,
+        global_ids: &[u32],
+        residents: &mut HashMap<u32, Arc<ExpertResident>>,
+    ) -> Result<Vec<GpuAdmission>, GpuNativeDemandResidencyError> {
+        let gpu = self.execution_context().gpu_expert_cache();
+        let mut payloads = HashMap::with_capacity(global_ids.len());
+        for attempt in 1..=GPU_NATIVE_LOGICAL_DEMAND_SET_ATTEMPTS {
+            match gpu.demand_admit_set(global_ids, &payloads)? {
+                GpuDemandSetAdmission::Ready {
+                    admissions,
+                    newly_admitted,
+                } => {
+                    if newly_admitted > 0 {
+                        if let Some(prom) = self.metrics.prom.as_ref() {
+                            prom.record_promotions(newly_admitted as u64);
+                            prom.set_vram_used_bytes(gpu.used_bytes());
+                        }
+                    }
+                    return Ok(admissions);
+                }
+                GpuDemandSetAdmission::PayloadRequired(missing)
+                    if attempt == GPU_NATIVE_LOGICAL_DEMAND_SET_ATTEMPTS =>
+                {
+                    return Err(
+                        GpuNativeDemandResidencyError::LogicalDemandSetRecoveryExhausted {
+                            global_ids: missing,
+                            attempts: GPU_NATIVE_LOGICAL_DEMAND_SET_ATTEMPTS,
+                        },
+                    );
+                }
+                GpuDemandSetAdmission::PayloadRequired(missing) => {
+                    for global_id in missing {
+                        let resident = self.gpu_native_demand_source(global_id, residents).await?;
+                        payloads.insert(
+                            global_id,
+                            Arc::new(GpuResident::new_with_dtype(
+                                global_id,
+                                resident.data().to_vec(),
+                                self.core.options.dtype,
+                            )),
+                        );
+                    }
+                }
+            }
+        }
+        unreachable!("logical demand-set loop has a fixed positive attempt count")
+    }
+
+    /// GPU-native foreground demand service. Healthy physical hits never
+    /// touch RAM or storage. A complete selected set is protected in the
+    /// logical LRU before any async source acquisition; missing sources use
+    /// the exact existing RAM -> `fetch_with_retry` hierarchy and are admitted
+    /// atomically before physical resolution. Demand never consults the
+    /// speculative governor or semaphore.
     pub(crate) async fn ensure_gpu_native_demand_residency(
         self: &Arc<Self>,
         layer_index: usize,
@@ -3793,35 +3900,100 @@ impl Engine {
             }
         }
 
-        let mut demands = Vec::with_capacity(global_ids.len());
+        let gpu = self.execution_context().gpu_expert_cache().clone();
+        let _logical_protection = gpu.protect_demand_set(global_ids)?;
+
+        // Lock order is deliberately non-nested: protection registration
+        // released the logical-cache mutex before these physical layer probes,
+        // and the guard retains metadata only. No cache/layer mutex is held
+        // across the RAM/NVMe awaits below. Physical resolution may take its
+        // layer lock and then validate logical generations without inversion.
+        let mut initially_current = Vec::with_capacity(global_ids.len());
+        let mut residents = HashMap::with_capacity(global_ids.len());
         for &global_id in global_ids {
-            if manager.has_current_for_demand(global_id)? {
-                demands.push(GpuNativeDemandExpert::current(global_id));
-                continue;
+            let current = manager.has_current_for_demand(global_id)?;
+            initially_current.push(current);
+            if !current {
+                self.gpu_native_demand_source(global_id, &mut residents)
+                    .await?;
             }
-            let resident = match self.core.cache.get(global_id) {
-                Some(resident) => resident,
-                None => self.fetch_with_retry(global_id).await?,
-            };
-            self.demand_admit_resident_to_gpu(layer_index as u32, resident.as_ref())
-                .map_err(GpuNativeDemandResidencyError::LogicalAdmission)?;
-            let admission = self
-                .core
-                .execution_context
-                .gpu_expert_cache()
-                .current_admission(global_id)
-                .ok_or_else(|| {
-                    GpuNativeDemandResidencyError::Tiered(
-                        GpuNativeTieredResidencyError::DemandSourceMissing { global_id },
-                    )
-                })?;
-            demands.push(GpuNativeDemandExpert::install(
-                global_id, resident, admission,
-            ));
         }
-        manager
-            .ensure_demand_set(GpuNativeResidencyPriority::Demand, layer_index, &demands)
-            .map_err(Into::into)
+
+        let mut admissions = self
+            .ensure_gpu_native_logical_demand_set(global_ids, &mut residents)
+            .await?;
+        let mut demands = global_ids
+            .iter()
+            .copied()
+            .enumerate()
+            .map(|(index, global_id)| {
+                if initially_current[index] {
+                    GpuNativeDemandExpert::current(global_id)
+                } else {
+                    GpuNativeDemandExpert::install(
+                        global_id,
+                        residents
+                            .get(&global_id)
+                            .expect("physical miss acquired an authoritative source")
+                            .clone(),
+                        admissions[index].clone(),
+                    )
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let mut recovery_attempts = 0usize;
+        loop {
+            match manager.ensure_demand_set(
+                GpuNativeResidencyPriority::Demand,
+                layer_index,
+                &demands,
+            ) {
+                Ok(residencies) => return Ok(residencies),
+                Err(GpuNativeTieredResidencyError::DemandSourceMissing { global_id: _ })
+                    if gpu_native_physical_demand_recovery_allowed(recovery_attempts) =>
+                {
+                    recovery_attempts += 1;
+
+                    // A Current record changed before the physical transaction.
+                    // Reacquire sources for the whole selected set so the one
+                    // bounded retry cannot fail merely because a later Current
+                    // member also changed. Install demands still resolve VRAM
+                    // hits without reinstalling them.
+                    for &selected_id in global_ids {
+                        self.gpu_native_demand_source(selected_id, &mut residents)
+                            .await?;
+                    }
+                    admissions = self
+                        .ensure_gpu_native_logical_demand_set(global_ids, &mut residents)
+                        .await?;
+                    demands = global_ids
+                        .iter()
+                        .copied()
+                        .enumerate()
+                        .map(|(index, selected_id)| {
+                            GpuNativeDemandExpert::install(
+                                selected_id,
+                                residents
+                                    .get(&selected_id)
+                                    .expect("bounded recovery acquired every selected source")
+                                    .clone(),
+                                admissions[index].clone(),
+                            )
+                        })
+                        .collect();
+                }
+                Err(GpuNativeTieredResidencyError::DemandSourceMissing { global_id }) => {
+                    return Err(
+                        GpuNativeDemandResidencyError::PhysicalDemandRecoveryExhausted {
+                            global_id,
+                            recovery_attempts,
+                        },
+                    );
+                }
+                Err(error) => return Err(error.into()),
+            }
+        }
     }
 
     /// One single fetch attempt. Acquires a buffer (yielding briefly
@@ -6524,6 +6696,24 @@ mod tests {
         fn drop(&mut self) {
             let _ = std::fs::remove_dir_all(&self.path);
         }
+    }
+
+    #[test]
+    fn gpu_native_current_to_missing_recovery_is_bounded_fail_closed() {
+        assert!(gpu_native_physical_demand_recovery_allowed(0));
+        assert!(!gpu_native_physical_demand_recovery_allowed(1));
+        assert!(!gpu_native_physical_demand_recovery_allowed(usize::MAX));
+        assert_eq!(GPU_NATIVE_PHYSICAL_DEMAND_RECOVERY_LIMIT, 1);
+        assert_eq!(GPU_NATIVE_LOGICAL_DEMAND_SET_ATTEMPTS, 2);
+
+        let error = GpuNativeDemandResidencyError::PhysicalDemandRecoveryExhausted {
+            global_id: 6065,
+            recovery_attempts: GPU_NATIVE_PHYSICAL_DEMAND_RECOVERY_LIMIT,
+        };
+        assert_eq!(
+            error.to_string(),
+            "tiered residency physical demand-set recovery remained stale/missing for expert 6065 after 1 bounded recovery attempt(s)"
+        );
     }
 
     fn build_engine(

--- a/rust-engine/src/engine.rs
+++ b/rust-engine/src/engine.rs
@@ -454,6 +454,20 @@ const fn gpu_native_physical_demand_recovery_allowed(completed_attempts: usize) 
     completed_attempts < GPU_NATIVE_PHYSICAL_DEMAND_RECOVERY_LIMIT
 }
 
+fn gpu_native_physical_missing_ids(global_ids: &[u32], physical_current: &[bool]) -> Vec<u32> {
+    assert_eq!(
+        global_ids.len(),
+        physical_current.len(),
+        "physical probe results must cover the complete selected set"
+    );
+    global_ids
+        .iter()
+        .copied()
+        .zip(physical_current.iter().copied())
+        .filter_map(|(global_id, current)| (!current).then_some(global_id))
+        .collect()
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum GpuNativeResidencyInstallError {
     LegacyPhysicalExpertPlaneActive,
@@ -4057,7 +4071,7 @@ impl Engine {
         self: &Arc<Self>,
         global_ids: &[u32],
         residents: &mut HashMap<u32, Arc<ExpertResident>>,
-    ) -> Result<Vec<GpuAdmission>, GpuNativeDemandResidencyError> {
+    ) -> Result<(Vec<GpuAdmission>, usize), GpuNativeDemandResidencyError> {
         let gpu = self.execution_context().gpu_expert_cache();
         let mut payloads = HashMap::with_capacity(global_ids.len());
         for attempt in 1..=GPU_NATIVE_LOGICAL_DEMAND_SET_ATTEMPTS {
@@ -4072,7 +4086,7 @@ impl Engine {
                             prom.set_vram_used_bytes(gpu.used_bytes());
                         }
                     }
-                    return Ok(admissions);
+                    return Ok((admissions, newly_admitted));
                 }
                 GpuDemandSetAdmission::PayloadRequired(missing)
                     if attempt == GPU_NATIVE_LOGICAL_DEMAND_SET_ATTEMPTS =>
@@ -4102,12 +4116,12 @@ impl Engine {
         unreachable!("logical demand-set loop has a fixed positive attempt count")
     }
 
-    /// GPU-native foreground demand service. Healthy physical hits never
-    /// touch RAM or storage. A complete selected set is protected in the
-    /// logical LRU before any async source acquisition; missing sources use
-    /// the exact existing RAM -> `fetch_with_retry` hierarchy and are admitted
-    /// atomically before physical resolution. Demand never consults the
-    /// speculative governor or semaphore.
+    /// GPU-native foreground demand service. Exact physical hits are
+    /// authoritative and never touch the logical cache, RAM, or storage.
+    /// Only physical misses use the existing RAM -> `fetch_with_retry`
+    /// hierarchy, protect/admit their complete missing subset atomically, and
+    /// authorize a physical install. Demand never consults the speculative
+    /// governor or semaphore.
     pub(crate) async fn ensure_gpu_native_demand_residency(
         self: &Arc<Self>,
         layer_index: usize,
@@ -4143,50 +4157,67 @@ impl Engine {
             }
         }
 
-        let gpu = self.execution_context().gpu_expert_cache().clone();
-        let _logical_protection = gpu.protect_demand_set(global_ids)?;
-
-        // Lock order is deliberately non-nested: protection registration
-        // released the logical-cache mutex before these physical layer probes,
-        // and the guard retains metadata only. No cache/layer mutex is held
-        // across the RAM/NVMe awaits below. Physical resolution may take its
-        // layer lock and then validate logical generations without inversion.
-        let mut initially_current = Vec::with_capacity(global_ids.len());
         let mut residents = HashMap::with_capacity(global_ids.len());
-        for &global_id in global_ids {
-            let current = manager.has_current_for_demand(global_id)?;
-            initially_current.push(current);
-            if !current {
-                self.gpu_native_demand_source(global_id, &mut residents)
-                    .await?;
-            }
-        }
-
-        let mut admissions = self
-            .ensure_gpu_native_logical_demand_set(global_ids, &mut residents)
-            .await?;
-        let mut demands = global_ids
-            .iter()
-            .copied()
-            .enumerate()
-            .map(|(index, global_id)| {
-                if initially_current[index] {
-                    GpuNativeDemandExpert::current(global_id)
-                } else {
-                    GpuNativeDemandExpert::install(
-                        global_id,
-                        residents
-                            .get(&global_id)
-                            .expect("physical miss acquired an authoritative source")
-                            .clone(),
-                        admissions[index].clone(),
-                    )
-                }
-            })
-            .collect::<Vec<_>>();
-
         let mut recovery_attempts = 0usize;
         loop {
+            // No logical-cache lock is held while probing the physical layer.
+            // A probe result may race with a later physical eviction; the
+            // fixed one-retry recovery below re-probes the complete set.
+            let mut physical_current = Vec::with_capacity(global_ids.len());
+            for &global_id in global_ids {
+                let current = manager.has_current_for_demand(global_id)?;
+                physical_current.push(current);
+            }
+            let physical_missing = gpu_native_physical_missing_ids(global_ids, &physical_current);
+
+            // Physical hits never reach this logical/source block. Protection
+            // is metadata-only and releases the logical mutex before every
+            // RAM/NVMe await, so there is no logical -> physical nesting.
+            let mut admissions_by_id = HashMap::with_capacity(physical_missing.len());
+            let _logical_protection = if physical_missing.is_empty() {
+                None
+            } else {
+                let gpu = self.execution_context().gpu_expert_cache().clone();
+                let protection = gpu.protect_demand_set(&physical_missing)?;
+                for &global_id in &physical_missing {
+                    if !residents.contains_key(&global_id) {
+                        manager.record_physical_source_acquisition();
+                        self.gpu_native_demand_source(global_id, &mut residents)
+                            .await?;
+                    }
+                }
+                let (admissions, newly_admitted) = self
+                    .ensure_gpu_native_logical_demand_set(&physical_missing, &mut residents)
+                    .await?;
+                manager.record_logical_admissions_for_physical_misses(newly_admitted);
+                admissions_by_id
+                    .extend(physical_missing.iter().copied().zip(admissions.into_iter()));
+                Some(protection)
+            };
+
+            let demands = global_ids
+                .iter()
+                .copied()
+                .enumerate()
+                .map(|(index, global_id)| {
+                    if physical_current[index] {
+                        GpuNativeDemandExpert::current(global_id)
+                    } else {
+                        GpuNativeDemandExpert::install(
+                            global_id,
+                            residents
+                                .get(&global_id)
+                                .expect("physical miss acquired an authoritative source")
+                                .clone(),
+                            admissions_by_id
+                                .get(&global_id)
+                                .expect("physical miss established a logical admission")
+                                .clone(),
+                        )
+                    }
+                })
+                .collect::<Vec<_>>();
+
             match manager.ensure_demand_set(
                 GpuNativeResidencyPriority::Demand,
                 layer_index,
@@ -4197,34 +4228,9 @@ impl Engine {
                     if gpu_native_physical_demand_recovery_allowed(recovery_attempts) =>
                 {
                     recovery_attempts += 1;
-
                     // A Current record changed before the physical transaction.
-                    // Reacquire sources for the whole selected set so the one
-                    // bounded retry cannot fail merely because a later Current
-                    // member also changed. Install demands still resolve VRAM
-                    // hits without reinstalling them.
-                    for &selected_id in global_ids {
-                        self.gpu_native_demand_source(selected_id, &mut residents)
-                            .await?;
-                    }
-                    admissions = self
-                        .ensure_gpu_native_logical_demand_set(global_ids, &mut residents)
-                        .await?;
-                    demands = global_ids
-                        .iter()
-                        .copied()
-                        .enumerate()
-                        .map(|(index, selected_id)| {
-                            GpuNativeDemandExpert::install(
-                                selected_id,
-                                residents
-                                    .get(&selected_id)
-                                    .expect("bounded recovery acquired every selected source")
-                                    .clone(),
-                                admissions[index].clone(),
-                            )
-                        })
-                        .collect();
+                    // The loop re-probes the whole selected set, but only the
+                    // now-missing members may acquire source/admission state.
                 }
                 Err(GpuNativeTieredResidencyError::DemandSourceMissing { global_id }) => {
                     return Err(
@@ -6959,6 +6965,16 @@ mod tests {
         );
     }
 
+    #[test]
+    fn gpu_native_physical_partition_skips_hits_and_preserves_miss_order() {
+        let selected = [7, 3, 11, 5];
+        assert!(gpu_native_physical_missing_ids(&selected, &[true; 4]).is_empty());
+        assert_eq!(
+            gpu_native_physical_missing_ids(&selected, &[true, false, true, false]),
+            vec![3, 5]
+        );
+    }
+
     fn build_engine(
         data_dir: &std::path::Path,
         num_experts: u32,
@@ -7016,6 +7032,36 @@ mod tests {
                 hidden_seed: seed,
             },
         ))
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn gpu_native_demand_source_reuses_ram_without_duplicate_nvme_read() {
+        let dir = TempDir::new("gpu-native-demand-source");
+        let engine = build_engine(&dir.path, 4, 8, 8, 2, 1, 1, 17);
+        assert_eq!(engine.report().bytes_read, 0);
+
+        let mut first_request = HashMap::new();
+        let first = engine
+            .gpu_native_demand_source(0, &mut first_request)
+            .await
+            .unwrap();
+        let after_nvme = engine.report().bytes_read;
+        assert_eq!(after_nvme, engine.core.storage.config().expert_size as u64);
+
+        let mut second_request = HashMap::new();
+        let ram_hit = engine
+            .gpu_native_demand_source(0, &mut second_request)
+            .await
+            .unwrap();
+        assert!(Arc::ptr_eq(&first, &ram_hit));
+        assert_eq!(engine.report().bytes_read, after_nvme);
+
+        let same_request = engine
+            .gpu_native_demand_source(0, &mut second_request)
+            .await
+            .unwrap();
+        assert!(Arc::ptr_eq(&ram_hit, &same_request));
+        assert_eq!(engine.report().bytes_read, after_nvme);
     }
 
     #[test]

--- a/rust-engine/src/engine.rs
+++ b/rust-engine/src/engine.rs
@@ -2458,6 +2458,164 @@ impl Engine {
         })
     }
 
+    /// Diagnostic-only internal-stage attribution for one exact Q4_0 expert.
+    /// It fetches the canonical production payload, observes the unchanged
+    /// Candle reference sequence, and constructs host-only mixed replays. No
+    /// result from this method is admitted back into production execution.
+    pub(crate) async fn diagnose_q4_0_expert_stages(
+        self: &Arc<Self>,
+        global_expert_id: u32,
+        gpu_effective_input: &[f32],
+        actual_gpu_gate: &[f32],
+        actual_gpu_up: &[f32],
+        actual_gpu_gated: &[f32],
+    ) -> Result<crate::inference::Q4ExpertStageDiagnosticBundle, String> {
+        use sha2::{Digest, Sha256};
+
+        if self.core.options.dtype != WeightDtype::Q4_0
+            || self.execution_context().plan().routed_experts()
+                != crate::backend::ExecutionPlane::Cpu
+            || self.core.options.policy != crate::inference::RealInferencePolicy::STRICT
+        {
+            return Err(
+                "Q4 stage attribution requires a strict CPU Q4_0 routed-expert plan".to_string(),
+            );
+        }
+        if gpu_effective_input.len() != self.core.shape.d_model
+            || actual_gpu_gate.len() != self.core.shape.d_ff
+            || actual_gpu_up.len() != self.core.shape.d_ff
+            || actual_gpu_gated.len() != self.core.shape.d_ff
+            || gpu_effective_input
+                .iter()
+                .chain(actual_gpu_gate)
+                .chain(actual_gpu_up)
+                .chain(actual_gpu_gated)
+                .any(|value| !value.is_finite())
+        {
+            return Err("Q4 stage attribution received nonfinite or malformed vectors".to_string());
+        }
+
+        self.core
+            .storage
+            .validate_expert_file_layout(std::iter::once(global_expert_id))
+            .map_err(|error| {
+                format!(
+                    "global expert {global_expert_id} does not have the exact configured checkpoint file size: {error}"
+                )
+            })?;
+        let expected_payload = crate::inference::expert_weight_bytes_for(
+            self.core.shape.d_model,
+            self.core.shape.d_ff,
+            WeightDtype::Q4_0,
+        );
+        let block_align = self.core.storage.config().block_align;
+        let checkpoint_payload_bytes =
+            crate::q4_parity::aligned_checkpoint_payload_bytes(expected_payload, block_align)?;
+        let resident = self
+            .fetch_with_retry(global_expert_id)
+            .await
+            .map_err(|error| {
+                format!("failed to fetch global expert {global_expert_id}: {error}")
+            })?;
+        if resident.data().len() != checkpoint_payload_bytes {
+            return Err(format!(
+                "global expert {global_expert_id} checkpoint payload has {} bytes, expected {checkpoint_payload_bytes}",
+                resident.data().len()
+            ));
+        }
+        let (payload, padding) = resident.data().split_at(expected_payload);
+        if padding.iter().any(|byte| *byte != 0) {
+            return Err(format!(
+                "global expert {global_expert_id} has non-zero checkpoint alignment padding"
+            ));
+        }
+        let weights = crate::inference::OwnedExpertWeights::from_bytes_q4_0_with_tolerance(
+            payload,
+            self.core.shape.d_model,
+            self.core.shape.d_ff,
+            0,
+        )
+        .map_err(|error| format!("CPU Q4 stage weights failed: {error}"))?;
+        let cpu_boundary_input =
+            crate::numerical_diagnostics::round_trip_f16_values(gpu_effective_input)
+                .map_err(|error| format!("CPU input boundary emulation failed: {error}"))?;
+        let cpu_production = weights
+            .diagnostic_forward_stage_trace(&cpu_boundary_input)
+            .map_err(|error| format!("CPU production stage trace failed: {error}"))?;
+        let ordinary_cpu = crate::inference::q4_0_cpu_reference_forward(
+            payload,
+            &cpu_boundary_input,
+            self.core.shape.d_model,
+            self.core.shape.d_ff,
+        )
+        .map_err(|error| format!("ordinary CPU production expert failed: {error}"))?;
+        if ordinary_cpu
+            .iter()
+            .map(|value| value.to_bits())
+            .ne(cpu_production.down.iter().map(|value| value.to_bits()))
+        {
+            return Err(
+                "CPU diagnostic stage final output differs from ordinary production output"
+                    .to_string(),
+            );
+        }
+        let cpu_effective_output =
+            crate::numerical_diagnostics::round_trip_f16_values(&cpu_production.down)
+                .map_err(|error| format!("CPU output boundary emulation failed: {error}"))?;
+        let current_gpu_emulation = crate::inference::diagnostic_q4_0_expert_arithmetic(
+            payload,
+            gpu_effective_input,
+            self.core.shape.d_model,
+            self.core.shape.d_ff,
+            crate::inference::DiagnosticQ4DotArithmetic::CurrentGpu,
+        )
+        .map_err(|error| format!("current-GPU arithmetic emulation failed: {error}"))?;
+        let rejected_logical_dequant_emulation =
+            crate::inference::diagnostic_q4_0_expert_arithmetic(
+                payload,
+                gpu_effective_input,
+                self.core.shape.d_model,
+                self.core.shape.d_ff,
+                crate::inference::DiagnosticQ4DotArithmetic::RejectedLogicalDequant,
+            )
+            .map_err(|error| format!("rejected logical-dequant emulation failed: {error}"))?;
+        let gpu_gate_up_through_cpu_swiglu_down = weights
+            .diagnostic_replay_gate_up(actual_gpu_gate, actual_gpu_up)
+            .map_err(|error| format!("GPU gate/up CPU replay failed: {error}"))?;
+        let gpu_gated_through_cpu_down = weights
+            .diagnostic_replay_down(actual_gpu_gated)
+            .map_err(|error| format!("GPU gated CPU-down replay failed: {error}"))?;
+        let cpu_gated_through_current_gpu_down = crate::inference::diagnostic_q4_0_down_arithmetic(
+            payload,
+            &cpu_production.gated,
+            self.core.shape.d_model,
+            self.core.shape.d_ff,
+            crate::inference::DiagnosticQ4DotArithmetic::CurrentGpu,
+        )
+        .map_err(|error| format!("CPU gated current-GPU down replay failed: {error}"))?;
+        let gpu_gated_through_current_gpu_down = crate::inference::diagnostic_q4_0_down_arithmetic(
+            payload,
+            actual_gpu_gated,
+            self.core.shape.d_model,
+            self.core.shape.d_ff,
+            crate::inference::DiagnosticQ4DotArithmetic::CurrentGpu,
+        )
+        .map_err(|error| format!("GPU gated current-GPU down replay failed: {error}"))?;
+
+        Ok(crate::inference::Q4ExpertStageDiagnosticBundle {
+            canonical_payload_sha256: format!("{:x}", Sha256::digest(payload)),
+            cpu_boundary_input,
+            cpu_production,
+            cpu_effective_output,
+            current_gpu_emulation,
+            rejected_logical_dequant_emulation,
+            gpu_gate_up_through_cpu_swiglu_down,
+            gpu_gated_through_cpu_down,
+            cpu_gated_through_current_gpu_down,
+            gpu_gated_through_current_gpu_down,
+        })
+    }
+
     /// Snapshot the qualification-only real routed-expert execution counters.
     pub fn routed_expert_execution_snapshot(&self) -> RoutedExpertExecutionSnapshot {
         RoutedExpertExecutionSnapshot {

--- a/rust-engine/src/engine.rs
+++ b/rust-engine/src/engine.rs
@@ -2381,7 +2381,9 @@ impl Engine {
         let resident = self
             .fetch_with_retry(global_expert_id)
             .await
-            .map_err(|error| format!("failed to fetch global expert {global_expert_id}: {error}"))?;
+            .map_err(|error| {
+                format!("failed to fetch global expert {global_expert_id}: {error}")
+            })?;
         if resident.data().len() != checkpoint_payload_bytes {
             return Err(format!(
                 "global expert {global_expert_id} checkpoint payload has {} bytes, expected exactly {checkpoint_payload_bytes} ({expected_payload} canonical Q4_0 bytes plus alignment padding)",
@@ -2456,6 +2458,89 @@ impl Engine {
             checkpoint_payload_sha256,
             dispatches,
         })
+    }
+
+    /// Diagnostic-only replay of one frozen exact-f32 GPU expert input through
+    /// the old boundary-emulated CPU reference, the ordinary production CPU
+    /// Q4 reference, and the existing current-GPU arithmetic emulator. The
+    /// canonical payload hash is checked before any arithmetic is performed.
+    pub(crate) async fn audit_q4_0_f32_reference_boundary(
+        self: &Arc<Self>,
+        global_expert_id: u32,
+        exact_gpu_f32_input: &[f32],
+        expected_canonical_payload_sha256: &str,
+    ) -> Result<crate::gpu_native_f32_reference_boundary_audit::Q4F32ReferenceReplayBundle, String>
+    {
+        use sha2::{Digest, Sha256};
+
+        if self.core.options.dtype != WeightDtype::Q4_0
+            || self.execution_context().plan().routed_experts()
+                != crate::backend::ExecutionPlane::Cpu
+            || self.core.options.policy != crate::inference::RealInferencePolicy::STRICT
+        {
+            return Err(
+                "f32 reference-boundary audit requires a strict CPU Q4_0 routed-expert plan"
+                    .to_string(),
+            );
+        }
+        if exact_gpu_f32_input.len() != self.core.shape.d_model
+            || exact_gpu_f32_input.iter().any(|value| !value.is_finite())
+            || expected_canonical_payload_sha256.len() != 64
+            || !expected_canonical_payload_sha256
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit())
+        {
+            return Err(
+                "f32 reference-boundary audit received malformed input or payload identity"
+                    .to_string(),
+            );
+        }
+        self.core
+            .storage
+            .validate_expert_file_layout(std::iter::once(global_expert_id))
+            .map_err(|error| {
+                format!(
+                    "global expert {global_expert_id} does not have the exact configured checkpoint file size: {error}"
+                )
+            })?;
+        let expected_payload = crate::inference::expert_weight_bytes_for(
+            self.core.shape.d_model,
+            self.core.shape.d_ff,
+            WeightDtype::Q4_0,
+        );
+        let checkpoint_payload_bytes = crate::q4_parity::aligned_checkpoint_payload_bytes(
+            expected_payload,
+            self.core.storage.config().block_align,
+        )?;
+        let resident = self
+            .fetch_with_retry(global_expert_id)
+            .await
+            .map_err(|error| format!("failed to fetch global expert {global_expert_id}: {error}"))?;
+        if resident.data().len() != checkpoint_payload_bytes {
+            return Err(format!(
+                "global expert {global_expert_id} checkpoint payload has {} bytes, expected {checkpoint_payload_bytes}",
+                resident.data().len()
+            ));
+        }
+        let (payload, padding) = resident.data().split_at(expected_payload);
+        if padding.iter().any(|byte| *byte != 0) {
+            return Err(format!(
+                "global expert {global_expert_id} has non-zero checkpoint alignment padding"
+            ));
+        }
+        let canonical_payload_sha256 = format!("{:x}", Sha256::digest(payload));
+        if !canonical_payload_sha256.eq_ignore_ascii_case(expected_canonical_payload_sha256) {
+            return Err(format!(
+                "global expert {global_expert_id} canonical Q4 payload SHA differs: observed {canonical_payload_sha256} expected {expected_canonical_payload_sha256}"
+            ));
+        }
+        crate::gpu_native_f32_reference_boundary_audit::audit_q4_reference_paths(
+            payload,
+            exact_gpu_f32_input,
+            self.core.shape.d_model,
+            self.core.shape.d_ff,
+            canonical_payload_sha256,
+        )
     }
 
     /// Diagnostic-only internal-stage attribution for one exact Q4_0 expert.

--- a/rust-engine/src/engine.rs
+++ b/rust-engine/src/engine.rs
@@ -44,9 +44,10 @@ use dashmap::DashMap;
 use hdrhistogram::Histogram;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::future::Future;
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use tokio::sync::Notify;
 use tracing::{debug, info, warn};
 
@@ -1585,6 +1586,144 @@ impl EngineMetrics {
     }
 }
 
+/// Explicit lifecycle for asynchronous work owned by an [`Engine`].
+///
+/// Background promotion and speculative-prefetch tasks used to be detached
+/// `tokio::spawn` calls. Several of those futures own an `Arc<Engine>`, so
+/// dropping the caller's last runtime handle was not sufficient to retire the
+/// engine or any resource family reachable through it. This controller stops
+/// new admissions, cooperatively cancels every registered future, and retains
+/// abort handles only as a bounded fallback for work that does not yield
+/// promptly. It never owns a task future or an `Arc<Engine>` itself.
+struct EngineBackgroundTasks {
+    shutdown_requested: AtomicBool,
+    active: AtomicUsize,
+    state: parking_lot::Mutex<EngineBackgroundTaskState>,
+    shutdown_notify: Notify,
+    idle_notify: Notify,
+}
+
+#[derive(Default)]
+struct EngineBackgroundTaskState {
+    abort_handles: Vec<tokio::task::AbortHandle>,
+}
+
+struct EngineBackgroundTaskGuard {
+    owner: Arc<EngineBackgroundTasks>,
+}
+
+impl Drop for EngineBackgroundTaskGuard {
+    fn drop(&mut self) {
+        if self.owner.active.fetch_sub(1, Ordering::AcqRel) == 1 {
+            self.owner.idle_notify.notify_waiters();
+        }
+    }
+}
+
+impl EngineBackgroundTasks {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            shutdown_requested: AtomicBool::new(false),
+            active: AtomicUsize::new(0),
+            state: parking_lot::Mutex::new(EngineBackgroundTaskState::default()),
+            shutdown_notify: Notify::new(),
+            idle_notify: Notify::new(),
+        })
+    }
+
+    #[inline]
+    fn accepts_work(&self) -> bool {
+        !self.shutdown_requested.load(Ordering::Acquire)
+    }
+
+    /// Register and detach one runtime-owned background future.
+    ///
+    /// The state lock makes the admission check and handle registration atomic
+    /// with respect to `shutdown`: once shutdown flips the flag while holding
+    /// the same lock, no later task can escape registration.
+    fn spawn<F>(self: &Arc<Self>, future: F) -> bool
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        let mut state = self.state.lock();
+        if !self.accepts_work() {
+            return false;
+        }
+        state.abort_handles.retain(|handle| !handle.is_finished());
+        self.active.fetch_add(1, Ordering::AcqRel);
+        let owner = self.clone();
+        let cancellation = self.clone();
+        let handle = tokio::spawn(async move {
+            let _guard = EngineBackgroundTaskGuard { owner };
+            tokio::select! {
+                biased;
+                _ = cancellation.cancelled() => {}
+                _ = future => {}
+            }
+        });
+        state.abort_handles.push(handle.abort_handle());
+        true
+    }
+
+    async fn cancelled(&self) {
+        if self.shutdown_requested.load(Ordering::Acquire) {
+            return;
+        }
+        let notified = self.shutdown_notify.notified();
+        if self.shutdown_requested.load(Ordering::Acquire) {
+            return;
+        }
+        notified.await;
+    }
+
+    async fn wait_for_idle(&self, timeout: Duration) -> bool {
+        let wait = async {
+            loop {
+                let notified = self.idle_notify.notified();
+                if self.active.load(Ordering::Acquire) == 0 {
+                    return;
+                }
+                notified.await;
+            }
+        };
+        tokio::time::timeout(timeout, wait).await.is_ok()
+    }
+
+    async fn shutdown(&self) -> Result<(), String> {
+        const COOPERATIVE_GRACE: Duration = Duration::from_secs(1);
+        const ABORT_GRACE: Duration = Duration::from_secs(4);
+
+        let abort_handles = {
+            let mut state = self.state.lock();
+            self.shutdown_requested.store(true, Ordering::Release);
+            state.abort_handles.retain(|handle| !handle.is_finished());
+            state.abort_handles.clone()
+        };
+        self.shutdown_notify.notify_waiters();
+
+        if self.wait_for_idle(COOPERATIVE_GRACE).await {
+            self.state.lock().abort_handles.clear();
+            return Ok(());
+        }
+
+        // Speculation and logical-GPU promotion are best-effort background
+        // work. Aborting their futures is resource-safe: buffer, semaphore,
+        // singleflight, and promotion claims all have drop/error cleanup.
+        for handle in abort_handles {
+            handle.abort();
+        }
+        if self.wait_for_idle(ABORT_GRACE).await {
+            self.state.lock().abort_handles.clear();
+            Ok(())
+        } else {
+            Err(format!(
+                "engine background tasks remained active after controlled shutdown: active={}",
+                self.active.load(Ordering::Acquire)
+            ))
+        }
+    }
+}
+
 /// Top-level façade: composes [`EngineCore`] (MoE/IO), [`EngineSpeculation`]
 /// (aliasing, locality, neural speculator) and [`EngineMetrics`]
 /// (histograms, counters, Prometheus / trace sinks).
@@ -1596,6 +1735,7 @@ pub struct Engine {
     pub(crate) core: EngineCore,
     pub(crate) speculation: EngineSpeculation,
     pub(crate) metrics: EngineMetrics,
+    background_tasks: Arc<EngineBackgroundTasks>,
     diagnostic_cpu_q4_boundary_emulation: std::sync::atomic::AtomicBool,
     diagnostic_cpu_q4_boundary_emulated_dispatches: AtomicU64,
     diagnostic_route_capture_armed: std::sync::atomic::AtomicBool,
@@ -1953,6 +2093,7 @@ impl Engine {
             ),
             speculation: EngineSpeculation::new(speculator_topk_default),
             metrics: EngineMetrics::new(),
+            background_tasks: EngineBackgroundTasks::new(),
             diagnostic_cpu_q4_boundary_emulation: std::sync::atomic::AtomicBool::new(false),
             diagnostic_cpu_q4_boundary_emulated_dispatches: AtomicU64::new(0),
             diagnostic_route_capture_armed: std::sync::atomic::AtomicBool::new(false),
@@ -2639,7 +2780,7 @@ impl Engine {
         if let Some(p) = prom_for_task.as_ref() {
             p.set_vram_capacity_bytes(gpu.capacity_bytes() as u64);
         }
-        tokio::spawn(async move {
+        let spawned = self.background_tasks.spawn(async move {
             while let Some((id, resident)) = rx.recv().await {
                 // Existing LRU admissions graduate atomically without a host
                 // payload copy. Absent ids copy outside the cache mutex and
@@ -2653,8 +2794,20 @@ impl Engine {
                 );
             }
         });
+        debug_assert!(
+            spawned,
+            "a newly built engine must accept GPU promotion work"
+        );
         self.core.gpu_cache = Some(gpu.clone());
         self.core.gpu_promotion_tx = Some(tx);
+    }
+
+    /// Stop admission and deterministically retire every anonymous async task
+    /// owned by this engine. Isolated qualification runtimes call this before
+    /// dropping their strong engine handle; ordinary steady-state serving is
+    /// unchanged until a caller explicitly requests shutdown.
+    pub(crate) async fn shutdown_background_tasks(&self) -> Result<(), String> {
+        self.background_tasks.shutdown().await
     }
 
     /// **Test-only** wiring of the GPU promotion channel without
@@ -3059,14 +3212,16 @@ impl Engine {
                 // the (previously dead) `prefetch_used` counter so the
                 // run summary can report end-to-end prefetch precision.
                 self.credit_prefetch_use(&r, new_hits);
-                if let (Some(gpu), Some(tx)) = (
-                    self.core.gpu_cache.as_ref(),
-                    self.core.gpu_promotion_tx.as_ref(),
-                ) {
-                    if gpu.claim_promotion(id, new_hits)
-                        && tx.send((id, r.clone())).is_err()
-                    {
-                        gpu.cancel_promotion(id);
+                if self.background_tasks.accepts_work() {
+                    if let (Some(gpu), Some(tx)) = (
+                        self.core.gpu_cache.as_ref(),
+                        self.core.gpu_promotion_tx.as_ref(),
+                    ) {
+                        if gpu.claim_promotion(id, new_hits)
+                            && tx.send((id, r.clone())).is_err()
+                        {
+                            gpu.cancel_promotion(id);
+                        }
                     }
                 }
                 residents[i] = Some(r);
@@ -3759,6 +3914,9 @@ impl Engine {
         resident: Arc<ExpertResident>,
         p: f64,
     ) {
+        if !self.background_tasks.accepts_work() {
+            return;
+        }
         let id = resident.id;
         // This is the prediction's one and only governor decision. A PCIe
         // write does not call `record_completed`; that denominator remains
@@ -3781,7 +3939,7 @@ impl Engine {
             }
         };
         let me = self.clone();
-        tokio::spawn(async move {
+        self.background_tasks.spawn(async move {
             let _permit = permit;
             let Some(admission) = me.ensure_speculative_gpu_admission(&resident) else {
                 return;
@@ -3808,6 +3966,9 @@ impl Engine {
     }
 
     fn spawn_prefetch(self: &Arc<Self>, id: u32, p: f64) {
+        if !self.background_tasks.accepts_work() {
+            return;
+        }
         if let Some(manager) = self.core.gpu_native_residency.as_ref().cloned() {
             match manager.probe_speculative(
                 id,
@@ -3885,7 +4046,7 @@ impl Engine {
             }
         };
         let me = self.clone();
-        tokio::spawn(async move {
+        self.background_tasks.spawn(async move {
             // Permit released on task completion (drop). Holding it
             // across the I/O is what enforces the bound.
             let _permit = permit;
@@ -5351,18 +5512,20 @@ impl Engine {
                 // first hit on a shadow-backed resident is a prefetch
                 // that paid off. No-op when the governor is disabled.
                 self.credit_prefetch_use(&r, new_hits);
-                if let (Some(gpu), Some(tx)) = (
-                    self.core.gpu_cache.as_ref(),
-                    self.core.gpu_promotion_tx.as_ref(),
-                ) {
-                    // One outstanding claim prevents queue flooding while
-                    // allowing a new request after logical eviction, even
-                    // though the RAM resident's hit count no longer has a
-                    // fresh threshold-crossing edge.
-                    if gpu.claim_promotion(id, new_hits)
-                        && tx.send((id, r.clone())).is_err()
-                    {
-                        gpu.cancel_promotion(id);
+                if self.background_tasks.accepts_work() {
+                    if let (Some(gpu), Some(tx)) = (
+                        self.core.gpu_cache.as_ref(),
+                        self.core.gpu_promotion_tx.as_ref(),
+                    ) {
+                        // One outstanding claim prevents queue flooding while
+                        // allowing a new request after logical eviction, even
+                        // though the RAM resident's hit count no longer has a
+                        // fresh threshold-crossing edge.
+                        if gpu.claim_promotion(id, new_hits)
+                            && tx.send((id, r.clone())).is_err()
+                        {
+                            gpu.cancel_promotion(id);
+                        }
                     }
                 }
                 residents[i] = Some(r);
@@ -8200,6 +8363,72 @@ mod tests {
         );
         // Sanity: the report surface mirrors the counter.
         assert_eq!(engine.report().prefetch_dropped_concurrency, dropped);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn controlled_shutdown_cancels_in_flight_engine_owned_background_work() {
+        let dir = TempDir::new("controlled-background-shutdown");
+        let engine = build_engine(&dir.path, 4, 16, 32, 2, 1, 1, 0x5A17);
+        let weak_engine = Arc::downgrade(&engine);
+
+        // Test seam with the exact ownership shape of spawn_prefetch: the
+        // detached future owns Arc<Engine> and otherwise cannot finish. The
+        // old untracked spawn design would keep the full engine graph alive.
+        let task_engine = engine.clone();
+        assert!(engine.background_tasks.spawn(async move {
+            std::future::pending::<()>().await;
+            drop(task_engine);
+        }));
+        assert_eq!(engine.background_tasks.active.load(Ordering::Acquire), 1);
+        assert!(weak_engine.strong_count() >= 2);
+
+        engine.shutdown_background_tasks().await.unwrap();
+        assert!(!engine.background_tasks.accepts_work());
+        assert_eq!(engine.background_tasks.active.load(Ordering::Acquire), 0);
+
+        // Shutdown is an admission boundary: neither direct tracker users nor
+        // the real speculative-prefetch producer may create later work.
+        assert!(!engine.background_tasks.spawn(std::future::pending::<()>()));
+        engine.spawn_prefetch(0, 0.5);
+        assert_eq!(engine.background_tasks.active.load(Ordering::Acquire), 0);
+
+        drop(engine);
+        assert!(weak_engine.upgrade().is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn controlled_shutdown_prevents_cross_engine_cache_and_counter_contamination() {
+        let first_dir = TempDir::new("isolated-runtime-a");
+        let first = build_engine(&first_dir.path, 4, 16, 32, 2, 1, 1, 0xA11CE);
+        first.warm_with(&[0]).await.unwrap();
+        let _ = first.generate(0).await.unwrap();
+        assert!(first.core.cache.len() > 0);
+        assert!(first.report().tokens_processed > 0);
+
+        // Include work in flight so this is not merely a clean empty-engine
+        // drop. It retains the same Arc<Engine> graph as speculation.
+        let task_engine = first.clone();
+        assert!(first.background_tasks.spawn(async move {
+            std::future::pending::<()>().await;
+            drop(task_engine);
+        }));
+        first.shutdown_background_tasks().await.unwrap();
+        drop(first);
+
+        let second_dir = TempDir::new("isolated-runtime-b");
+        let second = build_engine(&second_dir.path, 4, 16, 32, 2, 1, 1, 0xB0B);
+        let report = second.report();
+        assert_eq!(second.core.cache.len(), 0);
+        assert_eq!(report.tokens_processed, 0);
+        assert_eq!(report.hits, 0);
+        assert_eq!(report.misses, 0);
+        assert_eq!(report.bytes_read, 0);
+        assert_eq!(
+            second.routed_expert_execution_snapshot(),
+            RoutedExpertExecutionSnapshot::default()
+        );
+        assert!(second.gpu_expert_io_snapshot().is_none());
+        second.shutdown_background_tasks().await.unwrap();
     }
 
     /// Regression test for the post-`predict_min_prob` panic:

--- a/rust-engine/src/expert_cache.rs
+++ b/rust-engine/src/expert_cache.rs
@@ -648,7 +648,26 @@ impl GpuLookup {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum GpuDemandAdmissionError {
     EmptyPayload,
-    PayloadExceedsLruCapacity { bytes: usize, capacity: usize },
+    PayloadExceedsLruCapacity {
+        bytes: usize,
+        capacity: usize,
+    },
+    DuplicateDemandExpert {
+        expert_id: u32,
+    },
+    DemandSourceIdentityMismatch {
+        selected_id: u32,
+        source_id: u32,
+    },
+    DemandSetExceedsLruCapacity {
+        required_bytes: usize,
+        capacity: usize,
+    },
+    ProtectedDemandCapacity {
+        required_bytes: usize,
+        protected_bytes: usize,
+        capacity: usize,
+    },
     GenerationExhausted,
 }
 
@@ -656,6 +675,19 @@ pub enum GpuDemandAdmissionError {
 pub enum GpuDemandAdmissionPreflight {
     AlreadyAdmitted,
     NeedsPayload,
+}
+
+/// Atomic result of resolving one complete foreground selected-expert set.
+pub enum GpuDemandSetAdmission {
+    /// Every selected id has a current logical admission. Existing identities
+    /// are retained and `newly_admitted` counts only genuinely new identities.
+    Ready {
+        admissions: Vec<GpuAdmission>,
+        newly_admitted: usize,
+    },
+    /// The cache needs owned payloads for these currently absent selected ids.
+    /// No logical state was changed.
+    PayloadRequired(Vec<u32>),
 }
 
 /// Precise result of one threshold-driven logical GPU promotion attempt.
@@ -702,6 +734,31 @@ impl std::fmt::Display for GpuDemandAdmissionError {
             Self::PayloadExceedsLruCapacity { bytes, capacity } => write!(
                 f,
                 "expert payload {bytes} bytes exceeds logical GPU demand LRU capacity {capacity} bytes"
+            ),
+            Self::DuplicateDemandExpert { expert_id } => {
+                write!(f, "logical GPU demand set repeats expert {expert_id}")
+            }
+            Self::DemandSourceIdentityMismatch {
+                selected_id,
+                source_id,
+            } => write!(
+                f,
+                "logical GPU demand source expert {source_id} does not match selected expert {selected_id}"
+            ),
+            Self::DemandSetExceedsLruCapacity {
+                required_bytes,
+                capacity,
+            } => write!(
+                f,
+                "selected logical GPU demand set requires {required_bytes} LRU bytes but capacity is {capacity} bytes"
+            ),
+            Self::ProtectedDemandCapacity {
+                required_bytes,
+                protected_bytes,
+                capacity,
+            } => write!(
+                f,
+                "logical GPU demand requires {required_bytes} bytes but {protected_bytes} bytes are protected within {capacity}-byte LRU capacity"
             ),
             Self::GenerationExhausted => {
                 f.write_str("logical GPU admission generation space exhausted")
@@ -757,6 +814,36 @@ pub struct GpuExpertCache {
     misses: AtomicU64,
 }
 
+/// RAII protection for one complete foreground selected-expert set.
+///
+/// The guard records ids in cache metadata but never retains the cache mutex,
+/// so it is safe to hold across async RAM/NVMe acquisition. Every logical LRU
+/// eviction path consults this registry. Dropping the guard releases only this
+/// transaction's references, allowing overlapping demand sets to share ids.
+pub struct GpuDemandSetProtection {
+    cache: Arc<GpuExpertCache>,
+    expert_ids: Vec<u32>,
+}
+
+impl Drop for GpuDemandSetProtection {
+    fn drop(&mut self) {
+        let mut g = self.cache.inner.lock();
+        for expert_id in &self.expert_ids {
+            let remove = {
+                let count = g
+                    .demand_protections
+                    .get_mut(expert_id)
+                    .expect("foreground demand protection must remain registered");
+                *count -= 1;
+                *count == 0
+            };
+            if remove {
+                g.demand_protections.remove(expert_id);
+            }
+        }
+    }
+}
+
 struct GpuExpertCacheInner {
     /// **Anchor Core** — permanently pinned high-frequency experts.
     anchor: HashMap<u32, GpuAdmission>,
@@ -776,6 +863,10 @@ struct GpuExpertCacheInner {
     /// a fresh hit-count edge. Consuming this marker prevents a failed or
     /// oversized promotion from retrying on every later RAM hit.
     promotion_rearm: HashSet<u32>,
+    /// Reference-counted selected ids protected by in-flight foreground
+    /// demand-set transactions. This is metadata only; no lock is retained
+    /// while a transaction performs async source acquisition.
+    demand_protections: HashMap<u32, usize>,
 }
 
 impl GpuExpertCacheInner {
@@ -784,6 +875,41 @@ impl GpuExpertCacheInner {
         self.next_generation = generation.checked_add(1)?;
         Some(generation)
     }
+}
+
+fn logical_lru_is_protected(
+    inner: &GpuExpertCacheInner,
+    expert_id: u32,
+    additionally_protected: &HashSet<u32>,
+) -> bool {
+    additionally_protected.contains(&expert_id)
+        || inner
+            .demand_protections
+            .get(&expert_id)
+            .is_some_and(|count| *count > 0)
+}
+
+fn oldest_unprotected_logical_lru(
+    inner: &GpuExpertCacheInner,
+    additionally_protected: &HashSet<u32>,
+) -> Option<u32> {
+    inner.lru.iter().rev().find_map(|(&expert_id, _)| {
+        (!logical_lru_is_protected(inner, expert_id, additionally_protected)).then_some(expert_id)
+    })
+}
+
+fn unprotected_logical_lru_bytes(
+    inner: &GpuExpertCacheInner,
+    additionally_protected: &HashSet<u32>,
+) -> usize {
+    inner
+        .lru
+        .iter()
+        .filter_map(|(&expert_id, admission)| {
+            (!logical_lru_is_protected(inner, expert_id, additionally_protected))
+                .then_some(admission.byte_len())
+        })
+        .sum()
 }
 
 impl GpuExpertCache {
@@ -813,6 +939,7 @@ impl GpuExpertCache {
                 next_generation: 1,
                 promotion_pending: HashSet::new(),
                 promotion_rearm: HashSet::new(),
+                demand_protections: HashMap::new(),
             }),
             anchor_capacity_bytes,
             lru_capacity_bytes,
@@ -1001,6 +1128,16 @@ impl GpuExpertCache {
             g.promotion_rearm.remove(&id);
             return GpuHotPromotionOutcome::NoCapacity;
         }
+        if !use_anchor {
+            let additionally_protected = HashSet::new();
+            let required_bytes = g.lru_used_bytes.saturating_add(bytes);
+            let bytes_to_evict = required_bytes.saturating_sub(self.lru_capacity_bytes);
+            if bytes_to_evict > unprotected_logical_lru_bytes(&g, &additionally_protected) {
+                g.promotion_pending.remove(&id);
+                g.promotion_rearm.remove(&id);
+                return GpuHotPromotionOutcome::NoCapacity;
+            }
+        }
         let Some(generation) = g.allocate_generation() else {
             g.promotion_pending.remove(&id);
             g.promotion_rearm.remove(&id);
@@ -1018,15 +1155,18 @@ impl GpuExpertCache {
                 .expect("logical GPU anchor byte overflow after capacity check");
             GpuHotPromotionOutcome::InstalledAnchor
         } else {
+            let additionally_protected = HashSet::new();
             while g
                 .lru_used_bytes
                 .checked_add(bytes)
                 .is_none_or(|used| used > self.lru_capacity_bytes)
             {
-                let (evicted_id, victim) = g
+                let evicted_id = oldest_unprotected_logical_lru(&g, &additionally_protected)
+                    .expect("hot capacity preflight proved an unprotected logical victim");
+                let victim = g
                     .lru
-                    .pop_lru()
-                    .expect("hot payload fits an empty LRU by prior capacity check");
+                    .pop(&evicted_id)
+                    .expect("selected hot logical victim remained under cache lock");
                 g.lru_used_bytes = g
                     .lru_used_bytes
                     .checked_sub(victim.byte_len())
@@ -1142,6 +1282,14 @@ impl GpuExpertCache {
         if !use_anchor && bytes > self.lru_capacity_bytes {
             return false;
         }
+        if !use_anchor {
+            let additionally_protected = HashSet::new();
+            let required_bytes = g.lru_used_bytes.saturating_add(bytes);
+            let bytes_to_evict = required_bytes.saturating_sub(self.lru_capacity_bytes);
+            if bytes_to_evict > unprotected_logical_lru_bytes(&g, &additionally_protected) {
+                return false;
+            }
+        }
         let Some(generation) = g.allocate_generation() else {
             return false;
         };
@@ -1159,18 +1307,20 @@ impl GpuExpertCache {
         }
         // Evict LRU entries until there is room. `LruCache::pop_lru`
         // returns the least-recently-used (k, v).
+        let additionally_protected = HashSet::new();
         while g
             .lru_used_bytes
             .checked_add(bytes)
             .is_none_or(|used| used > self.lru_capacity_bytes)
         {
-            match g.lru.pop_lru() {
-                Some((evicted_id, victim)) => {
-                    g.lru_used_bytes = g.lru_used_bytes.saturating_sub(victim.byte_len());
-                    g.promotion_rearm.insert(evicted_id);
-                }
-                None => break,
-            }
+            let evicted_id = oldest_unprotected_logical_lru(&g, &additionally_protected)
+                .expect("promotion capacity preflight proved an unprotected logical victim");
+            let victim = g
+                .lru
+                .pop(&evicted_id)
+                .expect("selected promotion victim remained under cache lock");
+            g.lru_used_bytes = g.lru_used_bytes.saturating_sub(victim.byte_len());
+            g.promotion_rearm.insert(evicted_id);
         }
         let already = g.lru.put(admission.resident.id, admission);
         if let Some(prev) = already {
@@ -1245,6 +1395,213 @@ impl GpuExpertCache {
         true
     }
 
+    /// Protect one complete foreground selected-expert set from logical LRU
+    /// eviction until the returned guard is dropped. Registration is atomic,
+    /// but the guard holds no mutex and may cross async RAM/NVMe awaits.
+    pub fn protect_demand_set(
+        self: &Arc<Self>,
+        expert_ids: &[u32],
+    ) -> Result<GpuDemandSetProtection, GpuDemandAdmissionError> {
+        let mut seen = HashSet::with_capacity(expert_ids.len());
+        for &expert_id in expert_ids {
+            if !seen.insert(expert_id) {
+                return Err(GpuDemandAdmissionError::DuplicateDemandExpert { expert_id });
+            }
+        }
+
+        let mut g = self.inner.lock();
+        for &expert_id in expert_ids {
+            let count = g.demand_protections.entry(expert_id).or_insert(0);
+            *count = count
+                .checked_add(1)
+                .expect("foreground demand protection reference count overflowed");
+        }
+        drop(g);
+        Ok(GpuDemandSetProtection {
+            cache: self.clone(),
+            expert_ids: expert_ids.to_vec(),
+        })
+    }
+
+    /// Resolve a complete foreground selected-expert set as one logical
+    /// transaction. Existing admissions retain their exact generation and
+    /// payload. Missing admissions are installed together after evicting only
+    /// non-selected, non-protected LRU entries. Every validation and capacity
+    /// check completes before the first eviction, so failures are atomic.
+    ///
+    /// Callers first pass no `sources`. `PayloadRequired` identifies exactly
+    /// which multi-megabyte payload copies are needed outside the cache mutex;
+    /// a second call supplies only those copies and revalidates atomically.
+    pub fn demand_admit_set(
+        &self,
+        expert_ids: &[u32],
+        sources: &HashMap<u32, Arc<GpuResident>>,
+    ) -> Result<GpuDemandSetAdmission, GpuDemandAdmissionError> {
+        let mut selected = HashSet::with_capacity(expert_ids.len());
+        for &expert_id in expert_ids {
+            if !selected.insert(expert_id) {
+                return Err(GpuDemandAdmissionError::DuplicateDemandExpert { expert_id });
+            }
+        }
+
+        let mut g = self.inner.lock();
+        let mut payload_required = Vec::new();
+        let mut new_ids = Vec::new();
+        let mut selected_lru_bytes = 0usize;
+        let mut new_bytes = 0usize;
+
+        for &expert_id in expert_ids {
+            if g.anchor.contains_key(&expert_id) {
+                continue;
+            }
+            if let Some(admission) = g.lru.peek(&expert_id) {
+                selected_lru_bytes = selected_lru_bytes.checked_add(admission.byte_len()).ok_or(
+                    GpuDemandAdmissionError::DemandSetExceedsLruCapacity {
+                        required_bytes: usize::MAX,
+                        capacity: self.lru_capacity_bytes,
+                    },
+                )?;
+                continue;
+            }
+
+            let Some(source) = sources.get(&expert_id) else {
+                payload_required.push(expert_id);
+                continue;
+            };
+            if source.id != expert_id {
+                return Err(GpuDemandAdmissionError::DemandSourceIdentityMismatch {
+                    selected_id: expert_id,
+                    source_id: source.id,
+                });
+            }
+            let bytes = source.byte_len();
+            if bytes == 0 {
+                return Err(GpuDemandAdmissionError::EmptyPayload);
+            }
+            if bytes > self.lru_capacity_bytes {
+                return Err(GpuDemandAdmissionError::PayloadExceedsLruCapacity {
+                    bytes,
+                    capacity: self.lru_capacity_bytes,
+                });
+            }
+            selected_lru_bytes = selected_lru_bytes.checked_add(bytes).ok_or(
+                GpuDemandAdmissionError::DemandSetExceedsLruCapacity {
+                    required_bytes: usize::MAX,
+                    capacity: self.lru_capacity_bytes,
+                },
+            )?;
+            new_bytes = new_bytes.checked_add(bytes).ok_or(
+                GpuDemandAdmissionError::DemandSetExceedsLruCapacity {
+                    required_bytes: usize::MAX,
+                    capacity: self.lru_capacity_bytes,
+                },
+            )?;
+            new_ids.push(expert_id);
+        }
+
+        if !payload_required.is_empty() {
+            return Ok(GpuDemandSetAdmission::PayloadRequired(payload_required));
+        }
+        if selected_lru_bytes > self.lru_capacity_bytes {
+            return Err(GpuDemandAdmissionError::DemandSetExceedsLruCapacity {
+                required_bytes: selected_lru_bytes,
+                capacity: self.lru_capacity_bytes,
+            });
+        }
+
+        let required_bytes = g.lru_used_bytes.checked_add(new_bytes).ok_or(
+            GpuDemandAdmissionError::ProtectedDemandCapacity {
+                required_bytes: usize::MAX,
+                protected_bytes: g.lru_used_bytes,
+                capacity: self.lru_capacity_bytes,
+            },
+        )?;
+        let bytes_to_evict = required_bytes.saturating_sub(self.lru_capacity_bytes);
+        let evictable_bytes = unprotected_logical_lru_bytes(&g, &selected);
+        if bytes_to_evict > evictable_bytes {
+            return Err(GpuDemandAdmissionError::ProtectedDemandCapacity {
+                required_bytes,
+                protected_bytes: g.lru_used_bytes.saturating_sub(evictable_bytes),
+                capacity: self.lru_capacity_bytes,
+            });
+        }
+
+        let generation_count = u64::try_from(new_ids.len())
+            .map_err(|_| GpuDemandAdmissionError::GenerationExhausted)?;
+        let next_generation = g
+            .next_generation
+            .checked_add(generation_count)
+            .ok_or(GpuDemandAdmissionError::GenerationExhausted)?;
+
+        while g
+            .lru_used_bytes
+            .checked_add(new_bytes)
+            .is_none_or(|used| used > self.lru_capacity_bytes)
+        {
+            let victim_id = oldest_unprotected_logical_lru(&g, &selected)
+                .expect("set capacity preflight proved an unprotected logical victim");
+            let victim = g
+                .lru
+                .pop(&victim_id)
+                .expect("selected logical victim remained under cache lock");
+            g.lru_used_bytes = g
+                .lru_used_bytes
+                .checked_sub(victim.byte_len())
+                .expect("logical GPU LRU byte underflow during demand-set admission");
+            g.promotion_rearm.insert(victim_id);
+        }
+
+        let first_generation = g.next_generation;
+        g.next_generation = next_generation;
+        for (offset, expert_id) in new_ids.iter().copied().enumerate() {
+            let source = sources
+                .get(&expert_id)
+                .expect("demand-set source validated before mutation")
+                .clone();
+            let generation = first_generation
+                .checked_add(offset as u64)
+                .expect("generation range preflight covered every new admission");
+            let bytes = source.byte_len();
+            g.promotion_pending.remove(&expert_id);
+            g.promotion_rearm.remove(&expert_id);
+            let previous = g.lru.put(
+                expert_id,
+                GpuAdmission {
+                    resident: source,
+                    generation,
+                },
+            );
+            debug_assert!(previous.is_none(), "demand set rechecked under one lock");
+            g.lru_used_bytes = g
+                .lru_used_bytes
+                .checked_add(bytes)
+                .expect("logical GPU demand-set LRU byte overflow after capacity check");
+        }
+
+        let admissions = expert_ids
+            .iter()
+            .map(|expert_id| {
+                g.anchor
+                    .get(expert_id)
+                    .or_else(|| g.lru.peek(expert_id))
+                    .cloned()
+                    .expect("every selected expert is admitted by the atomic transaction")
+            })
+            .collect();
+        let newly_admitted = new_ids.len();
+        drop(g);
+
+        if newly_admitted > 0 {
+            self.promotions
+                .fetch_add(newly_admitted as u64, Ordering::Relaxed);
+            self.refresh_used_bytes();
+        }
+        Ok(GpuDemandSetAdmission::Ready {
+            admissions,
+            newly_admitted,
+        })
+    }
+
     /// Check whether a selected foreground expert needs an owned host payload
     /// before attempting logical LRU admission. This probe never changes
     /// routing telemetry, LRU recency, generations, or byte accounting.
@@ -1297,6 +1654,22 @@ impl GpuExpertCache {
                 capacity: self.lru_capacity_bytes,
             });
         }
+        let additionally_protected = HashSet::new();
+        let required_bytes = g.lru_used_bytes.checked_add(bytes).ok_or(
+            GpuDemandAdmissionError::ProtectedDemandCapacity {
+                required_bytes: usize::MAX,
+                protected_bytes: g.lru_used_bytes,
+                capacity: self.lru_capacity_bytes,
+            },
+        )?;
+        let evictable_bytes = unprotected_logical_lru_bytes(&g, &additionally_protected);
+        if required_bytes.saturating_sub(self.lru_capacity_bytes) > evictable_bytes {
+            return Err(GpuDemandAdmissionError::ProtectedDemandCapacity {
+                required_bytes,
+                protected_bytes: g.lru_used_bytes.saturating_sub(evictable_bytes),
+                capacity: self.lru_capacity_bytes,
+            });
+        }
         // Allocate identity before eviction so generation exhaustion cannot
         // disturb any existing admission or byte accounting.
         let generation = g
@@ -1308,10 +1681,12 @@ impl GpuExpertCache {
             .checked_add(bytes)
             .is_none_or(|used| used > self.lru_capacity_bytes)
         {
-            let (evicted_id, victim) = g
+            let evicted_id = oldest_unprotected_logical_lru(&g, &additionally_protected)
+                .expect("demand capacity preflight proved an unprotected logical victim");
+            let victim = g
                 .lru
-                .pop_lru()
-                .expect("demand payload fits an empty LRU by prior capacity check");
+                .pop(&evicted_id)
+                .expect("selected demand victim remained under cache lock");
             g.lru_used_bytes = g.lru_used_bytes.saturating_sub(victim.byte_len());
             g.promotion_rearm.insert(evicted_id);
         }
@@ -1643,6 +2018,203 @@ mod tests {
 
     fn gpu_res(id: u32, bytes: usize) -> Arc<GpuResident> {
         Arc::new(GpuResident::new(id, vec![0u8; bytes]))
+    }
+
+    fn ready_demand_set(outcome: GpuDemandSetAdmission) -> (Vec<GpuAdmission>, usize) {
+        match outcome {
+            GpuDemandSetAdmission::Ready {
+                admissions,
+                newly_admitted,
+            } => (admissions, newly_admitted),
+            GpuDemandSetAdmission::PayloadRequired(missing) => {
+                panic!("unexpected missing demand payloads: {missing:?}")
+            }
+        }
+    }
+
+    #[test]
+    fn all_current_demand_set_is_hit_only_and_preserves_identity() {
+        let cache = Arc::new(GpuExpertCache::new(16, 0.0, 0));
+        assert_eq!(cache.demand_admit_lru(gpu_res(1, 8)), Ok(true));
+        assert_eq!(cache.demand_admit_lru(gpu_res(2, 8)), Ok(true));
+        let generations = [
+            cache.current_generation(1).unwrap(),
+            cache.current_generation(2).unwrap(),
+        ];
+        let promotions = cache.promotions();
+        let used = cache.used_bytes();
+        let _protection = cache.protect_demand_set(&[1, 2]).unwrap();
+
+        let (admissions, newly_admitted) =
+            ready_demand_set(cache.demand_admit_set(&[1, 2], &HashMap::new()).unwrap());
+
+        assert_eq!(newly_admitted, 0);
+        assert_eq!(admissions[0].generation(), generations[0]);
+        assert_eq!(admissions[1].generation(), generations[1]);
+        assert_eq!(cache.promotions(), promotions);
+        assert_eq!(cache.used_bytes(), used);
+    }
+
+    #[test]
+    fn all_missing_demand_set_is_admitted_atomically() {
+        let cache = Arc::new(GpuExpertCache::new(16, 0.0, 0));
+        let _protection = cache.protect_demand_set(&[1, 2]).unwrap();
+        assert!(matches!(
+            cache.demand_admit_set(&[1, 2], &HashMap::new()).unwrap(),
+            GpuDemandSetAdmission::PayloadRequired(ids) if ids == vec![1, 2]
+        ));
+        let sources = HashMap::from([(1, gpu_res(1, 8)), (2, gpu_res(2, 8))]);
+
+        let (admissions, newly_admitted) =
+            ready_demand_set(cache.demand_admit_set(&[1, 2], &sources).unwrap());
+
+        assert_eq!(newly_admitted, 2);
+        assert_eq!(admissions.len(), 2);
+        assert!(cache.contains_generation(1, admissions[0].generation()));
+        assert!(cache.contains_generation(2, admissions[1].generation()));
+        assert_eq!(cache.used_bytes(), 16);
+    }
+
+    #[test]
+    fn mixed_demand_set_evicts_non_selected_lru_not_current_member() {
+        let cache = Arc::new(GpuExpertCache::new(24, 0.0, 0));
+        assert_eq!(cache.demand_admit_lru(gpu_res(1, 8)), Ok(true));
+        assert_eq!(cache.demand_admit_lru(gpu_res(90, 8)), Ok(true));
+        assert_eq!(cache.demand_admit_lru(gpu_res(91, 8)), Ok(true));
+        let generation = cache.current_generation(1).unwrap();
+        let _protection = cache.protect_demand_set(&[1, 2]).unwrap();
+        let sources = HashMap::from([(2, gpu_res(2, 8))]);
+
+        let (admissions, newly_admitted) =
+            ready_demand_set(cache.demand_admit_set(&[1, 2], &sources).unwrap());
+
+        assert_eq!(newly_admitted, 1);
+        assert_eq!(admissions[0].generation(), generation);
+        assert!(cache.contains_generation(1, generation));
+        assert!(cache.contains(2));
+        assert!(
+            !cache.contains(90),
+            "oldest non-selected entry must be evicted"
+        );
+        assert!(cache.contains(91));
+    }
+
+    #[test]
+    fn insufficient_selected_set_capacity_fails_atomically() {
+        let cache = Arc::new(GpuExpertCache::new(12, 0.0, 0));
+        assert_eq!(cache.demand_admit_lru(gpu_res(90, 4)), Ok(true));
+        let generation = cache.current_generation(90).unwrap();
+        let used = cache.used_bytes();
+        let promotions = cache.promotions();
+        let next_generation = cache.inner.lock().next_generation;
+        let _protection = cache.protect_demand_set(&[1, 2]).unwrap();
+        let sources = HashMap::from([(1, gpu_res(1, 8)), (2, gpu_res(2, 8))]);
+
+        assert!(matches!(
+            cache.demand_admit_set(&[1, 2], &sources),
+            Err(GpuDemandAdmissionError::DemandSetExceedsLruCapacity {
+                required_bytes: 16,
+                capacity: 12,
+            })
+        ));
+        assert!(cache.contains_generation(90, generation));
+        assert!(!cache.contains(1));
+        assert!(!cache.contains(2));
+        assert_eq!(cache.used_bytes(), used);
+        assert_eq!(cache.promotions(), promotions);
+        assert_eq!(cache.inner.lock().next_generation, next_generation);
+    }
+
+    #[test]
+    fn foreground_protection_blocks_individual_self_eviction() {
+        let cache = Arc::new(GpuExpertCache::new(16, 0.0, 0));
+        assert_eq!(cache.demand_admit_lru(gpu_res(1, 8)), Ok(true));
+        assert_eq!(cache.demand_admit_lru(gpu_res(90, 8)), Ok(true));
+        let generation = cache.current_generation(1).unwrap();
+        let protection = cache.protect_demand_set(&[1, 2]).unwrap();
+
+        assert_eq!(cache.demand_admit_lru(gpu_res(2, 8)), Ok(true));
+        assert!(cache.contains_generation(1, generation));
+        assert!(cache.contains(2));
+        assert!(!cache.contains(90));
+
+        drop(protection);
+        assert_eq!(cache.demand_admit_lru(gpu_res(3, 8)), Ok(true));
+        assert!(
+            !cache.contains(1),
+            "released protection restores ordinary LRU eviction"
+        );
+    }
+
+    #[test]
+    fn protected_capacity_conflict_fails_without_oscillation() {
+        let cache = Arc::new(GpuExpertCache::new(16, 0.0, 0));
+        assert_eq!(cache.demand_admit_lru(gpu_res(1, 8)), Ok(true));
+        assert_eq!(cache.demand_admit_lru(gpu_res(2, 8)), Ok(true));
+        let _other_foreground = cache.protect_demand_set(&[1, 2]).unwrap();
+        let sources = HashMap::from([(3, gpu_res(3, 8))]);
+
+        assert!(matches!(
+            cache.demand_admit_set(&[3], &sources),
+            Err(GpuDemandAdmissionError::ProtectedDemandCapacity {
+                required_bytes: 24,
+                protected_bytes: 16,
+                capacity: 16,
+            })
+        ));
+        assert!(cache.contains(1));
+        assert!(cache.contains(2));
+        assert!(!cache.contains(3));
+    }
+
+    #[test]
+    fn stale_probe_generation_is_rejected_and_recovery_allocates_fresh_identity() {
+        let cache = Arc::new(GpuExpertCache::new(8, 0.0, 0));
+        assert_eq!(cache.demand_admit_lru(gpu_res(1, 8)), Ok(true));
+        let stale_generation = cache.current_generation(1).unwrap();
+        assert_eq!(cache.demand_admit_lru(gpu_res(90, 8)), Ok(true));
+        assert!(!cache.contains_generation(1, stale_generation));
+        let _protection = cache.protect_demand_set(&[1]).unwrap();
+        let sources = HashMap::from([(1, gpu_res(1, 8))]);
+
+        let (admissions, newly_admitted) =
+            ready_demand_set(cache.demand_admit_set(&[1], &sources).unwrap());
+
+        assert_eq!(newly_admitted, 1);
+        assert!(admissions[0].generation() > stale_generation);
+        assert!(!cache.contains_generation(1, stale_generation));
+        assert!(cache.contains_generation(1, admissions[0].generation()));
+    }
+
+    #[test]
+    fn speculative_hot_promotion_cannot_evict_foreground_set() {
+        let cache = Arc::new(GpuExpertCache::new(16, 0.0, 3));
+        assert_eq!(cache.demand_admit_lru(gpu_res(1, 8)), Ok(true));
+        assert_eq!(cache.demand_admit_lru(gpu_res(2, 8)), Ok(true));
+        let generations = [
+            cache.current_generation(1).unwrap(),
+            cache.current_generation(2).unwrap(),
+        ];
+        assert!(cache.claim_promotion(3, 3));
+        let _protection = cache.protect_demand_set(&[1, 2]).unwrap();
+
+        assert_eq!(
+            cache.promote_hot_sync(gpu_res(3, 8)),
+            GpuHotPromotionOutcome::NoCapacity
+        );
+        assert!(cache.contains_generation(1, generations[0]));
+        assert!(cache.contains_generation(2, generations[1]));
+        assert!(!cache.contains(3));
+    }
+
+    #[test]
+    fn duplicate_demand_protection_is_fail_closed() {
+        let cache = Arc::new(GpuExpertCache::new(16, 0.0, 0));
+        assert!(matches!(
+            cache.protect_demand_set(&[1, 1]),
+            Err(GpuDemandAdmissionError::DuplicateDemandExpert { expert_id: 1 })
+        ));
+        assert!(cache.inner.lock().demand_protections.is_empty());
     }
 
     #[test]

--- a/rust-engine/src/gpu_native_diagnostics.rs
+++ b/rust-engine/src/gpu_native_diagnostics.rs
@@ -428,6 +428,9 @@ pub struct ModelDiagnosticTrace {
     pub layer_router_input: Vec<Vec<f32>>,
     pub layer_selected_ids: Vec<Vec<u32>>,
     pub layer_selected_weights: Vec<Vec<f32>>,
+    /// Exact pre-residual routed-expert weighted accumulation from the
+    /// authoritative CPU reference implementation.
+    pub layer_routed_moe_output: Vec<Vec<f32>>,
     pub layer_post_moe: Vec<Vec<f32>>,
     pub final_norm: Vec<f32>,
     pub logits: Vec<f32>,
@@ -983,6 +986,7 @@ mod tests {
             layer_router_input: vec![vec![3.0; d_model]; layers],
             layer_selected_ids: vec![vec![0; top_k]; layers],
             layer_selected_weights: vec![vec![0.5; top_k]; layers],
+            layer_routed_moe_output: vec![vec![0.25; d_model]; layers],
             layer_post_moe: vec![vec![4.0; d_model]; layers],
             final_norm: vec![5.0; d_model],
             logits: vec![6.0; vocab],

--- a/rust-engine/src/gpu_native_diagnostics.rs
+++ b/rust-engine/src/gpu_native_diagnostics.rs
@@ -788,7 +788,7 @@ pub fn compare_diagnostic_traces(
             Some(l),
             &reference.layer_post_attn[l],
             &gpu_native.layer_post_attn[l],
-            Some(RAW_PROJECTION_TOLERANCE),
+            None,
         )?;
 
         comparator.record_vector_stage(
@@ -796,7 +796,7 @@ pub fn compare_diagnostic_traces(
             Some(l),
             &reference.layer_router_input[l],
             &gpu_native.layer_router_input[l],
-            Some(RAW_PROJECTION_TOLERANCE),
+            None,
         )?;
 
         comparator.record_discrete_stage(
@@ -811,7 +811,7 @@ pub fn compare_diagnostic_traces(
             Some(l),
             &reference.layer_selected_weights[l],
             &gpu_native.layer_selected_weights[l],
-            Some(RAW_PROJECTION_TOLERANCE),
+            None,
         )?;
 
         comparator.record_vector_stage(
@@ -819,7 +819,7 @@ pub fn compare_diagnostic_traces(
             Some(l),
             &reference.layer_post_moe[l],
             &gpu_native.layer_post_moe[l],
-            Some(Q4_EXPERT_F16_BOUNDARY_TOLERANCE),
+            None,
         )?;
     }
 
@@ -829,7 +829,7 @@ pub fn compare_diagnostic_traces(
         None,
         &reference.final_norm,
         &gpu_native.final_norm,
-        Some(RAW_PROJECTION_TOLERANCE),
+        None,
     )?;
 
     // 4. Logits
@@ -838,7 +838,7 @@ pub fn compare_diagnostic_traces(
         None,
         &reference.logits,
         &gpu_native.logits,
-        Some(Q4_EXPERT_F16_BOUNDARY_TOLERANCE),
+        None,
     )?;
 
     // 5. Sampled Token: exact discrete match
@@ -1201,5 +1201,69 @@ mod tests {
         assert!(!report.qualification_pass);
         let json = serde_json::to_string(&report).unwrap();
         assert!(json.contains("\"qualification_pass\":false"));
+    }
+
+    #[test]
+    fn small_delta_on_cumulative_stage_flags_first_divergence_with_no_tolerance() {
+        // A small delta (1e-4) on layer_post_moe would have satisfied the old
+        // Q4_EXPERT_F16_BOUNDARY_TOLERANCE (abs=2e-3, rel=5e-3). With tolerance=None,
+        // it must now immediately flag first divergence and exact divergence.
+        let reference = sample_trace(2, 4, 2, 8);
+        let mut gpu = model_to_gpu_trace(&reference);
+        gpu.layer_post_moe[0][0] = 4.0 + 1e-4;
+
+        let (first_exact, first_div, stages) = compare_diagnostic_traces(&reference, &gpu).unwrap();
+
+        assert!(first_exact.is_some());
+        assert_eq!(
+            first_exact.unwrap().stage,
+            DiagnosticStage::LayerPostMoe { layer: 0 }
+        );
+
+        assert!(first_div.is_some());
+        let div = first_div.unwrap();
+        assert_eq!(div.stage, DiagnosticStage::LayerPostMoe { layer: 0 });
+        assert_eq!(div.layer, Some(0));
+
+        let moe_stage = stages
+            .iter()
+            .find(|s| s.stage == DiagnosticStage::LayerPostMoe { layer: 0 })
+            .unwrap();
+        assert!(!moe_stage.exact_match);
+        assert!(!moe_stage.tolerance_pass);
+
+        // Same for small delta on Logits (1e-4)
+        let mut gpu_logits = model_to_gpu_trace(&reference);
+        gpu_logits.logits[0] = 6.0 + 1e-4;
+        let (first_exact_l, first_div_l, stages_l) =
+            compare_diagnostic_traces(&reference, &gpu_logits).unwrap();
+        assert_eq!(first_exact_l.unwrap().stage, DiagnosticStage::Logits);
+        assert_eq!(first_div_l.unwrap().stage, DiagnosticStage::Logits);
+        let logits_stage = stages_l
+            .iter()
+            .find(|s| s.stage == DiagnosticStage::Logits)
+            .unwrap();
+        assert!(!logits_stage.exact_match);
+        assert!(!logits_stage.tolerance_pass);
+
+        // Same for small delta on LayerPostAttention (1e-6, which satisfied RAW_PROJECTION_TOLERANCE)
+        let mut gpu_attn = model_to_gpu_trace(&reference);
+        gpu_attn.layer_post_attn[0][0] = 2.0 + 1e-6;
+        let (first_exact_a, first_div_a, stages_a) =
+            compare_diagnostic_traces(&reference, &gpu_attn).unwrap();
+        assert_eq!(
+            first_exact_a.unwrap().stage,
+            DiagnosticStage::LayerPostAttention { layer: 0 }
+        );
+        assert_eq!(
+            first_div_a.unwrap().stage,
+            DiagnosticStage::LayerPostAttention { layer: 0 }
+        );
+        let attn_stage = stages_a
+            .iter()
+            .find(|s| s.stage == DiagnosticStage::LayerPostAttention { layer: 0 })
+            .unwrap();
+        assert!(!attn_stage.exact_match);
+        assert!(!attn_stage.tolerance_pass);
     }
 }

--- a/rust-engine/src/gpu_native_diagnostics.rs
+++ b/rust-engine/src/gpu_native_diagnostics.rs
@@ -1,0 +1,1205 @@
+//! Phase-B GPU-native first-token mathematical divergence diagnostics.
+//!
+//! Compares the authoritative CPU reference (emulating the production Hybrid
+//! f16 expert input/output boundary with f32 routing aggregation) against the
+//! full GPU-native transformer execution path stage-by-stage for token 0.
+//!
+//! Diagnostic-only: normal serving and GPU token loop execution paths remain
+//! untouched. Qualification pass is always false.
+
+use serde::{Deserialize, Serialize};
+
+use crate::backend::gpu_native::MAX_GPU_NATIVE_ROUTER_TOP_K;
+use crate::backend::GpuDeviceIdentity;
+use crate::gpu_native_token_loop::{
+    GpuNativeModelGeometry, GpuNativeTokenLoopError, GpuNativeTokenLoopSnapshot,
+};
+use crate::greedy_parity::GreedySamplingEvidence;
+use crate::numerical_diagnostics::VectorComparisonEvidence;
+use crate::qualification::{BuildProvenance, ExpertMetadataEvidence};
+
+pub const SCHEMA_VERSION: &str = "mer.gpu-native-q4-first-divergence-diagnostic.v1";
+pub const MODE: &str = "diagnose-gpu-native-q4-first-divergence";
+pub const TARGET_CASE: &str = "json-transformation";
+
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ErrorTolerance {
+    pub absolute: f32,
+    pub relative: f32,
+    pub formula: &'static str,
+}
+
+impl ErrorTolerance {
+    pub fn evaluates(&self, reference: f32, actual: f32) -> bool {
+        if !reference.is_finite() || !actual.is_finite() {
+            return false;
+        }
+        let abs_error = (actual - reference).abs();
+        let allowed = self.absolute + self.relative * reference.abs();
+        abs_error <= allowed
+    }
+}
+
+/// Reference tolerances derived from established MER qualification contracts.
+///
+/// Provenance:
+/// - `RAW_PROJECTION_TOLERANCE`: derived from `q4_parity::RAW_TOLERANCE` (absolute 1.0e-5, relative 1.0e-4)
+///   for raw shader execution against scalar float dot product.
+/// - `Q4_EXPERT_F16_BOUNDARY_TOLERANCE`: derived from `q4_parity::COMPLETE_TOLERANCE` (absolute 2.0e-3, relative 5.0e-3)
+///   for complete single-expert execution at the production F16 input/output boundary.
+///
+/// Note: Accumulated multi-layer hidden states (post-attention across layers, full 48-layer post-MoE state,
+/// final RMSNorm, and vocabulary logits) do not have a closed-form single-operation contract in MER.
+/// The diagnostic reports exact bitwise match, max absolute error, and RMS error without pretending
+/// unestablished thresholds prove end-to-end qualification.
+pub const RAW_PROJECTION_TOLERANCE: ErrorTolerance = ErrorTolerance {
+    absolute: 1.0e-5,
+    relative: 1.0e-4,
+    formula: "abs_error <= absolute + relative * abs(reference)",
+};
+
+pub const Q4_EXPERT_F16_BOUNDARY_TOLERANCE: ErrorTolerance = ErrorTolerance {
+    absolute: 2.0e-3,
+    relative: 5.0e-3,
+    formula: "abs_error <= absolute + relative * abs(reference)",
+};
+
+/// Fixed byte layout for the single contiguous diagnostic staging buffer.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct GpuNativeDiagnosticTraceLayout {
+    pub num_layers: usize,
+    pub d_model: usize,
+    pub top_k: usize,
+    pub vocab_size: usize,
+    pub embedding_offset: usize,
+    pub embedding_bytes: usize,
+    pub layer_post_attn_offset: usize,
+    pub layer_post_attn_bytes: usize,
+    pub layer_router_input_offset: usize,
+    pub layer_router_input_bytes: usize,
+    pub layer_selected_ids_offset: usize,
+    pub layer_selected_ids_bytes: usize,
+    pub layer_selected_weights_offset: usize,
+    pub layer_selected_weights_bytes: usize,
+    pub layer_post_moe_offset: usize,
+    pub layer_post_moe_bytes: usize,
+    pub layer_status_offset: usize,
+    pub layer_status_bytes: usize,
+    pub final_norm_offset: usize,
+    pub final_norm_bytes: usize,
+    pub logits_offset: usize,
+    pub logits_bytes: usize,
+    pub final_status_offset: usize,
+    pub final_status_bytes: usize,
+    pub sampled_token_offset: usize,
+    pub sampled_token_bytes: usize,
+    pub total_bytes: u64,
+}
+
+impl GpuNativeDiagnosticTraceLayout {
+    pub fn try_new(
+        num_layers: usize,
+        d_model: usize,
+        top_k: usize,
+        vocab_size: usize,
+    ) -> Result<Self, GpuNativeTokenLoopError> {
+        if num_layers == 0 {
+            return Err(GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "num_layers must be > 0".into(),
+            });
+        }
+        if d_model == 0 {
+            return Err(GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "d_model must be > 0".into(),
+            });
+        }
+        if top_k == 0 || top_k > MAX_GPU_NATIVE_ROUTER_TOP_K {
+            return Err(GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: format!("top_k must be in 1..={MAX_GPU_NATIVE_ROUTER_TOP_K}"),
+            });
+        }
+        if vocab_size == 0 {
+            return Err(GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "vocab_size must be > 0".into(),
+            });
+        }
+
+        let f32_bytes = std::mem::size_of::<f32>();
+        let u32_bytes = std::mem::size_of::<u32>();
+
+        let embedding_offset = 0usize;
+        let embedding_bytes = d_model.checked_mul(f32_bytes).ok_or_else(|| {
+            GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "embedding bytes overflow".into(),
+            }
+        })?;
+
+        let layer_post_attn_offset =
+            embedding_offset
+                .checked_add(embedding_bytes)
+                .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
+                    detail: "layer_post_attn_offset overflow".into(),
+                })?;
+        let single_vector_bytes = embedding_bytes;
+        let layer_post_attn_bytes =
+            num_layers.checked_mul(single_vector_bytes).ok_or_else(|| {
+                GpuNativeTokenLoopError::InvalidBoundaryReport {
+                    detail: "layer_post_attn_bytes overflow".into(),
+                }
+            })?;
+
+        let layer_router_input_offset =
+            layer_post_attn_offset
+                .checked_add(layer_post_attn_bytes)
+                .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
+                    detail: "layer_router_input_offset overflow".into(),
+                })?;
+        let layer_router_input_bytes = layer_post_attn_bytes;
+
+        let layer_selected_ids_offset = layer_router_input_offset
+            .checked_add(layer_router_input_bytes)
+            .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "layer_selected_ids_offset overflow".into(),
+            })?;
+        let single_topk_u32_bytes = top_k.checked_mul(u32_bytes).ok_or_else(|| {
+            GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "single topk u32 bytes overflow".into(),
+            }
+        })?;
+        let layer_selected_ids_bytes =
+            num_layers
+                .checked_mul(single_topk_u32_bytes)
+                .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
+                    detail: "layer_selected_ids_bytes overflow".into(),
+                })?;
+
+        let layer_selected_weights_offset = layer_selected_ids_offset
+            .checked_add(layer_selected_ids_bytes)
+            .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "layer_selected_weights_offset overflow".into(),
+            })?;
+        let single_topk_f32_bytes = top_k.checked_mul(f32_bytes).ok_or_else(|| {
+            GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "single topk f32 bytes overflow".into(),
+            }
+        })?;
+        let layer_selected_weights_bytes = num_layers
+            .checked_mul(single_topk_f32_bytes)
+            .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "layer_selected_weights_bytes overflow".into(),
+            })?;
+
+        let layer_post_moe_offset = layer_selected_weights_offset
+            .checked_add(layer_selected_weights_bytes)
+            .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "layer_post_moe_offset overflow".into(),
+            })?;
+        let layer_post_moe_bytes = layer_post_attn_bytes;
+
+        let layer_status_offset = layer_post_moe_offset
+            .checked_add(layer_post_moe_bytes)
+            .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "layer_status_offset overflow".into(),
+            })?;
+        let layer_status_bytes = num_layers.checked_mul(u32_bytes).ok_or_else(|| {
+            GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "layer_status_bytes overflow".into(),
+            }
+        })?;
+
+        let final_norm_offset = layer_status_offset
+            .checked_add(layer_status_bytes)
+            .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "final_norm_offset overflow".into(),
+            })?;
+        let final_norm_bytes = single_vector_bytes;
+
+        let logits_offset = final_norm_offset
+            .checked_add(final_norm_bytes)
+            .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "logits_offset overflow".into(),
+            })?;
+        let logits_bytes = vocab_size.checked_mul(f32_bytes).ok_or_else(|| {
+            GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "logits_bytes overflow".into(),
+            }
+        })?;
+
+        let final_status_offset = logits_offset.checked_add(logits_bytes).ok_or_else(|| {
+            GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "final_status_offset overflow".into(),
+            }
+        })?;
+        let final_status_bytes = u32_bytes;
+
+        let sampled_token_offset = final_status_offset
+            .checked_add(final_status_bytes)
+            .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "sampled_token_offset overflow".into(),
+            })?;
+        let sampled_token_bytes = u32_bytes;
+
+        let total_size = sampled_token_offset
+            .checked_add(sampled_token_bytes)
+            .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "total size overflow".into(),
+            })?;
+
+        let total_bytes = u64::try_from(total_size).map_err(|_| {
+            GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "total size exceeds u64".into(),
+            }
+        })?;
+
+        Ok(Self {
+            num_layers,
+            d_model,
+            top_k,
+            vocab_size,
+            embedding_offset,
+            embedding_bytes,
+            layer_post_attn_offset,
+            layer_post_attn_bytes,
+            layer_router_input_offset,
+            layer_router_input_bytes,
+            layer_selected_ids_offset,
+            layer_selected_ids_bytes,
+            layer_selected_weights_offset,
+            layer_selected_weights_bytes,
+            layer_post_moe_offset,
+            layer_post_moe_bytes,
+            layer_status_offset,
+            layer_status_bytes,
+            final_norm_offset,
+            final_norm_bytes,
+            logits_offset,
+            logits_bytes,
+            final_status_offset,
+            final_status_bytes,
+            sampled_token_offset,
+            sampled_token_bytes,
+            total_bytes,
+        })
+    }
+
+    #[inline]
+    pub fn layer_post_attn_offset(&self, layer: usize) -> u64 {
+        (self.layer_post_attn_offset + layer * self.d_model * 4) as u64
+    }
+
+    #[inline]
+    pub fn layer_router_input_offset(&self, layer: usize) -> u64 {
+        (self.layer_router_input_offset + layer * self.d_model * 4) as u64
+    }
+
+    #[inline]
+    pub fn layer_selected_ids_offset(&self, layer: usize) -> u64 {
+        (self.layer_selected_ids_offset + layer * self.top_k * 4) as u64
+    }
+
+    #[inline]
+    pub fn layer_selected_weights_offset(&self, layer: usize) -> u64 {
+        (self.layer_selected_weights_offset + layer * self.top_k * 4) as u64
+    }
+
+    #[inline]
+    pub fn layer_post_moe_offset(&self, layer: usize) -> u64 {
+        (self.layer_post_moe_offset + layer * self.d_model * 4) as u64
+    }
+
+    #[inline]
+    pub fn layer_status_offset(&self, layer: usize) -> u64 {
+        (self.layer_status_offset + layer * 4) as u64
+    }
+
+    pub fn parse(&self, bytes: &[u8]) -> Result<GpuNativeDiagnosticTrace, GpuNativeTokenLoopError> {
+        if (bytes.len() as u64) < self.total_bytes {
+            return Err(GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: format!(
+                    "diagnostic trace byte buffer too small: expected {}, got {}",
+                    self.total_bytes,
+                    bytes.len()
+                ),
+            });
+        }
+
+        let parse_f32_vec = |offset: usize, count: usize| -> Vec<f32> {
+            let slice = &bytes[offset..offset + count * 4];
+            slice
+                .chunks_exact(4)
+                .map(|chunk| f32::from_le_bytes(chunk.try_into().unwrap()))
+                .collect()
+        };
+
+        let parse_u32_vec = |offset: usize, count: usize| -> Vec<u32> {
+            let slice = &bytes[offset..offset + count * 4];
+            slice
+                .chunks_exact(4)
+                .map(|chunk| u32::from_le_bytes(chunk.try_into().unwrap()))
+                .collect()
+        };
+
+        let embedding = parse_f32_vec(self.embedding_offset, self.d_model);
+
+        let mut layer_post_attn = Vec::with_capacity(self.num_layers);
+        let mut layer_router_input = Vec::with_capacity(self.num_layers);
+        let mut layer_selected_ids = Vec::with_capacity(self.num_layers);
+        let mut layer_selected_weights = Vec::with_capacity(self.num_layers);
+        let mut layer_post_moe = Vec::with_capacity(self.num_layers);
+        let mut layer_statuses = Vec::with_capacity(self.num_layers);
+
+        for l in 0..self.num_layers {
+            layer_post_attn.push(parse_f32_vec(
+                self.layer_post_attn_offset(l) as usize,
+                self.d_model,
+            ));
+            layer_router_input.push(parse_f32_vec(
+                self.layer_router_input_offset(l) as usize,
+                self.d_model,
+            ));
+            layer_selected_ids.push(parse_u32_vec(
+                self.layer_selected_ids_offset(l) as usize,
+                self.top_k,
+            ));
+            layer_selected_weights.push(parse_f32_vec(
+                self.layer_selected_weights_offset(l) as usize,
+                self.top_k,
+            ));
+            layer_post_moe.push(parse_f32_vec(
+                self.layer_post_moe_offset(l) as usize,
+                self.d_model,
+            ));
+            let status_off = self.layer_status_offset(l) as usize;
+            layer_statuses.push(u32::from_le_bytes(
+                bytes[status_off..status_off + 4].try_into().unwrap(),
+            ));
+        }
+
+        let final_norm = parse_f32_vec(self.final_norm_offset, self.d_model);
+        let logits = parse_f32_vec(self.logits_offset, self.vocab_size);
+        let final_status = u32::from_le_bytes(
+            bytes[self.final_status_offset..self.final_status_offset + 4]
+                .try_into()
+                .unwrap(),
+        );
+        let sampled_token = u32::from_le_bytes(
+            bytes[self.sampled_token_offset..self.sampled_token_offset + 4]
+                .try_into()
+                .unwrap(),
+        );
+
+        Ok(GpuNativeDiagnosticTrace {
+            embedding,
+            layer_post_attn,
+            layer_router_input,
+            layer_selected_ids,
+            layer_selected_weights,
+            layer_post_moe,
+            layer_statuses,
+            final_norm,
+            logits,
+            final_status,
+            sampled_token,
+        })
+    }
+}
+
+/// Parsed results of one full GPU-native diagnostic execution step.
+#[derive(Clone, Debug, PartialEq)]
+pub struct GpuNativeDiagnosticTrace {
+    pub embedding: Vec<f32>,
+    pub layer_post_attn: Vec<Vec<f32>>,
+    pub layer_router_input: Vec<Vec<f32>>,
+    pub layer_selected_ids: Vec<Vec<u32>>,
+    pub layer_selected_weights: Vec<Vec<f32>>,
+    pub layer_post_moe: Vec<Vec<f32>>,
+    pub layer_statuses: Vec<u32>,
+    pub final_norm: Vec<f32>,
+    pub logits: Vec<f32>,
+    pub final_status: u32,
+    pub sampled_token: u32,
+}
+
+/// Captured boundaries from the authoritative reference model forward.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ModelDiagnosticTrace {
+    pub embedding: Vec<f32>,
+    pub layer_post_attn: Vec<Vec<f32>>,
+    pub layer_router_input: Vec<Vec<f32>>,
+    pub layer_selected_ids: Vec<Vec<u32>>,
+    pub layer_selected_weights: Vec<Vec<f32>>,
+    pub layer_post_moe: Vec<Vec<f32>>,
+    pub final_norm: Vec<f32>,
+    pub logits: Vec<f32>,
+    pub sampled_token: u32,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "stage", rename_all = "snake_case")]
+pub enum DiagnosticStage {
+    Embedding,
+    LayerPostAttention { layer: usize },
+    LayerRouterInput { layer: usize },
+    LayerSelectedExpertIds { layer: usize },
+    LayerSelectedExpertWeights { layer: usize },
+    LayerPostMoe { layer: usize },
+    FinalNorm,
+    Logits,
+    SampledToken,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct DiscreteComparisonEvidence {
+    pub reference: Vec<u32>,
+    pub gpu_native: Vec<u32>,
+    pub matches: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct StageComparisonEvidence {
+    pub stage: DiagnosticStage,
+    pub exact_match: bool,
+    pub tolerance_pass: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vector_comparison: Option<VectorComparisonEvidence>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub discrete_comparison: Option<DiscreteComparisonEvidence>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct FirstDivergenceEvidence {
+    pub stage: DiagnosticStage,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub layer: Option<usize>,
+    pub reason: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_absolute_error: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rms_error: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub worst_index: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub worst_reference_value: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub worst_gpu_native_value: Option<f32>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct CaseEvidence {
+    pub case_name: String,
+    pub prompt_sha256: String,
+    pub prompt_token_count: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct GpuNativeFirstDivergenceReport {
+    pub schema_version: String,
+    pub mode: String,
+    pub diagnostic_complete: bool,
+    pub qualification_pass: bool,
+    pub failure: Option<String>,
+
+    pub provenance: BuildProvenance,
+    pub build_git_sha: String,
+    pub executable_sha256: String,
+    pub resolved_config_sha256: String,
+    pub model_geometry: GpuNativeModelGeometry,
+    pub expert_metadata: ExpertMetadataEvidence,
+    pub case: CaseEvidence,
+    pub prompt_token_ids_sha256: String,
+    pub sampling: GreedySamplingEvidence,
+    pub expected_adapter_name: String,
+    pub actual_adapter: Option<GpuDeviceIdentity>,
+
+    pub reference_sampled_token_id: Option<u32>,
+    pub gpu_native_sampled_token_id: Option<u32>,
+    pub token_match: Option<bool>,
+
+    pub first_exact_divergence: Option<FirstDivergenceEvidence>,
+    pub first_divergence: Option<FirstDivergenceEvidence>,
+    pub stages: Vec<StageComparisonEvidence>,
+
+    pub token_loop_counters_delta: GpuNativeTokenLoopSnapshot,
+    pub attempt_count: usize,
+}
+
+impl GpuNativeFirstDivergenceReport {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        provenance: BuildProvenance,
+        build_git_sha: String,
+        executable_sha256: String,
+        resolved_config_sha256: String,
+        model_geometry: GpuNativeModelGeometry,
+        expert_metadata: ExpertMetadataEvidence,
+        case: CaseEvidence,
+        prompt_token_ids_sha256: String,
+        expected_adapter_name: String,
+    ) -> Self {
+        Self {
+            schema_version: SCHEMA_VERSION.to_string(),
+            mode: MODE.to_string(),
+            diagnostic_complete: false,
+            qualification_pass: false,
+            failure: None,
+            provenance,
+            build_git_sha,
+            executable_sha256,
+            resolved_config_sha256,
+            model_geometry,
+            expert_metadata,
+            case,
+            prompt_token_ids_sha256,
+            sampling: GreedySamplingEvidence::fixed(),
+            expected_adapter_name,
+            actual_adapter: None,
+            reference_sampled_token_id: None,
+            gpu_native_sampled_token_id: None,
+            token_match: None,
+            first_exact_divergence: None,
+            first_divergence: None,
+            stages: Vec::new(),
+            token_loop_counters_delta: GpuNativeTokenLoopSnapshot::default(),
+            attempt_count: 0,
+        }
+    }
+
+    pub fn fail(&mut self, reason: String) {
+        self.diagnostic_complete = true;
+        self.qualification_pass = false;
+        self.failure = Some(reason);
+    }
+}
+
+struct DiagnosticTraceComparator {
+    stages: Vec<StageComparisonEvidence>,
+    first_exact_divergence: Option<FirstDivergenceEvidence>,
+    first_divergence: Option<FirstDivergenceEvidence>,
+}
+
+impl DiagnosticTraceComparator {
+    fn new() -> Self {
+        Self {
+            stages: Vec::new(),
+            first_exact_divergence: None,
+            first_divergence: None,
+        }
+    }
+
+    fn record_vector_stage(
+        &mut self,
+        stage: DiagnosticStage,
+        layer: Option<usize>,
+        ref_vec: &[f32],
+        gpu_vec: &[f32],
+        tolerance: Option<ErrorTolerance>,
+    ) -> Result<(), String> {
+        let comp = crate::numerical_diagnostics::compare_vectors(ref_vec, gpu_vec)?;
+        let nonfinite = comp.cpu_nonfinite_count > 0 || comp.hybrid_nonfinite_count > 0;
+
+        let tolerance_pass = if nonfinite {
+            false
+        } else if let Some(tol) = tolerance {
+            let mut pass = true;
+            for (&r, &g) in ref_vec.iter().zip(gpu_vec) {
+                if !tol.evaluates(r, g) {
+                    pass = false;
+                    break;
+                }
+            }
+            pass
+        } else {
+            comp.exact_f32_bits
+        };
+
+        let stage_evidence = StageComparisonEvidence {
+            stage: stage.clone(),
+            exact_match: comp.exact_f32_bits,
+            tolerance_pass,
+            vector_comparison: Some(comp.clone()),
+            discrete_comparison: None,
+        };
+
+        if !comp.exact_f32_bits && self.first_exact_divergence.is_none() {
+            self.first_exact_divergence = Some(FirstDivergenceEvidence {
+                stage: stage.clone(),
+                layer,
+                reason: if nonfinite {
+                    format!(
+                        "nonfinite value: reference nonfinite={}, gpu_native nonfinite={}",
+                        comp.cpu_nonfinite_count, comp.hybrid_nonfinite_count
+                    )
+                } else {
+                    format!(
+                        "exact f32 bits differ (max absolute error {:?}, RMS error {:?})",
+                        comp.max_absolute_error, comp.rms_error
+                    )
+                },
+                max_absolute_error: comp.max_absolute_error,
+                rms_error: comp.rms_error,
+                worst_index: comp.max_error.as_ref().map(|e| e.index),
+                worst_reference_value: comp.max_error.as_ref().and_then(|e| e.cpu.value),
+                worst_gpu_native_value: comp.max_error.as_ref().and_then(|e| e.hybrid.value),
+            });
+        }
+
+        if !tolerance_pass && self.first_divergence.is_none() {
+            let reason = if nonfinite {
+                format!(
+                    "nonfinite value detected: reference nonfinite={}, gpu_native nonfinite={}",
+                    comp.cpu_nonfinite_count, comp.hybrid_nonfinite_count
+                )
+            } else if let Some(tol) = tolerance {
+                if let Some(ref max_err) = comp.max_error {
+                    format!(
+                        "max absolute error {:?} exceeds reference tolerance (abs={}, rel={}) at index {}: ref={:?}, gpu={:?}",
+                        comp.max_absolute_error, tol.absolute, tol.relative, max_err.index, max_err.cpu, max_err.hybrid
+                    )
+                } else {
+                    "tolerance check failed".to_string()
+                }
+            } else {
+                format!(
+                    "exact f32 bit mismatch at stage with no formal multi-layer tolerance contract (max abs error {:?})",
+                    comp.max_absolute_error
+                )
+            };
+
+            self.first_divergence = Some(FirstDivergenceEvidence {
+                stage,
+                layer,
+                reason,
+                max_absolute_error: comp.max_absolute_error,
+                rms_error: comp.rms_error,
+                worst_index: comp.max_error.as_ref().map(|e| e.index),
+                worst_reference_value: comp.max_error.as_ref().and_then(|e| e.cpu.value),
+                worst_gpu_native_value: comp.max_error.as_ref().and_then(|e| e.hybrid.value),
+            });
+        }
+
+        self.stages.push(stage_evidence);
+        Ok(())
+    }
+
+    fn record_discrete_stage(
+        &mut self,
+        stage: DiagnosticStage,
+        layer: Option<usize>,
+        ref_vals: &[u32],
+        gpu_vals: &[u32],
+    ) -> Result<(), String> {
+        if ref_vals.len() != gpu_vals.len() {
+            return Err(format!(
+                "discrete stage length mismatch: ref={}, gpu={}",
+                ref_vals.len(),
+                gpu_vals.len()
+            ));
+        }
+        let matches = ref_vals == gpu_vals;
+        let stage_evidence = StageComparisonEvidence {
+            stage: stage.clone(),
+            exact_match: matches,
+            tolerance_pass: matches,
+            vector_comparison: None,
+            discrete_comparison: Some(DiscreteComparisonEvidence {
+                reference: ref_vals.to_vec(),
+                gpu_native: gpu_vals.to_vec(),
+                matches,
+            }),
+        };
+
+        if !matches && self.first_exact_divergence.is_none() {
+            self.first_exact_divergence = Some(FirstDivergenceEvidence {
+                stage: stage.clone(),
+                layer,
+                reason: format!(
+                    "discrete values mismatch: reference {:?}, gpu_native {:?}",
+                    ref_vals, gpu_vals
+                ),
+                max_absolute_error: None,
+                rms_error: None,
+                worst_index: None,
+                worst_reference_value: None,
+                worst_gpu_native_value: None,
+            });
+        }
+
+        if !matches && self.first_divergence.is_none() {
+            self.first_divergence = Some(FirstDivergenceEvidence {
+                stage,
+                layer,
+                reason: format!(
+                    "discrete values mismatch: reference {:?}, gpu_native {:?}",
+                    ref_vals, gpu_vals
+                ),
+                max_absolute_error: None,
+                rms_error: None,
+                worst_index: None,
+                worst_reference_value: None,
+                worst_gpu_native_value: None,
+            });
+        }
+
+        self.stages.push(stage_evidence);
+        Ok(())
+    }
+}
+
+pub fn compare_diagnostic_traces(
+    reference: &ModelDiagnosticTrace,
+    gpu_native: &GpuNativeDiagnosticTrace,
+) -> Result<
+    (
+        Option<FirstDivergenceEvidence>,
+        Option<FirstDivergenceEvidence>,
+        Vec<StageComparisonEvidence>,
+    ),
+    String,
+> {
+    let mut comparator = DiagnosticTraceComparator::new();
+
+    // 1. Embedding: expected exact f32 weights
+    comparator.record_vector_stage(
+        DiagnosticStage::Embedding,
+        None,
+        &reference.embedding,
+        &gpu_native.embedding,
+        None,
+    )?;
+
+    // 2. Per-layer stages
+    let num_layers = reference.layer_post_attn.len();
+    if gpu_native.layer_post_attn.len() != num_layers
+        || reference.layer_router_input.len() != num_layers
+        || gpu_native.layer_router_input.len() != num_layers
+        || reference.layer_selected_ids.len() != num_layers
+        || gpu_native.layer_selected_ids.len() != num_layers
+        || reference.layer_selected_weights.len() != num_layers
+        || gpu_native.layer_selected_weights.len() != num_layers
+        || reference.layer_post_moe.len() != num_layers
+        || gpu_native.layer_post_moe.len() != num_layers
+    {
+        return Err("layer count mismatch between reference and GPU-native traces".to_string());
+    }
+
+    for l in 0..num_layers {
+        comparator.record_vector_stage(
+            DiagnosticStage::LayerPostAttention { layer: l },
+            Some(l),
+            &reference.layer_post_attn[l],
+            &gpu_native.layer_post_attn[l],
+            Some(RAW_PROJECTION_TOLERANCE),
+        )?;
+
+        comparator.record_vector_stage(
+            DiagnosticStage::LayerRouterInput { layer: l },
+            Some(l),
+            &reference.layer_router_input[l],
+            &gpu_native.layer_router_input[l],
+            Some(RAW_PROJECTION_TOLERANCE),
+        )?;
+
+        comparator.record_discrete_stage(
+            DiagnosticStage::LayerSelectedExpertIds { layer: l },
+            Some(l),
+            &reference.layer_selected_ids[l],
+            &gpu_native.layer_selected_ids[l],
+        )?;
+
+        comparator.record_vector_stage(
+            DiagnosticStage::LayerSelectedExpertWeights { layer: l },
+            Some(l),
+            &reference.layer_selected_weights[l],
+            &gpu_native.layer_selected_weights[l],
+            Some(RAW_PROJECTION_TOLERANCE),
+        )?;
+
+        comparator.record_vector_stage(
+            DiagnosticStage::LayerPostMoe { layer: l },
+            Some(l),
+            &reference.layer_post_moe[l],
+            &gpu_native.layer_post_moe[l],
+            Some(Q4_EXPERT_F16_BOUNDARY_TOLERANCE),
+        )?;
+    }
+
+    // 3. Final Norm
+    comparator.record_vector_stage(
+        DiagnosticStage::FinalNorm,
+        None,
+        &reference.final_norm,
+        &gpu_native.final_norm,
+        Some(RAW_PROJECTION_TOLERANCE),
+    )?;
+
+    // 4. Logits
+    comparator.record_vector_stage(
+        DiagnosticStage::Logits,
+        None,
+        &reference.logits,
+        &gpu_native.logits,
+        Some(Q4_EXPERT_F16_BOUNDARY_TOLERANCE),
+    )?;
+
+    // 5. Sampled Token: exact discrete match
+    comparator.record_discrete_stage(
+        DiagnosticStage::SampledToken,
+        None,
+        &[reference.sampled_token],
+        &[gpu_native.sampled_token],
+    )?;
+
+    Ok((
+        comparator.first_exact_divergence,
+        comparator.first_divergence,
+        comparator.stages,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trace_layout_offset_arithmetic_is_exact_and_contiguous() {
+        let layout = GpuNativeDiagnosticTraceLayout::try_new(2, 4, 2, 8).unwrap();
+        // embedding: 0..16
+        assert_eq!(layout.embedding_offset, 0);
+        assert_eq!(layout.embedding_bytes, 16);
+        // layer_post_attn: 16..48 (2 * 16 = 32)
+        assert_eq!(layout.layer_post_attn_offset, 16);
+        assert_eq!(layout.layer_post_attn_bytes, 32);
+        assert_eq!(layout.layer_post_attn_offset(0), 16);
+        assert_eq!(layout.layer_post_attn_offset(1), 32);
+        // layer_router_input: 48..80 (32)
+        assert_eq!(layout.layer_router_input_offset, 48);
+        assert_eq!(layout.layer_router_input_bytes, 32);
+        assert_eq!(layout.layer_router_input_offset(0), 48);
+        assert_eq!(layout.layer_router_input_offset(1), 64);
+        // layer_selected_ids: 80..96 (2 * 2 * 4 = 16)
+        assert_eq!(layout.layer_selected_ids_offset, 80);
+        assert_eq!(layout.layer_selected_ids_bytes, 16);
+        assert_eq!(layout.layer_selected_ids_offset(0), 80);
+        assert_eq!(layout.layer_selected_ids_offset(1), 88);
+        // layer_selected_weights: 96..112 (16)
+        assert_eq!(layout.layer_selected_weights_offset, 96);
+        assert_eq!(layout.layer_selected_weights_bytes, 16);
+        assert_eq!(layout.layer_selected_weights_offset(0), 96);
+        assert_eq!(layout.layer_selected_weights_offset(1), 104);
+        // layer_post_moe: 112..144 (32)
+        assert_eq!(layout.layer_post_moe_offset, 112);
+        assert_eq!(layout.layer_post_moe_bytes, 32);
+        assert_eq!(layout.layer_post_moe_offset(0), 112);
+        assert_eq!(layout.layer_post_moe_offset(1), 128);
+        // layer_status: 144..152 (2 * 4 = 8)
+        assert_eq!(layout.layer_status_offset, 144);
+        assert_eq!(layout.layer_status_bytes, 8);
+        assert_eq!(layout.layer_status_offset(0), 144);
+        assert_eq!(layout.layer_status_offset(1), 148);
+        // final_norm: 152..168 (16)
+        assert_eq!(layout.final_norm_offset, 152);
+        assert_eq!(layout.final_norm_bytes, 16);
+        // logits: 168..200 (8 * 4 = 32)
+        assert_eq!(layout.logits_offset, 168);
+        assert_eq!(layout.logits_bytes, 32);
+        // final_status: 200..204 (4)
+        assert_eq!(layout.final_status_offset, 200);
+        assert_eq!(layout.final_status_bytes, 4);
+        // sampled_token: 204..208 (4)
+        assert_eq!(layout.sampled_token_offset, 204);
+        assert_eq!(layout.sampled_token_bytes, 4);
+        // total: 208
+        assert_eq!(layout.total_bytes, 208);
+    }
+
+    #[test]
+    fn trace_layout_overflow_rejections() {
+        assert!(GpuNativeDiagnosticTraceLayout::try_new(0, 4, 2, 8).is_err());
+        assert!(GpuNativeDiagnosticTraceLayout::try_new(2, 0, 2, 8).is_err());
+        assert!(GpuNativeDiagnosticTraceLayout::try_new(2, 4, 0, 8).is_err());
+        assert!(GpuNativeDiagnosticTraceLayout::try_new(2, 4, 9999, 8).is_err());
+        assert!(GpuNativeDiagnosticTraceLayout::try_new(2, 4, 2, 0).is_err());
+        assert!(GpuNativeDiagnosticTraceLayout::try_new(usize::MAX, 4, 2, 8).is_err());
+    }
+
+    #[test]
+    fn trace_layout_parse_exact_round_trip() {
+        let layout = GpuNativeDiagnosticTraceLayout::try_new(2, 4, 2, 4).unwrap();
+        let mut bytes = vec![0u8; layout.total_bytes as usize];
+
+        // embedding: [1.0, 2.0, 3.0, 4.0]
+        let emb = [1.0f32, 2.0, 3.0, 4.0];
+        for (i, v) in emb.iter().enumerate() {
+            bytes[i * 4..i * 4 + 4].copy_from_slice(&v.to_le_bytes());
+        }
+
+        // layer 0 post_attn
+        let l0_attn = [10.0f32, 11.0, 12.0, 13.0];
+        let off = layout.layer_post_attn_offset(0) as usize;
+        for (i, v) in l0_attn.iter().enumerate() {
+            bytes[off + i * 4..off + i * 4 + 4].copy_from_slice(&v.to_le_bytes());
+        }
+
+        // layer 1 selected ids
+        let l1_ids = [5u32, 7u32];
+        let off = layout.layer_selected_ids_offset(1) as usize;
+        for (i, v) in l1_ids.iter().enumerate() {
+            bytes[off + i * 4..off + i * 4 + 4].copy_from_slice(&v.to_le_bytes());
+        }
+
+        // final_norm
+        let fnorm = [50.0f32, 51.0, 52.0, 53.0];
+        let off = layout.final_norm_offset;
+        for (i, v) in fnorm.iter().enumerate() {
+            bytes[off + i * 4..off + i * 4 + 4].copy_from_slice(&v.to_le_bytes());
+        }
+
+        // sampled_token
+        bytes[layout.sampled_token_offset..layout.sampled_token_offset + 4]
+            .copy_from_slice(&42u32.to_le_bytes());
+
+        let trace = layout.parse(&bytes).unwrap();
+        assert_eq!(trace.embedding, emb);
+        assert_eq!(trace.layer_post_attn[0], l0_attn);
+        assert_eq!(trace.layer_selected_ids[1], l1_ids);
+        assert_eq!(trace.final_norm, fnorm);
+        assert_eq!(trace.sampled_token, 42);
+
+        // Under-sized buffer fails
+        assert!(layout
+            .parse(&bytes[..layout.total_bytes as usize - 1])
+            .is_err());
+    }
+
+    fn sample_trace(
+        layers: usize,
+        d_model: usize,
+        top_k: usize,
+        vocab: usize,
+    ) -> ModelDiagnosticTrace {
+        ModelDiagnosticTrace {
+            embedding: vec![1.0; d_model],
+            layer_post_attn: vec![vec![2.0; d_model]; layers],
+            layer_router_input: vec![vec![3.0; d_model]; layers],
+            layer_selected_ids: vec![vec![0; top_k]; layers],
+            layer_selected_weights: vec![vec![0.5; top_k]; layers],
+            layer_post_moe: vec![vec![4.0; d_model]; layers],
+            final_norm: vec![5.0; d_model],
+            logits: vec![6.0; vocab],
+            sampled_token: 5212,
+        }
+    }
+
+    fn model_to_gpu_trace(m: &ModelDiagnosticTrace) -> GpuNativeDiagnosticTrace {
+        GpuNativeDiagnosticTrace {
+            embedding: m.embedding.clone(),
+            layer_post_attn: m.layer_post_attn.clone(),
+            layer_router_input: m.layer_router_input.clone(),
+            layer_selected_ids: m.layer_selected_ids.clone(),
+            layer_selected_weights: m.layer_selected_weights.clone(),
+            layer_post_moe: m.layer_post_moe.clone(),
+            layer_statuses: vec![0; m.layer_post_attn.len()],
+            final_norm: m.final_norm.clone(),
+            logits: m.logits.clone(),
+            final_status: 0,
+            sampled_token: m.sampled_token,
+        }
+    }
+
+    #[test]
+    fn no_divergence_when_identical() {
+        let reference = sample_trace(2, 4, 2, 8);
+        let gpu = model_to_gpu_trace(&reference);
+
+        let (first_exact, first_div, stages) = compare_diagnostic_traces(&reference, &gpu).unwrap();
+        assert!(first_exact.is_none());
+        assert!(first_div.is_none());
+        assert!(stages.iter().all(|s| s.tolerance_pass && s.exact_match));
+    }
+
+    #[test]
+    fn first_divergence_embedding() {
+        let reference = sample_trace(2, 4, 2, 8);
+        let mut gpu = model_to_gpu_trace(&reference);
+        gpu.embedding[0] = 100.0;
+
+        let (_first_exact, first_div, _) = compare_diagnostic_traces(&reference, &gpu).unwrap();
+        assert!(first_div.is_some());
+        let div = first_div.unwrap();
+        assert_eq!(div.stage, DiagnosticStage::Embedding);
+        assert_eq!(div.layer, None);
+        assert_eq!(div.worst_index, Some(0));
+    }
+
+    #[test]
+    fn first_divergence_layer_post_attention() {
+        let reference = sample_trace(2, 4, 2, 8);
+        let mut gpu = model_to_gpu_trace(&reference);
+        gpu.layer_post_attn[1][2] = 99.0;
+
+        let (_first_exact, first_div, _) = compare_diagnostic_traces(&reference, &gpu).unwrap();
+        assert!(first_div.is_some());
+        let div = first_div.unwrap();
+        assert_eq!(div.stage, DiagnosticStage::LayerPostAttention { layer: 1 });
+        assert_eq!(div.layer, Some(1));
+    }
+
+    #[test]
+    fn first_divergence_layer_router_input() {
+        let reference = sample_trace(2, 4, 2, 8);
+        let mut gpu = model_to_gpu_trace(&reference);
+        gpu.layer_router_input[0][1] = 99.0;
+
+        let (_first_exact, first_div, _) = compare_diagnostic_traces(&reference, &gpu).unwrap();
+        assert!(first_div.is_some());
+        let div = first_div.unwrap();
+        assert_eq!(div.stage, DiagnosticStage::LayerRouterInput { layer: 0 });
+        assert_eq!(div.layer, Some(0));
+    }
+
+    #[test]
+    fn first_divergence_layer_routing_ids() {
+        let reference = sample_trace(2, 4, 2, 8);
+        let mut gpu = model_to_gpu_trace(&reference);
+        gpu.layer_selected_ids[0][1] = 99;
+
+        let (_first_exact, first_div, _) = compare_diagnostic_traces(&reference, &gpu).unwrap();
+        assert!(first_div.is_some());
+        let div = first_div.unwrap();
+        assert_eq!(
+            div.stage,
+            DiagnosticStage::LayerSelectedExpertIds { layer: 0 }
+        );
+        assert_eq!(div.layer, Some(0));
+    }
+
+    #[test]
+    fn first_divergence_layer_routing_weights() {
+        let reference = sample_trace(2, 4, 2, 8);
+        let mut gpu = model_to_gpu_trace(&reference);
+        gpu.layer_selected_weights[1][0] = 0.99;
+
+        let (_first_exact, first_div, _) = compare_diagnostic_traces(&reference, &gpu).unwrap();
+        assert!(first_div.is_some());
+        let div = first_div.unwrap();
+        assert_eq!(
+            div.stage,
+            DiagnosticStage::LayerSelectedExpertWeights { layer: 1 }
+        );
+        assert_eq!(div.layer, Some(1));
+    }
+
+    #[test]
+    fn first_divergence_layer_post_moe() {
+        let reference = sample_trace(2, 4, 2, 8);
+        let mut gpu = model_to_gpu_trace(&reference);
+        gpu.layer_post_moe[1][0] = 99.0;
+
+        let (_first_exact, first_div, _) = compare_diagnostic_traces(&reference, &gpu).unwrap();
+        assert!(first_div.is_some());
+        let div = first_div.unwrap();
+        assert_eq!(div.stage, DiagnosticStage::LayerPostMoe { layer: 1 });
+        assert_eq!(div.layer, Some(1));
+    }
+
+    #[test]
+    fn first_divergence_final_norm() {
+        let reference = sample_trace(2, 4, 2, 8);
+        let mut gpu = model_to_gpu_trace(&reference);
+        gpu.final_norm[3] = 99.0;
+
+        let (_first_exact, first_div, _) = compare_diagnostic_traces(&reference, &gpu).unwrap();
+        assert!(first_div.is_some());
+        let div = first_div.unwrap();
+        assert_eq!(div.stage, DiagnosticStage::FinalNorm);
+    }
+
+    #[test]
+    fn first_divergence_logits() {
+        let reference = sample_trace(2, 4, 2, 8);
+        let mut gpu = model_to_gpu_trace(&reference);
+        gpu.logits[5] = 99.0;
+
+        let (_first_exact, first_div, _) = compare_diagnostic_traces(&reference, &gpu).unwrap();
+        assert!(first_div.is_some());
+        let div = first_div.unwrap();
+        assert_eq!(div.stage, DiagnosticStage::Logits);
+    }
+
+    #[test]
+    fn first_divergence_sampled_token() {
+        let reference = sample_trace(2, 4, 2, 8);
+        let mut gpu = model_to_gpu_trace(&reference);
+        gpu.sampled_token = 715;
+
+        let (_first_exact, first_div, _) = compare_diagnostic_traces(&reference, &gpu).unwrap();
+        assert!(first_div.is_some());
+        let div = first_div.unwrap();
+        assert_eq!(div.stage, DiagnosticStage::SampledToken);
+    }
+
+    #[test]
+    fn nonfinite_handling_fails_tolerance_and_flags_divergence() {
+        let reference = sample_trace(2, 4, 2, 8);
+        let mut gpu = model_to_gpu_trace(&reference);
+        gpu.embedding[0] = f32::NAN;
+
+        let (_first_exact, first_div, stages) =
+            compare_diagnostic_traces(&reference, &gpu).unwrap();
+        assert!(first_div.is_some());
+        assert_eq!(first_div.unwrap().stage, DiagnosticStage::Embedding);
+        assert!(!stages[0].tolerance_pass);
+    }
+
+    #[test]
+    fn length_mismatch_fails_closed() {
+        let mut reference = sample_trace(2, 4, 2, 8);
+        let gpu = model_to_gpu_trace(&reference);
+        reference.layer_post_attn.pop();
+
+        assert!(compare_diagnostic_traces(&reference, &gpu).is_err());
+    }
+
+    #[test]
+    fn report_cannot_claim_qualification_pass() {
+        let report = GpuNativeFirstDivergenceReport::new(
+            BuildProvenance::embedded(),
+            "0123456789012345678901234567890123456789".to_string(),
+            "a".repeat(64),
+            "b".repeat(64),
+            GpuNativeModelGeometry {
+                num_layers: 48,
+                d_model: 2048,
+                d_ff: 1024,
+                num_experts: 64,
+                top_k: 8,
+                num_heads: 16,
+                num_kv_heads: 2,
+                head_dim: 128,
+                rope_dim: 64,
+                vocab_size: 151936,
+                max_seq_len: 2048,
+                rms_eps: 1e-6,
+                rope_base: 10000.0,
+            },
+            ExpertMetadataEvidence {
+                dtype: Some("q4_0".to_string()),
+                q4_0_layout: Some("canonical".to_string()),
+                conversion_mode: Some("native".to_string()),
+                source: Some("checkpoint".to_string()),
+                explicitly_synthetic: false,
+            },
+            CaseEvidence {
+                case_name: TARGET_CASE.to_string(),
+                prompt_sha256: "c".repeat(64),
+                prompt_token_count: 32,
+            },
+            "d".repeat(64),
+            "NVIDIA L4".to_string(),
+        );
+
+        assert!(!report.qualification_pass);
+        let json = serde_json::to_string(&report).unwrap();
+        assert!(json.contains("\"qualification_pass\":false"));
+    }
+}

--- a/rust-engine/src/gpu_native_expert_permutation_semantic_parity.rs
+++ b/rust-engine/src/gpu_native_expert_permutation_semantic_parity.rs
@@ -1,0 +1,1097 @@
+//! Diagnostic-only semantic witness for a GPU-native expert-rank permutation.
+//!
+//! This module owns typed evidence and host-only recomputation. Production
+//! routing, expert execution, accumulation, and qualifier PASS semantics do not
+//! depend on it.
+
+use std::cmp::Ordering;
+use std::collections::{BTreeMap, HashSet};
+
+use serde::Serialize;
+
+use crate::gpu_native_router_rank_diagnostics::{
+    ActualGpuRouterEvidence, CutoffMarginEvidence, DiagnosticProvenance, GateIdentityEvidence,
+    PrefixEvidence, RankedExpertEvidence, RouterEvaluationEvidence, RouterInputEvidence,
+    TargetEvidence,
+};
+use crate::gpu_native_token_loop::GpuNativeModelGeometry;
+use crate::numerical_diagnostics::FloatEvidence;
+
+pub const SCHEMA_VERSION: &str = "mer.gpu-native-expert-permutation-semantic-parity.v1";
+pub const MODE: &str = "diagnose-gpu-native-expert-permutation-semantic-parity";
+
+/// Target-layer-only staging layout used solely by the semantic diagnostic.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct SemanticTraceLayout {
+    pub target_layer: usize,
+    pub d_model: usize,
+    pub num_experts: usize,
+    pub top_k: usize,
+    pub router_input_offset: u64,
+    pub router_input_bytes: u64,
+    pub raw_logits_offset: u64,
+    pub raw_logits_bytes: u64,
+    pub selected_ids_offset: u64,
+    pub selected_ids_bytes: u64,
+    pub selected_weights_offset: u64,
+    pub selected_weights_bytes: u64,
+    pub route_outputs_offset: u64,
+    pub route_outputs_bytes: u64,
+    pub routed_moe_output_offset: u64,
+    pub routed_moe_output_bytes: u64,
+    pub total_bytes: u64,
+}
+
+impl SemanticTraceLayout {
+    pub fn try_new(geometry: GpuNativeModelGeometry, target_layer: usize) -> Result<Self, String> {
+        if target_layer >= geometry.num_layers
+            || geometry.d_model == 0
+            || geometry.num_experts == 0
+            || geometry.top_k == 0
+            || geometry.top_k > geometry.num_experts
+        {
+            return Err("invalid semantic trace geometry or target layer".to_string());
+        }
+        let bytes = |elements: usize, label: &str| {
+            elements
+                .checked_mul(std::mem::size_of::<u32>())
+                .and_then(|value| u64::try_from(value).ok())
+                .ok_or_else(|| format!("{label} byte size overflow"))
+        };
+        let router_input_offset = 0;
+        let router_input_bytes = bytes(geometry.d_model, "router input")?;
+        let raw_logits_offset = router_input_bytes;
+        let raw_logits_bytes = bytes(geometry.num_experts, "raw logits")?;
+        let selected_ids_offset = raw_logits_offset
+            .checked_add(raw_logits_bytes)
+            .ok_or("selected IDs offset overflow")?;
+        let selected_ids_bytes = bytes(geometry.top_k, "selected IDs")?;
+        let selected_weights_offset = selected_ids_offset
+            .checked_add(selected_ids_bytes)
+            .ok_or("selected weights offset overflow")?;
+        let selected_weights_bytes = bytes(geometry.top_k, "selected weights")?;
+        let route_outputs_offset = selected_weights_offset
+            .checked_add(selected_weights_bytes)
+            .ok_or("route outputs offset overflow")?;
+        let route_outputs_elements = geometry
+            .top_k
+            .checked_mul(geometry.d_model)
+            .ok_or("route outputs element count overflow")?;
+        let route_outputs_bytes = bytes(route_outputs_elements, "route outputs")?;
+        let routed_moe_output_offset = route_outputs_offset
+            .checked_add(route_outputs_bytes)
+            .ok_or("routed MoE output offset overflow")?;
+        let routed_moe_output_bytes = bytes(geometry.d_model, "routed MoE output")?;
+        let total_bytes = routed_moe_output_offset
+            .checked_add(routed_moe_output_bytes)
+            .ok_or("semantic trace total size overflow")?;
+        Ok(Self {
+            target_layer,
+            d_model: geometry.d_model,
+            num_experts: geometry.num_experts,
+            top_k: geometry.top_k,
+            router_input_offset,
+            router_input_bytes,
+            raw_logits_offset,
+            raw_logits_bytes,
+            selected_ids_offset,
+            selected_ids_bytes,
+            selected_weights_offset,
+            selected_weights_bytes,
+            route_outputs_offset,
+            route_outputs_bytes,
+            routed_moe_output_offset,
+            routed_moe_output_bytes,
+            total_bytes,
+        })
+    }
+
+    pub fn parse(&self, bytes: &[u8]) -> Result<SemanticGpuTrace, String> {
+        if bytes.len() < self.total_bytes as usize {
+            return Err(format!(
+                "semantic staging has {} bytes, expected {}",
+                bytes.len(),
+                self.total_bytes
+            ));
+        }
+        let parse_f32 = |offset: u64, count: usize| {
+            bytes[offset as usize..offset as usize + count * 4]
+                .chunks_exact(4)
+                .map(|chunk| f32::from_le_bytes(chunk.try_into().unwrap()))
+                .collect::<Vec<_>>()
+        };
+        let parse_u32 = |offset: u64, count: usize| {
+            bytes[offset as usize..offset as usize + count * 4]
+                .chunks_exact(4)
+                .map(|chunk| u32::from_le_bytes(chunk.try_into().unwrap()))
+                .collect::<Vec<_>>()
+        };
+        let flat_outputs = parse_f32(self.route_outputs_offset, self.top_k * self.d_model);
+        Ok(SemanticGpuTrace {
+            router_input: parse_f32(self.router_input_offset, self.d_model),
+            raw_logits: parse_f32(self.raw_logits_offset, self.num_experts),
+            selected_ids: parse_u32(self.selected_ids_offset, self.top_k),
+            selected_weights: parse_f32(self.selected_weights_offset, self.top_k),
+            route_outputs: flat_outputs
+                .chunks_exact(self.d_model)
+                .map(<[f32]>::to_vec)
+                .collect(),
+            routed_moe_output: parse_f32(self.routed_moe_output_offset, self.d_model),
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct SemanticGpuTrace {
+    pub router_input: Vec<f32>,
+    pub raw_logits: Vec<f32>,
+    pub selected_ids: Vec<u32>,
+    pub selected_weights: Vec<f32>,
+    pub route_outputs: Vec<Vec<f32>>,
+    pub routed_moe_output: Vec<f32>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct CpuSameInputRoutedMoeCapture {
+    pub selected_ids: Vec<u32>,
+    pub selected_weights: Vec<f32>,
+    pub expert_outputs: Vec<Vec<f32>>,
+    pub routed_moe_output: Vec<f32>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct SelectedExpertSemanticEvidence {
+    pub expert_id: u32,
+    pub rank: usize,
+    pub raw_logit: Option<FloatEvidence>,
+    pub pre_normalization_score: Option<FloatEvidence>,
+    pub selected_normalized_weight: FloatEvidence,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct RoutingViewEvidence {
+    pub source: &'static str,
+    pub production_rank_order: Vec<SelectedExpertSemanticEvidence>,
+    pub canonical_expert_id_order: Vec<SelectedExpertSemanticEvidence>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct WeightDeltaEvidence {
+    pub expert_id: u32,
+    pub left: FloatEvidence,
+    pub right: FloatEvidence,
+    pub absolute_error: Option<f64>,
+    pub relative_error: Option<f64>,
+    pub ulp_distance: Option<u32>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct CanonicalAssociationWitness {
+    pub authoritative_cpu_reference_routing: RoutingViewEvidence,
+    pub cpu_production_routing_on_exact_gpu_input: RoutingViewEvidence,
+    pub actual_production_gpu_routing: RoutingViewEvidence,
+    pub reference_vs_gpu_top_k_membership_equal: bool,
+    pub cpu_on_gpu_input_vs_actual_gpu_membership_equal: bool,
+    pub actual_gpu_selected_weights_paired_with_expert_ids: bool,
+    pub reference_vs_gpu_common_expert_weight_deltas_by_expert_id: Vec<WeightDeltaEvidence>,
+    pub cpu_on_gpu_input_vs_actual_gpu_weight_deltas_by_expert_id: Vec<WeightDeltaEvidence>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct VectorNumericalEvidence {
+    pub left_source: &'static str,
+    pub right_source: &'static str,
+    pub vector_length: usize,
+    pub left_f32_bits_sha256: String,
+    pub right_f32_bits_sha256: String,
+    pub exact_bit_equal: bool,
+    pub exact_bit_equal_element_count: usize,
+    pub max_absolute_error: Option<f64>,
+    pub rms_error: Option<f64>,
+    pub mean_absolute_error: Option<f64>,
+    pub max_relative_error_where_defined: Option<f64>,
+    pub relative_error_defined_element_count: usize,
+    pub left_nonfinite_count: usize,
+    pub right_nonfinite_count: usize,
+    pub nonfinite_bit_mismatch_count: usize,
+    pub worst_element_index: Option<usize>,
+    pub left_value_at_worst_element: Option<FloatEvidence>,
+    pub right_value_at_worst_element: Option<FloatEvidence>,
+}
+
+impl VectorNumericalEvidence {
+    pub fn compare(
+        left_source: &'static str,
+        right_source: &'static str,
+        left: &[f32],
+        right: &[f32],
+    ) -> Result<Self, String> {
+        if left.is_empty() || left.len() != right.len() {
+            return Err("semantic vector lengths differ or are empty".to_string());
+        }
+        let left_bits: Vec<u32> = left.iter().map(|value| value.to_bits()).collect();
+        let right_bits: Vec<u32> = right.iter().map(|value| value.to_bits()).collect();
+        let exact_bit_equal_element_count = left_bits
+            .iter()
+            .zip(&right_bits)
+            .filter(|(left, right)| left == right)
+            .count();
+        let mut finite_pairs = 0usize;
+        let mut absolute_sum = 0.0f64;
+        let mut squared_sum = 0.0f64;
+        let mut max_absolute = None::<f64>;
+        let mut max_relative = None::<f64>;
+        let mut relative_count = 0usize;
+        let mut worst_index = None;
+        let mut left_nonfinite_count = 0usize;
+        let mut right_nonfinite_count = 0usize;
+        let mut nonfinite_bit_mismatch_count = 0usize;
+        for (index, (&left_value, &right_value)) in left.iter().zip(right).enumerate() {
+            left_nonfinite_count += usize::from(!left_value.is_finite());
+            right_nonfinite_count += usize::from(!right_value.is_finite());
+            if !left_value.is_finite() || !right_value.is_finite() {
+                nonfinite_bit_mismatch_count +=
+                    usize::from(left_value.to_bits() != right_value.to_bits());
+                continue;
+            }
+            finite_pairs += 1;
+            let absolute = (f64::from(right_value) - f64::from(left_value)).abs();
+            absolute_sum += absolute;
+            squared_sum += absolute * absolute;
+            if max_absolute.is_none_or(|current| absolute > current) {
+                max_absolute = Some(absolute);
+                worst_index = Some(index);
+            }
+            if left_value != 0.0 {
+                relative_count += 1;
+                let relative = absolute / f64::from(left_value).abs();
+                if relative.is_finite() && max_relative.is_none_or(|current| relative > current) {
+                    max_relative = Some(relative);
+                }
+            }
+        }
+        Ok(Self {
+            left_source,
+            right_source,
+            vector_length: left.len(),
+            left_f32_bits_sha256: crate::numerical_diagnostics::f32_bits_sha256(&left_bits),
+            right_f32_bits_sha256: crate::numerical_diagnostics::f32_bits_sha256(&right_bits),
+            exact_bit_equal: exact_bit_equal_element_count == left.len(),
+            exact_bit_equal_element_count,
+            max_absolute_error: max_absolute,
+            rms_error: (finite_pairs > 0).then(|| (squared_sum / finite_pairs as f64).sqrt()),
+            mean_absolute_error: (finite_pairs > 0).then(|| absolute_sum / finite_pairs as f64),
+            max_relative_error_where_defined: max_relative,
+            relative_error_defined_element_count: relative_count,
+            left_nonfinite_count,
+            right_nonfinite_count,
+            nonfinite_bit_mismatch_count,
+            worst_element_index: worst_index,
+            left_value_at_worst_element: worst_index.map(|index| FloatEvidence::new(left[index])),
+            right_value_at_worst_element: worst_index.map(|index| FloatEvidence::new(right[index])),
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct FrozenExpertOutputEvidence {
+    pub expert_id: u32,
+    pub associated_weight: FloatEvidence,
+    pub expert_output_f32_bits_sha256: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct PermutationOnlyWitness {
+    pub frozen_expert_outputs_in_production_rank_order: Vec<FrozenExpertOutputEvidence>,
+    pub production_rank_order_expert_ids: Vec<u32>,
+    pub canonical_expert_id_sorted_order: Vec<u32>,
+    pub comparison: VectorNumericalEvidence,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct BoundaryViewEvidence {
+    pub source: &'static str,
+    pub top_12_experts: Vec<RankedExpertEvidence>,
+    pub rank_7_expert_id: u32,
+    pub rank_8_expert_id: u32,
+    pub rank_9_expert_id: u32,
+    pub rank_7_minus_rank_8_score_margin: FloatEvidence,
+    pub rank_8_minus_rank_9_score_margin: FloatEvidence,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct MembershipBoundaryWitness {
+    pub authoritative_reference: BoundaryViewEvidence,
+    pub cpu_on_exact_gpu_input: BoundaryViewEvidence,
+    pub actual_gpu: BoundaryViewEvidence,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ProductionAccumulationSemanticsEvidence {
+    pub cpu: &'static str,
+    pub gpu: &'static str,
+    pub route_order_can_affect_last_bits: bool,
+    pub production_order_was_not_changed: bool,
+    pub canonicalization_scope: &'static str,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct ExpertPermutationSemanticParityReport {
+    pub schema: &'static str,
+    pub mode: &'static str,
+    pub status: &'static str,
+    pub diagnostic_complete: bool,
+    qualification_pass: bool,
+    pub failure: Option<String>,
+    pub provenance: DiagnosticProvenance,
+    pub target: TargetEvidence,
+    pub prefix: PrefixEvidence,
+    pub router_input: RouterInputEvidence,
+    pub gate_identity: GateIdentityEvidence,
+    pub witness_a_canonical_expert_weight_association: CanonicalAssociationWitness,
+    pub witness_b_same_input_cpu_vs_gpu_routed_moe_output: VectorNumericalEvidence,
+    pub witness_c_reference_vs_gpu_routed_moe_output: VectorNumericalEvidence,
+    pub witness_d_permutation_only_accumulation: PermutationOnlyWitness,
+    pub witness_e_membership_boundary_context: MembershipBoundaryWitness,
+    pub production_accumulation_semantics: ProductionAccumulationSemanticsEvidence,
+}
+
+impl ExpertPermutationSemanticParityReport {
+    #[allow(clippy::too_many_arguments)]
+    pub fn build(
+        provenance: DiagnosticProvenance,
+        case: &str,
+        generated_position: usize,
+        layer: usize,
+        prompt_token_ids: Vec<u32>,
+        reference_generated: Vec<u32>,
+        gpu_generated: Vec<u32>,
+        reference_router_input: &[f32],
+        gpu_router_input: &[f32],
+        gate_identity: GateIdentityEvidence,
+        authoritative_reference: RouterEvaluationEvidence,
+        cpu_on_gpu_input: RouterEvaluationEvidence,
+        actual_gpu: ActualGpuRouterEvidence,
+        reference_routed_moe_output: &[f32],
+        same_input_cpu_routed_moe_output: &[f32],
+        actual_gpu_routed_moe_output: &[f32],
+        actual_gpu_route_outputs: &[Vec<f32>],
+    ) -> Result<Self, String> {
+        if reference_generated.len() != generated_position + 1
+            || gpu_generated.len() != generated_position + 1
+        {
+            return Err("target generation evidence is incomplete".to_string());
+        }
+        let reference_preceding = reference_generated[..generated_position].to_vec();
+        let gpu_preceding = gpu_generated[..generated_position].to_vec();
+        let fixed_case = crate::greedy_parity::fixed_case(case)
+            .ok_or_else(|| format!("unknown fixed corpus case {case:?}"))?;
+        let preceding_generated_prefix_match = reference_preceding == gpu_preceding;
+        let failure = if !preceding_generated_prefix_match {
+            Some(
+                "preceding generated token prefix differs; semantic comparison is invalid"
+                    .to_string(),
+            )
+        } else if !gate_identity.exact_identity_match {
+            Some("reference and GPU runtimes loaded different gate tensors".to_string())
+        } else {
+            None
+        };
+        let target_generated_token_match =
+            reference_generated[generated_position] == gpu_generated[generated_position];
+        let witness_a = CanonicalAssociationWitness::build(
+            &authoritative_reference,
+            &cpu_on_gpu_input,
+            &actual_gpu,
+        )?;
+        let witness_b = VectorNumericalEvidence::compare(
+            "cpu-production-routed-moe-on-exact-gpu-input",
+            "actual-production-gpu-routed-moe-on-exact-gpu-input",
+            same_input_cpu_routed_moe_output,
+            actual_gpu_routed_moe_output,
+        )?;
+        let witness_c = VectorNumericalEvidence::compare(
+            "authoritative-cpu-reference-routed-moe",
+            "actual-production-gpu-routed-moe",
+            reference_routed_moe_output,
+            actual_gpu_routed_moe_output,
+        )?;
+        let witness_d = permutation_only_witness(
+            &actual_gpu.top_8_ids,
+            &actual_gpu
+                .top_8_weights
+                .iter()
+                .map(|weight| f32::from_bits(weight.bits))
+                .collect::<Vec<_>>(),
+            actual_gpu_route_outputs,
+        )?;
+        let witness_e = MembershipBoundaryWitness {
+            authoritative_reference: boundary_view(
+                authoritative_reference.source,
+                &authoritative_reference.top_12_ranked_experts,
+                &authoritative_reference.cutoff_margins,
+            ),
+            cpu_on_exact_gpu_input: boundary_view(
+                cpu_on_gpu_input.source,
+                &cpu_on_gpu_input.top_12_ranked_experts,
+                &cpu_on_gpu_input.cutoff_margins,
+            ),
+            actual_gpu: boundary_view(
+                actual_gpu.source,
+                &actual_gpu.top_12_ranked_experts,
+                &actual_gpu.cutoff_margins,
+            ),
+        };
+        Ok(Self {
+            schema: SCHEMA_VERSION,
+            mode: MODE,
+            status: if failure.is_some() {
+                "incomplete"
+            } else {
+                "diagnostic-only"
+            },
+            diagnostic_complete: failure.is_none(),
+            qualification_pass: false,
+            failure,
+            target: TargetEvidence {
+                case: case.to_string(),
+                generated_position,
+                generated_position_zero_based: true,
+                layer,
+                expected_reference_ids: authoritative_reference.top_8_ids.clone(),
+                observed_gpu_ids: actual_gpu.top_8_ids.clone(),
+                top_8_set_match: same_membership(
+                    &authoritative_reference.top_8_ids,
+                    &actual_gpu.top_8_ids,
+                ),
+                rank_order_match: authoritative_reference.top_8_ids == actual_gpu.top_8_ids,
+                only_internal_rank_change: same_membership(
+                    &authoritative_reference.top_8_ids,
+                    &actual_gpu.top_8_ids,
+                ) && authoritative_reference.top_8_ids != actual_gpu.top_8_ids,
+            },
+            prefix: PrefixEvidence {
+                corpus: crate::greedy_parity::CorpusEvidence::fixed(),
+                prompt_sha256: crate::greedy_parity::sha256_hex(fixed_case.prompt.as_bytes()),
+                prompt_token_ids_sha256: crate::greedy_parity::token_ids_sha256(&prompt_token_ids),
+                prompt_token_ids,
+                reference_preceding_generated_token_ids: reference_preceding,
+                gpu_native_preceding_generated_token_ids: gpu_preceding,
+                preceding_generated_prefix_match,
+                reference_target_generated_token_id: reference_generated[generated_position],
+                gpu_native_target_generated_token_id: gpu_generated[generated_position],
+                target_generated_token_match,
+            },
+            router_input: RouterInputEvidence::compare(
+                reference_router_input,
+                gpu_router_input,
+            )?,
+            gate_identity,
+            witness_a_canonical_expert_weight_association: witness_a,
+            witness_b_same_input_cpu_vs_gpu_routed_moe_output: witness_b,
+            witness_c_reference_vs_gpu_routed_moe_output: witness_c,
+            witness_d_permutation_only_accumulation: witness_d,
+            witness_e_membership_boundary_context: witness_e,
+            production_accumulation_semantics: ProductionAccumulationSemanticsEvidence {
+                cpu: "sequential f32: accumulator[element] += weight[route] * expert_output[route][element]",
+                gpu: "sequential WGSL f32 loop over route slots in expert_combine_main",
+                route_order_can_affect_last_bits: true,
+                production_order_was_not_changed: true,
+                canonicalization_scope: "diagnostic-only host recomputation over frozen GPU expert outputs",
+            },
+            provenance,
+        })
+    }
+
+    pub const fn qualification_pass(&self) -> bool {
+        self.qualification_pass
+    }
+}
+
+impl CanonicalAssociationWitness {
+    pub fn build(
+        reference: &RouterEvaluationEvidence,
+        cpu_on_gpu: &RouterEvaluationEvidence,
+        actual_gpu: &ActualGpuRouterEvidence,
+    ) -> Result<Self, String> {
+        let reference_view = cpu_route_view(reference)?;
+        let cpu_on_gpu_view = cpu_route_view(cpu_on_gpu)?;
+        let actual_gpu_view = gpu_route_view(actual_gpu)?;
+        Ok(Self {
+            reference_vs_gpu_top_k_membership_equal: same_membership(
+                &reference.top_8_ids,
+                &actual_gpu.top_8_ids,
+            ),
+            cpu_on_gpu_input_vs_actual_gpu_membership_equal: same_membership(
+                &cpu_on_gpu.top_8_ids,
+                &actual_gpu.top_8_ids,
+            ),
+            actual_gpu_selected_weights_paired_with_expert_ids:
+                actual_gpu_pairing_is_structurally_consistent(actual_gpu),
+            reference_vs_gpu_common_expert_weight_deltas_by_expert_id: weight_deltas(
+                &reference_view.production_rank_order,
+                &actual_gpu_view.production_rank_order,
+            ),
+            cpu_on_gpu_input_vs_actual_gpu_weight_deltas_by_expert_id: weight_deltas(
+                &cpu_on_gpu_view.production_rank_order,
+                &actual_gpu_view.production_rank_order,
+            ),
+            authoritative_cpu_reference_routing: reference_view,
+            cpu_production_routing_on_exact_gpu_input: cpu_on_gpu_view,
+            actual_production_gpu_routing: actual_gpu_view,
+        })
+    }
+}
+
+fn cpu_route_view(evaluation: &RouterEvaluationEvidence) -> Result<RoutingViewEvidence, String> {
+    route_view(
+        evaluation.source,
+        &evaluation.raw_logits,
+        &evaluation.scored_probabilities,
+        &evaluation.top_8_ids,
+        &evaluation.top_8_weights,
+    )
+}
+
+fn gpu_route_view(evaluation: &ActualGpuRouterEvidence) -> Result<RoutingViewEvidence, String> {
+    route_view(
+        evaluation.source,
+        &evaluation.raw_logits,
+        &evaluation.scored_probabilities,
+        &evaluation.top_8_ids,
+        &evaluation.top_8_weights,
+    )
+}
+
+fn route_view(
+    source: &'static str,
+    raw_logits: &[FloatEvidence],
+    scores: &[FloatEvidence],
+    ids: &[u32],
+    weights: &[FloatEvidence],
+) -> Result<RoutingViewEvidence, String> {
+    if ids.is_empty() || ids.len() != weights.len() {
+        return Err("selected expert IDs and weights are empty or misaligned".to_string());
+    }
+    let mut seen = HashSet::with_capacity(ids.len());
+    let production_rank_order = ids
+        .iter()
+        .copied()
+        .zip(weights.iter().cloned())
+        .enumerate()
+        .map(|(rank, (expert_id, selected_normalized_weight))| {
+            if !seen.insert(expert_id) {
+                return Err(format!("duplicate selected expert ID {expert_id}"));
+            }
+            let index = expert_id as usize;
+            Ok(SelectedExpertSemanticEvidence {
+                expert_id,
+                rank: rank + 1,
+                raw_logit: raw_logits.get(index).cloned(),
+                pre_normalization_score: scores.get(index).cloned(),
+                selected_normalized_weight,
+            })
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    let mut canonical_expert_id_order = production_rank_order.clone();
+    canonical_expert_id_order.sort_by_key(|expert| expert.expert_id);
+    Ok(RoutingViewEvidence {
+        source,
+        production_rank_order,
+        canonical_expert_id_order,
+    })
+}
+
+fn weight_deltas(
+    left: &[SelectedExpertSemanticEvidence],
+    right: &[SelectedExpertSemanticEvidence],
+) -> Vec<WeightDeltaEvidence> {
+    let left_by_id: BTreeMap<u32, f32> = left
+        .iter()
+        .map(|item| {
+            (
+                item.expert_id,
+                f32::from_bits(item.selected_normalized_weight.bits),
+            )
+        })
+        .collect();
+    let right_by_id: BTreeMap<u32, f32> = right
+        .iter()
+        .map(|item| {
+            (
+                item.expert_id,
+                f32::from_bits(item.selected_normalized_weight.bits),
+            )
+        })
+        .collect();
+    left_by_id
+        .into_iter()
+        .filter_map(|(expert_id, left)| {
+            right_by_id.get(&expert_id).copied().map(|right| {
+                let absolute = (f64::from(right) - f64::from(left)).abs();
+                WeightDeltaEvidence {
+                    expert_id,
+                    left: FloatEvidence::new(left),
+                    right: FloatEvidence::new(right),
+                    absolute_error: (left.is_finite() && right.is_finite()).then_some(absolute),
+                    relative_error: (left.is_finite() && right.is_finite() && left != 0.0)
+                        .then(|| absolute / f64::from(left).abs())
+                        .filter(|value| value.is_finite()),
+                    ulp_distance: crate::gpu_native_router_rank_diagnostics::ulp_distance(
+                        left, right,
+                    ),
+                }
+            })
+        })
+        .collect()
+}
+
+fn actual_gpu_pairing_is_structurally_consistent(actual: &ActualGpuRouterEvidence) -> bool {
+    if actual.top_8_ids.len() != actual.top_8_weights.len()
+        || actual
+            .top_8_ids
+            .iter()
+            .copied()
+            .collect::<HashSet<_>>()
+            .len()
+            != actual.top_8_ids.len()
+    {
+        return false;
+    }
+    let mut expected_ids = actual.top_8_ids.clone();
+    expected_ids.sort_by(|left, right| {
+        let left_score = actual
+            .scored_probabilities
+            .get(*left as usize)
+            .and_then(|value| value.value);
+        let right_score = actual
+            .scored_probabilities
+            .get(*right as usize)
+            .and_then(|value| value.value);
+        match (left_score, right_score) {
+            (Some(left_score), Some(right_score)) => right_score
+                .total_cmp(&left_score)
+                .then_with(|| left.cmp(right)),
+            _ => Ordering::Equal,
+        }
+    });
+    expected_ids == actual.top_8_ids
+        && actual
+            .top_8_weights
+            .windows(2)
+            .all(|pair| match (pair[0].value, pair[1].value) {
+                (Some(left), Some(right)) => left.total_cmp(&right) != Ordering::Less,
+                _ => false,
+            })
+}
+
+pub fn same_membership(left: &[u32], right: &[u32]) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+    let mut left = left.to_vec();
+    let mut right = right.to_vec();
+    left.sort_unstable();
+    right.sort_unstable();
+    left == right
+}
+
+pub fn permutation_only_witness(
+    ids: &[u32],
+    weights: &[f32],
+    expert_outputs: &[Vec<f32>],
+) -> Result<PermutationOnlyWitness, String> {
+    if ids.is_empty() || ids.len() != weights.len() || ids.len() != expert_outputs.len() {
+        return Err("permutation witness inputs are empty or misaligned".to_string());
+    }
+    if ids.iter().copied().collect::<HashSet<_>>().len() != ids.len() {
+        return Err("permutation witness contains duplicate expert IDs".to_string());
+    }
+    let width = expert_outputs[0].len();
+    if width == 0 || expert_outputs.iter().any(|output| output.len() != width) {
+        return Err("permutation witness expert output geometry is invalid".to_string());
+    }
+    let production = ids
+        .iter()
+        .copied()
+        .zip(weights.iter().copied())
+        .zip(expert_outputs.iter())
+        .map(|((id, weight), output)| (id, weight, output))
+        .collect::<Vec<_>>();
+    let mut canonical = production.clone();
+    canonical.sort_by_key(|(id, _, _)| *id);
+    let accumulate = |ordered: &[(u32, f32, &Vec<f32>)]| {
+        let mut output = vec![0.0f32; width];
+        for (_, weight, expert_output) in ordered {
+            for (destination, value) in output.iter_mut().zip(expert_output.iter()) {
+                *destination += *weight * *value;
+            }
+        }
+        output
+    };
+    let production_sum = accumulate(&production);
+    let canonical_sum = accumulate(&canonical);
+    Ok(PermutationOnlyWitness {
+        frozen_expert_outputs_in_production_rank_order: production
+            .iter()
+            .map(|(expert_id, weight, output)| FrozenExpertOutputEvidence {
+                expert_id: *expert_id,
+                associated_weight: FloatEvidence::new(*weight),
+                expert_output_f32_bits_sha256: crate::numerical_diagnostics::f32_bits_sha256(
+                    &output
+                        .iter()
+                        .map(|value| value.to_bits())
+                        .collect::<Vec<_>>(),
+                ),
+            })
+            .collect(),
+        production_rank_order_expert_ids: production.iter().map(|(id, _, _)| *id).collect(),
+        canonical_expert_id_sorted_order: canonical.iter().map(|(id, _, _)| *id).collect(),
+        comparison: VectorNumericalEvidence::compare(
+            "host-accumulation-production-rank-order",
+            "host-accumulation-canonical-expert-id-order",
+            &production_sum,
+            &canonical_sum,
+        )?,
+    })
+}
+
+fn boundary_view(
+    source: &'static str,
+    top_12: &[RankedExpertEvidence],
+    cutoff: &CutoffMarginEvidence,
+) -> BoundaryViewEvidence {
+    BoundaryViewEvidence {
+        source,
+        top_12_experts: top_12.to_vec(),
+        rank_7_expert_id: cutoff.rank_7_expert_id,
+        rank_8_expert_id: cutoff.rank_8_expert_id,
+        rank_9_expert_id: cutoff.rank_9_expert_id,
+        rank_7_minus_rank_8_score_margin: cutoff.rank_7_minus_rank_8_score.clone(),
+        rank_8_minus_rank_9_score_margin: cutoff.rank_8_minus_rank_9_score.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn geometry() -> GpuNativeModelGeometry {
+        GpuNativeModelGeometry {
+            num_layers: 48,
+            d_model: 4,
+            d_ff: 8,
+            num_experts: 128,
+            top_k: 8,
+            num_heads: 2,
+            num_kv_heads: 1,
+            head_dim: 2,
+            rope_dim: 2,
+            vocab_size: 32,
+            max_seq_len: 64,
+            rms_eps: 1.0e-6,
+            rope_base: 1_000_000.0,
+        }
+    }
+
+    #[test]
+    fn semantic_trace_layout_round_trips_every_observation() {
+        let layout = SemanticTraceLayout::try_new(geometry(), 44).unwrap();
+        let mut bytes = vec![0u8; layout.total_bytes as usize];
+        let write_f32 = |bytes: &mut [u8], offset: u64, values: &[f32]| {
+            for (index, value) in values.iter().enumerate() {
+                bytes[offset as usize + index * 4..offset as usize + index * 4 + 4]
+                    .copy_from_slice(&value.to_le_bytes());
+            }
+        };
+        let ids = [30u32, 37, 114, 86, 29, 113, 68, 35];
+        for (index, id) in ids.iter().enumerate() {
+            bytes[layout.selected_ids_offset as usize + index * 4
+                ..layout.selected_ids_offset as usize + index * 4 + 4]
+                .copy_from_slice(&id.to_le_bytes());
+        }
+        write_f32(
+            &mut bytes,
+            layout.router_input_offset,
+            &[1.0, 2.0, 3.0, 4.0],
+        );
+        write_f32(
+            &mut bytes,
+            layout.raw_logits_offset,
+            &(0..128).map(|value| value as f32).collect::<Vec<_>>(),
+        );
+        write_f32(
+            &mut bytes,
+            layout.selected_weights_offset,
+            &[0.3, 0.2, 0.15, 0.12, 0.1, 0.06, 0.04, 0.03],
+        );
+        write_f32(
+            &mut bytes,
+            layout.route_outputs_offset,
+            &(0..32).map(|value| value as f32).collect::<Vec<_>>(),
+        );
+        write_f32(
+            &mut bytes,
+            layout.routed_moe_output_offset,
+            &[5.0, 6.0, 7.0, 8.0],
+        );
+        let trace = layout.parse(&bytes).unwrap();
+        assert_eq!(trace.selected_ids, ids);
+        assert_eq!(trace.route_outputs.len(), 8);
+        assert_eq!(trace.route_outputs[7], [28.0, 29.0, 30.0, 31.0]);
+        assert_eq!(trace.routed_moe_output, [5.0, 6.0, 7.0, 8.0]);
+    }
+
+    #[test]
+    fn canonicalization_preserves_expert_weight_association() {
+        let outputs = vec![vec![1.0], vec![2.0], vec![3.0]];
+        let witness = permutation_only_witness(&[9, 2, 5], &[0.1, 0.2, 0.7], &outputs).unwrap();
+        assert_eq!(witness.production_rank_order_expert_ids, [9, 2, 5]);
+        assert_eq!(witness.canonical_expert_id_sorted_order, [2, 5, 9]);
+        let by_id: BTreeMap<_, _> = witness
+            .frozen_expert_outputs_in_production_rank_order
+            .iter()
+            .map(|item| (item.expert_id, item.associated_weight.bits))
+            .collect();
+        assert_eq!(by_id[&9], 0.1f32.to_bits());
+        assert_eq!(by_id[&2], 0.2f32.to_bits());
+        assert_eq!(by_id[&5], 0.7f32.to_bits());
+    }
+
+    #[test]
+    fn membership_detects_permutation_and_difference() {
+        assert!(same_membership(&[68, 113, 35], &[113, 68, 35]));
+        assert!(!same_membership(&[68, 113, 35], &[113, 67, 35]));
+    }
+
+    #[test]
+    fn permutation_uses_identical_frozen_expert_outputs() {
+        let outputs = vec![
+            vec![-16_777_216.0, 1.0],
+            vec![16_777_216.0, 2.0],
+            vec![1.0, 3.0],
+        ];
+        let witness = permutation_only_witness(&[9, 2, 5], &[1.0; 3], &outputs).unwrap();
+        assert_eq!(witness.comparison.vector_length, 2);
+        assert_eq!(witness.comparison.exact_bit_equal_element_count, 1);
+        assert!(!witness.comparison.exact_bit_equal);
+    }
+
+    #[test]
+    fn vector_metrics_cover_exact_and_relative_denominators() {
+        let exact =
+            VectorNumericalEvidence::compare("left", "right", &[0.0, 1.0], &[0.0, 1.0]).unwrap();
+        assert!(exact.exact_bit_equal);
+        assert_eq!(exact.relative_error_defined_element_count, 1);
+        assert_eq!(exact.max_absolute_error, Some(0.0));
+
+        let near_zero = f32::from_bits(1);
+        let evidence =
+            VectorNumericalEvidence::compare("left", "right", &[0.0, near_zero], &[1.0, 1.0])
+                .unwrap();
+        assert_eq!(evidence.relative_error_defined_element_count, 1);
+        assert!(evidence.max_relative_error_where_defined.unwrap() > 1.0e40);
+    }
+
+    #[test]
+    fn vector_metrics_report_nonfinite_bits_without_serialization_failure() {
+        let evidence = VectorNumericalEvidence::compare(
+            "left",
+            "right",
+            &[f32::NAN, f32::INFINITY, 1.0],
+            &[f32::NAN, f32::NEG_INFINITY, 2.0],
+        )
+        .unwrap();
+        assert_eq!(evidence.left_nonfinite_count, 2);
+        assert_eq!(evidence.right_nonfinite_count, 2);
+        assert_eq!(evidence.nonfinite_bit_mismatch_count, 1);
+        serde_json::to_string(&evidence).unwrap();
+    }
+
+    #[test]
+    fn ulp_metric_is_raw_and_threshold_free() {
+        assert_eq!(
+            crate::gpu_native_router_rank_diagnostics::ulp_distance(
+                1.0,
+                f32::from_bits(1.0f32.to_bits() + 1),
+            ),
+            Some(1)
+        );
+        assert_eq!(
+            crate::gpu_native_router_rank_diagnostics::ulp_distance(f32::NAN, 1.0),
+            None
+        );
+    }
+
+    #[test]
+    fn schema_name_and_qualification_contract_are_stable() {
+        assert_eq!(
+            SCHEMA_VERSION,
+            "mer.gpu-native-expert-permutation-semantic-parity.v1"
+        );
+        #[derive(Serialize)]
+        struct Contract<'a> {
+            schema: &'a str,
+            qualification_pass: bool,
+        }
+        let value = serde_json::to_value(Contract {
+            schema: SCHEMA_VERSION,
+            qualification_pass: false,
+        })
+        .unwrap();
+        assert_eq!(value["schema"], SCHEMA_VERSION);
+        assert_eq!(value["qualification_pass"], false);
+    }
+
+    #[test]
+    fn same_membership_with_different_weight_pairing_is_detected() {
+        let mut logits = vec![-10.0; 128];
+        let ids = vec![30, 37, 114, 86, 29, 113, 68, 35];
+        for (rank, id) in ids.iter().copied().enumerate() {
+            logits[id as usize] = 10.0 - rank as f32;
+        }
+        let correctly_paired =
+            crate::gpu_native_router_rank_diagnostics::evaluate_actual_gpu_router(
+                logits.clone(),
+                ids.clone(),
+                vec![0.30, 0.20, 0.15, 0.12, 0.10, 0.06, 0.04, 0.03],
+            )
+            .unwrap();
+        assert!(actual_gpu_pairing_is_structurally_consistent(
+            &correctly_paired
+        ));
+        let wrongly_paired = crate::gpu_native_router_rank_diagnostics::evaluate_actual_gpu_router(
+            logits,
+            ids,
+            vec![0.20, 0.30, 0.15, 0.12, 0.10, 0.06, 0.04, 0.03],
+        )
+        .unwrap();
+        assert!(!actual_gpu_pairing_is_structurally_consistent(
+            &wrongly_paired
+        ));
+    }
+
+    #[test]
+    fn complete_report_json_serialization_hardcodes_qualification_false() {
+        let mut logits = vec![-10.0; 128];
+        let actual_ids = vec![30, 37, 114, 86, 29, 113, 68, 35];
+        for (rank, id) in actual_ids.iter().copied().enumerate() {
+            logits[id as usize] = 10.0 - rank as f32;
+        }
+        let actual = crate::gpu_native_router_rank_diagnostics::evaluate_actual_gpu_router(
+            logits,
+            actual_ids,
+            vec![0.30, 0.20, 0.15, 0.12, 0.10, 0.06, 0.04, 0.03],
+        )
+        .unwrap();
+        let cpu_view = |source: &'static str, ids: Vec<u32>| RouterEvaluationEvidence {
+            source,
+            score_origin: "cpu-production-softmax",
+            raw_logits: actual.raw_logits.clone(),
+            scored_probabilities: actual.scored_probabilities.clone(),
+            top_8_ids: ids,
+            top_8_weights: actual.top_8_weights.clone(),
+            top_12_ranked_experts: actual.top_12_ranked_experts.clone(),
+            experts_68_and_113: actual.experts_68_and_113.clone(),
+            cutoff_margins: actual.cutoff_margins.clone(),
+        };
+        let reference = cpu_view(
+            "reference-hidden-to-cpu-production-router",
+            vec![30, 37, 114, 86, 29, 68, 113, 35],
+        );
+        let cpu_on_gpu = cpu_view(
+            "gpu-hidden-to-cpu-production-router",
+            vec![30, 37, 114, 86, 29, 113, 68, 35],
+        );
+        let gate = crate::gpu_native_router_rank_diagnostics::GateTensorIdentity {
+            canonical_tensor_name: "model.layers.44.mlp.gate.weight".to_string(),
+            dtype: "f32".to_string(),
+            rows: 128,
+            cols: 4,
+            loaded_f32_bits_sha256: "a".repeat(64),
+        };
+        let model_load = crate::greedy_parity::ModelLoadEvidence {
+            strict: true,
+            loader: "safetensors".to_string(),
+            loaded_tensors: 1,
+            required_tensors: 1,
+            optional_probed: 0,
+            optional_loaded: 0,
+            seeded_fallback_remained: false,
+        };
+        let shutdown = crate::greedy_parity::BackgroundShutdownEvidence {
+            controlled_shutdown_requested: true,
+            all_runtime_resources_released: true,
+            poll_iterations: 1,
+        };
+        let report = ExpertPermutationSemanticParityReport::build(
+            DiagnosticProvenance {
+                build: crate::qualification::BuildProvenance {
+                    git_sha: Some("b".repeat(40)),
+                    dirty: Some(false),
+                    package_version: "test".to_string(),
+                },
+                executable_sha256: "c".repeat(64),
+                artifacts: crate::qualification::QualificationArtifacts::default(),
+                gpu_resolved_config_sha256: "d".repeat(64),
+                reference_resolved_config_sha256: "e".repeat(64),
+                model_identity: crate::greedy_parity::ModelIdentityEvidence {
+                    architecture: "qwen3_moe".to_string(),
+                    num_layers: 48,
+                    num_experts_per_layer: 128,
+                    total_experts: 6144,
+                    top_k: 8,
+                    d_model: 4,
+                    d_ff: 8,
+                    routed_expert_dtype: "q4_0".to_string(),
+                },
+                reference_model_load: model_load.clone(),
+                gpu_native_model_load: model_load,
+                reference_background_shutdown: shutdown,
+                gpu_native_background_shutdown: shutdown,
+                expert_metadata: crate::qualification::ExpertMetadataEvidence {
+                    dtype: Some("q4_0".to_string()),
+                    q4_0_layout: Some("standard-v1".to_string()),
+                    conversion_mode: Some("real".to_string()),
+                    source: Some("test".to_string()),
+                    explicitly_synthetic: false,
+                },
+                device: crate::backend::GpuDeviceIdentity {
+                    name: "NVIDIA L4".to_string(),
+                    vendor_id: 0x10de,
+                    device_id: 0,
+                    device_type: "DiscreteGpu".to_string(),
+                    wgpu_backend: "vulkan".to_string(),
+                    driver: "test".to_string(),
+                    driver_info: "test".to_string(),
+                    compute_plane: "wgpu-vulkan".to_string(),
+                    software_adapter: false,
+                },
+            },
+            "rust-generation",
+            0,
+            44,
+            vec![1, 2, 3],
+            vec![10],
+            vec![10],
+            &[1.0, 2.0, 3.0, 4.0],
+            &[1.0, 2.0, 3.0, 4.0],
+            GateIdentityEvidence::new(gate.clone(), gate),
+            reference,
+            cpu_on_gpu,
+            actual,
+            &[1.0, 2.0, 3.0, 4.0],
+            &[1.0, 2.0, 3.0, 4.0],
+            &[1.0, 2.0, 3.0, 4.0],
+            &vec![vec![1.0, 2.0, 3.0, 4.0]; 8],
+        )
+        .unwrap();
+        assert!(!report.qualification_pass());
+        let value = serde_json::to_value(report).unwrap();
+        assert_eq!(value["schema"], SCHEMA_VERSION);
+        assert_eq!(value["mode"], MODE);
+        assert_eq!(value["qualification_pass"], false);
+        assert!(value["witness_b_same_input_cpu_vs_gpu_routed_moe_output"].is_object());
+        assert!(value["witness_d_permutation_only_accumulation"].is_object());
+    }
+}

--- a/rust-engine/src/gpu_native_f32_reference_boundary_audit.rs
+++ b/rust-engine/src/gpu_native_f32_reference_boundary_audit.rs
@@ -1,0 +1,2015 @@
+//! Diagnostic-only audit of the CPU-reference boundary used by frozen
+//! GPU-native Q4 evidence.
+//!
+//! This module never constructs a GPU runtime and never contributes to a
+//! qualification decision. It consumes immutable report snapshots, replays
+//! their exact f32 vectors through existing CPU/diagnostic arithmetic, and
+//! generates the frozen v2 corpus through an ordinary strict CPU Q4 runtime.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+use crate::gpu_native_expert_permutation_semantic_parity::VectorNumericalEvidence;
+use crate::{IsolatedRuntimeShutdownError, RealCliRuntimeMode, ResolvedRealCliSpec};
+
+pub const SCHEMA_VERSION: &str = "mer.gpu-native-f32-reference-boundary-audit.v1";
+pub const MODE: &str = "diagnose-gpu-native-f32-reference-boundary";
+pub const QUALIFICATION_PASS: bool = false;
+
+pub const FROZEN_V2_REPORT_SHA256: &str =
+    "9629de35a18f4457bbe38aeeaeb208fd979bb08e9d2eccb283437d6c16a5c4ad";
+pub const FROZEN_STAGE_REPORT_SHA256: &str =
+    "f81827b39d2ece62b9c1af432f71ca70045fe41c13e6e6ac15b03d460246365d";
+pub const FROZEN_V2_BUILD_SHA: &str = "300448ac3da48ac74ef86fcd2c62ffca27ffa634";
+pub const FROZEN_FIRST_ATTRIBUTION_BUILD_SHA: &str = "d826d4578bc7037fb96ad67372f1442b20f5e4d1";
+pub const FROZEN_BEA_BUILD_SHA: &str = "bea43722a8fc00fd76d3c45702f70c16e2b63041";
+pub const FROZEN_STAGE_BUILD_SHA: &str = "987e7e4b8791dc70f75b62a772e89ad9f1948ec5";
+pub const FROZEN_STAGE_OFFLINE_ANALYSIS_SHA256: &str =
+    "053ef60e71cbc46f5d035c0f60a90b9fdfc429da6efed44262f58813b2b187cd";
+pub const FROZEN_RUST_UPSTREAM_TRACE_SHA256: &str =
+    "94d1d00e69a83f4510aece9c3c338f85d57a051619b73e897610d61a3e958920";
+
+const EXPECTED_TARGET_COUNT: usize = 9;
+const EXPECTED_EXPERTS_PER_TARGET: usize = 8;
+const EXPECTED_EXPERT_RECORD_COUNT: usize = EXPECTED_TARGET_COUNT * EXPECTED_EXPERTS_PER_TARGET;
+const EXPECTED_NUM_LAYERS: usize = 48;
+const EXPECTED_NUM_EXPERTS: usize = 128;
+const EXPECTED_D_MODEL: usize = 2_048;
+const AUDIT_RUNTIME_MODE: RealCliRuntimeMode = RealCliRuntimeMode::IsolatedGreedyParityCpu;
+const CPU_REFERENCE_IMPLEMENTATION: &str = "existing-production-q4_0_cpu_reference_forward-candle";
+const CURRENT_GPU_EMULATOR_IMPLEMENTATION: &str =
+    "existing-diagnostic-current-production-gpu-q4-arithmetic-emulator";
+
+fn is_hex(value: &str, length: usize) -> bool {
+    value.len() == length && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn exact_f64(left: f64, right: f64) -> bool {
+    left.to_bits() == right.to_bits()
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+struct FrozenTargetIdentity {
+    id: String,
+    case: String,
+    generated_position: usize,
+    layer: usize,
+    frozen_worst_local_expert: Option<u32>,
+}
+
+fn expected_targets() -> Vec<FrozenTargetIdentity> {
+    crate::gpu_native_q4_expert_stage_attribution::FROZEN_TARGETS
+        .into_iter()
+        .map(|target| FrozenTargetIdentity {
+            id: target.id.to_string(),
+            case: target.case.to_string(),
+            generated_position: target.generated_position,
+            layer: target.layer,
+            frozen_worst_local_expert: target.frozen_worst_local_expert,
+        })
+        .collect()
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct FrozenBuildEnvelope {
+    git_sha: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct FrozenProvenanceEnvelope {
+    build: FrozenBuildEnvelope,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize)]
+struct FrozenNumericalLimitsEnvelope {
+    max_absolute_error_limit: f64,
+    rms_error_limit: f64,
+    mean_absolute_error_limit: f64,
+    nonfinite_mismatch_limit: usize,
+    semantic_correctness_not_bit_parity: bool,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct FrozenCorpusEnvelope {
+    id: String,
+    version: u32,
+    sha256: String,
+    case_count: usize,
+    output_token_limit: usize,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct FrozenTokenCaseEnvelope {
+    case: String,
+    reference_generated_token_ids: Vec<u32>,
+    gpu_generated_token_ids: Vec<u32>,
+    exact_match_count: usize,
+    mismatch_count: usize,
+    first_mismatch_position: Option<usize>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct FrozenV2Envelope {
+    schema: String,
+    qualification_pass: bool,
+    holdout_corpus: FrozenCorpusEnvelope,
+    numerical_limits: FrozenNumericalLimitsEnvelope,
+    provenance: FrozenProvenanceEnvelope,
+    token_cases: Vec<FrozenTokenCaseEnvelope>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct FrozenExactVectorEnvelope {
+    source: String,
+    vector_length: usize,
+    f32_bits_sha256: String,
+    f32_bits: Vec<u32>,
+    nonfinite_count: usize,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct FrozenInputBoundaryEnvelope {
+    effective_gpu_expert_input: FrozenExactVectorEnvelope,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct FrozenOutputBoundaryEnvelope {
+    cpu_effective_output: FrozenExactVectorEnvelope,
+    actual_gpu_effective_output: FrozenExactVectorEnvelope,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct FrozenStageExpertEnvelope {
+    rank: usize,
+    local_expert_id: u32,
+    global_expert_id: u32,
+    canonical_q4_payload_sha256: String,
+    final_output_boundary: FrozenOutputBoundaryEnvelope,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct FrozenStageTargetEnvelope {
+    target: FrozenTargetIdentity,
+    input_boundary: Option<FrozenInputBoundaryEnvelope>,
+    experts: Vec<FrozenStageExpertEnvelope>,
+    failure: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct FrozenStageEnvelope {
+    schema: String,
+    diagnostic_complete: bool,
+    qualification_pass: bool,
+    failure: Option<String>,
+    provenance: FrozenProvenanceEnvelope,
+    frozen_targets: Vec<FrozenTargetIdentity>,
+    targets: Vec<FrozenStageTargetEnvelope>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct FrozenExpertIdentity {
+    pub target_id: String,
+    pub case: String,
+    pub generated_position: usize,
+    pub layer: usize,
+    pub rank: usize,
+    pub local_expert_id: u32,
+    pub global_expert_id: u32,
+    pub canonical_q4_payload_sha256: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct FrozenHistoricalEvidenceIdentity {
+    pub v2_qualification_build_sha: &'static str,
+    pub v2_report_sha256: &'static str,
+    pub first_attribution_setup_failure_build_sha: &'static str,
+    pub successful_v2_failure_attribution_build_sha: &'static str,
+    pub successful_q4_stage_attribution_build_sha: &'static str,
+    pub stage_report_sha256: &'static str,
+    pub stage_offline_analysis_sha256: &'static str,
+    pub rust_upstream_trace_sha256: &'static str,
+    pub modified_or_reclassified: bool,
+}
+
+impl Default for FrozenHistoricalEvidenceIdentity {
+    fn default() -> Self {
+        Self {
+            v2_qualification_build_sha: FROZEN_V2_BUILD_SHA,
+            v2_report_sha256: FROZEN_V2_REPORT_SHA256,
+            first_attribution_setup_failure_build_sha: FROZEN_FIRST_ATTRIBUTION_BUILD_SHA,
+            successful_v2_failure_attribution_build_sha: FROZEN_BEA_BUILD_SHA,
+            successful_q4_stage_attribution_build_sha: FROZEN_STAGE_BUILD_SHA,
+            stage_report_sha256: FROZEN_STAGE_REPORT_SHA256,
+            stage_offline_analysis_sha256: FROZEN_STAGE_OFFLINE_ANALYSIS_SHA256,
+            rust_upstream_trace_sha256: FROZEN_RUST_UPSTREAM_TRACE_SHA256,
+            modified_or_reclassified: false,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct FrozenReportsIdentity {
+    pub v2_report: crate::qualification::ArtifactDigest,
+    pub expected_v2_report_sha256_argument: String,
+    pub stage_report: crate::qualification::ArtifactDigest,
+    pub expected_stage_report_sha256_argument: String,
+    pub v2_schema: &'static str,
+    pub stage_schema: &'static str,
+    pub v2_build_sha: &'static str,
+    pub stage_build_sha: &'static str,
+    pub holdout_corpus_id: &'static str,
+    pub holdout_corpus_sha256: &'static str,
+    pub holdout_case_count: usize,
+    pub output_token_limit: usize,
+    pub exact_expert_identity_count: usize,
+    pub exact_expert_identities: Vec<FrozenExpertIdentity>,
+    pub immutable_inputs_verified_before_runtime: bool,
+    pub historical: FrozenHistoricalEvidenceIdentity,
+}
+
+struct FrozenAuditInputs {
+    v2: FrozenV2Envelope,
+    stage: FrozenStageEnvelope,
+    identity: FrozenReportsIdentity,
+}
+
+fn validate_expected_report_sha(value: &str, frozen: &str, label: &str) -> Result<(), String> {
+    if !is_hex(value, 64) || !value.eq_ignore_ascii_case(frozen) {
+        return Err(format!("{label} expected SHA must equal frozen {frozen}"));
+    }
+    Ok(())
+}
+
+fn artifact_from_snapshot(
+    path: &Path,
+    bytes: &[u8],
+) -> Result<crate::qualification::ArtifactDigest, Box<dyn std::error::Error>> {
+    Ok(crate::qualification::ArtifactDigest {
+        configured_path: path.display().to_string(),
+        canonical_path: std::fs::canonicalize(path)?.display().to_string(),
+        byte_length: u64::try_from(bytes.len()).map_err(|_| "report byte length overflow")?,
+        sha256: crate::greedy_parity::sha256_hex(bytes),
+    })
+}
+
+fn validate_snapshot_hash(
+    artifact: &crate::qualification::ArtifactDigest,
+    expected_argument: &str,
+    frozen: &str,
+    label: &str,
+) -> Result<(), String> {
+    if !artifact.sha256.eq_ignore_ascii_case(expected_argument)
+        || !artifact.sha256.eq_ignore_ascii_case(frozen)
+    {
+        return Err(format!(
+            "frozen {label} SHA differs: observed {} expected {frozen}",
+            artifact.sha256
+        ));
+    }
+    Ok(())
+}
+
+fn validate_frozen_v2(envelope: &FrozenV2Envelope) -> Result<(), String> {
+    use crate::gpu_native_semantic_parity_v2 as v2;
+
+    if envelope.schema != v2::SCHEMA_VERSION {
+        return Err("frozen v2 report schema differs".into());
+    }
+    if envelope.qualification_pass {
+        return Err("frozen v2 qualification_pass must remain false".into());
+    }
+    if envelope.provenance.build.git_sha.as_deref() != Some(FROZEN_V2_BUILD_SHA) {
+        return Err("frozen v2 report build SHA differs".into());
+    }
+    let corpus = &envelope.holdout_corpus;
+    if corpus.id != v2::HOLDOUT_CORPUS_ID
+        || corpus.version != v2::HOLDOUT_CORPUS_VERSION
+        || corpus.sha256 != v2::HOLDOUT_CORPUS_SHA256
+        || corpus.case_count != v2::HOLDOUT_CORPUS_CASE_COUNT
+        || corpus.output_token_limit != v2::OUTPUT_TOKEN_LIMIT
+        || v2::holdout_corpus_sha256() != v2::HOLDOUT_CORPUS_SHA256
+    {
+        return Err("frozen v2 holdout corpus identity differs".into());
+    }
+    let expected_limits = v2::NumericalLimits::frozen();
+    let limits = envelope.numerical_limits;
+    if !exact_f64(
+        limits.max_absolute_error_limit,
+        expected_limits.max_absolute_error_limit,
+    ) || !exact_f64(limits.rms_error_limit, expected_limits.rms_error_limit)
+        || !exact_f64(
+            limits.mean_absolute_error_limit,
+            expected_limits.mean_absolute_error_limit,
+        )
+        || limits.nonfinite_mismatch_limit != expected_limits.nonfinite_mismatch_limit
+        || limits.semantic_correctness_not_bit_parity
+            != expected_limits.semantic_correctness_not_bit_parity
+    {
+        return Err("frozen v2 numerical limits differ".into());
+    }
+    if envelope.token_cases.len() != v2::HOLDOUT_CORPUS_CASE_COUNT {
+        return Err("frozen v2 token-case count differs".into());
+    }
+    for (observed, expected) in envelope.token_cases.iter().zip(v2::HOLDOUT_CORPUS) {
+        if observed.case != expected.name
+            || observed.reference_generated_token_ids.len() != v2::OUTPUT_TOKEN_LIMIT
+            || observed.gpu_generated_token_ids.len() != v2::OUTPUT_TOKEN_LIMIT
+        {
+            return Err(format!(
+                "frozen v2 token case {} is incomplete",
+                expected.name
+            ));
+        }
+        let recomputed = crate::gpu_native_semantic_parity_corpus::TokenCaseEvidence::new(
+            observed.case.clone(),
+            observed.reference_generated_token_ids.clone(),
+            observed.gpu_generated_token_ids.clone(),
+        );
+        if observed.exact_match_count != recomputed.exact_match_count
+            || observed.mismatch_count != recomputed.mismatch_count
+            || observed.first_mismatch_position != recomputed.first_mismatch_position
+        {
+            return Err(format!(
+                "frozen v2 token comparison fields differ for {}",
+                expected.name
+            ));
+        }
+    }
+    let rust = envelope
+        .token_cases
+        .iter()
+        .find(|case| case.case == "rust-ownership-holdout")
+        .ok_or("frozen v2 rust-ownership case is missing")?;
+    if rust.reference_generated_token_ids.get(1) != Some(&785)
+        || rust.gpu_generated_token_ids.get(1) != Some(&8822)
+    {
+        return Err("frozen v2 rust-ownership position-1 evidence differs".into());
+    }
+    Ok(())
+}
+
+fn validate_exact_vector(
+    vector: &FrozenExactVectorEnvelope,
+    expected_source: &str,
+    label: &str,
+) -> Result<(), String> {
+    if vector.source != expected_source
+        || vector.vector_length != EXPECTED_D_MODEL
+        || vector.f32_bits.len() != EXPECTED_D_MODEL
+        || !is_hex(&vector.f32_bits_sha256, 64)
+        || crate::numerical_diagnostics::f32_bits_sha256(&vector.f32_bits) != vector.f32_bits_sha256
+    {
+        return Err(format!("frozen {label} vector identity differs"));
+    }
+    let observed_nonfinite = vector
+        .f32_bits
+        .iter()
+        .filter(|bits| !f32::from_bits(**bits).is_finite())
+        .count();
+    if vector.nonfinite_count != observed_nonfinite || observed_nonfinite != 0 {
+        return Err(format!(
+            "frozen {label} contains invalid nonfinite evidence"
+        ));
+    }
+    Ok(())
+}
+
+fn validate_frozen_stage(
+    envelope: &FrozenStageEnvelope,
+) -> Result<Vec<FrozenExpertIdentity>, String> {
+    if envelope.schema != crate::gpu_native_q4_expert_stage_attribution::SCHEMA_VERSION {
+        return Err("frozen stage report schema differs".into());
+    }
+    if !envelope.diagnostic_complete || envelope.qualification_pass || envelope.failure.is_some() {
+        return Err("frozen stage report completion/qualification/failure fields differ".into());
+    }
+    if envelope.provenance.build.git_sha.as_deref() != Some(FROZEN_STAGE_BUILD_SHA) {
+        return Err("frozen stage report build SHA differs".into());
+    }
+    let expected = expected_targets();
+    if envelope.frozen_targets != expected || envelope.targets.len() != expected.len() {
+        return Err("frozen Q1-Q4/R1-R5 target identities differ".into());
+    }
+
+    let mut identities = Vec::with_capacity(EXPECTED_EXPERT_RECORD_COUNT);
+    for (target, expected_target) in envelope.targets.iter().zip(expected) {
+        if target.target != expected_target || target.failure.is_some() {
+            return Err(format!(
+                "frozen stage target {} identity/failure differs",
+                expected_target.id
+            ));
+        }
+        let input = target.input_boundary.as_ref().ok_or_else(|| {
+            format!(
+                "frozen stage target {} has no input boundary",
+                target.target.id
+            )
+        })?;
+        validate_exact_vector(
+            &input.effective_gpu_expert_input,
+            "effective-production-gpu-expert-input",
+            &format!("{} effective GPU input", target.target.id),
+        )?;
+        if target.experts.len() != EXPECTED_EXPERTS_PER_TARGET {
+            return Err(format!(
+                "frozen stage target {} does not contain exactly eight experts",
+                target.target.id
+            ));
+        }
+        let mut local_ids = BTreeSet::new();
+        for (index, expert) in target.experts.iter().enumerate() {
+            if expert.rank != index + 1
+                || expert.local_expert_id as usize >= EXPECTED_NUM_EXPERTS
+                || !local_ids.insert(expert.local_expert_id)
+                || expert.global_expert_id
+                    != (target.target.layer * EXPECTED_NUM_EXPERTS) as u32 + expert.local_expert_id
+                || !is_hex(&expert.canonical_q4_payload_sha256, 64)
+            {
+                return Err(format!(
+                    "frozen expert identity differs at target {} rank {}",
+                    target.target.id,
+                    index + 1
+                ));
+            }
+            validate_exact_vector(
+                &expert.final_output_boundary.cpu_effective_output,
+                "cpu-diagnostic-f16-boundary-emulated-expert-output",
+                &format!(
+                    "{} rank {} historical CPU output",
+                    target.target.id, expert.rank
+                ),
+            )?;
+            validate_exact_vector(
+                &expert.final_output_boundary.actual_gpu_effective_output,
+                "actual-production-gpu-expert-output",
+                &format!(
+                    "{} rank {} actual GPU output",
+                    target.target.id, expert.rank
+                ),
+            )?;
+            identities.push(FrozenExpertIdentity {
+                target_id: target.target.id.clone(),
+                case: target.target.case.clone(),
+                generated_position: target.target.generated_position,
+                layer: target.target.layer,
+                rank: expert.rank,
+                local_expert_id: expert.local_expert_id,
+                global_expert_id: expert.global_expert_id,
+                canonical_q4_payload_sha256: expert.canonical_q4_payload_sha256.clone(),
+            });
+        }
+        if let Some(worst) = target.target.frozen_worst_local_expert {
+            if !local_ids.contains(&worst) {
+                return Err(format!(
+                    "frozen target {} is missing its frozen worst expert {worst}",
+                    target.target.id
+                ));
+            }
+        }
+    }
+    if identities.len() != EXPECTED_EXPERT_RECORD_COUNT {
+        return Err("frozen stage report does not contain exactly 72 expert identities".into());
+    }
+    Ok(identities)
+}
+
+impl FrozenAuditInputs {
+    fn read_and_validate(
+        v2_report: &Path,
+        expected_v2_sha256: &str,
+        stage_report: &Path,
+        expected_stage_sha256: &str,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        validate_expected_report_sha(expected_v2_sha256, FROZEN_V2_REPORT_SHA256, "v2 report")?;
+        validate_expected_report_sha(
+            expected_stage_sha256,
+            FROZEN_STAGE_REPORT_SHA256,
+            "stage report",
+        )?;
+
+        // Each immutable report is read exactly once. The corresponding hash
+        // and typed deserialization both consume this same byte snapshot.
+        let v2_bytes = std::fs::read(v2_report)?;
+        let stage_bytes = std::fs::read(stage_report)?;
+        let v2_artifact = artifact_from_snapshot(v2_report, &v2_bytes)?;
+        let stage_artifact = artifact_from_snapshot(stage_report, &stage_bytes)?;
+        validate_snapshot_hash(
+            &v2_artifact,
+            expected_v2_sha256,
+            FROZEN_V2_REPORT_SHA256,
+            "v2 report",
+        )?;
+        validate_snapshot_hash(
+            &stage_artifact,
+            expected_stage_sha256,
+            FROZEN_STAGE_REPORT_SHA256,
+            "stage report",
+        )?;
+        let v2: FrozenV2Envelope = serde_json::from_slice(&v2_bytes)
+            .map_err(|error| format!("malformed frozen v2 report: {error}"))?;
+        let stage: FrozenStageEnvelope = serde_json::from_slice(&stage_bytes)
+            .map_err(|error| format!("malformed frozen stage report: {error}"))?;
+        validate_frozen_v2(&v2)?;
+        let exact_expert_identities = validate_frozen_stage(&stage)?;
+        let identity = FrozenReportsIdentity {
+            v2_report: v2_artifact,
+            expected_v2_report_sha256_argument: expected_v2_sha256.to_ascii_lowercase(),
+            stage_report: stage_artifact,
+            expected_stage_report_sha256_argument: expected_stage_sha256.to_ascii_lowercase(),
+            v2_schema: crate::gpu_native_semantic_parity_v2::SCHEMA_VERSION,
+            stage_schema: crate::gpu_native_q4_expert_stage_attribution::SCHEMA_VERSION,
+            v2_build_sha: FROZEN_V2_BUILD_SHA,
+            stage_build_sha: FROZEN_STAGE_BUILD_SHA,
+            holdout_corpus_id: crate::gpu_native_semantic_parity_v2::HOLDOUT_CORPUS_ID,
+            holdout_corpus_sha256: crate::gpu_native_semantic_parity_v2::HOLDOUT_CORPUS_SHA256,
+            holdout_case_count: crate::gpu_native_semantic_parity_v2::HOLDOUT_CORPUS_CASE_COUNT,
+            output_token_limit: crate::gpu_native_semantic_parity_v2::OUTPUT_TOKEN_LIMIT,
+            exact_expert_identity_count: exact_expert_identities.len(),
+            exact_expert_identities,
+            immutable_inputs_verified_before_runtime: true,
+            historical: FrozenHistoricalEvidenceIdentity::default(),
+        };
+        Ok(Self {
+            v2,
+            stage,
+            identity,
+        })
+    }
+}
+
+fn output_path_conflicts_with_frozen_input(
+    report_out: &Path,
+    inputs: &FrozenReportsIdentity,
+) -> Result<bool, Box<dyn std::error::Error>> {
+    let output = if report_out.exists() {
+        std::fs::canonicalize(report_out)?
+    } else {
+        let absolute = if report_out.is_absolute() {
+            report_out.to_path_buf()
+        } else {
+            std::env::current_dir()?.join(report_out)
+        };
+        let mut existing = absolute.as_path();
+        let mut missing = Vec::new();
+        while !existing.exists() {
+            missing.push(
+                existing
+                    .file_name()
+                    .ok_or("report output path has no existing ancestor")?
+                    .to_os_string(),
+            );
+            existing = existing
+                .parent()
+                .ok_or("report output path has no existing ancestor")?;
+        }
+        let mut canonical = std::fs::canonicalize(existing)?;
+        for component in missing.into_iter().rev() {
+            canonical.push(component);
+        }
+        canonical
+    };
+    Ok(output == PathBuf::from(&inputs.v2_report.canonical_path)
+        || output == PathBuf::from(&inputs.stage_report.canonical_path))
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct Q4F32ReferenceReplayBundle {
+    pub canonical_payload_sha256: String,
+    pub old_boundary_input: Vec<f32>,
+    pub old_pre_output: Vec<f32>,
+    pub old_effective_output: Vec<f32>,
+    pub exact_f32_output: Vec<f32>,
+    pub current_gpu_emulator_output: Vec<f32>,
+}
+
+fn compute_reference_paths_with<RoundTrip, Production, Emulator>(
+    exact_input: &[f32],
+    mut round_trip: RoundTrip,
+    mut production: Production,
+    mut emulator: Emulator,
+) -> Result<Q4F32ReferenceReplayBundle, String>
+where
+    RoundTrip: FnMut(&[f32]) -> Result<Vec<f32>, String>,
+    Production: FnMut(&[f32]) -> Result<Vec<f32>, String>,
+    Emulator: FnMut(&[f32]) -> Result<Vec<f32>, String>,
+{
+    let old_boundary_input = round_trip(exact_input)?;
+    let old_pre_output = production(&old_boundary_input)?;
+    let old_effective_output = round_trip(&old_pre_output)?;
+    let exact_f32_output = production(exact_input)?;
+    let current_gpu_emulator_output = emulator(exact_input)?;
+    Ok(Q4F32ReferenceReplayBundle {
+        canonical_payload_sha256: String::new(),
+        old_boundary_input,
+        old_pre_output,
+        old_effective_output,
+        exact_f32_output,
+        current_gpu_emulator_output,
+    })
+}
+
+pub(crate) fn audit_q4_reference_paths(
+    payload: &[u8],
+    exact_input: &[f32],
+    d_model: usize,
+    d_ff: usize,
+    canonical_payload_sha256: String,
+) -> Result<Q4F32ReferenceReplayBundle, String> {
+    let mut bundle = compute_reference_paths_with(
+        exact_input,
+        |values| {
+            crate::numerical_diagnostics::round_trip_f16_values(values)
+                .map_err(|error| error.to_string())
+        },
+        |values| {
+            crate::inference::q4_0_cpu_reference_forward(payload, values, d_model, d_ff)
+                .map_err(|error| error.to_string())
+        },
+        |values| {
+            crate::inference::diagnostic_q4_0_expert_arithmetic(
+                payload,
+                values,
+                d_model,
+                d_ff,
+                crate::inference::DiagnosticQ4DotArithmetic::CurrentGpu,
+            )
+            .map(|trace| trace.down)
+            .map_err(|error| error.to_string())
+        },
+    )?;
+    bundle.canonical_payload_sha256 = canonical_payload_sha256;
+    Ok(bundle)
+}
+
+fn reconstruct_exact_f32(bits: &[u32]) -> Vec<f32> {
+    bits.iter().copied().map(f32::from_bits).collect()
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct VectorIdentityEvidence {
+    pub source: &'static str,
+    pub vector_length: usize,
+    pub f32_bits_sha256: String,
+    pub nonfinite_count: usize,
+}
+
+impl VectorIdentityEvidence {
+    fn new(source: &'static str, values: &[f32]) -> Self {
+        let bits = values
+            .iter()
+            .map(|value| value.to_bits())
+            .collect::<Vec<_>>();
+        Self {
+            source,
+            vector_length: values.len(),
+            f32_bits_sha256: crate::numerical_diagnostics::f32_bits_sha256(&bits),
+            nonfinite_count: values.iter().filter(|value| !value.is_finite()).count(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct ErrorImprovementEvidence {
+    pub exact_f32_error_smaller_than_old_f16_error_maxabs: bool,
+    pub exact_f32_error_smaller_than_old_f16_error_rms: bool,
+    pub exact_f32_error_smaller_than_old_f16_error_meanabs: bool,
+    pub exact_f32_to_old_f16_maxabs_ratio: Option<f64>,
+    pub exact_f32_to_old_f16_rms_ratio: Option<f64>,
+    pub exact_f32_to_old_f16_meanabs_ratio: Option<f64>,
+}
+
+fn finite_ratio(numerator: Option<f64>, denominator: Option<f64>) -> Option<f64> {
+    numerator
+        .zip(denominator)
+        .filter(|(numerator, denominator)| {
+            numerator.is_finite() && denominator.is_finite() && *denominator != 0.0
+        })
+        .map(|(numerator, denominator)| numerator / denominator)
+        .filter(|ratio| ratio.is_finite())
+}
+
+fn strictly_smaller(left: Option<f64>, right: Option<f64>) -> bool {
+    left.zip(right)
+        .is_some_and(|(left, right)| left.is_finite() && right.is_finite() && left < right)
+}
+
+impl ErrorImprovementEvidence {
+    fn new(exact: &VectorNumericalEvidence, old: &VectorNumericalEvidence) -> Self {
+        Self {
+            exact_f32_error_smaller_than_old_f16_error_maxabs: strictly_smaller(
+                exact.max_absolute_error,
+                old.max_absolute_error,
+            ),
+            exact_f32_error_smaller_than_old_f16_error_rms: strictly_smaller(
+                exact.rms_error,
+                old.rms_error,
+            ),
+            exact_f32_error_smaller_than_old_f16_error_meanabs: strictly_smaller(
+                exact.mean_absolute_error,
+                old.mean_absolute_error,
+            ),
+            exact_f32_to_old_f16_maxabs_ratio: finite_ratio(
+                exact.max_absolute_error,
+                old.max_absolute_error,
+            ),
+            exact_f32_to_old_f16_rms_ratio: finite_ratio(exact.rms_error, old.rms_error),
+            exact_f32_to_old_f16_meanabs_ratio: finite_ratio(
+                exact.mean_absolute_error,
+                old.mean_absolute_error,
+            ),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct ExpertBoundaryAuditRecord {
+    pub target_id: String,
+    pub case: String,
+    pub generated_position: usize,
+    pub layer: usize,
+    pub rank: usize,
+    pub local_expert_id: u32,
+    pub global_expert_id: u32,
+    pub canonical_q4_payload_sha256: String,
+    pub exact_gpu_f32_input: VectorIdentityEvidence,
+    pub old_f16_boundary_input: VectorIdentityEvidence,
+    pub old_f16_reference_reproduces_frozen_historical_output_bit_exactly: bool,
+    pub old_f16_reference_reproduction: VectorNumericalEvidence,
+    pub old_f16_emulated_cpu_reference_vs_frozen_actual_gpu_output: VectorNumericalEvidence,
+    pub exact_f32_cpu_reference_vs_frozen_actual_gpu_output: VectorNumericalEvidence,
+    pub current_gpu_arithmetic_emulator_vs_frozen_actual_gpu_output: VectorNumericalEvidence,
+    pub exact_f32_cpu_reference_vs_current_gpu_arithmetic_emulator: VectorNumericalEvidence,
+    pub improvement: ErrorImprovementEvidence,
+    pub exact_f32_cpu_reference_implementation: &'static str,
+    pub old_input_f16_round_trip_performed: bool,
+    pub old_output_f16_round_trip_performed: bool,
+    pub exact_f32_input_f16_round_trip_performed: bool,
+    pub exact_f32_output_f16_round_trip_performed: bool,
+    pub current_gpu_emulator_implementation: &'static str,
+    pub frozen_gpu_output_source: &'static str,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct SelectedWorstExpertAudit {
+    pub target_id: String,
+    pub selection_basis: &'static str,
+    pub expert: ExpertBoundaryAuditRecord,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct MetricDistribution {
+    pub total_expert_records: usize,
+    pub finite_value_count: usize,
+    pub minimum: Option<f64>,
+    pub median: Option<f64>,
+    pub mean: Option<f64>,
+    pub p90_nearest_rank: Option<f64>,
+    pub p95_nearest_rank: Option<f64>,
+    pub p99_nearest_rank: Option<f64>,
+    pub maximum: Option<f64>,
+    pub sorted_finite_values: Vec<f64>,
+}
+
+fn nearest_rank(values: &[f64], percentile: f64) -> Option<f64> {
+    if values.is_empty() {
+        return None;
+    }
+    let rank = (percentile * values.len() as f64).ceil() as usize;
+    values
+        .get(rank.saturating_sub(1).min(values.len() - 1))
+        .copied()
+}
+
+fn metric_distribution(
+    total: usize,
+    values: impl IntoIterator<Item = Option<f64>>,
+) -> MetricDistribution {
+    let mut values = values
+        .into_iter()
+        .flatten()
+        .filter(|value| value.is_finite())
+        .collect::<Vec<_>>();
+    values.sort_by(f64::total_cmp);
+    let count = values.len();
+    let mean = (count != 0).then(|| values.iter().sum::<f64>() / count as f64);
+    MetricDistribution {
+        total_expert_records: total,
+        finite_value_count: count,
+        minimum: values.first().copied(),
+        median: nearest_rank(&values, 0.50),
+        mean,
+        p90_nearest_rank: nearest_rank(&values, 0.90),
+        p95_nearest_rank: nearest_rank(&values, 0.95),
+        p99_nearest_rank: nearest_rank(&values, 0.99),
+        maximum: values.last().copied(),
+        sorted_finite_values: values,
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct ReferenceErrorDistributions {
+    pub max_absolute_error: MetricDistribution,
+    pub rms_error: MetricDistribution,
+    pub mean_absolute_error: MetricDistribution,
+}
+
+fn error_distributions<'a>(
+    comparisons: impl IntoIterator<Item = &'a VectorNumericalEvidence> + Clone,
+) -> ReferenceErrorDistributions {
+    let comparisons = comparisons.into_iter().collect::<Vec<_>>();
+    let total = comparisons.len();
+    ReferenceErrorDistributions {
+        max_absolute_error: metric_distribution(
+            total,
+            comparisons
+                .iter()
+                .map(|comparison| comparison.max_absolute_error),
+        ),
+        rms_error: metric_distribution(
+            total,
+            comparisons.iter().map(|comparison| comparison.rms_error),
+        ),
+        mean_absolute_error: metric_distribution(
+            total,
+            comparisons
+                .iter()
+                .map(|comparison| comparison.mean_absolute_error),
+        ),
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct PartAAggregation {
+    pub expert_record_count: usize,
+    pub old_f16_reference: ReferenceErrorDistributions,
+    pub exact_f32_reference: ReferenceErrorDistributions,
+    pub current_gpu_arithmetic_emulator: ReferenceErrorDistributions,
+    pub exact_f32_smaller_than_old_f16_maxabs_count: usize,
+    pub exact_f32_smaller_than_old_f16_rms_count: usize,
+    pub exact_f32_smaller_than_old_f16_meanabs_count: usize,
+}
+
+fn aggregate_part_a(records: &[ExpertBoundaryAuditRecord]) -> PartAAggregation {
+    PartAAggregation {
+        expert_record_count: records.len(),
+        old_f16_reference: error_distributions(
+            records
+                .iter()
+                .map(|record| &record.old_f16_emulated_cpu_reference_vs_frozen_actual_gpu_output),
+        ),
+        exact_f32_reference: error_distributions(
+            records
+                .iter()
+                .map(|record| &record.exact_f32_cpu_reference_vs_frozen_actual_gpu_output),
+        ),
+        current_gpu_arithmetic_emulator: error_distributions(
+            records
+                .iter()
+                .map(|record| &record.current_gpu_arithmetic_emulator_vs_frozen_actual_gpu_output),
+        ),
+        exact_f32_smaller_than_old_f16_maxabs_count: records
+            .iter()
+            .filter(|record| {
+                record
+                    .improvement
+                    .exact_f32_error_smaller_than_old_f16_error_maxabs
+            })
+            .count(),
+        exact_f32_smaller_than_old_f16_rms_count: records
+            .iter()
+            .filter(|record| {
+                record
+                    .improvement
+                    .exact_f32_error_smaller_than_old_f16_error_rms
+            })
+            .count(),
+        exact_f32_smaller_than_old_f16_meanabs_count: records
+            .iter()
+            .filter(|record| {
+                record
+                    .improvement
+                    .exact_f32_error_smaller_than_old_f16_error_meanabs
+            })
+            .count(),
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct CpuTokenCaseAudit {
+    pub case: String,
+    pub requested_tokens: usize,
+    pub completed_tokens: usize,
+    pub exact_token_matches: usize,
+    pub mismatch_count: usize,
+    pub first_mismatch_position: Option<usize>,
+    pub corrected_ordinary_f32_cpu_token_ids: Vec<u32>,
+    pub frozen_gpu_token_ids: Vec<u32>,
+    pub historical_old_boundary_cpu_reference_token_ids: Vec<u32>,
+    pub frozen_gpu_tokens_source: &'static str,
+}
+
+impl CpuTokenCaseAudit {
+    fn new(frozen: &FrozenTokenCaseEnvelope, corrected: Vec<u32>) -> Self {
+        let comparison = crate::gpu_native_semantic_parity_corpus::TokenCaseEvidence::new(
+            frozen.case.clone(),
+            corrected.clone(),
+            frozen.gpu_generated_token_ids.clone(),
+        );
+        Self {
+            case: frozen.case.clone(),
+            requested_tokens: crate::gpu_native_semantic_parity_v2::OUTPUT_TOKEN_LIMIT,
+            completed_tokens: corrected.len(),
+            exact_token_matches: comparison.exact_match_count,
+            mismatch_count: comparison.mismatch_count,
+            first_mismatch_position: comparison.first_mismatch_position,
+            corrected_ordinary_f32_cpu_token_ids: corrected,
+            frozen_gpu_token_ids: frozen.gpu_generated_token_ids.clone(),
+            historical_old_boundary_cpu_reference_token_ids: frozen
+                .reference_generated_token_ids
+                .clone(),
+            frozen_gpu_tokens_source: "immutable-frozen-v2-report-byte-snapshot",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct RustOwnershipPositionOneEvidence {
+    pub case: &'static str,
+    pub generated_position: usize,
+    pub historical_old_cpu_token_id: u32,
+    pub frozen_gpu_token_id: u32,
+    pub new_ordinary_f32_cpu_token_id: u32,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct PartBTokenSummary {
+    pub requested_tokens: usize,
+    pub completed_tokens: usize,
+    pub exact_token_matches: usize,
+    pub mismatch_count: usize,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct RuntimeContractEvidence {
+    pub runtime_mode: &'static str,
+    pub execution_plan: crate::qualification::ExecutionPlanEvidence,
+    pub gpu_runtime_constructed: bool,
+    pub gpu_device_identity_exposed: bool,
+    pub gpu_native_token_loop_constructed: bool,
+    pub boundary_emulation_before_part_a: crate::engine::CpuQ4BoundaryEmulationSnapshot,
+    pub boundary_emulation_before_part_b: crate::engine::CpuQ4BoundaryEmulationSnapshot,
+    pub boundary_emulation_after_part_b: crate::engine::CpuQ4BoundaryEmulationSnapshot,
+    pub routed_execution_after: crate::engine::RoutedExpertExecutionSnapshot,
+    pub background_shutdown: crate::greedy_parity::BackgroundShutdownEvidence,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct AuditProvenance {
+    pub build: crate::qualification::BuildProvenance,
+    pub executable_sha256: String,
+    pub artifacts: crate::qualification::QualificationArtifacts,
+    pub source_config: crate::gpu_native_greedy_parity::SourceConfigEvidence,
+    pub cpu_resolved_config_sha256: String,
+    pub model_identity: crate::greedy_parity::ModelIdentityEvidence,
+    pub model_load: crate::greedy_parity::ModelLoadEvidence,
+    pub expert_metadata: crate::qualification::ExpertMetadataEvidence,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ProductionSemanticsEvidence {
+    pub diagnostic_only: bool,
+    pub production_inference_changed: bool,
+    pub production_q4_changed: bool,
+    pub production_q4_wgsl_changed: bool,
+    pub production_router_changed: bool,
+    pub production_attention_changed: bool,
+    pub v1_changed: bool,
+    pub v2_changed: bool,
+    pub v2_limits_changed: bool,
+    pub v2_corpus_or_prompts_changed: bool,
+    pub cpu_q4_boundary_emulation_behavior_changed: bool,
+    pub numerical_qualification_threshold_introduced: bool,
+    pub production_correction_made_or_justified: bool,
+    pub frozen_gpu_outputs_read_only_from_stage_report: bool,
+    pub frozen_gpu_tokens_read_only_from_v2_report: bool,
+}
+
+impl Default for ProductionSemanticsEvidence {
+    fn default() -> Self {
+        Self {
+            diagnostic_only: true,
+            production_inference_changed: false,
+            production_q4_changed: false,
+            production_q4_wgsl_changed: false,
+            production_router_changed: false,
+            production_attention_changed: false,
+            v1_changed: false,
+            v2_changed: false,
+            v2_limits_changed: false,
+            v2_corpus_or_prompts_changed: false,
+            cpu_q4_boundary_emulation_behavior_changed: false,
+            numerical_qualification_threshold_introduced: false,
+            production_correction_made_or_justified: false,
+            frozen_gpu_outputs_read_only_from_stage_report: true,
+            frozen_gpu_tokens_read_only_from_v2_report: true,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct F32ReferenceBoundaryAuditReport {
+    pub schema: &'static str,
+    pub mode: &'static str,
+    pub diagnostic_only: bool,
+    pub diagnostic_complete: bool,
+    qualification_pass: bool,
+    pub failure: Option<String>,
+    pub frozen_inputs: FrozenReportsIdentity,
+    pub provenance: AuditProvenance,
+    pub expert_records: Vec<ExpertBoundaryAuditRecord>,
+    pub q1_q4_frozen_worst_experts: Vec<SelectedWorstExpertAudit>,
+    pub r1_r5_worst_old_boundary_error_experts: Vec<SelectedWorstExpertAudit>,
+    pub part_a_aggregation: PartAAggregation,
+    pub corrected_cpu_token_cases: Vec<CpuTokenCaseAudit>,
+    pub rust_ownership_position_one: RustOwnershipPositionOneEvidence,
+    pub part_b_token_summary: PartBTokenSummary,
+    pub runtime: RuntimeContractEvidence,
+    pub production_semantics: ProductionSemanticsEvidence,
+    pub scientific_interpretation: Vec<String>,
+}
+
+impl F32ReferenceBoundaryAuditReport {
+    pub const fn qualification_pass(&self) -> bool {
+        self.qualification_pass
+    }
+}
+
+struct ExecutionCapture {
+    expert_records: Vec<ExpertBoundaryAuditRecord>,
+    token_cases: Vec<CpuTokenCaseAudit>,
+    rust_ownership_position_one: RustOwnershipPositionOneEvidence,
+    model_load: crate::greedy_parity::ModelLoadEvidence,
+    runtime: RuntimeContractEvidence,
+}
+
+fn model_load_is_strict(load: &crate::greedy_parity::ModelLoadEvidence) -> bool {
+    load.strict
+        && load.required_tensors > 0
+        && load.loaded_tensors == load.required_tensors
+        && !load.seeded_fallback_remained
+        && load.loader != "seeded"
+}
+
+fn boundary_disabled_and_clean(
+    snapshot: crate::engine::CpuQ4BoundaryEmulationSnapshot,
+) -> Result<(), String> {
+    if snapshot.enabled || snapshot.routed_expert_dispatches != 0 {
+        return Err(
+            "CPU Q4 boundary emulation must remain disabled with zero routed dispatches".into(),
+        );
+    }
+    Ok(())
+}
+
+async fn audit_one_expert(
+    engine: &Arc<crate::engine::Engine>,
+    target: &FrozenStageTargetEnvelope,
+    expert: &FrozenStageExpertEnvelope,
+) -> Result<ExpertBoundaryAuditRecord, Box<dyn std::error::Error>> {
+    let input = target
+        .input_boundary
+        .as_ref()
+        .ok_or("validated target lost its input boundary")?;
+    let exact_input = reconstruct_exact_f32(&input.effective_gpu_expert_input.f32_bits);
+    if exact_input.iter().map(|value| value.to_bits()).ne(input
+        .effective_gpu_expert_input
+        .f32_bits
+        .iter()
+        .copied())
+    {
+        return Err("exact GPU f32 input reconstruction changed frozen bits".into());
+    }
+    let frozen_old =
+        reconstruct_exact_f32(&expert.final_output_boundary.cpu_effective_output.f32_bits);
+    let frozen_gpu = reconstruct_exact_f32(
+        &expert
+            .final_output_boundary
+            .actual_gpu_effective_output
+            .f32_bits,
+    );
+    let bundle = engine
+        .audit_q4_0_f32_reference_boundary(
+            expert.global_expert_id,
+            &exact_input,
+            &expert.canonical_q4_payload_sha256,
+        )
+        .await?;
+    let old_reproduction = VectorNumericalEvidence::compare(
+        "replayed-old-f16-boundary-cpu-reference",
+        "frozen-historical-old-f16-boundary-cpu-reference",
+        &bundle.old_effective_output,
+        &frozen_old,
+    )?;
+    if !old_reproduction.exact_bit_equal {
+        return Err(format!(
+            "old boundary reference did not reproduce frozen output bit-exactly for {} rank {} expert {}",
+            target.target.id, expert.rank, expert.local_expert_id
+        )
+        .into());
+    }
+    let old_vs_gpu = VectorNumericalEvidence::compare(
+        "old-f16-emulated-cpu-reference",
+        "frozen-actual-production-gpu-output",
+        &bundle.old_effective_output,
+        &frozen_gpu,
+    )?;
+    let exact_vs_gpu = VectorNumericalEvidence::compare(
+        "exact-f32-production-cpu-reference",
+        "frozen-actual-production-gpu-output",
+        &bundle.exact_f32_output,
+        &frozen_gpu,
+    )?;
+    let emulator_vs_gpu = VectorNumericalEvidence::compare(
+        "current-gpu-q4-arithmetic-cpu-emulator",
+        "frozen-actual-production-gpu-output",
+        &bundle.current_gpu_emulator_output,
+        &frozen_gpu,
+    )?;
+    let exact_vs_emulator = VectorNumericalEvidence::compare(
+        "exact-f32-production-cpu-reference",
+        "current-gpu-q4-arithmetic-cpu-emulator",
+        &bundle.exact_f32_output,
+        &bundle.current_gpu_emulator_output,
+    )?;
+    let improvement = ErrorImprovementEvidence::new(&exact_vs_gpu, &old_vs_gpu);
+    Ok(ExpertBoundaryAuditRecord {
+        target_id: target.target.id.clone(),
+        case: target.target.case.clone(),
+        generated_position: target.target.generated_position,
+        layer: target.target.layer,
+        rank: expert.rank,
+        local_expert_id: expert.local_expert_id,
+        global_expert_id: expert.global_expert_id,
+        canonical_q4_payload_sha256: bundle.canonical_payload_sha256,
+        exact_gpu_f32_input: VectorIdentityEvidence::new(
+            "reconstructed-exact-frozen-actual-gpu-f32-expert-input",
+            &exact_input,
+        ),
+        old_f16_boundary_input: VectorIdentityEvidence::new(
+            "explicit-f32-to-f16-to-f32-old-reference-input",
+            &bundle.old_boundary_input,
+        ),
+        old_f16_reference_reproduces_frozen_historical_output_bit_exactly: true,
+        old_f16_reference_reproduction: old_reproduction,
+        old_f16_emulated_cpu_reference_vs_frozen_actual_gpu_output: old_vs_gpu,
+        exact_f32_cpu_reference_vs_frozen_actual_gpu_output: exact_vs_gpu,
+        current_gpu_arithmetic_emulator_vs_frozen_actual_gpu_output: emulator_vs_gpu,
+        exact_f32_cpu_reference_vs_current_gpu_arithmetic_emulator: exact_vs_emulator,
+        improvement,
+        exact_f32_cpu_reference_implementation: CPU_REFERENCE_IMPLEMENTATION,
+        old_input_f16_round_trip_performed: true,
+        old_output_f16_round_trip_performed: true,
+        exact_f32_input_f16_round_trip_performed: false,
+        exact_f32_output_f16_round_trip_performed: false,
+        current_gpu_emulator_implementation: CURRENT_GPU_EMULATOR_IMPLEMENTATION,
+        frozen_gpu_output_source: "immutable-frozen-stage-report-byte-snapshot",
+    })
+}
+
+async fn execute_cpu_audit(
+    spec: &ResolvedRealCliSpec,
+    tokenizer: Arc<crate::tokenizer::Tokenizer>,
+    resolved_config_sha256: &str,
+    frozen: &FrozenAuditInputs,
+    watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+) -> Result<ExecutionCapture, Box<dyn std::error::Error>> {
+    let runtime =
+        crate::build_isolated_greedy_runtime(spec, AUDIT_RUNTIME_MODE, tokenizer.clone()).await?;
+    let attempt = async {
+        let observed_config_sha256 = crate::resolved_real_runtime_identity_sha256(
+            &runtime.cfg,
+            runtime.model.config.architecture,
+            runtime.model.config.first_k_dense_replace,
+            &runtime.model.config.advanced,
+        )?;
+        if observed_config_sha256 != resolved_config_sha256 {
+            return Err("CPU audit runtime configuration identity drifted".into());
+        }
+        let execution_plan: crate::qualification::ExecutionPlanEvidence =
+            runtime.engine.execution_context().plan().into();
+        let gpu_device_identity_exposed = runtime.engine.gpu_device_identity().is_some();
+        let gpu_native_token_loop_constructed = runtime.gpu_native_token_loop.is_some();
+        let gpu_runtime_constructed =
+            gpu_device_identity_exposed || gpu_native_token_loop_constructed;
+        if gpu_runtime_constructed || !crate::greedy_parity::cpu_plan_exact(&execution_plan) {
+            return Err("audit did not resolve to an exact CPU-only execution plan".into());
+        }
+        if runtime.model.config.num_layers != EXPECTED_NUM_LAYERS
+            || runtime.model.config.num_experts != EXPECTED_NUM_EXPERTS
+            || runtime.model.config.top_k != EXPECTED_EXPERTS_PER_TARGET
+            || runtime.model.config.d_model != EXPECTED_D_MODEL
+        {
+            return Err(
+                "CPU audit runtime model geometry differs from frozen Qwen geometry".into(),
+            );
+        }
+        let model_load = crate::greedy_parity_model_load(&runtime);
+        if !model_load_is_strict(&model_load) {
+            return Err("CPU audit runtime did not load the strict model".into());
+        }
+        let boundary_before_part_a = runtime.engine.cpu_q4_boundary_emulation_snapshot();
+        boundary_disabled_and_clean(boundary_before_part_a)?;
+
+        let mut expert_records = Vec::with_capacity(EXPECTED_EXPERT_RECORD_COUNT);
+        for target in &frozen.stage.targets {
+            for expert in &target.experts {
+                expert_records.push(
+                    crate::with_progress_timeout(
+                        format!(
+                            "f32 boundary audit {} rank {} expert {}",
+                            target.target.id, expert.rank, expert.local_expert_id
+                        ),
+                        watchdog,
+                        audit_one_expert(&runtime.engine, target, expert),
+                    )
+                    .await?,
+                );
+            }
+        }
+        if expert_records.len() != EXPECTED_EXPERT_RECORD_COUNT {
+            return Err("CPU audit did not replay exactly 72 experts".into());
+        }
+
+        let boundary_before_part_b = runtime.engine.cpu_q4_boundary_emulation_snapshot();
+        boundary_disabled_and_clean(boundary_before_part_b)?;
+        let mut token_cases =
+            Vec::with_capacity(crate::gpu_native_semantic_parity_v2::HOLDOUT_CORPUS_CASE_COUNT);
+        for (case_index, fixed) in crate::gpu_native_semantic_parity_v2::HOLDOUT_CORPUS
+            .into_iter()
+            .enumerate()
+        {
+            let frozen_case = &frozen.v2.token_cases[case_index];
+            if frozen_case.case != fixed.name {
+                return Err("validated frozen v2 token-case order drifted".into());
+            }
+            let prompt_ids = tokenizer.encode(fixed.prompt)?;
+            let measured = crate::with_progress_timeout(
+                format!("f32 boundary audit ordinary CPU generation {}", fixed.name),
+                watchdog,
+                crate::run_real_once_from_token_ids(
+                    &runtime,
+                    &prompt_ids,
+                    crate::gpu_native_semantic_parity_v2::OUTPUT_TOKEN_LIMIT,
+                    crate::sampling::SamplingParams::greedy(),
+                    case_index,
+                ),
+            )
+            .await?;
+            let corrected = measured.report.output_token_ids;
+            if corrected.len() != crate::gpu_native_semantic_parity_v2::OUTPUT_TOKEN_LIMIT {
+                return Err(format!(
+                    "ordinary CPU generation {} completed {} tokens, expected {}",
+                    fixed.name,
+                    corrected.len(),
+                    crate::gpu_native_semantic_parity_v2::OUTPUT_TOKEN_LIMIT
+                )
+                .into());
+            }
+            token_cases.push(CpuTokenCaseAudit::new(frozen_case, corrected));
+        }
+        let boundary_after_part_b = runtime.engine.cpu_q4_boundary_emulation_snapshot();
+        boundary_disabled_and_clean(boundary_after_part_b)?;
+        let rust_case = token_cases
+            .iter()
+            .find(|case| case.case == "rust-ownership-holdout")
+            .ok_or("ordinary CPU audit omitted rust-ownership holdout")?;
+        let rust_ownership_position_one = RustOwnershipPositionOneEvidence {
+            case: "rust-ownership-holdout",
+            generated_position: 1,
+            historical_old_cpu_token_id: *rust_case
+                .historical_old_boundary_cpu_reference_token_ids
+                .get(1)
+                .ok_or("historical rust CPU position 1 is missing")?,
+            frozen_gpu_token_id: *rust_case
+                .frozen_gpu_token_ids
+                .get(1)
+                .ok_or("frozen rust GPU position 1 is missing")?,
+            new_ordinary_f32_cpu_token_id: *rust_case
+                .corrected_ordinary_f32_cpu_token_ids
+                .get(1)
+                .ok_or("ordinary rust CPU position 1 is missing")?,
+        };
+        if rust_ownership_position_one.historical_old_cpu_token_id != 785
+            || rust_ownership_position_one.frozen_gpu_token_id != 8822
+        {
+            return Err("rust-ownership frozen position-1 evidence changed".into());
+        }
+        Ok::<_, Box<dyn std::error::Error>>(ExecutionCapture {
+            expert_records,
+            token_cases,
+            rust_ownership_position_one,
+            model_load,
+            runtime: RuntimeContractEvidence {
+                runtime_mode: "RealCliRuntimeMode::IsolatedGreedyParityCpu",
+                execution_plan,
+                gpu_runtime_constructed,
+                gpu_device_identity_exposed,
+                gpu_native_token_loop_constructed,
+                boundary_emulation_before_part_a: boundary_before_part_a,
+                boundary_emulation_before_part_b: boundary_before_part_b,
+                boundary_emulation_after_part_b: boundary_after_part_b,
+                routed_execution_after: runtime.engine.routed_expert_execution_snapshot(),
+                background_shutdown: crate::greedy_parity::BackgroundShutdownEvidence::default(),
+            },
+        })
+    }
+    .await;
+    let shutdown = runtime.shutdown_isolated().await;
+    match (attempt, shutdown) {
+        (Ok(mut capture), Ok(shutdown)) => {
+            capture.runtime.background_shutdown = shutdown;
+            if !shutdown.controlled_shutdown_requested || !shutdown.all_runtime_resources_released {
+                return Err("CPU audit runtime failed controlled shutdown".into());
+            }
+            Ok(capture)
+        }
+        (Err(error), Ok(_)) => Err(error),
+        (Ok(_), Err(shutdown_error)) => Err(shutdown_error.into()),
+        (Err(error), Err(shutdown_error)) => Err(IsolatedRuntimeShutdownError::new(format!(
+            "{error}; CPU audit runtime shutdown also failed: {shutdown_error}"
+        ))
+        .into()),
+    }
+}
+
+fn select_worst_experts(
+    records: &[ExpertBoundaryAuditRecord],
+) -> Result<(Vec<SelectedWorstExpertAudit>, Vec<SelectedWorstExpertAudit>), String> {
+    let mut q = Vec::with_capacity(4);
+    let mut r = Vec::with_capacity(5);
+    for target in expected_targets() {
+        let candidates = records
+            .iter()
+            .filter(|record| record.target_id == target.id)
+            .collect::<Vec<_>>();
+        if candidates.len() != EXPECTED_EXPERTS_PER_TARGET {
+            return Err(format!("target {} audit record count differs", target.id));
+        }
+        if let Some(frozen_worst) = target.frozen_worst_local_expert {
+            let record = candidates
+                .into_iter()
+                .find(|record| record.local_expert_id == frozen_worst)
+                .ok_or_else(|| format!("target {} frozen worst expert is missing", target.id))?;
+            q.push(SelectedWorstExpertAudit {
+                target_id: target.id,
+                selection_basis: "frozen-q1-q4-worst-local-expert-identity",
+                expert: record.clone(),
+            });
+        } else {
+            let record = candidates
+                .into_iter()
+                .max_by(|left, right| {
+                    left.old_f16_emulated_cpu_reference_vs_frozen_actual_gpu_output
+                        .max_absolute_error
+                        .unwrap_or(f64::NEG_INFINITY)
+                        .total_cmp(
+                            &right
+                                .old_f16_emulated_cpu_reference_vs_frozen_actual_gpu_output
+                                .max_absolute_error
+                                .unwrap_or(f64::NEG_INFINITY),
+                        )
+                        .then_with(|| right.rank.cmp(&left.rank))
+                })
+                .ok_or_else(|| format!("target {} has no old-boundary comparison", target.id))?;
+            r.push(SelectedWorstExpertAudit {
+                target_id: target.id,
+                selection_basis: "largest-old-f16-reference-vs-frozen-gpu-max-absolute-error",
+                expert: record.clone(),
+            });
+        }
+    }
+    Ok((q, r))
+}
+
+fn emit_report(
+    report: &F32ReferenceBoundaryAuditReport,
+    report_out: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if report.qualification_pass() || !report.diagnostic_only || !report.diagnostic_complete {
+        return Err(
+            "f32 boundary audit report must be complete, diagnostic-only, and qualification false"
+                .into(),
+        );
+    }
+    if let Some(parent) = report_out.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut json = serde_json::to_vec_pretty(report)?;
+    json.push(b'\n');
+    std::fs::write(report_out, json)?;
+    eprintln!(
+        "GPU-native f32 reference-boundary audit report written to {}",
+        report_out.display()
+    );
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn run_diagnostic(
+    config: PathBuf,
+    cfg: crate::config::Config,
+    v2_report: PathBuf,
+    expected_v2_report_sha256: String,
+    stage_report: PathBuf,
+    expected_stage_report_sha256: String,
+    report_out: PathBuf,
+    progress_watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use crate::qualification::BuildProvenance;
+
+    // Immutable report validation is deliberately the first operation in the
+    // command handler, before tokenizer, model, engine, or backend creation.
+    let frozen = FrozenAuditInputs::read_and_validate(
+        &v2_report,
+        &expected_v2_report_sha256,
+        &stage_report,
+        &expected_stage_report_sha256,
+    )?;
+    if output_path_conflicts_with_frozen_input(&report_out, &frozen.identity)? {
+        return Err("report output must not overwrite either frozen historical input".into());
+    }
+    if progress_watchdog.timeout.is_none() {
+        return Err("f32 reference-boundary audit requires a positive progress timeout".into());
+    }
+    let build = BuildProvenance::embedded();
+    if build.dirty != Some(false) || build.git_sha.as_deref().is_none_or(|sha| !is_hex(sha, 40)) {
+        return Err("f32 reference-boundary audit requires clean embedded Git provenance".into());
+    }
+    let (artifacts, artifact_errors) = crate::qualification_artifacts(&config, &cfg);
+    if !artifact_errors.is_empty() {
+        return Err(format!(
+            "f32 reference-boundary artifact preflight failed: {}",
+            artifact_errors.join("; ")
+        )
+        .into());
+    }
+    let capacity_bytes = cfg
+        .gpu_cache
+        .vram_capacity_mb
+        .checked_mul(1024 * 1024)
+        .and_then(|bytes| u64::try_from(bytes).ok())
+        .unwrap_or(0);
+    let source_config = crate::gpu_native_greedy_parity::SourceConfigEvidence {
+        real_transformer_enabled: cfg.real_transformer.enabled,
+        gpu_native_enabled: cfg.real_transformer.gpu_native,
+        weights_dir_configured: cfg.real_transformer.weights_dir.is_some(),
+        strict_weights: cfg.real_transformer.strict_weights,
+        allow_seeded_fallback: cfg.real_transformer.allow_seeded_fallback,
+        allow_degraded_experts: cfg.real_transformer.allow_degraded_experts,
+        allow_nonfinite_attention_fallback: cfg.real_transformer.allow_nonfinite_attention_fallback,
+        allow_truncated_expert_payloads: cfg.real_transformer.allow_truncated_expert_payloads,
+        distributed_enabled: cfg.distributed.enabled,
+        gpu_cache_enabled: cfg.gpu_cache.enabled,
+        gpu_expert_capacity_bytes: capacity_bytes,
+        routed_expert_dtype: cfg.model.dtype.as_str().to_string(),
+    };
+    if !source_config.is_strict() {
+        return Err(
+            "f32 reference-boundary audit requires strict GPU-native Q4 source configuration"
+                .into(),
+        );
+    }
+    let expert_metadata =
+        crate::qualification::read_expert_metadata(&cfg.model.data_dir.join("metadata.json"))
+            .map_err(|error| {
+                format!("f32 boundary audit expert metadata preflight failed: {error}")
+            })?;
+    if expert_metadata.dtype.as_deref() != Some("q4_0")
+        || expert_metadata.q4_0_layout.as_deref() != Some(crate::inference::Q4_0_LAYOUT_STANDARD_V1)
+        || expert_metadata.explicitly_synthetic
+    {
+        return Err(
+            "f32 reference-boundary audit requires canonical nonsynthetic Q4_0 metadata".into(),
+        );
+    }
+
+    let mut cpu_spec =
+        crate::resolve_real_cli_spec_from_config(cfg, RealCliRuntimeMode::IsolatedGreedyParityCpu)?;
+    let model_identity = crate::greedy_parity_model_identity(&cpu_spec);
+    if !model_identity.is_qwen3_coder_30b_a3b_q4_0() {
+        return Err(
+            "f32 reference-boundary audit requires exact Qwen3-Coder 30B-A3B Q4_0 geometry".into(),
+        );
+    }
+    cpu_spec.cfg.real_transformer.gpu_native = false;
+    cpu_spec.cfg.real_transformer.compute_offload = crate::backend::ComputeOffload::Cpu;
+    let cpu_resolved_config_sha256 = crate::resolved_real_cli_spec_sha256(&cpu_spec)?;
+    let tokenizer_path = cpu_spec
+        .cfg
+        .tokenizer
+        .path
+        .as_ref()
+        .ok_or("f32 reference-boundary audit requires tokenizer.path")?;
+    let tokenizer = Arc::new(crate::tokenizer::Tokenizer::from_file(tokenizer_path)?);
+
+    let capture = execute_cpu_audit(
+        &cpu_spec,
+        tokenizer,
+        &cpu_resolved_config_sha256,
+        &frozen,
+        progress_watchdog,
+    )
+    .await?;
+    let (q1_q4, r1_r5) = select_worst_experts(&capture.expert_records)?;
+    let part_a_aggregation = aggregate_part_a(&capture.expert_records);
+    let part_b_token_summary = PartBTokenSummary {
+        requested_tokens: capture
+            .token_cases
+            .iter()
+            .map(|case| case.requested_tokens)
+            .sum(),
+        completed_tokens: capture
+            .token_cases
+            .iter()
+            .map(|case| case.completed_tokens)
+            .sum(),
+        exact_token_matches: capture
+            .token_cases
+            .iter()
+            .map(|case| case.exact_token_matches)
+            .sum(),
+        mismatch_count: capture
+            .token_cases
+            .iter()
+            .map(|case| case.mismatch_count)
+            .sum(),
+    };
+    let (_, executable_sha256) = crate::current_executable_identity()?;
+    let scientific_interpretation = vec![
+        format!(
+            "exact-F32 CPU reference has smaller max-absolute error than the old f16-emulated reference on {}/72 frozen experts",
+            part_a_aggregation.exact_f32_smaller_than_old_f16_maxabs_count
+        ),
+        format!(
+            "corrected ordinary CPU token stream matches the frozen GPU stream at {}/64 positions",
+            part_b_token_summary.exact_token_matches
+        ),
+        "observations are diagnostic-only and do not establish GPU correctness or justify a production correction".to_string(),
+    ];
+    let report = F32ReferenceBoundaryAuditReport {
+        schema: SCHEMA_VERSION,
+        mode: MODE,
+        diagnostic_only: true,
+        diagnostic_complete: true,
+        qualification_pass: QUALIFICATION_PASS,
+        failure: None,
+        frozen_inputs: frozen.identity,
+        provenance: AuditProvenance {
+            build,
+            executable_sha256,
+            artifacts,
+            source_config,
+            cpu_resolved_config_sha256,
+            model_identity,
+            model_load: capture.model_load,
+            expert_metadata,
+        },
+        expert_records: capture.expert_records,
+        q1_q4_frozen_worst_experts: q1_q4,
+        r1_r5_worst_old_boundary_error_experts: r1_r5,
+        part_a_aggregation,
+        corrected_cpu_token_cases: capture.token_cases,
+        rust_ownership_position_one: capture.rust_ownership_position_one,
+        part_b_token_summary,
+        runtime: capture.runtime,
+        production_semantics: ProductionSemanticsEvidence::default(),
+        scientific_interpretation,
+    };
+    emit_report(&report, &report_out)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+
+    use super::*;
+
+    fn valid_v2_envelope() -> FrozenV2Envelope {
+        let limits = crate::gpu_native_semantic_parity_v2::NumericalLimits::frozen();
+        let token_cases = crate::gpu_native_semantic_parity_v2::HOLDOUT_CORPUS
+            .into_iter()
+            .map(|case| {
+                let mut reference =
+                    vec![11u32; crate::gpu_native_semantic_parity_v2::OUTPUT_TOKEN_LIMIT];
+                let mut gpu = reference.clone();
+                if case.name == "rust-ownership-holdout" {
+                    reference[1] = 785;
+                    gpu[1] = 8822;
+                }
+                let comparison = crate::gpu_native_semantic_parity_corpus::TokenCaseEvidence::new(
+                    case.name,
+                    reference.clone(),
+                    gpu.clone(),
+                );
+                FrozenTokenCaseEnvelope {
+                    case: case.name.to_string(),
+                    reference_generated_token_ids: reference,
+                    gpu_generated_token_ids: gpu,
+                    exact_match_count: comparison.exact_match_count,
+                    mismatch_count: comparison.mismatch_count,
+                    first_mismatch_position: comparison.first_mismatch_position,
+                }
+            })
+            .collect();
+        FrozenV2Envelope {
+            schema: crate::gpu_native_semantic_parity_v2::SCHEMA_VERSION.to_string(),
+            qualification_pass: false,
+            holdout_corpus: FrozenCorpusEnvelope {
+                id: crate::gpu_native_semantic_parity_v2::HOLDOUT_CORPUS_ID.to_string(),
+                version: crate::gpu_native_semantic_parity_v2::HOLDOUT_CORPUS_VERSION,
+                sha256: crate::gpu_native_semantic_parity_v2::HOLDOUT_CORPUS_SHA256.to_string(),
+                case_count: crate::gpu_native_semantic_parity_v2::HOLDOUT_CORPUS_CASE_COUNT,
+                output_token_limit: crate::gpu_native_semantic_parity_v2::OUTPUT_TOKEN_LIMIT,
+            },
+            numerical_limits: FrozenNumericalLimitsEnvelope {
+                max_absolute_error_limit: limits.max_absolute_error_limit,
+                rms_error_limit: limits.rms_error_limit,
+                mean_absolute_error_limit: limits.mean_absolute_error_limit,
+                nonfinite_mismatch_limit: limits.nonfinite_mismatch_limit,
+                semantic_correctness_not_bit_parity: limits.semantic_correctness_not_bit_parity,
+            },
+            provenance: FrozenProvenanceEnvelope {
+                build: FrozenBuildEnvelope {
+                    git_sha: Some(FROZEN_V2_BUILD_SHA.to_string()),
+                },
+            },
+            token_cases,
+        }
+    }
+
+    fn exact_vector(source: &str) -> FrozenExactVectorEnvelope {
+        let f32_bits = vec![0u32; EXPECTED_D_MODEL];
+        FrozenExactVectorEnvelope {
+            source: source.to_string(),
+            vector_length: f32_bits.len(),
+            f32_bits_sha256: crate::numerical_diagnostics::f32_bits_sha256(&f32_bits),
+            f32_bits,
+            nonfinite_count: 0,
+        }
+    }
+
+    fn valid_stage_envelope() -> FrozenStageEnvelope {
+        let targets = expected_targets()
+            .into_iter()
+            .map(|target| {
+                let mut local_ids = target
+                    .frozen_worst_local_expert
+                    .into_iter()
+                    .collect::<Vec<_>>();
+                for candidate in 0..EXPECTED_NUM_EXPERTS as u32 {
+                    if local_ids.len() == EXPECTED_EXPERTS_PER_TARGET {
+                        break;
+                    }
+                    if !local_ids.contains(&candidate) {
+                        local_ids.push(candidate);
+                    }
+                }
+                let experts = local_ids
+                    .into_iter()
+                    .enumerate()
+                    .map(|(index, local_expert_id)| FrozenStageExpertEnvelope {
+                        rank: index + 1,
+                        local_expert_id,
+                        global_expert_id: (target.layer * EXPECTED_NUM_EXPERTS) as u32
+                            + local_expert_id,
+                        canonical_q4_payload_sha256: "a".repeat(64),
+                        final_output_boundary: FrozenOutputBoundaryEnvelope {
+                            cpu_effective_output: exact_vector(
+                                "cpu-diagnostic-f16-boundary-emulated-expert-output",
+                            ),
+                            actual_gpu_effective_output: exact_vector(
+                                "actual-production-gpu-expert-output",
+                            ),
+                        },
+                    })
+                    .collect();
+                FrozenStageTargetEnvelope {
+                    target,
+                    input_boundary: Some(FrozenInputBoundaryEnvelope {
+                        effective_gpu_expert_input: exact_vector(
+                            "effective-production-gpu-expert-input",
+                        ),
+                    }),
+                    experts,
+                    failure: None,
+                }
+            })
+            .collect::<Vec<_>>();
+        FrozenStageEnvelope {
+            schema: crate::gpu_native_q4_expert_stage_attribution::SCHEMA_VERSION.to_string(),
+            diagnostic_complete: true,
+            qualification_pass: false,
+            failure: None,
+            provenance: FrozenProvenanceEnvelope {
+                build: FrozenBuildEnvelope {
+                    git_sha: Some(FROZEN_STAGE_BUILD_SHA.to_string()),
+                },
+            },
+            frozen_targets: expected_targets(),
+            targets,
+        }
+    }
+
+    #[test]
+    fn schema_mode_and_qualification_contract_are_versioned_and_false() {
+        assert_eq!(
+            SCHEMA_VERSION,
+            "mer.gpu-native-f32-reference-boundary-audit.v1"
+        );
+        assert_eq!(MODE, "diagnose-gpu-native-f32-reference-boundary");
+        assert!(!QUALIFICATION_PASS);
+        let semantics = ProductionSemanticsEvidence::default();
+        assert!(!semantics.numerical_qualification_threshold_introduced);
+        assert!(!semantics.production_correction_made_or_justified);
+    }
+
+    #[test]
+    fn exact_f32_reconstruction_preserves_every_u32_bit_pattern() {
+        let bits = [0x0000_0000, 0x8000_0000, 0x3f80_0001, 0xbf7f_ffff];
+        assert_eq!(
+            reconstruct_exact_f32(&bits)
+                .iter()
+                .map(|value| value.to_bits())
+                .collect::<Vec<_>>(),
+            bits
+        );
+    }
+
+    #[test]
+    fn old_path_round_trips_both_boundaries_and_exact_path_round_trips_neither() {
+        let round_trips = RefCell::new(Vec::<Vec<u32>>::new());
+        let production_inputs = RefCell::new(Vec::<Vec<u32>>::new());
+        let emulator_inputs = RefCell::new(Vec::<Vec<u32>>::new());
+        let input = [1.25f32, -2.5];
+        let out = compute_reference_paths_with(
+            &input,
+            |values| {
+                round_trips
+                    .borrow_mut()
+                    .push(values.iter().map(|value| value.to_bits()).collect());
+                Ok(values.iter().map(|value| value + 1.0).collect())
+            },
+            |values| {
+                production_inputs
+                    .borrow_mut()
+                    .push(values.iter().map(|value| value.to_bits()).collect());
+                Ok(values.iter().map(|value| value * 2.0).collect())
+            },
+            |values| {
+                emulator_inputs
+                    .borrow_mut()
+                    .push(values.iter().map(|value| value.to_bits()).collect());
+                Ok(values.to_vec())
+            },
+        )
+        .unwrap();
+        assert_eq!(round_trips.borrow().len(), 2);
+        assert_eq!(production_inputs.borrow().len(), 2);
+        assert_eq!(
+            production_inputs.borrow()[0],
+            out.old_boundary_input
+                .iter()
+                .map(|v| v.to_bits())
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            production_inputs.borrow()[1],
+            input.iter().map(|v| v.to_bits()).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            emulator_inputs.borrow()[0],
+            input.iter().map(|v| v.to_bits()).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            CPU_REFERENCE_IMPLEMENTATION,
+            "existing-production-q4_0_cpu_reference_forward-candle"
+        );
+    }
+
+    #[test]
+    fn exact_path_matches_the_existing_production_candle_q4_reference() {
+        let d_model = 32;
+        let d_ff = 32;
+        let payload = vec![
+            0u8;
+            crate::inference::expert_weight_bytes_for(
+                d_model,
+                d_ff,
+                crate::inference::WeightDtype::Q4_0,
+            )
+        ];
+        let input = (0..d_model)
+            .map(|index| index as f32 / d_model as f32)
+            .collect::<Vec<_>>();
+        let expected =
+            crate::inference::q4_0_cpu_reference_forward(&payload, &input, d_model, d_ff).unwrap();
+        let observed =
+            audit_q4_reference_paths(&payload, &input, d_model, d_ff, "b".repeat(64)).unwrap();
+        assert!(observed
+            .exact_f32_output
+            .iter()
+            .map(|value| value.to_bits())
+            .eq(expected.iter().map(|value| value.to_bits())));
+    }
+
+    #[test]
+    fn boundary_snapshot_must_remain_disabled_and_zero() {
+        assert!(boundary_disabled_and_clean(
+            crate::engine::CpuQ4BoundaryEmulationSnapshot::default()
+        )
+        .is_ok());
+        assert!(
+            boundary_disabled_and_clean(crate::engine::CpuQ4BoundaryEmulationSnapshot {
+                enabled: true,
+                routed_expert_dispatches: 0,
+            })
+            .is_err()
+        );
+        assert!(
+            boundary_disabled_and_clean(crate::engine::CpuQ4BoundaryEmulationSnapshot {
+                enabled: false,
+                routed_expert_dispatches: 1,
+            })
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn exact_72_expert_identity_contract_is_explicit() {
+        assert_eq!(EXPECTED_TARGET_COUNT, 9);
+        assert_eq!(EXPECTED_EXPERTS_PER_TARGET, 8);
+        assert_eq!(EXPECTED_EXPERT_RECORD_COUNT, 72);
+        assert_eq!(expected_targets().len(), EXPECTED_TARGET_COUNT);
+        assert_eq!(
+            expected_targets()
+                .iter()
+                .map(|target| target.id.as_str())
+                .collect::<Vec<_>>(),
+            ["Q1", "Q2", "Q3", "Q4", "R1", "R2", "R3", "R4", "R5"]
+        );
+    }
+
+    #[test]
+    fn frozen_sha_arguments_are_exact_and_fail_closed() {
+        assert!(validate_expected_report_sha(
+            FROZEN_V2_REPORT_SHA256,
+            FROZEN_V2_REPORT_SHA256,
+            "v2"
+        )
+        .is_ok());
+        assert!(
+            validate_expected_report_sha(&"0".repeat(64), FROZEN_V2_REPORT_SHA256, "v2").is_err()
+        );
+        assert!(validate_expected_report_sha(
+            FROZEN_STAGE_REPORT_SHA256,
+            FROZEN_STAGE_REPORT_SHA256,
+            "stage"
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn frozen_v2_schema_build_corpus_limits_and_tokens_fail_closed() {
+        let mut envelope = valid_v2_envelope();
+        assert!(validate_frozen_v2(&envelope).is_ok());
+        envelope.schema.push_str("-drift");
+        assert!(validate_frozen_v2(&envelope).is_err());
+        envelope = valid_v2_envelope();
+        envelope.provenance.build.git_sha = Some("0".repeat(40));
+        assert!(validate_frozen_v2(&envelope).is_err());
+        envelope = valid_v2_envelope();
+        envelope.holdout_corpus.sha256 = "0".repeat(64);
+        assert!(validate_frozen_v2(&envelope).is_err());
+        envelope = valid_v2_envelope();
+        envelope.numerical_limits.rms_error_limit = 1.0;
+        assert!(validate_frozen_v2(&envelope).is_err());
+        envelope = valid_v2_envelope();
+        envelope.token_cases[0].gpu_generated_token_ids.pop();
+        assert!(validate_frozen_v2(&envelope).is_err());
+    }
+
+    #[test]
+    fn frozen_stage_schema_build_completion_and_all_72_identities_fail_closed() {
+        let mut envelope = valid_stage_envelope();
+        assert_eq!(validate_frozen_stage(&envelope).unwrap().len(), 72);
+        envelope.targets[0].experts.pop();
+        assert!(validate_frozen_stage(&envelope).is_err());
+        envelope = valid_stage_envelope();
+        envelope.provenance.build.git_sha = Some("0".repeat(40));
+        assert!(validate_frozen_stage(&envelope).is_err());
+        envelope = valid_stage_envelope();
+        envelope.diagnostic_complete = false;
+        assert!(validate_frozen_stage(&envelope).is_err());
+        envelope = valid_stage_envelope();
+        envelope.targets[0].target.generated_position += 1;
+        assert!(validate_frozen_stage(&envelope).is_err());
+        envelope = valid_stage_envelope();
+        envelope.targets[0].experts[0]
+            .final_output_boundary
+            .actual_gpu_effective_output
+            .f32_bits_sha256 = "0".repeat(64);
+        assert!(validate_frozen_stage(&envelope).is_err());
+    }
+
+    #[test]
+    fn snapshot_hash_uses_the_same_bytes_and_rejects_drift() {
+        let bytes = b"immutable-report-snapshot";
+        let sha = crate::greedy_parity::sha256_hex(bytes);
+        let artifact = crate::qualification::ArtifactDigest {
+            configured_path: "frozen.json".into(),
+            canonical_path: "/frozen.json".into(),
+            byte_length: bytes.len() as u64,
+            sha256: sha.clone(),
+        };
+        assert!(validate_snapshot_hash(&artifact, &sha, &sha, "test").is_ok());
+        assert!(validate_snapshot_hash(&artifact, &"0".repeat(64), &sha, "test").is_err());
+    }
+
+    #[test]
+    fn runtime_and_historical_contracts_prohibit_gpu_and_overwrite() {
+        assert_eq!(
+            AUDIT_RUNTIME_MODE,
+            RealCliRuntimeMode::IsolatedGreedyParityCpu
+        );
+        let historical = FrozenHistoricalEvidenceIdentity::default();
+        assert!(!historical.modified_or_reclassified);
+        let semantics = ProductionSemanticsEvidence::default();
+        assert!(semantics.frozen_gpu_outputs_read_only_from_stage_report);
+        assert!(semantics.frozen_gpu_tokens_read_only_from_v2_report);
+        assert!(!semantics.cpu_q4_boundary_emulation_behavior_changed);
+    }
+
+    #[test]
+    fn report_destination_cannot_overwrite_frozen_inputs() {
+        let directory = std::env::temp_dir().join(format!(
+            "mer-f32-boundary-audit-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&directory).unwrap();
+        let v2_path = directory.join("v2.json");
+        let stage_path = directory.join("stage.json");
+        std::fs::write(&v2_path, b"v2").unwrap();
+        std::fs::write(&stage_path, b"stage").unwrap();
+        let artifact = |path: &Path| crate::qualification::ArtifactDigest {
+            configured_path: path.display().to_string(),
+            canonical_path: std::fs::canonicalize(path).unwrap().display().to_string(),
+            byte_length: std::fs::metadata(path).unwrap().len(),
+            sha256: "a".repeat(64),
+        };
+        let identity = FrozenReportsIdentity {
+            v2_report: artifact(&v2_path),
+            expected_v2_report_sha256_argument: FROZEN_V2_REPORT_SHA256.into(),
+            stage_report: artifact(&stage_path),
+            expected_stage_report_sha256_argument: FROZEN_STAGE_REPORT_SHA256.into(),
+            v2_schema: crate::gpu_native_semantic_parity_v2::SCHEMA_VERSION,
+            stage_schema: crate::gpu_native_q4_expert_stage_attribution::SCHEMA_VERSION,
+            v2_build_sha: FROZEN_V2_BUILD_SHA,
+            stage_build_sha: FROZEN_STAGE_BUILD_SHA,
+            holdout_corpus_id: crate::gpu_native_semantic_parity_v2::HOLDOUT_CORPUS_ID,
+            holdout_corpus_sha256: crate::gpu_native_semantic_parity_v2::HOLDOUT_CORPUS_SHA256,
+            holdout_case_count: 4,
+            output_token_limit: 16,
+            exact_expert_identity_count: 72,
+            exact_expert_identities: Vec::new(),
+            immutable_inputs_verified_before_runtime: true,
+            historical: FrozenHistoricalEvidenceIdentity::default(),
+        };
+        assert!(output_path_conflicts_with_frozen_input(&v2_path, &identity).unwrap());
+        assert!(output_path_conflicts_with_frozen_input(&stage_path, &identity).unwrap());
+        assert!(!output_path_conflicts_with_frozen_input(
+            &directory.join("new/nested/audit.json"),
+            &identity,
+        )
+        .unwrap());
+        std::fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn improvement_is_direct_and_has_no_acceptance_threshold() {
+        let old = VectorNumericalEvidence::compare("old", "gpu", &[0.0], &[2.0]).unwrap();
+        let exact = VectorNumericalEvidence::compare("exact", "gpu", &[1.0], &[2.0]).unwrap();
+        let evidence = ErrorImprovementEvidence::new(&exact, &old);
+        assert!(evidence.exact_f32_error_smaller_than_old_f16_error_maxabs);
+        assert_eq!(evidence.exact_f32_to_old_f16_maxabs_ratio, Some(0.5));
+        assert!(
+            !ProductionSemanticsEvidence::default().numerical_qualification_threshold_introduced
+        );
+    }
+}

--- a/rust-engine/src/gpu_native_greedy_parity.rs
+++ b/rust-engine/src/gpu_native_greedy_parity.rs
@@ -1,0 +1,1027 @@
+//! Fail-closed accounting for full GPU-native Q4 greedy-token qualification.
+//!
+//! Runtime construction remains in `main.rs`. This module owns the versioned
+//! report, fixed semantic contracts, exact token/routing comparisons, and
+//! hardware-independent PASS derivation.
+
+use crate::backend::GpuDeviceIdentity;
+use crate::engine::RoutedExpertExecutionSnapshot;
+use crate::gpu_native_token_loop::{GpuNativeModelGeometry, GpuNativeTokenLoopSnapshot};
+use crate::greedy_parity::{
+    BackgroundShutdownEvidence, CorpusEvidence, GenerationEvidence, GreedySamplingEvidence,
+    ModelLoadEvidence, PlaneRunEvidence,
+};
+use crate::qualification::{
+    BuildProvenance, ExpertMetadataEvidence, FailureStage, QualificationArtifacts,
+    QualificationFailure,
+};
+use serde::Serialize;
+
+pub const SCHEMA_VERSION: &str = "mer.gpu-native-q4-greedy-parity.v1";
+pub const MODE: &str = "gpu-native-q4-greedy-parity-qualification";
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ReferenceContractEvidence {
+    pub execution: &'static str,
+    pub routed_expert_boundary: &'static str,
+    pub routing_and_aggregation: &'static str,
+    pub strict_real_checkpoint: bool,
+    pub seeded_fallback_allowed: bool,
+    pub degraded_experts_allowed: bool,
+}
+
+impl ReferenceContractEvidence {
+    pub const fn authoritative() -> Self {
+        Self {
+            execution: "cpu",
+            routed_expert_boundary: "production-hybrid-f16-input-output",
+            routing_and_aggregation: "f32",
+            strict_real_checkpoint: true,
+            seeded_fallback_allowed: false,
+            degraded_experts_allowed: false,
+        }
+    }
+
+    fn is_exact(&self) -> bool {
+        self == &Self::authoritative()
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct GpuCandidatePathEvidence {
+    pub implementation: &'static str,
+    pub real_dense_weights: bool,
+    pub gpu_rmsnorm: bool,
+    pub gpu_attention: bool,
+    pub gpu_kv: bool,
+    pub gpu_router: bool,
+    pub q4_gpu_experts: bool,
+    pub gpu_combine: bool,
+    pub final_rmsnorm: bool,
+    pub lm_head: bool,
+    pub gpu_greedy_argmax: bool,
+    pub tiered_residency_retry: bool,
+}
+
+impl GpuCandidatePathEvidence {
+    pub const fn production() -> Self {
+        Self {
+            implementation: "GpuNativeTokenLoop",
+            real_dense_weights: true,
+            gpu_rmsnorm: true,
+            gpu_attention: true,
+            gpu_kv: true,
+            gpu_router: true,
+            q4_gpu_experts: true,
+            gpu_combine: true,
+            final_rmsnorm: true,
+            lm_head: true,
+            gpu_greedy_argmax: true,
+            tiered_residency_retry: true,
+        }
+    }
+
+    fn is_exact(&self) -> bool {
+        self == &Self::production()
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct SourceConfigEvidence {
+    pub real_transformer_enabled: bool,
+    pub gpu_native_enabled: bool,
+    pub weights_dir_configured: bool,
+    pub strict_weights: bool,
+    pub allow_seeded_fallback: bool,
+    pub allow_degraded_experts: bool,
+    pub allow_nonfinite_attention_fallback: bool,
+    pub allow_truncated_expert_payloads: bool,
+    pub distributed_enabled: bool,
+    pub gpu_cache_enabled: bool,
+    pub gpu_expert_capacity_bytes: u64,
+    pub routed_expert_dtype: String,
+}
+
+impl SourceConfigEvidence {
+    pub fn is_strict(&self) -> bool {
+        self.real_transformer_enabled
+            && self.gpu_native_enabled
+            && self.weights_dir_configured
+            && self.strict_weights
+            && !self.allow_seeded_fallback
+            && !self.allow_degraded_experts
+            && !self.allow_nonfinite_attention_fallback
+            && !self.allow_truncated_expert_payloads
+            && !self.distributed_enabled
+            && self.gpu_cache_enabled
+            && self.gpu_expert_capacity_bytes > 0
+            && self.routed_expert_dtype == "q4_0"
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct TokenMismatchEvidence {
+    pub case: String,
+    pub generated_position: usize,
+    pub reference_token_id: Option<u32>,
+    pub gpu_native_token_id: Option<u32>,
+    pub prompt_token_ids: Vec<u32>,
+    pub preceding_generated_ids: Vec<u32>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ExpertIdMismatchEvidence {
+    pub case: String,
+    pub generated_position: usize,
+    pub layer: usize,
+    pub expert_slot: usize,
+    pub reference_expert_id: Option<u32>,
+    pub gpu_native_expert_id: Option<u32>,
+    pub reference_selected_expert_ids: Vec<u32>,
+    pub gpu_native_selected_expert_ids: Vec<u32>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct CaseComparisonEvidence {
+    pub exact_token_matches: usize,
+    pub token_ids_match: bool,
+    pub first_token_mismatch: Option<TokenMismatchEvidence>,
+    pub expert_id_topology_match: bool,
+    pub routing_positions_compared: usize,
+    pub routing_layer_comparisons: usize,
+    pub first_expert_id_mismatch: Option<ExpertIdMismatchEvidence>,
+}
+
+pub fn compare_case_outputs(
+    case: &str,
+    prompt_token_ids: &[u32],
+    reference_token_ids: &[u32],
+    gpu_native_token_ids: &[u32],
+    reference_routes: &[Vec<Vec<u32>>],
+    gpu_native_routes: &[Vec<Vec<u32>>],
+    tokens_per_case: usize,
+    num_layers: usize,
+    top_k: usize,
+) -> Result<CaseComparisonEvidence, String> {
+    if tokens_per_case == 0 {
+        return Err("tokens_per_case must be greater than zero".to_string());
+    }
+    if reference_token_ids.len() != tokens_per_case || gpu_native_token_ids.len() != tokens_per_case
+    {
+        return Err(format!(
+            "case {case} expected {tokens_per_case} tokens per plane, got reference={} gpu_native={}",
+            reference_token_ids.len(),
+            gpu_native_token_ids.len()
+        ));
+    }
+    validate_route_shape(
+        case,
+        "reference",
+        reference_routes,
+        tokens_per_case,
+        num_layers,
+        top_k,
+    )?;
+    validate_route_shape(
+        case,
+        "gpu_native",
+        gpu_native_routes,
+        tokens_per_case,
+        num_layers,
+        top_k,
+    )?;
+
+    let exact_token_matches = reference_token_ids
+        .iter()
+        .zip(gpu_native_token_ids)
+        .filter(|(reference, gpu)| reference == gpu)
+        .count();
+    let first_token_mismatch = reference_token_ids
+        .iter()
+        .zip(gpu_native_token_ids)
+        .position(|(reference, gpu)| reference != gpu)
+        .map(|generated_position| TokenMismatchEvidence {
+            case: case.to_string(),
+            generated_position,
+            reference_token_id: reference_token_ids.get(generated_position).copied(),
+            gpu_native_token_id: gpu_native_token_ids.get(generated_position).copied(),
+            prompt_token_ids: prompt_token_ids.to_vec(),
+            preceding_generated_ids: reference_token_ids[..generated_position].to_vec(),
+        });
+
+    let mut first_expert_id_mismatch = None;
+    'positions: for generated_position in 0..tokens_per_case {
+        for layer in 0..num_layers {
+            let reference = &reference_routes[generated_position][layer];
+            let gpu_native = &gpu_native_routes[generated_position][layer];
+            if let Some(expert_slot) = reference
+                .iter()
+                .zip(gpu_native)
+                .position(|(reference_id, gpu_id)| reference_id != gpu_id)
+            {
+                first_expert_id_mismatch = Some(ExpertIdMismatchEvidence {
+                    case: case.to_string(),
+                    generated_position,
+                    layer,
+                    expert_slot,
+                    reference_expert_id: reference.get(expert_slot).copied(),
+                    gpu_native_expert_id: gpu_native.get(expert_slot).copied(),
+                    reference_selected_expert_ids: reference.clone(),
+                    gpu_native_selected_expert_ids: gpu_native.clone(),
+                });
+                break 'positions;
+            }
+        }
+    }
+
+    Ok(CaseComparisonEvidence {
+        exact_token_matches,
+        token_ids_match: first_token_mismatch.is_none(),
+        first_token_mismatch,
+        expert_id_topology_match: first_expert_id_mismatch.is_none(),
+        routing_positions_compared: tokens_per_case,
+        routing_layer_comparisons: tokens_per_case
+            .checked_mul(num_layers)
+            .ok_or("routing comparison count overflowed")?,
+        first_expert_id_mismatch,
+    })
+}
+
+fn validate_route_shape(
+    case: &str,
+    plane: &str,
+    routes: &[Vec<Vec<u32>>],
+    tokens_per_case: usize,
+    num_layers: usize,
+    top_k: usize,
+) -> Result<(), String> {
+    if routes.len() != tokens_per_case {
+        return Err(format!(
+            "case {case} {plane} routing evidence has {} positions, expected {tokens_per_case}",
+            routes.len()
+        ));
+    }
+    for (position, layers) in routes.iter().enumerate() {
+        if layers.len() != num_layers {
+            return Err(format!(
+                "case {case} {plane} position {position} has {} routed layers, expected {num_layers}",
+                layers.len()
+            ));
+        }
+        for (layer, selected) in layers.iter().enumerate() {
+            if selected.len() != top_k {
+                return Err(format!(
+                    "case {case} {plane} position {position} layer {layer} selected {} experts, expected {top_k}",
+                    selected.len()
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ReferenceRoutingReplayEvidence {
+    pub generation: GenerationEvidence,
+    pub matches_authoritative_reference: bool,
+    pub routing_positions_captured: usize,
+    pub routed_layers_per_position: usize,
+    pub selected_expert_ids_by_generated_position_layer: Vec<Vec<Vec<u32>>>,
+    pub background_shutdown: BackgroundShutdownEvidence,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct GpuCandidateCaseEvidence {
+    pub generation: GenerationEvidence,
+    pub model_load: ModelLoadEvidence,
+    pub selected_expert_ids_by_generated_position_layer: Vec<Vec<Vec<u32>>>,
+    pub token_loop_counters_delta: GpuNativeTokenLoopSnapshot,
+    pub routed_execution_delta: RoutedExpertExecutionSnapshot,
+    pub attention_softmax_nonfinite_fallbacks: u64,
+    pub request_completed_expected_tokens: bool,
+    pub background_shutdown: BackgroundShutdownEvidence,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct CaseReport {
+    pub name: String,
+    pub behavior: String,
+    pub prompt: String,
+    pub prompt_sha256: String,
+    pub prompt_token_ids: Vec<u32>,
+    pub prompt_token_ids_sha256: String,
+    pub tokens_per_case: usize,
+    pub authoritative_reference: PlaneRunEvidence,
+    pub reference_routing_replay: ReferenceRoutingReplayEvidence,
+    pub gpu_native: GpuCandidateCaseEvidence,
+    pub comparison: CaseComparisonEvidence,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
+pub struct FallbackDegradedEvidence {
+    pub all_model_loads_strict_complete: bool,
+    pub seeded_fallback_remained: bool,
+    pub degraded_expert_substitutions: u64,
+    pub gpu_dispatch_failures: u64,
+    pub gpu_cpu_fallbacks: u64,
+    pub nonfinite_attention_fallbacks: u64,
+    pub fatal_numerical_failures: u64,
+    pub no_progress_failures: u64,
+    pub unexpected_request_retirements: u64,
+    pub all_requests_completed_expected_tokens: bool,
+}
+
+impl FallbackDegradedEvidence {
+    fn passes(&self, source: &SourceConfigEvidence) -> bool {
+        source.is_strict()
+            && self.all_model_loads_strict_complete
+            && !self.seeded_fallback_remained
+            && self.degraded_expert_substitutions == 0
+            && self.gpu_dispatch_failures == 0
+            && self.gpu_cpu_fallbacks == 0
+            && self.nonfinite_attention_fallbacks == 0
+            && self.fatal_numerical_failures == 0
+            && self.no_progress_failures == 0
+            && self.unexpected_request_retirements == 0
+            && self.all_requests_completed_expected_tokens
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
+pub struct ResidencyEvidence {
+    pub miss_attempts: u64,
+    pub replay_attempts: u64,
+    pub services: u64,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
+pub struct QualificationChecks {
+    pub clean_build_provenance: bool,
+    pub source_config_strict: bool,
+    pub fixed_corpus_identity: bool,
+    pub fixed_greedy_sampling: bool,
+    pub authoritative_reference_contract: bool,
+    pub production_gpu_candidate_path: bool,
+    pub model_geometry_recorded: bool,
+    pub adapter_exact_match: bool,
+    pub hardware_adapter: bool,
+    pub exact_case_and_token_totals: bool,
+    pub exact_generated_token_ids: bool,
+    pub expert_id_topology_match: bool,
+    pub reference_routing_replays_match: bool,
+    pub residency_misses_fully_serviced: bool,
+    pub zero_fallback_degraded_or_fatal_evidence: bool,
+}
+
+impl QualificationChecks {
+    fn passes(&self) -> bool {
+        self.clean_build_provenance
+            && self.source_config_strict
+            && self.fixed_corpus_identity
+            && self.fixed_greedy_sampling
+            && self.authoritative_reference_contract
+            && self.production_gpu_candidate_path
+            && self.model_geometry_recorded
+            && self.adapter_exact_match
+            && self.hardware_adapter
+            && self.exact_case_and_token_totals
+            && self.exact_generated_token_ids
+            && self.expert_id_topology_match
+            && self.reference_routing_replays_match
+            && self.residency_misses_fully_serviced
+            && self.zero_fallback_degraded_or_fatal_evidence
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct GpuNativeGreedyParityReport {
+    pub schema_version: &'static str,
+    pub mode: &'static str,
+    pub qualification_pass: bool,
+    pub failure: Option<QualificationFailure>,
+    pub build_provenance: BuildProvenance,
+    pub artifacts: QualificationArtifacts,
+    pub expert_metadata: Option<ExpertMetadataEvidence>,
+    pub resolved_config_sha256: Option<String>,
+    pub reference_resolved_config_sha256: Option<String>,
+    pub model_geometry: Option<GpuNativeModelGeometry>,
+    pub expected_adapter_name: String,
+    pub actual_adapter: Option<GpuDeviceIdentity>,
+    pub reference_contract: ReferenceContractEvidence,
+    pub gpu_candidate_path: GpuCandidatePathEvidence,
+    pub source_config: SourceConfigEvidence,
+    pub corpus: CorpusEvidence,
+    pub sampling: GreedySamplingEvidence,
+    pub cases: Vec<CaseReport>,
+    pub tokens_per_case: usize,
+    pub total_tokens_expected: usize,
+    pub total_tokens_compared: usize,
+    pub exact_token_matches: usize,
+    pub first_token_mismatch: Option<TokenMismatchEvidence>,
+    pub expert_id_topology_match: bool,
+    pub routing_positions_compared: usize,
+    pub routing_layer_comparisons: usize,
+    pub first_expert_id_mismatch: Option<ExpertIdMismatchEvidence>,
+    pub fallback_degraded_evidence: FallbackDegradedEvidence,
+    pub token_loop_counter_deltas: GpuNativeTokenLoopSnapshot,
+    pub residency: ResidencyEvidence,
+    pub checks: QualificationChecks,
+}
+
+impl GpuNativeGreedyParityReport {
+    pub fn new(
+        build_provenance: BuildProvenance,
+        artifacts: QualificationArtifacts,
+        expert_metadata: Option<ExpertMetadataEvidence>,
+        expected_adapter_name: String,
+        source_config: SourceConfigEvidence,
+    ) -> Self {
+        Self {
+            schema_version: SCHEMA_VERSION,
+            mode: MODE,
+            qualification_pass: false,
+            failure: None,
+            build_provenance,
+            artifacts,
+            expert_metadata,
+            resolved_config_sha256: None,
+            reference_resolved_config_sha256: None,
+            model_geometry: None,
+            expected_adapter_name,
+            actual_adapter: None,
+            reference_contract: ReferenceContractEvidence::authoritative(),
+            gpu_candidate_path: GpuCandidatePathEvidence::production(),
+            source_config,
+            corpus: CorpusEvidence::fixed(),
+            sampling: GreedySamplingEvidence::fixed(),
+            cases: Vec::new(),
+            tokens_per_case: crate::greedy_parity::OUTPUT_TOKEN_LIMIT,
+            total_tokens_expected: crate::greedy_parity::CORPUS_CASE_COUNT
+                * crate::greedy_parity::OUTPUT_TOKEN_LIMIT,
+            total_tokens_compared: 0,
+            exact_token_matches: 0,
+            first_token_mismatch: None,
+            expert_id_topology_match: true,
+            routing_positions_compared: 0,
+            routing_layer_comparisons: 0,
+            first_expert_id_mismatch: None,
+            fallback_degraded_evidence: FallbackDegradedEvidence {
+                all_model_loads_strict_complete: true,
+                all_requests_completed_expected_tokens: true,
+                ..FallbackDegradedEvidence::default()
+            },
+            token_loop_counter_deltas: GpuNativeTokenLoopSnapshot::default(),
+            residency: ResidencyEvidence::default(),
+            checks: QualificationChecks::default(),
+        }
+    }
+
+    pub fn fail(&mut self, failure: QualificationFailure) {
+        self.qualification_pass = false;
+        self.failure = Some(failure);
+    }
+
+    pub fn record_case(&mut self, case: CaseReport) -> Result<(), String> {
+        let expected = crate::greedy_parity::FIXED_CORPUS
+            .get(self.cases.len())
+            .ok_or("qualification received more cases than the fixed corpus")?;
+        if case.name != expected.name {
+            return Err(format!(
+                "fixed corpus case order mismatch: expected {}, got {}",
+                expected.name, case.name
+            ));
+        }
+        let geometry = self
+            .model_geometry
+            .ok_or("model geometry must be recorded before case evidence")?;
+        if case.behavior != expected.behavior
+            || case.prompt != expected.prompt
+            || case.prompt_sha256 != crate::greedy_parity::sha256_hex(expected.prompt.as_bytes())
+            || case.prompt_token_ids.is_empty()
+            || case.prompt_token_ids_sha256
+                != crate::greedy_parity::token_ids_sha256(&case.prompt_token_ids)
+            || case.tokens_per_case != self.tokens_per_case
+            || case
+                .authoritative_reference
+                .generation
+                .generated_token_count
+                != self.tokens_per_case
+            || case.gpu_native.generation.generated_token_count != self.tokens_per_case
+            || case
+                .reference_routing_replay
+                .generation
+                .generated_token_count
+                != self.tokens_per_case
+            || case.reference_routing_replay.routing_positions_captured != self.tokens_per_case
+        {
+            return Err(format!(
+                "fixed corpus case {} has invalid identity, token, or routing evidence",
+                case.name
+            ));
+        }
+        let recomputed_comparison = compare_case_outputs(
+            &case.name,
+            &case.prompt_token_ids,
+            &case.authoritative_reference.generation.generated_token_ids,
+            &case.gpu_native.generation.generated_token_ids,
+            &case
+                .reference_routing_replay
+                .selected_expert_ids_by_generated_position_layer,
+            &case
+                .gpu_native
+                .selected_expert_ids_by_generated_position_layer,
+            self.tokens_per_case,
+            geometry.num_layers,
+            geometry.top_k,
+        )?;
+        if recomputed_comparison != case.comparison {
+            return Err(format!(
+                "fixed corpus case {} comparison does not reconcile with its exact token and expert-ID evidence",
+                case.name
+            ));
+        }
+        self.total_tokens_compared = self
+            .total_tokens_compared
+            .checked_add(case.tokens_per_case)
+            .ok_or("total_tokens_compared overflowed")?;
+        self.exact_token_matches = self
+            .exact_token_matches
+            .checked_add(case.comparison.exact_token_matches)
+            .ok_or("exact_token_matches overflowed")?;
+        self.routing_positions_compared = self
+            .routing_positions_compared
+            .checked_add(case.comparison.routing_positions_compared)
+            .ok_or("routing_positions_compared overflowed")?;
+        self.routing_layer_comparisons = self
+            .routing_layer_comparisons
+            .checked_add(case.comparison.routing_layer_comparisons)
+            .ok_or("routing_layer_comparisons overflowed")?;
+        if self.first_token_mismatch.is_none() {
+            self.first_token_mismatch = case.comparison.first_token_mismatch.clone();
+        }
+        if self.first_expert_id_mismatch.is_none() {
+            self.first_expert_id_mismatch = case.comparison.first_expert_id_mismatch.clone();
+        }
+        self.expert_id_topology_match &= case.comparison.expert_id_topology_match;
+        self.accumulate_fallback_evidence(&case)?;
+        self.token_loop_counter_deltas = checked_add_snapshots(
+            self.token_loop_counter_deltas,
+            case.gpu_native.token_loop_counters_delta,
+        )?;
+        self.residency = ResidencyEvidence {
+            miss_attempts: self.token_loop_counter_deltas.residency_miss_attempts,
+            replay_attempts: self.token_loop_counter_deltas.replay_attempts,
+            services: self.token_loop_counter_deltas.residency_services,
+        };
+        self.cases.push(case);
+        Ok(())
+    }
+
+    fn accumulate_fallback_evidence(&mut self, case: &CaseReport) -> Result<(), String> {
+        let reference = &case.authoritative_reference;
+        let gpu = &case.gpu_native;
+        self.fallback_degraded_evidence
+            .all_model_loads_strict_complete &= model_load_strict_complete(&reference.model_load)
+            && model_load_strict_complete(&gpu.model_load);
+        self.fallback_degraded_evidence.seeded_fallback_remained |=
+            reference.model_load.seeded_fallback_remained
+                || gpu.model_load.seeded_fallback_remained;
+        self.fallback_degraded_evidence
+            .degraded_expert_substitutions = checked_add(
+            self.fallback_degraded_evidence
+                .degraded_expert_substitutions,
+            reference
+                .routed_execution_delta
+                .degraded_expert_substitutions,
+            "reference degraded expert substitutions",
+        )?;
+        self.fallback_degraded_evidence.gpu_dispatch_failures = checked_add(
+            self.fallback_degraded_evidence.gpu_dispatch_failures,
+            reference.routed_execution_delta.gpu_dispatch_failures,
+            "reference GPU dispatch failures",
+        )?;
+        self.fallback_degraded_evidence.gpu_dispatch_failures = checked_add(
+            self.fallback_degraded_evidence.gpu_dispatch_failures,
+            gpu.routed_execution_delta.gpu_dispatch_failures,
+            "GPU-native GPU dispatch failures",
+        )?;
+        self.fallback_degraded_evidence.gpu_cpu_fallbacks = checked_add(
+            self.fallback_degraded_evidence.gpu_cpu_fallbacks,
+            reference.routed_execution_delta.gpu_cpu_fallbacks,
+            "reference GPU-to-CPU fallbacks",
+        )?;
+        self.fallback_degraded_evidence.gpu_cpu_fallbacks = checked_add(
+            self.fallback_degraded_evidence.gpu_cpu_fallbacks,
+            gpu.routed_execution_delta.gpu_cpu_fallbacks,
+            "GPU-native GPU-to-CPU fallbacks",
+        )?;
+        self.fallback_degraded_evidence
+            .degraded_expert_substitutions = checked_add(
+            self.fallback_degraded_evidence
+                .degraded_expert_substitutions,
+            gpu.routed_execution_delta.degraded_expert_substitutions,
+            "GPU-native degraded expert substitutions",
+        )?;
+        self.fallback_degraded_evidence
+            .nonfinite_attention_fallbacks = checked_add(
+            self.fallback_degraded_evidence
+                .nonfinite_attention_fallbacks,
+            reference.attention_softmax_nonfinite_fallbacks,
+            "reference attention fallbacks",
+        )?;
+        self.fallback_degraded_evidence
+            .nonfinite_attention_fallbacks = checked_add(
+            self.fallback_degraded_evidence
+                .nonfinite_attention_fallbacks,
+            gpu.attention_softmax_nonfinite_fallbacks,
+            "GPU-native attention fallbacks",
+        )?;
+        self.fallback_degraded_evidence.fatal_numerical_failures = checked_add(
+            self.fallback_degraded_evidence.fatal_numerical_failures,
+            gpu.token_loop_counters_delta.fatal_failures,
+            "GPU-native fatal numerical failures",
+        )?;
+        self.fallback_degraded_evidence.no_progress_failures = checked_add(
+            self.fallback_degraded_evidence.no_progress_failures,
+            gpu.token_loop_counters_delta.no_progress_failures,
+            "GPU-native no-progress failures",
+        )?;
+        self.fallback_degraded_evidence
+            .all_requests_completed_expected_tokens &= gpu.request_completed_expected_tokens;
+        Ok(())
+    }
+
+    pub fn semantic_failure(&self) -> Option<QualificationFailure> {
+        if let Some(mismatch) = &self.first_token_mismatch {
+            return Some(QualificationFailure::new(
+                FailureStage::Postcondition,
+                "generated-token-mismatch",
+                format!(
+                    "case {} generated position {}: reference={:?} gpu_native={:?}",
+                    mismatch.case,
+                    mismatch.generated_position,
+                    mismatch.reference_token_id,
+                    mismatch.gpu_native_token_id
+                ),
+            ));
+        }
+        if let Some(mismatch) = &self.first_expert_id_mismatch {
+            return Some(QualificationFailure::new(
+                FailureStage::Postcondition,
+                "expert-id-topology-mismatch",
+                format!(
+                    "case {} generated position {} layer {} expert slot {}: reference={:?} gpu_native={:?}",
+                    mismatch.case,
+                    mismatch.generated_position,
+                    mismatch.layer,
+                    mismatch.expert_slot,
+                    mismatch.reference_expert_id,
+                    mismatch.gpu_native_expert_id
+                ),
+            ));
+        }
+        None
+    }
+
+    pub fn finalize(&mut self) -> Result<(), QualificationFailure> {
+        let clean_build_provenance = self
+            .build_provenance
+            .git_sha
+            .as_deref()
+            .is_some_and(valid_git_sha)
+            && self.build_provenance.dirty == Some(false);
+        let exact_case_and_token_totals = self.cases.len()
+            == crate::greedy_parity::CORPUS_CASE_COUNT
+            && self.tokens_per_case == crate::greedy_parity::OUTPUT_TOKEN_LIMIT
+            && self.total_tokens_expected
+                == crate::greedy_parity::CORPUS_CASE_COUNT
+                    * crate::greedy_parity::OUTPUT_TOKEN_LIMIT
+            && self.total_tokens_compared == self.total_tokens_expected;
+        self.checks = QualificationChecks {
+            clean_build_provenance,
+            source_config_strict: self.source_config.is_strict(),
+            fixed_corpus_identity: self.corpus == CorpusEvidence::fixed(),
+            fixed_greedy_sampling: self.sampling == GreedySamplingEvidence::fixed(),
+            authoritative_reference_contract: self.reference_contract.is_exact(),
+            production_gpu_candidate_path: self.gpu_candidate_path.is_exact(),
+            model_geometry_recorded: self.model_geometry.is_some(),
+            adapter_exact_match: self
+                .actual_adapter
+                .as_ref()
+                .is_some_and(|adapter| adapter.name == self.expected_adapter_name),
+            hardware_adapter: self.actual_adapter.as_ref().is_some_and(|adapter| {
+                !adapter.software_adapter && !adapter.device_type.eq_ignore_ascii_case("cpu")
+            }),
+            exact_case_and_token_totals,
+            exact_generated_token_ids: self.exact_token_matches == self.total_tokens_expected
+                && self.first_token_mismatch.is_none(),
+            expert_id_topology_match: self.expert_id_topology_match
+                && self.first_expert_id_mismatch.is_none()
+                && self.routing_positions_compared == self.total_tokens_expected
+                && self.model_geometry.is_some_and(|geometry| {
+                    self.routing_layer_comparisons
+                        == self
+                            .total_tokens_expected
+                            .checked_mul(geometry.num_layers)
+                            .unwrap_or(usize::MAX)
+                }),
+            reference_routing_replays_match: self.cases.iter().all(|case| {
+                case.reference_routing_replay
+                    .matches_authoritative_reference
+            }),
+            residency_misses_fully_serviced: self.residency.miss_attempts
+                == self.residency.services
+                && self.residency.replay_attempts == self.residency.miss_attempts,
+            zero_fallback_degraded_or_fatal_evidence: self
+                .fallback_degraded_evidence
+                .passes(&self.source_config),
+        };
+
+        if let Some(failure) = self.semantic_failure() {
+            self.fail(failure.clone());
+            return Err(failure);
+        }
+        if !self.checks.passes() {
+            let failure = QualificationFailure::new(
+                FailureStage::Postcondition,
+                "qualification-checks-failed",
+                "one or more strict GPU-native greedy-parity qualification checks failed",
+            );
+            self.fail(failure.clone());
+            return Err(failure);
+        }
+        self.failure = None;
+        self.qualification_pass = true;
+        Ok(())
+    }
+}
+
+fn valid_git_sha(value: &str) -> bool {
+    value.len() == 40 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn model_load_strict_complete(load: &ModelLoadEvidence) -> bool {
+    load.strict
+        && load.loaded_tensors == load.required_tensors
+        && load.required_tensors > 0
+        && !load.seeded_fallback_remained
+        && load.loader != "seeded"
+}
+
+fn checked_add(left: u64, right: u64, field: &str) -> Result<u64, String> {
+    left.checked_add(right)
+        .ok_or_else(|| format!("{field} overflowed"))
+}
+
+fn checked_add_snapshots(
+    left: GpuNativeTokenLoopSnapshot,
+    right: GpuNativeTokenLoopSnapshot,
+) -> Result<GpuNativeTokenLoopSnapshot, String> {
+    Ok(GpuNativeTokenLoopSnapshot {
+        token_attempts: checked_add(left.token_attempts, right.token_attempts, "token_attempts")?,
+        tokens_completed: checked_add(
+            left.tokens_completed,
+            right.tokens_completed,
+            "tokens_completed",
+        )?,
+        warm_tokens_completed: checked_add(
+            left.warm_tokens_completed,
+            right.warm_tokens_completed,
+            "warm_tokens_completed",
+        )?,
+        residency_miss_attempts: checked_add(
+            left.residency_miss_attempts,
+            right.residency_miss_attempts,
+            "residency_miss_attempts",
+        )?,
+        replay_attempts: checked_add(
+            left.replay_attempts,
+            right.replay_attempts,
+            "replay_attempts",
+        )?,
+        residency_services: checked_add(
+            left.residency_services,
+            right.residency_services,
+            "residency_services",
+        )?,
+        fatal_failures: checked_add(left.fatal_failures, right.fatal_failures, "fatal_failures")?,
+        no_progress_failures: checked_add(
+            left.no_progress_failures,
+            right.no_progress_failures,
+            "no_progress_failures",
+        )?,
+        queue_submissions: checked_add(
+            left.queue_submissions,
+            right.queue_submissions,
+            "queue_submissions",
+        )?,
+        boundary_maps: checked_add(left.boundary_maps, right.boundary_maps, "boundary_maps")?,
+        boundary_readbacks: checked_add(
+            left.boundary_readbacks,
+            right.boundary_readbacks,
+            "boundary_readbacks",
+        )?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn routes(tokens: usize, layers: usize, top_k: usize) -> Vec<Vec<Vec<u32>>> {
+        (0..tokens)
+            .map(|position| {
+                (0..layers)
+                    .map(|layer| {
+                        (0..top_k)
+                            .map(|slot| (position * 100 + layer * 10 + slot) as u32)
+                            .collect()
+                    })
+                    .collect()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn report_schema_and_fixed_totals_are_versioned() {
+        let report = test_report();
+        let value = serde_json::to_value(&report).unwrap();
+        assert_eq!(value["schema_version"], SCHEMA_VERSION);
+        assert_eq!(value["mode"], MODE);
+        assert_eq!(value["tokens_per_case"], 16);
+        assert_eq!(value["total_tokens_expected"], 64);
+        assert_eq!(value["qualification_pass"], false);
+    }
+
+    #[test]
+    fn explicit_failure_keeps_qualification_fail_closed() {
+        let mut report = test_report();
+        report.fail(QualificationFailure::new(
+            FailureStage::Inference,
+            "candidate-failed",
+            "fatal numerical status",
+        ));
+        assert!(!report.qualification_pass);
+        assert_eq!(
+            report.failure.as_ref().map(|failure| failure.code.as_str()),
+            Some("candidate-failed")
+        );
+    }
+
+    fn test_report() -> GpuNativeGreedyParityReport {
+        GpuNativeGreedyParityReport::new(
+            BuildProvenance {
+                git_sha: Some("1".repeat(40)),
+                dirty: Some(false),
+                package_version: "test".to_string(),
+            },
+            QualificationArtifacts::default(),
+            None,
+            "NVIDIA L4".to_string(),
+            strict_source_config(),
+        )
+    }
+
+    #[test]
+    fn exact_token_match_accounting_requires_all_tokens() {
+        let reference: Vec<u32> = (0..16).collect();
+        let comparison = compare_case_outputs(
+            "case",
+            &[10, 11],
+            &reference,
+            &reference,
+            &routes(16, 2, 2),
+            &routes(16, 2, 2),
+            16,
+            2,
+            2,
+        )
+        .unwrap();
+        assert_eq!(comparison.exact_token_matches, 16);
+        assert!(comparison.token_ids_match);
+        assert!(comparison.expert_id_topology_match);
+        assert_eq!(comparison.routing_layer_comparisons, 32);
+    }
+
+    #[test]
+    fn first_token_mismatch_preserves_failure_context() {
+        let reference: Vec<u32> = (100..116).collect();
+        let mut gpu = reference.clone();
+        gpu[5] = 999;
+        gpu[9] = 998;
+        let comparison = compare_case_outputs(
+            "rust-generation",
+            &[7, 8, 9],
+            &reference,
+            &gpu,
+            &routes(16, 1, 2),
+            &routes(16, 1, 2),
+            16,
+            1,
+            2,
+        )
+        .unwrap();
+        let mismatch = comparison.first_token_mismatch.unwrap();
+        assert_eq!(mismatch.generated_position, 5);
+        assert_eq!(mismatch.reference_token_id, Some(105));
+        assert_eq!(mismatch.gpu_native_token_id, Some(999));
+        assert_eq!(mismatch.prompt_token_ids, vec![7, 8, 9]);
+        assert_eq!(mismatch.preceding_generated_ids, reference[..5]);
+        assert_eq!(comparison.exact_token_matches, 14);
+    }
+
+    #[test]
+    fn first_expert_id_mismatch_is_selected_in_token_layer_slot_order() {
+        let tokens: Vec<u32> = (0..16).collect();
+        let reference_routes = routes(16, 3, 2);
+        let mut gpu_routes = reference_routes.clone();
+        gpu_routes[4][2][1] ^= 1;
+        gpu_routes[8][0][0] ^= 1;
+        let comparison = compare_case_outputs(
+            "json-transformation",
+            &[1],
+            &tokens,
+            &tokens,
+            &reference_routes,
+            &gpu_routes,
+            16,
+            3,
+            2,
+        )
+        .unwrap();
+        let mismatch = comparison.first_expert_id_mismatch.unwrap();
+        assert_eq!(mismatch.generated_position, 4);
+        assert_eq!(mismatch.layer, 2);
+        assert_eq!(mismatch.expert_slot, 1);
+        assert!(!comparison.expert_id_topology_match);
+    }
+
+    #[test]
+    fn serialized_routing_evidence_preserves_exact_expert_ids() {
+        let selected_expert_ids = routes(2, 3, 2);
+        let evidence = ReferenceRoutingReplayEvidence {
+            generation: GenerationEvidence {
+                prompt_token_ids_sha256: "prompt".to_string(),
+                generated_token_ids: vec![1, 2],
+                generated_token_ids_sha256: "tokens".to_string(),
+                generated_text_sha256: "text".to_string(),
+                generated_token_count: 2,
+                termination_reason: crate::greedy_parity::TerminationReason::LengthLimit,
+            },
+            matches_authoritative_reference: true,
+            routing_positions_captured: 2,
+            routed_layers_per_position: 3,
+            selected_expert_ids_by_generated_position_layer: selected_expert_ids.clone(),
+            background_shutdown: BackgroundShutdownEvidence::default(),
+        };
+        let value = serde_json::to_value(evidence).unwrap();
+        assert_eq!(
+            value["selected_expert_ids_by_generated_position_layer"],
+            serde_json::json!(selected_expert_ids)
+        );
+        assert!(value.get("selected_expert_weights").is_none());
+    }
+
+    #[test]
+    fn zero_or_incomplete_token_configuration_fails_closed() {
+        let route = routes(16, 1, 1);
+        assert!(compare_case_outputs("case", &[1], &[], &[], &[], &[], 0, 1, 1).is_err());
+        assert!(
+            compare_case_outputs("case", &[1], &[1; 15], &[1; 16], &route, &route, 16, 1, 1,)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn fallback_evidence_fails_closed() {
+        let source = strict_source_config();
+        let mut evidence = FallbackDegradedEvidence {
+            all_model_loads_strict_complete: true,
+            all_requests_completed_expected_tokens: true,
+            ..FallbackDegradedEvidence::default()
+        };
+        assert!(evidence.passes(&source));
+        evidence.fatal_numerical_failures = 1;
+        assert!(!evidence.passes(&source));
+        evidence.fatal_numerical_failures = 0;
+        evidence.degraded_expert_substitutions = 1;
+        assert!(!evidence.passes(&source));
+    }
+
+    fn strict_source_config() -> SourceConfigEvidence {
+        SourceConfigEvidence {
+            real_transformer_enabled: true,
+            gpu_native_enabled: true,
+            weights_dir_configured: true,
+            strict_weights: true,
+            allow_seeded_fallback: false,
+            allow_degraded_experts: false,
+            allow_nonfinite_attention_fallback: false,
+            allow_truncated_expert_payloads: false,
+            distributed_enabled: false,
+            gpu_cache_enabled: true,
+            gpu_expert_capacity_bytes: 1,
+            routed_expert_dtype: "q4_0".to_string(),
+        }
+    }
+}

--- a/rust-engine/src/gpu_native_layer0_diagnostics.rs
+++ b/rust-engine/src/gpu_native_layer0_diagnostics.rs
@@ -479,11 +479,36 @@ pub fn compare_layer0_attention_traces(
 pub struct Slice11bCrossCheckEvidence {
     pub report_path: String,
     pub cross_check_status: String,
+    pub identity_match: bool,
+    pub stage_evidence_match: bool,
+    pub slice11b_schema: Option<String>,
+    pub slice11b_mode: Option<String>,
+    pub case_name: Option<String>,
+    pub prompt_sha256: Option<String>,
+    pub prompt_token_ids_sha256: Option<String>,
+    pub resolved_config_sha256: Option<String>,
+    pub expected_adapter_name: Option<String>,
     pub slice11b_layer0_post_attn_max_abs: Option<f32>,
     pub slice11b_layer0_post_attn_rms: Option<f64>,
     pub slice11c_layer0_post_attn_max_abs: Option<f32>,
     pub slice11c_layer0_post_attn_rms: Option<f64>,
     pub discrepancy: Option<String>,
+}
+
+pub fn first_layer0_divergence_across_positions(
+    position_comparisons: &[Layer0AttentionPositionComparison],
+) -> (
+    Option<usize>,
+    Option<Layer0AttentionFirstDivergenceEvidence>,
+) {
+    for pos_comp in position_comparisons {
+        if !pos_comp.exact_match {
+            if let Some(ref div) = pos_comp.first_divergence {
+                return (Some(pos_comp.position), Some(div.clone()));
+            }
+        }
+    }
+    (None, None)
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
@@ -564,6 +589,7 @@ impl Layer0AttentionFirstDivergenceReport {
 
 pub fn cross_check_slice11b_report(
     slice11b_path: &Path,
+    current_report: &Layer0AttentionFirstDivergenceReport,
     final_post_attn: &Layer0AttentionStageComparison,
 ) -> Result<Slice11bCrossCheckEvidence, String> {
     let file_str = std::fs::read_to_string(slice11b_path).map_err(|e| {
@@ -575,26 +601,154 @@ pub fn cross_check_slice11b_report(
     let val: serde_json::Value = serde_json::from_str(&file_str)
         .map_err(|e| format!("failed to parse Slice11B report JSON: {e}"))?;
 
+    let slice11b_schema = val
+        .get("schema_version")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+    let slice11b_mode = val
+        .get("mode")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+    let case_name = val
+        .get("case")
+        .and_then(|c| c.get("case_name"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+    let prompt_sha256 = val
+        .get("case")
+        .and_then(|c| c.get("prompt_sha256"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+    let prompt_token_count = val
+        .get("case")
+        .and_then(|c| c.get("prompt_token_count"))
+        .and_then(|v| v.as_u64())
+        .map(|u| u as usize);
+    let prompt_token_ids_sha256 = val
+        .get("prompt_token_ids_sha256")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+    let resolved_config_sha256 = val
+        .get("resolved_config_sha256")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+    let expected_adapter_name = val
+        .get("expected_adapter_name")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+    let diagnostic_complete = val.get("diagnostic_complete").and_then(|v| v.as_bool());
+    let failure = val.get("failure");
+
+    let mut identity_discrepancy = None;
+    if slice11b_schema.as_deref() != Some("mer.gpu-native-q4-first-divergence-diagnostic.v1") {
+        identity_discrepancy = Some(format!(
+            "Slice11B schema_version mismatch: expected 'mer.gpu-native-q4-first-divergence-diagnostic.v1', got {:?}",
+            slice11b_schema
+        ));
+    } else if slice11b_mode.as_deref() != Some("diagnose-gpu-native-q4-first-divergence") {
+        identity_discrepancy = Some(format!(
+            "Slice11B mode mismatch: expected 'diagnose-gpu-native-q4-first-divergence', got {:?}",
+            slice11b_mode
+        ));
+    } else if diagnostic_complete != Some(true) {
+        identity_discrepancy = Some(format!(
+            "Slice11B diagnostic_complete mismatch: expected true, got {:?}",
+            diagnostic_complete
+        ));
+    } else if failure.is_some() && !failure.unwrap().is_null() {
+        identity_discrepancy = Some(format!("Slice11B report recorded a failure: {:?}", failure));
+    } else if case_name.as_deref() != Some(&current_report.case.case_name) {
+        identity_discrepancy = Some(format!(
+            "Slice11B case.case_name mismatch: expected {:?}, got {:?}",
+            current_report.case.case_name, case_name
+        ));
+    } else if prompt_sha256.as_deref() != Some(&current_report.case.prompt_sha256) {
+        identity_discrepancy = Some(format!(
+            "Slice11B case.prompt_sha256 mismatch: expected {:?}, got {:?}",
+            current_report.case.prompt_sha256, prompt_sha256
+        ));
+    } else if prompt_token_count != Some(current_report.case.prompt_token_count) {
+        identity_discrepancy = Some(format!(
+            "Slice11B case.prompt_token_count mismatch: expected {:?}, got {:?}",
+            current_report.case.prompt_token_count, prompt_token_count
+        ));
+    } else if prompt_token_ids_sha256.as_deref() != Some(&current_report.prompt_token_ids_sha256) {
+        identity_discrepancy = Some(format!(
+            "Slice11B prompt_token_ids_sha256 mismatch: expected {:?}, got {:?}",
+            current_report.prompt_token_ids_sha256, prompt_token_ids_sha256
+        ));
+    } else if resolved_config_sha256.as_deref() != Some(&current_report.resolved_config_sha256) {
+        identity_discrepancy = Some(format!(
+            "Slice11B resolved_config_sha256 mismatch: expected {:?}, got {:?}",
+            current_report.resolved_config_sha256, resolved_config_sha256
+        ));
+    } else if expected_adapter_name.as_deref() != Some(&current_report.expected_adapter_name) {
+        identity_discrepancy = Some(format!(
+            "Slice11B expected_adapter_name mismatch: expected {:?}, got {:?}",
+            current_report.expected_adapter_name, expected_adapter_name
+        ));
+    } else {
+        let current_geom_val =
+            serde_json::to_value(&current_report.model_geometry).map_err(|e| e.to_string())?;
+        if let Some(old_geom) = val.get("model_geometry") {
+            if old_geom != &current_geom_val {
+                identity_discrepancy = Some(format!(
+                    "Slice11B model_geometry mismatch: expected {}, got {}",
+                    current_geom_val, old_geom
+                ));
+            }
+        } else {
+            identity_discrepancy = Some("Slice11B report missing 'model_geometry'".to_string());
+        }
+    }
+
+    let identity_match = identity_discrepancy.is_none();
+
     let stages = val
         .get("stages")
         .and_then(|s| s.as_array())
         .ok_or_else(|| "Slice11B report missing 'stages' array".to_string())?;
 
-    let mut slice11b_l0_comp: Option<&serde_json::Value> = None;
+    let mut matched_stages: Vec<&serde_json::Value> = Vec::new();
     for s in stages {
         if let Some(stage_val) = s.get("stage") {
             if stage_val.get("stage").and_then(|v| v.as_str()) == Some("layer_post_attention")
                 && stage_val.get("layer").and_then(|l| l.as_u64()) == Some(0)
             {
-                slice11b_l0_comp = s.get("vector_comparison");
-                break;
+                matched_stages.push(s);
             }
         }
     }
 
-    let slice11b_comp = slice11b_l0_comp.ok_or_else(|| {
-        "Slice11B report has no LayerPostAttention { layer: 0 } stage evidence".to_string()
-    })?;
+    if matched_stages.len() != 1 {
+        let msg = format!(
+            "Slice11B report must contain exactly 1 LayerPostAttention {{ layer: 0 }} stage, found {}",
+            matched_stages.len()
+        );
+        return Ok(Slice11bCrossCheckEvidence {
+            report_path: slice11b_path.display().to_string(),
+            cross_check_status: "mismatch".to_string(),
+            identity_match,
+            stage_evidence_match: false,
+            slice11b_schema,
+            slice11b_mode,
+            case_name,
+            prompt_sha256,
+            prompt_token_ids_sha256,
+            resolved_config_sha256,
+            expected_adapter_name,
+            slice11b_layer0_post_attn_max_abs: None,
+            slice11b_layer0_post_attn_rms: None,
+            slice11c_layer0_post_attn_max_abs: final_post_attn.vector_comparison.max_absolute_error,
+            slice11c_layer0_post_attn_rms: final_post_attn.vector_comparison.rms_error,
+            discrepancy: Some(identity_discrepancy.unwrap_or(msg)),
+        });
+    }
+
+    let slice11b_stage = matched_stages[0];
+    let slice11b_comp = slice11b_stage
+        .get("vector_comparison")
+        .ok_or_else(|| "Slice11B layer 0 stage missing 'vector_comparison'".to_string())?;
 
     let b_max_abs = slice11b_comp
         .get("max_absolute_error")
@@ -605,34 +759,48 @@ pub fn cross_check_slice11b_report(
     let c_max_abs = final_post_attn.vector_comparison.max_absolute_error;
     let c_rms = final_post_attn.vector_comparison.rms_error;
 
-    let mut discrepancy = None;
-    let matches = match (b_max_abs, c_max_abs, b_rms, c_rms) {
-        (Some(b_a), Some(c_a), Some(b_r), Some(c_r)) => {
-            let max_diff = (b_a - c_a).abs();
-            let rms_diff = (b_r - c_r).abs();
-            if max_diff > 1e-5 || rms_diff > 1e-6 {
-                discrepancy = Some(format!(
-                    "Slice11B max_abs={b_a}, Slice11C max_abs={c_a} (diff={max_diff}); Slice11B rms={b_r}, Slice11C rms={c_r} (diff={rms_diff})"
-                ));
-                false
-            } else {
-                true
-            }
-        }
-        _ => {
-            discrepancy =
-                Some("missing numerical evidence fields in Slice11B or Slice11C".to_string());
-            false
-        }
-    };
+    let b_exact_match = slice11b_stage
+        .get("exact_match")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let c_exact_match = final_post_attn.exact_match;
+
+    let current_comp_val = serde_json::to_value(&final_post_attn.vector_comparison)
+        .map_err(|e| format!("failed to serialize Slice11C vector_comparison: {e}"))?;
+
+    let mut stage_evidence_discrepancy = None;
+    if b_exact_match != c_exact_match {
+        stage_evidence_discrepancy = Some(format!(
+            "exact_match mismatch: Slice11B={}, Slice11C={}",
+            b_exact_match, c_exact_match
+        ));
+    } else if slice11b_comp != &current_comp_val {
+        stage_evidence_discrepancy = Some(format!(
+            "vector_comparison JSON mismatch: Slice11B={}, Slice11C={}",
+            slice11b_comp, current_comp_val
+        ));
+    }
+
+    let stage_evidence_match = stage_evidence_discrepancy.is_none();
+    let discrepancy = identity_discrepancy.or(stage_evidence_discrepancy);
+    let verified = identity_match && stage_evidence_match;
 
     Ok(Slice11bCrossCheckEvidence {
         report_path: slice11b_path.display().to_string(),
-        cross_check_status: if matches {
+        cross_check_status: if verified {
             "verified_match".to_string()
         } else {
             "mismatch".to_string()
         },
+        identity_match,
+        stage_evidence_match,
+        slice11b_schema,
+        slice11b_mode,
+        case_name,
+        prompt_sha256,
+        prompt_token_ids_sha256,
+        resolved_config_sha256,
+        expected_adapter_name,
         slice11b_layer0_post_attn_max_abs: b_max_abs,
         slice11b_layer0_post_attn_rms: b_rms,
         slice11c_layer0_post_attn_max_abs: c_max_abs,
@@ -792,5 +960,262 @@ mod tests {
         let div = pos_comp.first_divergence.unwrap();
         assert_eq!(div.position, 1);
         assert_eq!(div.stage, Layer0AttentionStage::AttentionContext);
+    }
+
+    #[test]
+    fn position_order_position_0_exact_position_1_divergent_selects_pos_1() {
+        let cpu = sample_cpu_sink(4, 8, 2);
+        let gpu0 = cpu_sink_to_gpu_trace(&cpu);
+        let mut gpu1 = cpu_sink_to_gpu_trace(&cpu);
+        gpu1.q_after_norm[0] += 1e-4;
+        let mut gpu2 = cpu_sink_to_gpu_trace(&cpu);
+        gpu2.q_raw[0] += 1e-3;
+
+        let comp0 = compare_layer0_attention_traces(0, 10, &cpu, &gpu0).unwrap();
+        let comp1 = compare_layer0_attention_traces(1, 11, &cpu, &gpu1).unwrap();
+        let comp2 = compare_layer0_attention_traces(2, 12, &cpu, &gpu2).unwrap();
+
+        let (pos, div) = first_layer0_divergence_across_positions(&[comp0, comp1, comp2]);
+        assert_eq!(pos, Some(1));
+        assert!(div.is_some());
+        let div = div.unwrap();
+        assert_eq!(div.position, 1);
+        assert_eq!(div.stage, Layer0AttentionStage::QAfterNorm);
+    }
+
+    #[test]
+    fn position_order_position_0_divergent_and_later_divergent_preserves_pos_0() {
+        let cpu = sample_cpu_sink(4, 8, 2);
+        let mut gpu0 = cpu_sink_to_gpu_trace(&cpu);
+        gpu0.k_raw[0] += 1e-4;
+        let mut gpu1 = cpu_sink_to_gpu_trace(&cpu);
+        gpu1.attention_pre_norm[0] += 1e-3;
+
+        let comp0 = compare_layer0_attention_traces(0, 10, &cpu, &gpu0).unwrap();
+        let comp1 = compare_layer0_attention_traces(1, 11, &cpu, &gpu1).unwrap();
+
+        let (pos, div) = first_layer0_divergence_across_positions(&[comp0, comp1]);
+        assert_eq!(pos, Some(0));
+        assert!(div.is_some());
+        let div = div.unwrap();
+        assert_eq!(div.position, 0);
+        assert_eq!(div.stage, Layer0AttentionStage::KRaw);
+    }
+
+    struct TempFile {
+        path: std::path::PathBuf,
+    }
+
+    impl TempFile {
+        fn new(name: &str, content: &str) -> Self {
+            static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+            let id = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "mer-test-slice11c-{name}-{id}-{}.json",
+                std::process::id()
+            ));
+            let _ = std::fs::remove_file(&path);
+            std::fs::write(&path, content).unwrap();
+            Self { path }
+        }
+    }
+
+    impl Drop for TempFile {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+
+    fn sample_test_evidence() -> (
+        Layer0AttentionFirstDivergenceReport,
+        Layer0AttentionStageComparison,
+    ) {
+        let geom = GpuNativeModelGeometry {
+            num_layers: 48,
+            d_model: 2048,
+            d_ff: 768,
+            num_experts: 128,
+            top_k: 8,
+            num_heads: 32,
+            num_kv_heads: 4,
+            head_dim: 128,
+            rope_dim: 128,
+            vocab_size: 151936,
+            max_seq_len: 2048,
+            rms_eps: 1e-6,
+            rope_base: 10000000.0,
+        };
+        let report = Layer0AttentionFirstDivergenceReport::new(
+            BuildProvenance::embedded(),
+            "git_sha_123".to_string(),
+            "exec_sha_123".to_string(),
+            "resolved_cfg_hash_123".to_string(),
+            geom,
+            ExpertMetadataEvidence {
+                dtype: Some("q4_0".to_string()),
+                q4_0_layout: Some("canonical".to_string()),
+                conversion_mode: Some("native".to_string()),
+                source: Some("checkpoint".to_string()),
+                explicitly_synthetic: false,
+            },
+            CaseEvidence {
+                case_name: "json-transformation".to_string(),
+                prompt_sha256: "prompt_hash_123".to_string(),
+                prompt_token_count: 4,
+            },
+            "prompt_token_ids_hash_123".to_string(),
+            vec![1, 2, 3, 4],
+            "NVIDIA L4".to_string(),
+        );
+
+        let comp = crate::numerical_diagnostics::compare_vectors(
+            &[1.0, 2.0, 3.0, 4.0],
+            &[1.001, 2.0, 3.0, 4.0],
+        )
+        .unwrap();
+
+        let stage_comp = Layer0AttentionStageComparison {
+            stage: Layer0AttentionStage::PostAttentionResidual,
+            exact_match: false,
+            vector_comparison: comp,
+        };
+
+        (report, stage_comp)
+    }
+
+    fn sample_slice11b_report_json(
+        case_name: &str,
+        prompt_token_ids_sha256: &str,
+        geom: &GpuNativeModelGeometry,
+        comp: &VectorComparisonEvidence,
+    ) -> String {
+        serde_json::json!({
+            "schema_version": "mer.gpu-native-q4-first-divergence-diagnostic.v1",
+            "mode": "diagnose-gpu-native-q4-first-divergence",
+            "diagnostic_complete": true,
+            "qualification_pass": false,
+            "failure": null,
+            "case": {
+                "case_name": case_name,
+                "prompt_sha256": "prompt_hash_123",
+                "prompt_token_count": 4
+            },
+            "prompt_token_ids_sha256": prompt_token_ids_sha256,
+            "resolved_config_sha256": "resolved_cfg_hash_123",
+            "model_geometry": geom,
+            "expected_adapter_name": "NVIDIA L4",
+            "stages": [
+                {
+                    "stage": {
+                        "stage": "layer_post_attention",
+                        "layer": 0
+                    },
+                    "exact_match": comp.exact_f32_bits,
+                    "tolerance_pass": false,
+                    "vector_comparison": comp
+                }
+            ]
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn cross_check_exact_matching_slice11b_identity_and_evidence_passes() {
+        let (report, stage_comp) = sample_test_evidence();
+        let json_str = sample_slice11b_report_json(
+            &report.case.case_name,
+            &report.prompt_token_ids_sha256,
+            &report.model_geometry,
+            &stage_comp.vector_comparison,
+        );
+        let temp = TempFile::new("exact_match", &json_str);
+
+        let res = cross_check_slice11b_report(&temp.path, &report, &stage_comp).unwrap();
+        assert_eq!(res.cross_check_status, "verified_match");
+        assert!(res.identity_match);
+        assert!(res.stage_evidence_match);
+        assert!(res.discrepancy.is_none());
+    }
+
+    #[test]
+    fn cross_check_wrong_case_name_fails() {
+        let (report, stage_comp) = sample_test_evidence();
+        let json_str = sample_slice11b_report_json(
+            "rust-generation",
+            &report.prompt_token_ids_sha256,
+            &report.model_geometry,
+            &stage_comp.vector_comparison,
+        );
+        let temp = TempFile::new("wrong_case", &json_str);
+
+        let res = cross_check_slice11b_report(&temp.path, &report, &stage_comp).unwrap();
+        assert_eq!(res.cross_check_status, "mismatch");
+        assert!(!res.identity_match);
+        assert!(res.discrepancy.unwrap().contains("case.case_name"));
+    }
+
+    #[test]
+    fn cross_check_wrong_prompt_token_hash_fails() {
+        let (report, stage_comp) = sample_test_evidence();
+        let json_str = sample_slice11b_report_json(
+            &report.case.case_name,
+            "wrong_prompt_hash",
+            &report.model_geometry,
+            &stage_comp.vector_comparison,
+        );
+        let temp = TempFile::new("wrong_prompt_hash", &json_str);
+
+        let res = cross_check_slice11b_report(&temp.path, &report, &stage_comp).unwrap();
+        assert_eq!(res.cross_check_status, "mismatch");
+        assert!(!res.identity_match);
+        assert!(res.discrepancy.unwrap().contains("prompt_token_ids_sha256"));
+    }
+
+    #[test]
+    fn cross_check_wrong_model_geometry_fails() {
+        let (report, stage_comp) = sample_test_evidence();
+        let mut wrong_geom = report.model_geometry;
+        wrong_geom.num_layers = 24; // differs from 48
+        let json_str = sample_slice11b_report_json(
+            &report.case.case_name,
+            &report.prompt_token_ids_sha256,
+            &wrong_geom,
+            &stage_comp.vector_comparison,
+        );
+        let temp = TempFile::new("wrong_geom", &json_str);
+
+        let res = cross_check_slice11b_report(&temp.path, &report, &stage_comp).unwrap();
+        assert_eq!(res.cross_check_status, "mismatch");
+        assert!(!res.identity_match);
+        assert!(res.discrepancy.unwrap().contains("model_geometry"));
+    }
+
+    #[test]
+    fn cross_check_same_aggregates_different_vector_evidence_fails() {
+        let (report, stage_comp) = sample_test_evidence();
+
+        // Build comp2 with identical max_abs (0.001) but different worst-error index and bits
+        let comp2 = crate::numerical_diagnostics::compare_vectors(
+            &[1.0, 2.0, 3.0, 4.0],
+            &[1.0, 2.0, 3.0, 4.001], // error at index 3 instead of index 0
+        )
+        .unwrap();
+
+        let json_str = sample_slice11b_report_json(
+            &report.case.case_name,
+            &report.prompt_token_ids_sha256,
+            &report.model_geometry,
+            &comp2,
+        );
+        let temp = TempFile::new("different_vector", &json_str);
+
+        let res = cross_check_slice11b_report(&temp.path, &report, &stage_comp).unwrap();
+        assert_eq!(res.cross_check_status, "mismatch");
+        assert!(res.identity_match);
+        assert!(!res.stage_evidence_match);
+        assert!(res
+            .discrepancy
+            .unwrap()
+            .contains("vector_comparison JSON mismatch"));
     }
 }

--- a/rust-engine/src/gpu_native_layer0_diagnostics.rs
+++ b/rust-engine/src/gpu_native_layer0_diagnostics.rs
@@ -585,6 +585,26 @@ impl Layer0AttentionFirstDivergenceReport {
         self.qualification_pass = false;
         self.failure = Some(reason);
     }
+
+    pub fn record_completed_position_evidence(
+        &mut self,
+        position_comparisons: Vec<Layer0AttentionPositionComparison>,
+        final_position_post_attention: Option<Layer0AttentionStageComparison>,
+    ) {
+        let (earliest_divergent_position, first_internal_divergence) =
+            first_layer0_divergence_across_positions(&position_comparisons);
+        self.earliest_divergent_position = earliest_divergent_position;
+        self.first_internal_divergence = first_internal_divergence;
+        self.position_comparisons = position_comparisons;
+        self.final_position_post_attention = final_position_post_attention;
+    }
+}
+
+fn canonical_serialized_json_value<T: Serialize>(value: &T) -> Result<serde_json::Value, String> {
+    let serialized =
+        serde_json::to_string(value).map_err(|e| format!("failed to serialize JSON value: {e}"))?;
+    serde_json::from_str(&serialized)
+        .map_err(|e| format!("failed to parse serialized JSON value: {e}"))
 }
 
 pub fn cross_check_slice11b_report(
@@ -687,19 +707,23 @@ pub fn cross_check_slice11b_report(
             "Slice11B expected_adapter_name mismatch: expected {:?}, got {:?}",
             current_report.expected_adapter_name, expected_adapter_name
         ));
-    } else {
-        let current_geom_val =
-            serde_json::to_value(&current_report.model_geometry).map_err(|e| e.to_string())?;
-        if let Some(old_geom) = val.get("model_geometry") {
-            if old_geom != &current_geom_val {
+    } else if let Some(old_geom) = val.get("model_geometry") {
+        match serde_json::from_value::<GpuNativeModelGeometry>(old_geom.clone()) {
+            Ok(old_geometry) if old_geometry != current_report.model_geometry => {
                 identity_discrepancy = Some(format!(
-                    "Slice11B model_geometry mismatch: expected {}, got {}",
-                    current_geom_val, old_geom
+                    "Slice11B model_geometry mismatch: expected {:?}, got {:?}",
+                    current_report.model_geometry, old_geometry
                 ));
             }
-        } else {
-            identity_discrepancy = Some("Slice11B report missing 'model_geometry'".to_string());
+            Ok(_) => {}
+            Err(e) => {
+                identity_discrepancy = Some(format!(
+                    "failed to deserialize Slice11B model_geometry: {e}"
+                ));
+            }
         }
+    } else {
+        identity_discrepancy = Some("Slice11B report missing 'model_geometry'".to_string());
     }
 
     let identity_match = identity_discrepancy.is_none();
@@ -765,8 +789,8 @@ pub fn cross_check_slice11b_report(
         .unwrap_or(false);
     let c_exact_match = final_post_attn.exact_match;
 
-    let current_comp_val = serde_json::to_value(&final_post_attn.vector_comparison)
-        .map_err(|e| format!("failed to serialize Slice11C vector_comparison: {e}"))?;
+    let current_comp_val = canonical_serialized_json_value(&final_post_attn.vector_comparison)
+        .map_err(|e| format!("failed to canonicalize Slice11C vector_comparison: {e}"))?;
 
     let mut stage_evidence_discrepancy = None;
     if b_exact_match != c_exact_match {
@@ -1002,6 +1026,36 @@ mod tests {
         assert_eq!(div.stage, Layer0AttentionStage::KRaw);
     }
 
+    #[test]
+    fn completed_position_evidence_survives_later_qualification_failure() {
+        let (mut report, _) = sample_test_evidence();
+        let cpu = sample_cpu_sink(4, 8, 2);
+        let mut gpu = cpu_sink_to_gpu_trace(&cpu);
+        gpu.post_attention_residual[0] += 1e-4;
+        let position_comparison = compare_layer0_attention_traces(0, 10, &cpu, &gpu).unwrap();
+        let final_position_post_attention = position_comparison
+            .stages
+            .iter()
+            .find(|stage| stage.stage == Layer0AttentionStage::PostAttentionResidual)
+            .cloned();
+
+        report.record_completed_position_evidence(
+            vec![position_comparison],
+            final_position_post_attention,
+        );
+        report.fail("later qualification gate failed".to_string());
+
+        assert!(report.diagnostic_complete);
+        assert!(!report.qualification_pass);
+        assert_eq!(report.earliest_divergent_position, Some(0));
+        assert_eq!(
+            report.first_internal_divergence.as_ref().unwrap().stage,
+            Layer0AttentionStage::PostAttentionResidual
+        );
+        assert_eq!(report.position_comparisons.len(), 1);
+        assert!(report.final_position_post_attention.is_some());
+    }
+
     struct TempFile {
         path: std::path::PathBuf,
     }
@@ -1089,34 +1143,100 @@ mod tests {
         geom: &GpuNativeModelGeometry,
         comp: &VectorComparisonEvidence,
     ) -> String {
-        serde_json::json!({
-            "schema_version": "mer.gpu-native-q4-first-divergence-diagnostic.v1",
-            "mode": "diagnose-gpu-native-q4-first-divergence",
-            "diagnostic_complete": true,
-            "qualification_pass": false,
-            "failure": null,
-            "case": {
-                "case_name": case_name,
-                "prompt_sha256": "prompt_hash_123",
-                "prompt_token_count": 4
+        #[derive(serde::Serialize)]
+        struct FrozenCase<'a> {
+            case_name: &'a str,
+            prompt_sha256: &'static str,
+            prompt_token_count: usize,
+        }
+
+        #[derive(serde::Serialize)]
+        struct FrozenStageName {
+            stage: &'static str,
+            layer: usize,
+        }
+
+        #[derive(serde::Serialize)]
+        struct FrozenStage<'a> {
+            stage: FrozenStageName,
+            exact_match: bool,
+            tolerance_pass: bool,
+            vector_comparison: &'a VectorComparisonEvidence,
+        }
+
+        #[derive(serde::Serialize)]
+        struct FrozenReport<'a> {
+            schema_version: &'static str,
+            mode: &'static str,
+            diagnostic_complete: bool,
+            qualification_pass: bool,
+            failure: Option<&'static str>,
+            case: FrozenCase<'a>,
+            prompt_token_ids_sha256: &'a str,
+            resolved_config_sha256: &'static str,
+            model_geometry: &'a GpuNativeModelGeometry,
+            expected_adapter_name: &'static str,
+            stages: [FrozenStage<'a>; 1],
+        }
+
+        serde_json::to_string(&FrozenReport {
+            schema_version: "mer.gpu-native-q4-first-divergence-diagnostic.v1",
+            mode: "diagnose-gpu-native-q4-first-divergence",
+            diagnostic_complete: true,
+            qualification_pass: false,
+            failure: None,
+            case: FrozenCase {
+                case_name,
+                prompt_sha256: "prompt_hash_123",
+                prompt_token_count: 4,
             },
-            "prompt_token_ids_sha256": prompt_token_ids_sha256,
-            "resolved_config_sha256": "resolved_cfg_hash_123",
-            "model_geometry": geom,
-            "expected_adapter_name": "NVIDIA L4",
-            "stages": [
-                {
-                    "stage": {
-                        "stage": "layer_post_attention",
-                        "layer": 0
-                    },
-                    "exact_match": comp.exact_f32_bits,
-                    "tolerance_pass": false,
-                    "vector_comparison": comp
-                }
-            ]
+            prompt_token_ids_sha256,
+            resolved_config_sha256: "resolved_cfg_hash_123",
+            model_geometry: geom,
+            expected_adapter_name: "NVIDIA L4",
+            stages: [FrozenStage {
+                stage: FrozenStageName {
+                    stage: "layer_post_attention",
+                    layer: 0,
+                },
+                exact_match: comp.exact_f32_bits,
+                tolerance_pass: false,
+                vector_comparison: comp,
+            }],
         })
-        .to_string()
+        .unwrap()
+    }
+
+    #[test]
+    fn cross_check_equivalent_1e_minus_6_f32_geometry_serialization_passes() {
+        let (report, _) = sample_test_evidence();
+        assert_eq!(report.model_geometry.rms_eps, 1e-6_f32);
+        let exact_comp = crate::numerical_diagnostics::compare_vectors(&[1.0], &[1.0]).unwrap();
+        let stage_comp = Layer0AttentionStageComparison {
+            stage: Layer0AttentionStage::PostAttentionResidual,
+            exact_match: true,
+            vector_comparison: exact_comp,
+        };
+        let normally_serialized = sample_slice11b_report_json(
+            &report.case.case_name,
+            &report.prompt_token_ids_sha256,
+            &report.model_geometry,
+            &stage_comp.vector_comparison,
+        );
+        let mut frozen_value: serde_json::Value =
+            serde_json::from_str(&normally_serialized).unwrap();
+        frozen_value["model_geometry"]["rms_eps"] = serde_json::Value::from(1e-6_f64);
+        let json_str = serde_json::to_string(&frozen_value).unwrap();
+        assert!(json_str.contains("\"rms_eps\":1e-6"), "{json_str}");
+
+        let widened_current = serde_json::to_value(report.model_geometry).unwrap();
+        assert_ne!(frozen_value["model_geometry"], widened_current);
+
+        let temp = TempFile::new("equivalent_f32_geometry", &json_str);
+        let res = cross_check_slice11b_report(&temp.path, &report, &stage_comp).unwrap();
+        assert_eq!(res.cross_check_status, "verified_match");
+        assert!(res.identity_match);
+        assert!(res.stage_evidence_match);
     }
 
     #[test]
@@ -1172,10 +1292,10 @@ mod tests {
     }
 
     #[test]
-    fn cross_check_wrong_model_geometry_fails() {
+    fn cross_check_genuinely_different_f32_geometry_fails() {
         let (report, stage_comp) = sample_test_evidence();
         let mut wrong_geom = report.model_geometry;
-        wrong_geom.num_layers = 24; // differs from 48
+        wrong_geom.rms_eps = 2e-6_f32;
         let json_str = sample_slice11b_report_json(
             &report.case.case_name,
             &report.prompt_token_ids_sha256,
@@ -1188,6 +1308,44 @@ mod tests {
         assert_eq!(res.cross_check_status, "mismatch");
         assert!(!res.identity_match);
         assert!(res.discrepancy.unwrap().contains("model_geometry"));
+    }
+
+    #[test]
+    fn cross_check_exact_nontrivial_f32_vector_evidence_serialization_passes() {
+        let (mut report, _) = sample_test_evidence();
+        report.model_geometry.rms_eps = 0.5;
+        report.model_geometry.rope_base = 16.0;
+        let comp =
+            crate::numerical_diagnostics::compare_vectors(&[-1.1858244_f32], &[-1.1846353_f32])
+                .unwrap();
+        assert_eq!(comp.max_absolute_error, Some(0.0011891127_f32));
+        let stage_comp = Layer0AttentionStageComparison {
+            stage: Layer0AttentionStage::PostAttentionResidual,
+            exact_match: false,
+            vector_comparison: comp,
+        };
+        let json_str = sample_slice11b_report_json(
+            &report.case.case_name,
+            &report.prompt_token_ids_sha256,
+            &report.model_geometry,
+            &stage_comp.vector_comparison,
+        );
+        assert!(json_str.contains("\"max_absolute_error\":0.0011891127"));
+        assert!(json_str.contains("\"value\":-1.1858244"));
+        assert!(json_str.contains("\"value\":-1.1846353"));
+
+        let frozen_value: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+        let widened_current = serde_json::to_value(&stage_comp.vector_comparison).unwrap();
+        assert_ne!(
+            frozen_value["stages"][0]["vector_comparison"],
+            widened_current
+        );
+
+        let temp = TempFile::new("equivalent_f32_vector", &json_str);
+        let res = cross_check_slice11b_report(&temp.path, &report, &stage_comp).unwrap();
+        assert_eq!(res.cross_check_status, "verified_match");
+        assert!(res.identity_match);
+        assert!(res.stage_evidence_match);
     }
 
     #[test]

--- a/rust-engine/src/gpu_native_layer0_diagnostics.rs
+++ b/rust-engine/src/gpu_native_layer0_diagnostics.rs
@@ -1,0 +1,796 @@
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+use crate::backend::GpuDeviceIdentity;
+use crate::gpu_native_diagnostics::CaseEvidence;
+use crate::gpu_native_token_loop::{GpuNativeModelGeometry, GpuNativeTokenLoopError};
+use crate::numerical_diagnostics::{compare_vectors, VectorComparisonEvidence};
+use crate::qualification::{BuildProvenance, ExpertMetadataEvidence};
+
+pub const LAYER0_SCHEMA_VERSION: &str = "mer.gpu-native-layer0-attention-first-divergence.v1";
+pub const LAYER0_MODE: &str = "diagnose-gpu-native-layer0-attention-first-divergence";
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "stage", rename_all = "snake_case")]
+pub enum Layer0AttentionStage {
+    Embedding,
+    AttentionPreNorm,
+    QRaw,
+    KRaw,
+    VRaw,
+    QAfterNorm,
+    KAfterNorm,
+    QAfterRope,
+    KAfterRope,
+    AttentionContext,
+    OProjection,
+    PostAttentionResidual,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Layer0AttentionDiagnosticTraceLayout {
+    pub d_model: usize,
+    pub q_width: usize,
+    pub kv_width: usize,
+
+    pub embedding_offset: usize,
+    pub embedding_bytes: usize,
+
+    pub attention_pre_norm_offset: usize,
+    pub attention_pre_norm_bytes: usize,
+
+    pub q_raw_offset: usize,
+    pub q_raw_bytes: usize,
+
+    pub k_raw_offset: usize,
+    pub k_raw_bytes: usize,
+
+    pub v_raw_offset: usize,
+    pub v_raw_bytes: usize,
+
+    pub q_after_norm_offset: usize,
+    pub q_after_norm_bytes: usize,
+
+    pub k_after_norm_offset: usize,
+    pub k_after_norm_bytes: usize,
+
+    pub q_after_rope_offset: usize,
+    pub q_after_rope_bytes: usize,
+
+    pub k_after_rope_offset: usize,
+    pub k_after_rope_bytes: usize,
+
+    pub attention_context_offset: usize,
+    pub attention_context_bytes: usize,
+
+    pub o_projection_offset: usize,
+    pub o_projection_bytes: usize,
+
+    pub post_attention_residual_offset: usize,
+    pub post_attention_residual_bytes: usize,
+
+    pub status_offset: usize,
+    pub status_bytes: usize,
+
+    pub total_bytes: u64,
+}
+
+impl Layer0AttentionDiagnosticTraceLayout {
+    pub fn try_new(
+        d_model: usize,
+        q_width: usize,
+        kv_width: usize,
+    ) -> Result<Self, GpuNativeTokenLoopError> {
+        if d_model == 0 {
+            return Err(GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "d_model must be > 0".into(),
+            });
+        }
+        if q_width == 0 {
+            return Err(GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "q_width must be > 0".into(),
+            });
+        }
+        if kv_width == 0 {
+            return Err(GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "kv_width must be > 0".into(),
+            });
+        }
+
+        let f32_bytes = std::mem::size_of::<f32>();
+        let u32_bytes = std::mem::size_of::<u32>();
+
+        let d_model_bytes = d_model.checked_mul(f32_bytes).ok_or_else(|| {
+            GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "d_model_bytes overflow".into(),
+            }
+        })?;
+        let q_bytes = q_width.checked_mul(f32_bytes).ok_or_else(|| {
+            GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "q_bytes overflow".into(),
+            }
+        })?;
+        let kv_bytes = kv_width.checked_mul(f32_bytes).ok_or_else(|| {
+            GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "kv_bytes overflow".into(),
+            }
+        })?;
+
+        let embedding_offset = 0usize;
+        let embedding_bytes = d_model_bytes;
+
+        let attention_pre_norm_offset =
+            embedding_offset
+                .checked_add(embedding_bytes)
+                .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
+                    detail: "attention_pre_norm_offset overflow".into(),
+                })?;
+        let attention_pre_norm_bytes = d_model_bytes;
+
+        let q_raw_offset = attention_pre_norm_offset
+            .checked_add(attention_pre_norm_bytes)
+            .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "q_raw_offset overflow".into(),
+            })?;
+        let q_raw_bytes = q_bytes;
+
+        let k_raw_offset = q_raw_offset.checked_add(q_raw_bytes).ok_or_else(|| {
+            GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "k_raw_offset overflow".into(),
+            }
+        })?;
+        let k_raw_bytes = kv_bytes;
+
+        let v_raw_offset = k_raw_offset.checked_add(k_raw_bytes).ok_or_else(|| {
+            GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "v_raw_offset overflow".into(),
+            }
+        })?;
+        let v_raw_bytes = kv_bytes;
+
+        let q_after_norm_offset = v_raw_offset.checked_add(v_raw_bytes).ok_or_else(|| {
+            GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "q_after_norm_offset overflow".into(),
+            }
+        })?;
+        let q_after_norm_bytes = q_bytes;
+
+        let k_after_norm_offset = q_after_norm_offset
+            .checked_add(q_after_norm_bytes)
+            .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "k_after_norm_offset overflow".into(),
+            })?;
+        let k_after_norm_bytes = kv_bytes;
+
+        let q_after_rope_offset = k_after_norm_offset
+            .checked_add(k_after_norm_bytes)
+            .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "q_after_rope_offset overflow".into(),
+            })?;
+        let q_after_rope_bytes = q_bytes;
+
+        let k_after_rope_offset = q_after_rope_offset
+            .checked_add(q_after_rope_bytes)
+            .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "k_after_rope_offset overflow".into(),
+            })?;
+        let k_after_rope_bytes = kv_bytes;
+
+        let attention_context_offset = k_after_rope_offset
+            .checked_add(k_after_rope_bytes)
+            .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "attention_context_offset overflow".into(),
+            })?;
+        let attention_context_bytes = q_bytes;
+
+        let o_projection_offset = attention_context_offset
+            .checked_add(attention_context_bytes)
+            .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "o_projection_offset overflow".into(),
+            })?;
+        let o_projection_bytes = d_model_bytes;
+
+        let post_attention_residual_offset = o_projection_offset
+            .checked_add(o_projection_bytes)
+            .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "post_attention_residual_offset overflow".into(),
+            })?;
+        let post_attention_residual_bytes = d_model_bytes;
+
+        let status_offset = post_attention_residual_offset
+            .checked_add(post_attention_residual_bytes)
+            .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "status_offset overflow".into(),
+            })?;
+        let status_bytes = u32_bytes;
+
+        let total_bytes_usize = status_offset.checked_add(status_bytes).ok_or_else(|| {
+            GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "total_bytes overflow".into(),
+            }
+        })?;
+
+        Ok(Self {
+            d_model,
+            q_width,
+            kv_width,
+            embedding_offset,
+            embedding_bytes,
+            attention_pre_norm_offset,
+            attention_pre_norm_bytes,
+            q_raw_offset,
+            q_raw_bytes,
+            k_raw_offset,
+            k_raw_bytes,
+            v_raw_offset,
+            v_raw_bytes,
+            q_after_norm_offset,
+            q_after_norm_bytes,
+            k_after_norm_offset,
+            k_after_norm_bytes,
+            q_after_rope_offset,
+            q_after_rope_bytes,
+            k_after_rope_offset,
+            k_after_rope_bytes,
+            attention_context_offset,
+            attention_context_bytes,
+            o_projection_offset,
+            o_projection_bytes,
+            post_attention_residual_offset,
+            post_attention_residual_bytes,
+            status_offset,
+            status_bytes,
+            total_bytes: total_bytes_usize as u64,
+        })
+    }
+
+    pub fn parse(&self, bytes: &[u8]) -> Result<Layer0AttentionDiagnosticTrace, String> {
+        if bytes.len() < self.total_bytes as usize {
+            return Err(format!(
+                "buffer too short for Layer0 diagnostic trace: expected >= {} bytes, got {}",
+                self.total_bytes,
+                bytes.len()
+            ));
+        }
+
+        let parse_f32_vec = |offset: usize, len: usize| -> Vec<f32> {
+            let byte_slice = &bytes[offset..offset + len * 4];
+            byte_slice
+                .chunks_exact(4)
+                .map(|chunk| f32::from_le_bytes(chunk.try_into().unwrap()))
+                .collect()
+        };
+
+        let embedding = parse_f32_vec(self.embedding_offset, self.d_model);
+        let attention_pre_norm = parse_f32_vec(self.attention_pre_norm_offset, self.d_model);
+        let q_raw = parse_f32_vec(self.q_raw_offset, self.q_width);
+        let k_raw = parse_f32_vec(self.k_raw_offset, self.kv_width);
+        let v_raw = parse_f32_vec(self.v_raw_offset, self.kv_width);
+        let q_after_norm = parse_f32_vec(self.q_after_norm_offset, self.q_width);
+        let k_after_norm = parse_f32_vec(self.k_after_norm_offset, self.kv_width);
+        let q_after_rope = parse_f32_vec(self.q_after_rope_offset, self.q_width);
+        let k_after_rope = parse_f32_vec(self.k_after_rope_offset, self.kv_width);
+        let attention_context = parse_f32_vec(self.attention_context_offset, self.q_width);
+        let o_projection = parse_f32_vec(self.o_projection_offset, self.d_model);
+        let post_attention_residual =
+            parse_f32_vec(self.post_attention_residual_offset, self.d_model);
+
+        let status = u32::from_le_bytes(
+            bytes[self.status_offset..self.status_offset + 4]
+                .try_into()
+                .unwrap(),
+        );
+
+        Ok(Layer0AttentionDiagnosticTrace {
+            embedding,
+            attention_pre_norm,
+            q_raw,
+            k_raw,
+            v_raw,
+            q_after_norm,
+            k_after_norm,
+            q_after_rope,
+            k_after_rope,
+            attention_context,
+            o_projection,
+            post_attention_residual,
+            status,
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Layer0AttentionDiagnosticTrace {
+    pub embedding: Vec<f32>,
+    pub attention_pre_norm: Vec<f32>,
+    pub q_raw: Vec<f32>,
+    pub k_raw: Vec<f32>,
+    pub v_raw: Vec<f32>,
+    pub q_after_norm: Vec<f32>,
+    pub k_after_norm: Vec<f32>,
+    pub q_after_rope: Vec<f32>,
+    pub k_after_rope: Vec<f32>,
+    pub attention_context: Vec<f32>,
+    pub o_projection: Vec<f32>,
+    pub post_attention_residual: Vec<f32>,
+    pub status: u32,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct Layer0AttentionStageComparison {
+    pub stage: Layer0AttentionStage,
+    pub exact_match: bool,
+    pub vector_comparison: VectorComparisonEvidence,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct Layer0AttentionFirstDivergenceEvidence {
+    pub position: usize,
+    pub token_id: u32,
+    pub stage: Layer0AttentionStage,
+    pub reason: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_absolute_error: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rms_error: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub worst_index: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub worst_reference_value: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub worst_gpu_native_value: Option<f32>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct Layer0AttentionPositionComparison {
+    pub position: usize,
+    pub token_id: u32,
+    pub exact_match: bool,
+    pub first_divergence: Option<Layer0AttentionFirstDivergenceEvidence>,
+    pub stages: Vec<Layer0AttentionStageComparison>,
+}
+
+pub fn compare_layer0_attention_traces(
+    position: usize,
+    token_id: u32,
+    reference: &crate::transformer::Layer0AttentionCpuDiagnosticSink,
+    gpu_native: &Layer0AttentionDiagnosticTrace,
+) -> Result<Layer0AttentionPositionComparison, String> {
+    let mut stages = Vec::with_capacity(12);
+    let mut first_divergence: Option<Layer0AttentionFirstDivergenceEvidence> = None;
+
+    let mut compare_one_stage = |stage: Layer0AttentionStage,
+                                 ref_opt: Option<&Vec<f32>>,
+                                 gpu_vec: &[f32]|
+     -> Result<(), String> {
+        let ref_vec = ref_opt.ok_or_else(|| {
+            format!("reference diagnostic trace missing stage {stage:?} at position {position}")
+        })?;
+        let comp = compare_vectors(ref_vec, gpu_vec)?;
+        let exact = comp.exact_f32_bits;
+        let nonfinite = comp.cpu_nonfinite_count > 0 || comp.hybrid_nonfinite_count > 0;
+
+        if (!exact || nonfinite) && first_divergence.is_none() {
+            let reason = if nonfinite {
+                format!(
+                    "nonfinite value: reference nonfinite={}, gpu_native nonfinite={}",
+                    comp.cpu_nonfinite_count, comp.hybrid_nonfinite_count
+                )
+            } else {
+                format!(
+                    "exact f32 bits differ (max absolute error {:?}, RMS error {:?})",
+                    comp.max_absolute_error, comp.rms_error
+                )
+            };
+
+            first_divergence = Some(Layer0AttentionFirstDivergenceEvidence {
+                position,
+                token_id,
+                stage: stage.clone(),
+                reason,
+                max_absolute_error: comp.max_absolute_error,
+                rms_error: comp.rms_error,
+                worst_index: comp.max_error.as_ref().map(|e| e.index),
+                worst_reference_value: comp.max_error.as_ref().and_then(|e| e.cpu.value),
+                worst_gpu_native_value: comp.max_error.as_ref().and_then(|e| e.hybrid.value),
+            });
+        }
+
+        stages.push(Layer0AttentionStageComparison {
+            stage,
+            exact_match: exact && !nonfinite,
+            vector_comparison: comp,
+        });
+        Ok(())
+    };
+
+    compare_one_stage(
+        Layer0AttentionStage::Embedding,
+        reference.embedding.as_ref(),
+        &gpu_native.embedding,
+    )?;
+    compare_one_stage(
+        Layer0AttentionStage::AttentionPreNorm,
+        reference.attention_pre_norm.as_ref(),
+        &gpu_native.attention_pre_norm,
+    )?;
+    compare_one_stage(
+        Layer0AttentionStage::QRaw,
+        reference.q_raw.as_ref(),
+        &gpu_native.q_raw,
+    )?;
+    compare_one_stage(
+        Layer0AttentionStage::KRaw,
+        reference.k_raw.as_ref(),
+        &gpu_native.k_raw,
+    )?;
+    compare_one_stage(
+        Layer0AttentionStage::VRaw,
+        reference.v_raw.as_ref(),
+        &gpu_native.v_raw,
+    )?;
+    compare_one_stage(
+        Layer0AttentionStage::QAfterNorm,
+        reference.q_after_norm.as_ref(),
+        &gpu_native.q_after_norm,
+    )?;
+    compare_one_stage(
+        Layer0AttentionStage::KAfterNorm,
+        reference.k_after_norm.as_ref(),
+        &gpu_native.k_after_norm,
+    )?;
+    compare_one_stage(
+        Layer0AttentionStage::QAfterRope,
+        reference.q_after_rope.as_ref(),
+        &gpu_native.q_after_rope,
+    )?;
+    compare_one_stage(
+        Layer0AttentionStage::KAfterRope,
+        reference.k_after_rope.as_ref(),
+        &gpu_native.k_after_rope,
+    )?;
+    compare_one_stage(
+        Layer0AttentionStage::AttentionContext,
+        reference.attention_context.as_ref(),
+        &gpu_native.attention_context,
+    )?;
+    compare_one_stage(
+        Layer0AttentionStage::OProjection,
+        reference.o_projection.as_ref(),
+        &gpu_native.o_projection,
+    )?;
+    compare_one_stage(
+        Layer0AttentionStage::PostAttentionResidual,
+        reference.post_attention_residual.as_ref(),
+        &gpu_native.post_attention_residual,
+    )?;
+
+    let exact_match = first_divergence.is_none();
+    Ok(Layer0AttentionPositionComparison {
+        position,
+        token_id,
+        exact_match,
+        first_divergence,
+        stages,
+    })
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct Slice11bCrossCheckEvidence {
+    pub report_path: String,
+    pub cross_check_status: String,
+    pub slice11b_layer0_post_attn_max_abs: Option<f32>,
+    pub slice11b_layer0_post_attn_rms: Option<f64>,
+    pub slice11c_layer0_post_attn_max_abs: Option<f32>,
+    pub slice11c_layer0_post_attn_rms: Option<f64>,
+    pub discrepancy: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct Layer0AttentionFirstDivergenceReport {
+    pub schema_version: String,
+    pub mode: String,
+    pub diagnostic_complete: bool,
+    pub qualification_pass: bool,
+    pub failure: Option<String>,
+
+    pub provenance: BuildProvenance,
+    pub build_git_sha: String,
+    pub executable_sha256: String,
+    pub resolved_config_sha256: String,
+    pub model_geometry: GpuNativeModelGeometry,
+    pub expert_metadata: ExpertMetadataEvidence,
+    pub case: CaseEvidence,
+    pub prompt_token_ids_sha256: String,
+    pub prompt_token_ids: Vec<u32>,
+    pub prompt_token_count: usize,
+    pub expected_adapter_name: String,
+    pub actual_adapter: Option<GpuDeviceIdentity>,
+
+    pub earliest_divergent_position: Option<usize>,
+    pub first_internal_divergence: Option<Layer0AttentionFirstDivergenceEvidence>,
+    pub position_comparisons: Vec<Layer0AttentionPositionComparison>,
+    pub final_position_post_attention: Option<Layer0AttentionStageComparison>,
+    pub slice11b_cross_check: Option<Slice11bCrossCheckEvidence>,
+}
+
+impl Layer0AttentionFirstDivergenceReport {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        provenance: BuildProvenance,
+        build_git_sha: String,
+        executable_sha256: String,
+        resolved_config_sha256: String,
+        model_geometry: GpuNativeModelGeometry,
+        expert_metadata: ExpertMetadataEvidence,
+        case: CaseEvidence,
+        prompt_token_ids_sha256: String,
+        prompt_token_ids: Vec<u32>,
+        expected_adapter_name: String,
+    ) -> Self {
+        let prompt_token_count = prompt_token_ids.len();
+        Self {
+            schema_version: LAYER0_SCHEMA_VERSION.to_string(),
+            mode: LAYER0_MODE.to_string(),
+            diagnostic_complete: false,
+            qualification_pass: false,
+            failure: None,
+            provenance,
+            build_git_sha,
+            executable_sha256,
+            resolved_config_sha256,
+            model_geometry,
+            expert_metadata,
+            case,
+            prompt_token_ids_sha256,
+            prompt_token_ids,
+            prompt_token_count,
+            expected_adapter_name,
+            actual_adapter: None,
+            earliest_divergent_position: None,
+            first_internal_divergence: None,
+            position_comparisons: Vec::new(),
+            final_position_post_attention: None,
+            slice11b_cross_check: None,
+        }
+    }
+
+    pub fn fail(&mut self, reason: String) {
+        self.diagnostic_complete = true;
+        self.qualification_pass = false;
+        self.failure = Some(reason);
+    }
+}
+
+pub fn cross_check_slice11b_report(
+    slice11b_path: &Path,
+    final_post_attn: &Layer0AttentionStageComparison,
+) -> Result<Slice11bCrossCheckEvidence, String> {
+    let file_str = std::fs::read_to_string(slice11b_path).map_err(|e| {
+        format!(
+            "failed to read Slice11B report at {}: {e}",
+            slice11b_path.display()
+        )
+    })?;
+    let val: serde_json::Value = serde_json::from_str(&file_str)
+        .map_err(|e| format!("failed to parse Slice11B report JSON: {e}"))?;
+
+    let stages = val
+        .get("stages")
+        .and_then(|s| s.as_array())
+        .ok_or_else(|| "Slice11B report missing 'stages' array".to_string())?;
+
+    let mut slice11b_l0_comp: Option<&serde_json::Value> = None;
+    for s in stages {
+        if let Some(stage_val) = s.get("stage") {
+            if stage_val.get("stage").and_then(|v| v.as_str()) == Some("layer_post_attention")
+                && stage_val.get("layer").and_then(|l| l.as_u64()) == Some(0)
+            {
+                slice11b_l0_comp = s.get("vector_comparison");
+                break;
+            }
+        }
+    }
+
+    let slice11b_comp = slice11b_l0_comp.ok_or_else(|| {
+        "Slice11B report has no LayerPostAttention { layer: 0 } stage evidence".to_string()
+    })?;
+
+    let b_max_abs = slice11b_comp
+        .get("max_absolute_error")
+        .and_then(|v| v.as_f64())
+        .map(|f| f as f32);
+    let b_rms = slice11b_comp.get("rms_error").and_then(|v| v.as_f64());
+
+    let c_max_abs = final_post_attn.vector_comparison.max_absolute_error;
+    let c_rms = final_post_attn.vector_comparison.rms_error;
+
+    let mut discrepancy = None;
+    let matches = match (b_max_abs, c_max_abs, b_rms, c_rms) {
+        (Some(b_a), Some(c_a), Some(b_r), Some(c_r)) => {
+            let max_diff = (b_a - c_a).abs();
+            let rms_diff = (b_r - c_r).abs();
+            if max_diff > 1e-5 || rms_diff > 1e-6 {
+                discrepancy = Some(format!(
+                    "Slice11B max_abs={b_a}, Slice11C max_abs={c_a} (diff={max_diff}); Slice11B rms={b_r}, Slice11C rms={c_r} (diff={rms_diff})"
+                ));
+                false
+            } else {
+                true
+            }
+        }
+        _ => {
+            discrepancy =
+                Some("missing numerical evidence fields in Slice11B or Slice11C".to_string());
+            false
+        }
+    };
+
+    Ok(Slice11bCrossCheckEvidence {
+        report_path: slice11b_path.display().to_string(),
+        cross_check_status: if matches {
+            "verified_match".to_string()
+        } else {
+            "mismatch".to_string()
+        },
+        slice11b_layer0_post_attn_max_abs: b_max_abs,
+        slice11b_layer0_post_attn_rms: b_rms,
+        slice11c_layer0_post_attn_max_abs: c_max_abs,
+        slice11c_layer0_post_attn_rms: c_rms,
+        discrepancy,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn layer0_trace_layout_offset_arithmetic_is_exact_and_4byte_aligned() {
+        let layout = Layer0AttentionDiagnosticTraceLayout::try_new(2048, 4096, 512).unwrap();
+
+        assert_eq!(layout.embedding_offset % 4, 0);
+        assert_eq!(layout.attention_pre_norm_offset % 4, 0);
+        assert_eq!(layout.q_raw_offset % 4, 0);
+        assert_eq!(layout.k_raw_offset % 4, 0);
+        assert_eq!(layout.v_raw_offset % 4, 0);
+        assert_eq!(layout.q_after_norm_offset % 4, 0);
+        assert_eq!(layout.k_after_norm_offset % 4, 0);
+        assert_eq!(layout.q_after_rope_offset % 4, 0);
+        assert_eq!(layout.k_after_rope_offset % 4, 0);
+        assert_eq!(layout.attention_context_offset % 4, 0);
+        assert_eq!(layout.o_projection_offset % 4, 0);
+        assert_eq!(layout.post_attention_residual_offset % 4, 0);
+        assert_eq!(layout.status_offset % 4, 0);
+
+        assert_eq!(layout.embedding_bytes, 2048 * 4);
+        assert_eq!(layout.attention_pre_norm_bytes, 2048 * 4);
+        assert_eq!(layout.q_raw_bytes, 4096 * 4);
+        assert_eq!(layout.k_raw_bytes, 512 * 4);
+        assert_eq!(layout.v_raw_bytes, 512 * 4);
+        assert_eq!(layout.q_after_norm_bytes, 4096 * 4);
+        assert_eq!(layout.k_after_norm_bytes, 512 * 4);
+        assert_eq!(layout.q_after_rope_bytes, 4096 * 4);
+        assert_eq!(layout.k_after_rope_bytes, 512 * 4);
+        assert_eq!(layout.attention_context_bytes, 4096 * 4);
+        assert_eq!(layout.o_projection_bytes, 2048 * 4);
+        assert_eq!(layout.post_attention_residual_bytes, 2048 * 4);
+        assert_eq!(layout.status_bytes, 4);
+
+        let sum_bytes = (2048 * 4)
+            + (2048 * 4)
+            + (4096 * 4)
+            + (512 * 4)
+            + (512 * 4)
+            + (4096 * 4)
+            + (512 * 4)
+            + (4096 * 4)
+            + (512 * 4)
+            + (4096 * 4)
+            + (2048 * 4)
+            + (2048 * 4)
+            + 4;
+        assert_eq!(layout.total_bytes, sum_bytes as u64);
+    }
+
+    #[test]
+    fn layer0_trace_layout_parse_roundtrip() {
+        let layout = Layer0AttentionDiagnosticTraceLayout::try_new(4, 8, 2).unwrap();
+        let mut buffer = vec![0u8; layout.total_bytes as usize];
+
+        let q_vals = [1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
+        for (i, &v) in q_vals.iter().enumerate() {
+            let off = layout.q_raw_offset + i * 4;
+            buffer[off..off + 4].copy_from_slice(&v.to_le_bytes());
+        }
+
+        buffer[layout.status_offset..layout.status_offset + 4]
+            .copy_from_slice(&42u32.to_le_bytes());
+
+        let trace = layout.parse(&buffer).unwrap();
+        assert_eq!(trace.q_raw, q_vals);
+        assert_eq!(trace.status, 42);
+        assert_eq!(trace.embedding.len(), 4);
+        assert_eq!(trace.k_raw.len(), 2);
+    }
+
+    fn sample_cpu_sink(
+        d_model: usize,
+        q_width: usize,
+        kv_width: usize,
+    ) -> crate::transformer::Layer0AttentionCpuDiagnosticSink {
+        crate::transformer::Layer0AttentionCpuDiagnosticSink {
+            embedding: Some(vec![1.0; d_model]),
+            attention_pre_norm: Some(vec![2.0; d_model]),
+            q_raw: Some(vec![3.0; q_width]),
+            k_raw: Some(vec![4.0; kv_width]),
+            v_raw: Some(vec![5.0; kv_width]),
+            q_after_norm: Some(vec![6.0; q_width]),
+            k_after_norm: Some(vec![7.0; kv_width]),
+            q_after_rope: Some(vec![8.0; q_width]),
+            k_after_rope: Some(vec![9.0; kv_width]),
+            attention_context: Some(vec![10.0; q_width]),
+            o_projection: Some(vec![11.0; d_model]),
+            post_attention_residual: Some(vec![12.0; d_model]),
+        }
+    }
+
+    fn cpu_sink_to_gpu_trace(
+        s: &crate::transformer::Layer0AttentionCpuDiagnosticSink,
+    ) -> Layer0AttentionDiagnosticTrace {
+        Layer0AttentionDiagnosticTrace {
+            embedding: s.embedding.clone().unwrap(),
+            attention_pre_norm: s.attention_pre_norm.clone().unwrap(),
+            q_raw: s.q_raw.clone().unwrap(),
+            k_raw: s.k_raw.clone().unwrap(),
+            v_raw: s.v_raw.clone().unwrap(),
+            q_after_norm: s.q_after_norm.clone().unwrap(),
+            k_after_norm: s.k_after_norm.clone().unwrap(),
+            q_after_rope: s.q_after_rope.clone().unwrap(),
+            k_after_rope: s.k_after_rope.clone().unwrap(),
+            attention_context: s.attention_context.clone().unwrap(),
+            o_projection: s.o_projection.clone().unwrap(),
+            post_attention_residual: s.post_attention_residual.clone().unwrap(),
+            status: 0,
+        }
+    }
+
+    #[test]
+    fn comparator_exact_match_yields_no_divergence() {
+        let cpu = sample_cpu_sink(4, 8, 2);
+        let gpu = cpu_sink_to_gpu_trace(&cpu);
+
+        let pos_comp = compare_layer0_attention_traces(0, 100, &cpu, &gpu).unwrap();
+        assert!(pos_comp.exact_match);
+        assert!(pos_comp.first_divergence.is_none());
+        assert!(pos_comp.stages.iter().all(|s| s.exact_match));
+    }
+
+    #[test]
+    fn comparator_flags_earliest_q_raw_divergence() {
+        let cpu = sample_cpu_sink(4, 8, 2);
+        let mut gpu = cpu_sink_to_gpu_trace(&cpu);
+        gpu.q_raw[3] += 1e-5;
+        gpu.attention_context[0] += 1.0;
+
+        let pos_comp = compare_layer0_attention_traces(0, 100, &cpu, &gpu).unwrap();
+        assert!(!pos_comp.exact_match);
+        assert!(pos_comp.first_divergence.is_some());
+        let div = pos_comp.first_divergence.unwrap();
+        assert_eq!(div.stage, Layer0AttentionStage::QRaw);
+        assert_eq!(div.worst_index, Some(3));
+    }
+
+    #[test]
+    fn comparator_flags_attention_context_divergence_when_qkv_exact() {
+        let cpu = sample_cpu_sink(4, 8, 2);
+        let mut gpu = cpu_sink_to_gpu_trace(&cpu);
+        gpu.attention_context[1] += 1e-4;
+
+        let pos_comp = compare_layer0_attention_traces(1, 200, &cpu, &gpu).unwrap();
+        assert!(!pos_comp.exact_match);
+        let div = pos_comp.first_divergence.unwrap();
+        assert_eq!(div.position, 1);
+        assert_eq!(div.stage, Layer0AttentionStage::AttentionContext);
+    }
+}

--- a/rust-engine/src/gpu_native_q4_expert_stage_attribution.rs
+++ b/rust-engine/src/gpu_native_q4_expert_stage_attribution.rs
@@ -1,0 +1,1971 @@
+//! Diagnostic-only internal-stage attribution for frozen GPU-native Q4_0
+//! routed-expert discrepancies.
+//!
+//! Nothing in this module is consulted by ordinary inference or by any
+//! qualification PASS derivation. The report deliberately preserves raw
+//! boundary, stage, replay, and arithmetic-emulator evidence without a
+//! numerical acceptance threshold.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+use crate::gpu_native_expert_permutation_semantic_parity::VectorNumericalEvidence;
+use crate::gpu_native_router_rank_diagnostics::{DiagnosticProvenance, GateTensorIdentity};
+use crate::gpu_native_token_loop::{GpuNativeModelGeometry, GpuNativeTokenLoopSnapshot};
+use crate::{IsolatedRuntimeShutdownError, RealCliRuntimeMode, ResolvedRealCliSpec};
+
+pub const SCHEMA_VERSION: &str = "mer.gpu-native-q4-expert-stage-attribution.v1";
+pub const MODE: &str = "diagnose-gpu-native-q4-expert-stages";
+pub const QUALIFICATION_PASS: bool = false;
+pub const FROZEN_BEA_BUILD_SHA: &str = "bea43722a8fc00fd76d3c45702f70c16e2b63041";
+pub const FROZEN_BEA_REPORT_SHA256: &str =
+    "804d14db1f521d5353046389d133e90c2cca1a258ea42a7fe33b689fd812025a";
+pub const FROZEN_BEA_LOG_SHA256: &str =
+    "8d744b343574e8ade1937e6943af1f67f19c1f03e345632f67883ff519e3c7d7";
+pub const FROZEN_RUST_UPSTREAM_TRACE_SHA256: &str =
+    "94d1d00e69a83f4510aece9c3c338f85d57a051619b73e897610d61a3e958920";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+pub struct FrozenStageTarget {
+    pub id: &'static str,
+    pub case: &'static str,
+    pub generated_position: usize,
+    pub layer: usize,
+    pub frozen_worst_local_expert: Option<u32>,
+}
+
+pub const FROZEN_TARGETS: [FrozenStageTarget; 9] = [
+    FrozenStageTarget {
+        id: "Q1",
+        case: "postgres-window-holdout",
+        generated_position: 13,
+        layer: 47,
+        frozen_worst_local_expert: Some(28),
+    },
+    FrozenStageTarget {
+        id: "Q2",
+        case: "spanish-refactor-holdout",
+        generated_position: 11,
+        layer: 47,
+        frozen_worst_local_expert: Some(58),
+    },
+    FrozenStageTarget {
+        id: "Q3",
+        case: "spanish-refactor-holdout",
+        generated_position: 13,
+        layer: 47,
+        frozen_worst_local_expert: Some(28),
+    },
+    FrozenStageTarget {
+        id: "Q4",
+        case: "spanish-refactor-holdout",
+        generated_position: 15,
+        layer: 47,
+        frozen_worst_local_expert: Some(116),
+    },
+    FrozenStageTarget {
+        id: "R1",
+        case: "rust-ownership-holdout",
+        generated_position: 1,
+        layer: 0,
+        frozen_worst_local_expert: None,
+    },
+    FrozenStageTarget {
+        id: "R2",
+        case: "rust-ownership-holdout",
+        generated_position: 1,
+        layer: 19,
+        frozen_worst_local_expert: None,
+    },
+    FrozenStageTarget {
+        id: "R3",
+        case: "rust-ownership-holdout",
+        generated_position: 1,
+        layer: 33,
+        frozen_worst_local_expert: None,
+    },
+    FrozenStageTarget {
+        id: "R4",
+        case: "rust-ownership-holdout",
+        generated_position: 1,
+        layer: 40,
+        frozen_worst_local_expert: None,
+    },
+    FrozenStageTarget {
+        id: "R5",
+        case: "rust-ownership-holdout",
+        generated_position: 1,
+        layer: 44,
+        frozen_worst_local_expert: None,
+    },
+];
+
+#[derive(Clone, Debug)]
+pub struct Q4ExpertStageTargetLayout {
+    pub layer: usize,
+    pub router_input_offset: u64,
+    pub router_input_bytes: u64,
+    pub selected_ids_offset: u64,
+    pub selected_ids_bytes: u64,
+    pub selected_weights_offset: u64,
+    pub selected_weights_bytes: u64,
+    pub stages_offset: u64,
+    pub stages_bytes: u64,
+    pub production_down_offset: u64,
+    pub production_down_bytes: u64,
+}
+
+#[derive(Clone, Debug)]
+pub struct Q4ExpertStageTraceLayout {
+    pub d_model: usize,
+    pub d_ff: usize,
+    pub top_k: usize,
+    pub targets: Vec<Q4ExpertStageTargetLayout>,
+    pub total_bytes: u64,
+}
+
+fn checked_region(cursor: &mut u64, elements: usize, label: &str) -> Result<(u64, u64), String> {
+    let bytes = u64::try_from(elements)
+        .ok()
+        .and_then(|value| value.checked_mul(4))
+        .ok_or_else(|| format!("{label} byte length overflow"))?;
+    let offset = *cursor;
+    *cursor = cursor
+        .checked_add(bytes)
+        .ok_or_else(|| format!("{label} offset overflow"))?;
+    Ok((offset, bytes))
+}
+
+impl Q4ExpertStageTraceLayout {
+    pub fn try_new(geometry: GpuNativeModelGeometry, layers: &[usize]) -> Result<Self, String> {
+        if geometry.d_model == 0 || geometry.d_ff == 0 || geometry.top_k == 0 || layers.is_empty() {
+            return Err("Q4 expert stage trace geometry is empty".to_string());
+        }
+        let unique = layers.iter().copied().collect::<BTreeSet<_>>();
+        if unique.len() != layers.len()
+            || layers.windows(2).any(|window| window[0] >= window[1])
+            || layers.iter().any(|layer| *layer >= geometry.num_layers)
+        {
+            return Err("Q4 expert stage trace layers must be unique, sorted, and in range".into());
+        }
+        let stage_elements = geometry
+            .top_k
+            .checked_mul(
+                geometry
+                    .d_ff
+                    .checked_mul(3)
+                    .and_then(|value| value.checked_add(geometry.d_model))
+                    .ok_or("Q4 expert stage element overflow")?,
+            )
+            .ok_or("Q4 expert stage element overflow")?;
+        let production_down_elements = geometry
+            .top_k
+            .checked_mul(geometry.d_model)
+            .ok_or("Q4 production down element overflow")?;
+        let mut cursor = 0u64;
+        let mut targets = Vec::with_capacity(layers.len());
+        for &layer in layers {
+            let (router_input_offset, router_input_bytes) =
+                checked_region(&mut cursor, geometry.d_model, "router input")?;
+            let (selected_ids_offset, selected_ids_bytes) =
+                checked_region(&mut cursor, geometry.top_k, "selected IDs")?;
+            let (selected_weights_offset, selected_weights_bytes) =
+                checked_region(&mut cursor, geometry.top_k, "selected weights")?;
+            let (stages_offset, stages_bytes) =
+                checked_region(&mut cursor, stage_elements, "expert stages")?;
+            let (production_down_offset, production_down_bytes) = checked_region(
+                &mut cursor,
+                production_down_elements,
+                "production expert down outputs",
+            )?;
+            targets.push(Q4ExpertStageTargetLayout {
+                layer,
+                router_input_offset,
+                router_input_bytes,
+                selected_ids_offset,
+                selected_ids_bytes,
+                selected_weights_offset,
+                selected_weights_bytes,
+                stages_offset,
+                stages_bytes,
+                production_down_offset,
+                production_down_bytes,
+            });
+        }
+        Ok(Self {
+            d_model: geometry.d_model,
+            d_ff: geometry.d_ff,
+            top_k: geometry.top_k,
+            targets,
+            total_bytes: cursor,
+        })
+    }
+
+    pub fn target_for_layer(&self, layer: usize) -> Option<&Q4ExpertStageTargetLayout> {
+        self.targets.iter().find(|target| target.layer == layer)
+    }
+
+    pub fn stage_elements(&self) -> usize {
+        self.top_k * (3 * self.d_ff + self.d_model)
+    }
+
+    pub fn parse(&self, bytes: &[u8]) -> Result<Q4ExpertStageGpuTrace, String> {
+        if bytes.len() != self.total_bytes as usize {
+            return Err(format!(
+                "Q4 expert stage readback has {} bytes, expected {}",
+                bytes.len(),
+                self.total_bytes
+            ));
+        }
+        let mut targets = Vec::with_capacity(self.targets.len());
+        for target in &self.targets {
+            let router_input = read_f32_region(bytes, target.router_input_offset, self.d_model)?;
+            let selected_ids = read_u32_region(bytes, target.selected_ids_offset, self.top_k)?;
+            let selected_weights =
+                read_f32_region(bytes, target.selected_weights_offset, self.top_k)?;
+            let stages = read_f32_region(bytes, target.stages_offset, self.stage_elements())?;
+            let production_down = read_f32_region(
+                bytes,
+                target.production_down_offset,
+                self.top_k * self.d_model,
+            )?;
+            let gate_base = 0;
+            let up_base = self.top_k * self.d_ff;
+            let gated_base = 2 * self.top_k * self.d_ff;
+            let down_base = 3 * self.top_k * self.d_ff;
+            let routes = (0..self.top_k)
+                .map(|rank| Q4ExpertStageGpuRouteTrace {
+                    rank,
+                    expert_id: selected_ids[rank],
+                    gate: stages[gate_base + rank * self.d_ff..gate_base + (rank + 1) * self.d_ff]
+                        .to_vec(),
+                    up: stages[up_base + rank * self.d_ff..up_base + (rank + 1) * self.d_ff]
+                        .to_vec(),
+                    gated: stages
+                        [gated_base + rank * self.d_ff..gated_base + (rank + 1) * self.d_ff]
+                        .to_vec(),
+                    diagnostic_down: stages
+                        [down_base + rank * self.d_model..down_base + (rank + 1) * self.d_model]
+                        .to_vec(),
+                    production_down: production_down
+                        [rank * self.d_model..(rank + 1) * self.d_model]
+                        .to_vec(),
+                })
+                .collect();
+            targets.push(Q4ExpertStageGpuTargetTrace {
+                layer: target.layer,
+                router_input,
+                selected_ids,
+                selected_weights,
+                routes,
+            });
+        }
+        Ok(Q4ExpertStageGpuTrace { targets })
+    }
+}
+
+fn read_f32_region(bytes: &[u8], offset: u64, elements: usize) -> Result<Vec<f32>, String> {
+    read_u32_region(bytes, offset, elements)
+        .map(|bits| bits.into_iter().map(f32::from_bits).collect())
+}
+
+fn read_u32_region(bytes: &[u8], offset: u64, elements: usize) -> Result<Vec<u32>, String> {
+    let start = usize::try_from(offset).map_err(|_| "readback offset does not fit usize")?;
+    let end = start
+        .checked_add(elements.checked_mul(4).ok_or("readback size overflow")?)
+        .ok_or("readback range overflow")?;
+    let region = bytes
+        .get(start..end)
+        .ok_or("readback region is out of bounds")?;
+    Ok(region
+        .chunks_exact(4)
+        .map(|chunk| u32::from_le_bytes(chunk.try_into().expect("four-byte chunk")))
+        .collect())
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Q4ExpertStageGpuRouteTrace {
+    pub rank: usize,
+    pub expert_id: u32,
+    pub gate: Vec<f32>,
+    pub up: Vec<f32>,
+    pub gated: Vec<f32>,
+    pub diagnostic_down: Vec<f32>,
+    pub production_down: Vec<f32>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Q4ExpertStageGpuTargetTrace {
+    pub layer: usize,
+    pub router_input: Vec<f32>,
+    pub selected_ids: Vec<u32>,
+    pub selected_weights: Vec<f32>,
+    pub routes: Vec<Q4ExpertStageGpuRouteTrace>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Q4ExpertStageGpuTrace {
+    pub targets: Vec<Q4ExpertStageGpuTargetTrace>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ExactVectorEvidence {
+    pub source: &'static str,
+    pub vector_length: usize,
+    pub f32_bits_sha256: String,
+    pub f32_bits: Vec<u32>,
+    pub nonfinite_count: usize,
+}
+
+impl ExactVectorEvidence {
+    fn new(source: &'static str, values: &[f32], retain_bits: bool) -> Self {
+        let bits = values
+            .iter()
+            .map(|value| value.to_bits())
+            .collect::<Vec<_>>();
+        Self {
+            source,
+            vector_length: values.len(),
+            f32_bits_sha256: crate::numerical_diagnostics::f32_bits_sha256(&bits),
+            f32_bits: retain_bits.then_some(bits).unwrap_or_default(),
+            nonfinite_count: values.iter().filter(|value| !value.is_finite()).count(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct OrderedRouterEvidence {
+    pub cpu_production_ids: Vec<u32>,
+    pub actual_gpu_ids: Vec<u32>,
+    pub exact_ordered_equal: bool,
+    pub decomposition_valid: bool,
+    pub mismatch_not_repaired_or_reordered: bool,
+}
+
+fn pair_routes_by_expert_id(cpu_ids: &[u32], gpu_ids: &[u32]) -> Result<Vec<usize>, String> {
+    if cpu_ids != gpu_ids {
+        return Err("same-input ordered router IDs differ; decomposition is invalid".to_string());
+    }
+    let gpu_by_id = gpu_ids
+        .iter()
+        .copied()
+        .enumerate()
+        .map(|(rank, expert)| (expert, rank))
+        .collect::<BTreeMap<_, _>>();
+    if gpu_by_id.len() != gpu_ids.len() {
+        return Err("actual GPU selected expert IDs contain duplicates".to_string());
+    }
+    cpu_ids
+        .iter()
+        .map(|expert| {
+            gpu_by_id
+                .get(expert)
+                .copied()
+                .ok_or_else(|| format!("actual GPU route is missing expert ID {expert}"))
+        })
+        .collect()
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum StageAttribution {
+    InputBoundaryDrift,
+    GateProjectionDrift,
+    UpProjectionDrift,
+    GateAndUpProjectionDrift,
+    SwigluDrift,
+    DownProjectionDrift,
+    MultiStageDrift,
+    NoMaterialLocalization,
+    Unresolved,
+}
+
+fn exact_bits_equal(left: &[f32], right: &[f32]) -> bool {
+    left.len() == right.len()
+        && left
+            .iter()
+            .zip(right)
+            .all(|(left, right)| left.to_bits() == right.to_bits())
+}
+
+fn strictly_positive_aggregate_error(stage: &VectorNumericalEvidence) -> bool {
+    stage.max_absolute_error.is_some_and(|value| value > 0.0)
+        && stage.rms_error.is_some_and(|value| value > 0.0)
+        && stage.mean_absolute_error.is_some_and(|value| value > 0.0)
+}
+
+fn derive_attribution(
+    boundary_equal: bool,
+    gate: &VectorNumericalEvidence,
+    up: &VectorNumericalEvidence,
+    production_down: &VectorNumericalEvidence,
+    projection_implied_final: &VectorNumericalEvidence,
+    swiglu_incremental_final: &VectorNumericalEvidence,
+    down_incremental_final: &VectorNumericalEvidence,
+) -> StageAttribution {
+    if !boundary_equal {
+        return StageAttribution::InputBoundaryDrift;
+    }
+    if [
+        gate,
+        up,
+        production_down,
+        projection_implied_final,
+        swiglu_incremental_final,
+        down_incremental_final,
+    ]
+    .into_iter()
+    .any(|stage| stage.left_nonfinite_count != 0 || stage.right_nonfinite_count != 0)
+    {
+        return StageAttribution::Unresolved;
+    }
+    // No hidden tolerance: a contribution is observable here only when every
+    // aggregate finite-error statistic is strictly non-zero. More
+    // importantly, classification uses the comparative A->B, B->C, and
+    // C->actual-GPU final-output residuals. A raw non-bit-equal internal stage
+    // is therefore never sufficient by itself to name a causal stage.
+    let gate_differs = strictly_positive_aggregate_error(gate);
+    let up_differs = strictly_positive_aggregate_error(up);
+    let projection_contributes = strictly_positive_aggregate_error(projection_implied_final);
+    let swiglu_contributes = strictly_positive_aggregate_error(swiglu_incremental_final);
+    let down_contributes = strictly_positive_aggregate_error(down_incremental_final);
+    let contribution_count = usize::from(projection_contributes)
+        + usize::from(swiglu_contributes)
+        + usize::from(down_contributes);
+    if contribution_count > 1 {
+        return StageAttribution::MultiStageDrift;
+    }
+    if projection_contributes {
+        return match (gate_differs, up_differs) {
+            (true, false) => StageAttribution::GateProjectionDrift,
+            (false, true) => StageAttribution::UpProjectionDrift,
+            (true, true) => StageAttribution::GateAndUpProjectionDrift,
+            (false, false) => StageAttribution::Unresolved,
+        };
+    }
+    if swiglu_contributes {
+        return StageAttribution::SwigluDrift;
+    }
+    if down_contributes {
+        return StageAttribution::DownProjectionDrift;
+    }
+    StageAttribution::NoMaterialLocalization
+}
+
+fn current_gpu_emulator_assessment(stages: &[&VectorNumericalEvidence]) -> &'static str {
+    if stages.iter().any(|stage| {
+        stage.left_nonfinite_count != 0
+            || stage.right_nonfinite_count != 0
+            || stage.nonfinite_bit_mismatch_count != 0
+    }) {
+        "unresolved-nonfinite-review-raw-metrics"
+    } else if stages.iter().all(|stage| stage.exact_bit_equal) {
+        "bit-exact-at-all-observed-stages"
+    } else {
+        "not-bit-exact-no-hidden-closeness-threshold-review-raw-metrics"
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct StageComparisonEvidence {
+    pub gate: VectorNumericalEvidence,
+    pub up: VectorNumericalEvidence,
+    pub gated_swiglu: VectorNumericalEvidence,
+    pub diagnostic_down: VectorNumericalEvidence,
+    pub diagnostic_vs_production_gpu_down: VectorNumericalEvidence,
+    pub production_down: VectorNumericalEvidence,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct MixedReplayEvidence {
+    pub cpu_baseline_vs_actual_gpu: VectorNumericalEvidence,
+    pub gpu_gate_up_cpu_swiglu_down_vs_cpu_baseline: VectorNumericalEvidence,
+    pub gpu_gate_up_cpu_swiglu_down_vs_actual_gpu: VectorNumericalEvidence,
+    pub gpu_gated_cpu_down_vs_cpu_baseline: VectorNumericalEvidence,
+    pub gpu_gated_cpu_down_vs_actual_gpu: VectorNumericalEvidence,
+    pub gpu_gate_up_cpu_swiglu_down_vs_gpu_gated_cpu_down: VectorNumericalEvidence,
+    pub cpu_gated_current_gpu_down_vs_cpu_baseline: VectorNumericalEvidence,
+    pub cpu_gated_current_gpu_down_vs_actual_gpu: VectorNumericalEvidence,
+    pub gpu_gated_current_gpu_down_vs_cpu_baseline: VectorNumericalEvidence,
+    pub gpu_gated_current_gpu_down_vs_actual_gpu: VectorNumericalEvidence,
+    pub diagnostic_only_never_fed_to_production: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ComparativeErrorGrowthEvidence {
+    pub contract: &'static str,
+    pub projection_implied_final_error_strictly_positive: bool,
+    pub swiglu_incremental_final_error_strictly_positive: bool,
+    pub down_incremental_final_error_strictly_positive: bool,
+    pub arbitrary_numerical_threshold_used: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct ArithmeticEmulatorEvidence {
+    pub current_gpu_q4_dot_status: &'static str,
+    pub current_gpu_q4_dot_hardware_model_assessment: &'static str,
+    pub rejected_logical_dequant_q4_dot_status: &'static str,
+    pub current_gpu_gate_vs_actual_gpu: VectorNumericalEvidence,
+    pub current_gpu_up_vs_actual_gpu: VectorNumericalEvidence,
+    pub current_gpu_gated_vs_actual_gpu: VectorNumericalEvidence,
+    pub current_gpu_down_vs_actual_gpu: VectorNumericalEvidence,
+    pub rejected_logical_gate_vs_cpu_production: VectorNumericalEvidence,
+    pub rejected_logical_up_vs_cpu_production: VectorNumericalEvidence,
+    pub rejected_logical_gated_vs_cpu_production: VectorNumericalEvidence,
+    pub rejected_logical_down_vs_cpu_production: VectorNumericalEvidence,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct ExpertStageAttributionEvidence {
+    pub rank: usize,
+    pub local_expert_id: u32,
+    pub global_expert_id: u32,
+    pub canonical_q4_payload_sha256: String,
+    pub gpu_route_paired_by_exact_expert_id: bool,
+    pub cpu_production_final_bit_identical_to_ordinary_path: bool,
+    pub final_output_boundary: OutputBoundaryEvidence,
+    pub stage_comparison: StageComparisonEvidence,
+    pub mixed_replay: MixedReplayEvidence,
+    pub comparative_error_growth: ComparativeErrorGrowthEvidence,
+    pub arithmetic_emulators: ArithmeticEmulatorEvidence,
+    pub attribution: StageAttribution,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct InputBoundaryEvidence {
+    pub exact_pre_boundary_gpu_router_input: ExactVectorEvidence,
+    pub effective_gpu_expert_input: ExactVectorEvidence,
+    pub cpu_boundary_emulated_input: ExactVectorEvidence,
+    pub effective_input_bit_identical: bool,
+    pub mismatch_cannot_be_coerced_into_equality: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct OutputBoundaryEvidence {
+    pub cpu_pre_output: ExactVectorEvidence,
+    pub cpu_effective_output: ExactVectorEvidence,
+    pub actual_gpu_effective_output: ExactVectorEvidence,
+    pub final_boundary_bit_identical: bool,
+    pub mismatch_cannot_be_coerced_into_equality: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct TargetStageAttributionEvidence {
+    pub target: FrozenStageTarget,
+    pub actual_gpu_selected_weights: ExactVectorEvidence,
+    pub router: OrderedRouterEvidence,
+    pub input_boundary: Option<InputBoundaryEvidence>,
+    pub experts: Vec<ExpertStageAttributionEvidence>,
+    pub failure: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FrozenBuildEnvelope {
+    git_sha: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FrozenProvenanceEnvelope {
+    build: FrozenBuildEnvelope,
+}
+
+#[derive(Debug, Deserialize)]
+struct FrozenNumericalLimitsEnvelope {
+    max_absolute_error_limit: f64,
+    rms_error_limit: f64,
+    mean_absolute_error_limit: f64,
+    nonfinite_mismatch_limit: usize,
+    semantic_correctness_not_bit_parity: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct FrozenArtifactEnvelope {
+    sha256: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct FrozenV2IdentityEnvelope {
+    report_artifact: FrozenArtifactEnvelope,
+    expected_report_sha256_argument: String,
+    expected_schema: String,
+    frozen_build_sha: String,
+    qualification_pass: bool,
+    holdout_corpus_id: String,
+    holdout_corpus_sha256: String,
+    numerical_limits: FrozenNumericalLimitsEnvelope,
+    immutable_input_verified: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct FrozenBeaEnvelope {
+    schema: String,
+    diagnostic_complete: bool,
+    qualification_pass: bool,
+    provenance: FrozenProvenanceEnvelope,
+    frozen_v2_result_identity: FrozenV2IdentityEnvelope,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct FrozenBeaResultIdentity {
+    pub report_artifact: crate::qualification::ArtifactDigest,
+    pub expected_report_sha256_argument: String,
+    pub expected_schema: &'static str,
+    pub frozen_build_sha: &'static str,
+    pub diagnostic_complete: bool,
+    pub qualification_pass: bool,
+    pub frozen_v2_report_sha256: &'static str,
+    pub frozen_v2_build_sha: &'static str,
+    pub frozen_v2_holdout_corpus_id: &'static str,
+    pub frozen_v2_holdout_corpus_sha256: &'static str,
+    pub immutable_input_verified: bool,
+    pub bea_execution_log_sha256: &'static str,
+    pub rust_upstream_trace_sha256: &'static str,
+}
+
+fn is_hex(value: &str, length: usize) -> bool {
+    value.len() == length && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn exact_f64(left: f64, right: f64) -> bool {
+    left.to_bits() == right.to_bits()
+}
+
+fn validate_expected_bea_report_sha_argument(value: &str) -> Result<(), String> {
+    if !is_hex(value, 64) || !value.eq_ignore_ascii_case(FROZEN_BEA_REPORT_SHA256) {
+        return Err(format!(
+            "expected bea report SHA must equal frozen {FROZEN_BEA_REPORT_SHA256}"
+        ));
+    }
+    Ok(())
+}
+
+fn validate_bea_envelope(envelope: &FrozenBeaEnvelope) -> Result<(), String> {
+    if envelope.schema != crate::gpu_native_v2_holdout_failure_attribution::SCHEMA_VERSION {
+        return Err("frozen bea report schema differs".into());
+    }
+    if !envelope.diagnostic_complete || envelope.qualification_pass {
+        return Err("frozen bea report completion/qualification flags differ".into());
+    }
+    if envelope.provenance.build.git_sha.as_deref() != Some(FROZEN_BEA_BUILD_SHA) {
+        return Err("frozen bea report build SHA differs".into());
+    }
+    let v2 = &envelope.frozen_v2_result_identity;
+    let expected_limits = crate::gpu_native_semantic_parity_v2::NumericalLimits::frozen();
+    if v2.report_artifact.sha256
+        != crate::gpu_native_v2_holdout_failure_attribution::FROZEN_V2_REPORT_SHA256
+        || v2.expected_report_sha256_argument
+            != crate::gpu_native_v2_holdout_failure_attribution::FROZEN_V2_REPORT_SHA256
+        || v2.expected_schema != crate::gpu_native_semantic_parity_v2::SCHEMA_VERSION
+        || v2.frozen_build_sha
+            != crate::gpu_native_v2_holdout_failure_attribution::FROZEN_V2_BUILD_SHA
+        || v2.qualification_pass
+        || v2.holdout_corpus_id != crate::gpu_native_semantic_parity_v2::HOLDOUT_CORPUS_ID
+        || v2.holdout_corpus_sha256 != crate::gpu_native_semantic_parity_v2::HOLDOUT_CORPUS_SHA256
+        || !v2.immutable_input_verified
+        || !exact_f64(
+            v2.numerical_limits.max_absolute_error_limit,
+            expected_limits.max_absolute_error_limit,
+        )
+        || !exact_f64(
+            v2.numerical_limits.rms_error_limit,
+            expected_limits.rms_error_limit,
+        )
+        || !exact_f64(
+            v2.numerical_limits.mean_absolute_error_limit,
+            expected_limits.mean_absolute_error_limit,
+        )
+        || v2.numerical_limits.nonfinite_mismatch_limit != expected_limits.nonfinite_mismatch_limit
+        || v2.numerical_limits.semantic_correctness_not_bit_parity
+            != expected_limits.semantic_correctness_not_bit_parity
+    {
+        return Err("frozen V2 identity inside bea report differs".into());
+    }
+    Ok(())
+}
+
+fn validate_frozen_bea_report(
+    path: &Path,
+    expected_sha256: &str,
+) -> Result<FrozenBeaResultIdentity, Box<dyn std::error::Error>> {
+    validate_expected_bea_report_sha_argument(expected_sha256)?;
+    let bytes = std::fs::read(path)?;
+    let artifact = crate::qualification::ArtifactDigest {
+        configured_path: path.display().to_string(),
+        canonical_path: std::fs::canonicalize(path)?.display().to_string(),
+        byte_length: u64::try_from(bytes.len()).map_err(|_| "bea report length overflow")?,
+        sha256: crate::greedy_parity::sha256_hex(&bytes),
+    };
+    if !artifact.sha256.eq_ignore_ascii_case(expected_sha256)
+        || !artifact
+            .sha256
+            .eq_ignore_ascii_case(FROZEN_BEA_REPORT_SHA256)
+    {
+        return Err(format!(
+            "frozen bea report SHA differs: observed {} expected {}",
+            artifact.sha256, FROZEN_BEA_REPORT_SHA256
+        )
+        .into());
+    }
+    let envelope: FrozenBeaEnvelope = serde_json::from_slice(&bytes)
+        .map_err(|error| format!("malformed frozen bea report: {error}"))?;
+    validate_bea_envelope(&envelope)?;
+    Ok(FrozenBeaResultIdentity {
+        report_artifact: artifact,
+        expected_report_sha256_argument: expected_sha256.to_ascii_lowercase(),
+        expected_schema: crate::gpu_native_v2_holdout_failure_attribution::SCHEMA_VERSION,
+        frozen_build_sha: FROZEN_BEA_BUILD_SHA,
+        diagnostic_complete: true,
+        qualification_pass: false,
+        frozen_v2_report_sha256:
+            crate::gpu_native_v2_holdout_failure_attribution::FROZEN_V2_REPORT_SHA256,
+        frozen_v2_build_sha: crate::gpu_native_v2_holdout_failure_attribution::FROZEN_V2_BUILD_SHA,
+        frozen_v2_holdout_corpus_id: crate::gpu_native_semantic_parity_v2::HOLDOUT_CORPUS_ID,
+        frozen_v2_holdout_corpus_sha256:
+            crate::gpu_native_semantic_parity_v2::HOLDOUT_CORPUS_SHA256,
+        immutable_input_verified: true,
+        bea_execution_log_sha256: FROZEN_BEA_LOG_SHA256,
+        rust_upstream_trace_sha256: FROZEN_RUST_UPSTREAM_TRACE_SHA256,
+    })
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ProductionSemanticsEvidence {
+    pub diagnostic_only: bool,
+    pub production_q4_dot_arithmetic_changed: bool,
+    pub production_q4_gate_up_arithmetic_changed: bool,
+    pub production_q4_down_arithmetic_changed: bool,
+    pub production_silu_changed: bool,
+    pub routed_expert_boundary_changed: bool,
+    pub router_changed: bool,
+    pub attention_changed: bool,
+    pub dense_gemv_changed: bool,
+    pub v1_changed: bool,
+    pub v2_changed: bool,
+    pub limits_changed: bool,
+    pub corpus_or_prompts_changed: bool,
+    pub diagnostic_shader_contract: &'static str,
+    pub qualification_threshold_introduced: bool,
+}
+
+impl Default for ProductionSemanticsEvidence {
+    fn default() -> Self {
+        Self {
+            diagnostic_only: true,
+            production_q4_dot_arithmetic_changed: false,
+            production_q4_gate_up_arithmetic_changed: false,
+            production_q4_down_arithmetic_changed: false,
+            production_silu_changed: false,
+            routed_expert_boundary_changed: false,
+            router_changed: false,
+            attention_changed: false,
+            dense_gemv_changed: false,
+            v1_changed: false,
+            v2_changed: false,
+            limits_changed: false,
+            corpus_or_prompts_changed: false,
+            diagnostic_shader_contract:
+                "dedicated diagnostic-only pipeline reads production arena/input/routes and writes caller-owned scratch; ordinary entrypoints and bind contract unchanged",
+            qualification_threshold_introduced: false,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
+pub struct DiagnosticRuntimeEvidence {
+    pub gpu_token_loop: GpuNativeTokenLoopSnapshot,
+    pub gpu_expected_completed_token_steps: u64,
+    pub reference_background_shutdown: crate::greedy_parity::BackgroundShutdownEvidence,
+    pub gpu_native_background_shutdown: crate::greedy_parity::BackgroundShutdownEvidence,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct Q4ExpertStageAttributionReport {
+    pub schema: &'static str,
+    pub mode: &'static str,
+    pub diagnostic_only: bool,
+    pub diagnostic_complete: bool,
+    qualification_pass: bool,
+    pub failure: Option<String>,
+    pub provenance: DiagnosticProvenance,
+    pub frozen_bea_result_identity: FrozenBeaResultIdentity,
+    pub frozen_targets: Vec<FrozenStageTarget>,
+    pub targets: Vec<TargetStageAttributionEvidence>,
+    pub runtime: DiagnosticRuntimeEvidence,
+    pub production_semantics: ProductionSemanticsEvidence,
+    pub observation_seams_not_implemented: Vec<String>,
+    pub production_numerical_correction_justified: bool,
+    pub frozen_historical_evidence_modified: bool,
+}
+
+impl Q4ExpertStageAttributionReport {
+    fn new(
+        provenance: DiagnosticProvenance,
+        frozen_bea_result_identity: FrozenBeaResultIdentity,
+        failure: Option<String>,
+        targets: Vec<TargetStageAttributionEvidence>,
+        runtime: DiagnosticRuntimeEvidence,
+        observation_seams_not_implemented: Vec<String>,
+    ) -> Self {
+        let diagnostic_complete = failure.is_none()
+            && targets.len() == FROZEN_TARGETS.len()
+            && targets.iter().all(|target| target.failure.is_none())
+            && observation_seams_not_implemented.is_empty();
+        Self {
+            schema: SCHEMA_VERSION,
+            mode: MODE,
+            diagnostic_only: true,
+            diagnostic_complete,
+            qualification_pass: QUALIFICATION_PASS,
+            failure,
+            provenance,
+            frozen_bea_result_identity,
+            frozen_targets: FROZEN_TARGETS.to_vec(),
+            targets,
+            runtime,
+            production_semantics: ProductionSemanticsEvidence::default(),
+            observation_seams_not_implemented,
+            production_numerical_correction_justified: false,
+            frozen_historical_evidence_modified: false,
+        }
+    }
+
+    pub const fn qualification_pass(&self) -> bool {
+        self.qualification_pass
+    }
+}
+
+struct GpuTargetCapture {
+    case: &'static str,
+    generated_position: usize,
+    trace: Q4ExpertStageGpuTrace,
+}
+
+struct GpuCapture {
+    targets: Vec<GpuTargetCapture>,
+    model_geometry: GpuNativeModelGeometry,
+    gate_identities: BTreeMap<usize, GateTensorIdentity>,
+    model_load: crate::greedy_parity::ModelLoadEvidence,
+    device: crate::backend::GpuDeviceIdentity,
+    background_shutdown: crate::greedy_parity::BackgroundShutdownEvidence,
+    token_loop_snapshot: GpuNativeTokenLoopSnapshot,
+    expected_completed_token_steps: u64,
+}
+
+impl GpuCapture {
+    fn target(&self, target: FrozenStageTarget) -> Result<&Q4ExpertStageGpuTargetTrace, String> {
+        self.targets
+            .iter()
+            .find(|capture| {
+                capture.case == target.case
+                    && capture.generated_position == target.generated_position
+            })
+            .and_then(|capture| {
+                capture
+                    .trace
+                    .targets
+                    .iter()
+                    .find(|trace| trace.layer == target.layer)
+            })
+            .ok_or_else(|| {
+                format!(
+                    "missing GPU stage target {} {} position {} layer {}",
+                    target.id, target.case, target.generated_position, target.layer
+                )
+            })
+    }
+}
+
+fn holdout_case(name: &str) -> Result<crate::gpu_native_semantic_parity_v2::HoldoutCase, String> {
+    crate::gpu_native_semantic_parity_v2::HOLDOUT_CORPUS
+        .into_iter()
+        .find(|case| case.name == name)
+        .ok_or_else(|| format!("unknown frozen v2 holdout case {name:?}"))
+}
+
+async fn capture_gpu_case(
+    runtime: &crate::BenchRealRuntime,
+    tokenizer: &crate::tokenizer::Tokenizer,
+    case_name: &'static str,
+    target_positions: &[(usize, Vec<usize>)],
+    watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+) -> Result<(Vec<GpuTargetCapture>, usize), Box<dyn std::error::Error>> {
+    let fixed = holdout_case(case_name)?;
+    let prompt_token_ids = tokenizer.encode(fixed.prompt)?;
+    if prompt_token_ids.is_empty() || target_positions.is_empty() {
+        return Err("stage target prompt or target list is empty".into());
+    }
+    let maximum_target = target_positions
+        .iter()
+        .map(|(position, _)| *position)
+        .max()
+        .ok_or("stage target list is empty")?;
+    let token_loop = runtime
+        .gpu_native_token_loop
+        .as_ref()
+        .ok_or("stage diagnostic GPU-native token loop was not initialized")?;
+    let mut request = token_loop.create_q4_expert_stage_diagnostic_request_state()?;
+    let captures = crate::with_progress_timeout(
+        format!("Q4 expert stage diagnostic GPU {case_name}"),
+        watchdog,
+        async {
+            let prefix_count = prompt_token_ids.len().saturating_sub(1);
+            for (position, &token_id) in prompt_token_ids[..prefix_count].iter().enumerate() {
+                token_loop
+                    .step_token(&runtime.engine, &mut request, token_id, position, false)
+                    .await?;
+            }
+            let mut input_token = *prompt_token_ids.last().ok_or("holdout prompt is empty")?;
+            let mut model_position = prefix_count;
+            let mut captures = Vec::with_capacity(target_positions.len());
+            for generated_position in 0..=maximum_target {
+                if let Some((_, layers)) = target_positions
+                    .iter()
+                    .find(|(position, _)| *position == generated_position)
+                {
+                    let layout =
+                        Q4ExpertStageTraceLayout::try_new(token_loop.model_geometry(), layers)?;
+                    let staging =
+                        token_loop.create_q4_expert_stage_diagnostic_staging_buffer(&layout)?;
+                    let (trace, sampled, _) = token_loop
+                        .step_token_q4_expert_stage_diagnostic(
+                            &runtime.engine,
+                            &mut request,
+                            input_token,
+                            model_position,
+                            &layout,
+                            &staging,
+                        )
+                        .await?;
+                    captures.push(GpuTargetCapture {
+                        case: case_name,
+                        generated_position,
+                        trace,
+                    });
+                    input_token = sampled;
+                } else {
+                    input_token = token_loop
+                        .step_token(
+                            &runtime.engine,
+                            &mut request,
+                            input_token,
+                            model_position,
+                            true,
+                        )
+                        .await?
+                        .ok_or("GPU stage step produced no sampled token")?;
+                }
+                model_position = model_position
+                    .checked_add(1)
+                    .ok_or("GPU stage model position overflow")?;
+            }
+            Ok::<_, Box<dyn std::error::Error>>(captures)
+        },
+    )
+    .await?;
+    let expected_completed = prompt_token_ids
+        .len()
+        .saturating_sub(1)
+        .checked_add(maximum_target + 1)
+        .ok_or("GPU stage completion count overflow")?;
+    if request.committed_position() != expected_completed {
+        return Err(format!(
+            "GPU stage case {case_name} retired at {}, expected {expected_completed}",
+            request.committed_position()
+        )
+        .into());
+    }
+    Ok((captures, expected_completed))
+}
+
+async fn execute_gpu(
+    spec: &ResolvedRealCliSpec,
+    tokenizer: Arc<crate::tokenizer::Tokenizer>,
+    resolved_config_sha256: &str,
+    expected_adapter_name: &str,
+    watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+) -> Result<GpuCapture, Box<dyn std::error::Error>> {
+    let runtime = crate::build_isolated_greedy_runtime(
+        spec,
+        RealCliRuntimeMode::IsolatedGpuNativeDiagnostic,
+        tokenizer.clone(),
+    )
+    .await?;
+    let attempt = async {
+        let observed_config_sha256 = crate::resolved_real_runtime_identity_sha256(
+            &runtime.cfg,
+            runtime.model.config.architecture,
+            runtime.model.config.first_k_dense_replace,
+            &runtime.model.config.advanced,
+        )?;
+        if observed_config_sha256 != resolved_config_sha256 {
+            return Err("stage diagnostic GPU resolved configuration identity drifted".into());
+        }
+        let device = runtime
+            .engine
+            .gpu_device_identity()
+            .ok_or("stage diagnostic GPU runtime has no adapter identity")?;
+        if device.name != expected_adapter_name
+            || device.software_adapter
+            || device.device_type.eq_ignore_ascii_case("cpu")
+        {
+            return Err(format!(
+                "stage diagnostic selected adapter {:?}, expected real {:?}",
+                device.name, expected_adapter_name
+            )
+            .into());
+        }
+        let token_loop = runtime
+            .gpu_native_token_loop
+            .as_ref()
+            .ok_or("stage diagnostic GPU-native token loop was not initialized")?;
+        let geometry = token_loop.model_geometry();
+        if geometry.num_layers != 48
+            || geometry.num_experts != 128
+            || geometry.top_k != 8
+            || geometry.d_model != 2048
+            || geometry.d_ff != 768
+        {
+            return Err("stage diagnostic GPU model geometry differs from frozen V2".into());
+        }
+        if token_loop.snapshot() != GpuNativeTokenLoopSnapshot::default() {
+            return Err("stage diagnostic GPU token-loop counters did not start at zero".into());
+        }
+        let model_load = crate::greedy_parity_model_load(&runtime);
+        let cases: [(&'static str, Vec<(usize, Vec<usize>)>); 3] = [
+            ("rust-ownership-holdout", vec![(1, vec![0, 19, 33, 40, 44])]),
+            ("postgres-window-holdout", vec![(13, vec![47])]),
+            (
+                "spanish-refactor-holdout",
+                vec![(11, vec![47]), (13, vec![47]), (15, vec![47])],
+            ),
+        ];
+        let mut targets = Vec::new();
+        let mut expected_completed = 0usize;
+        for (case, positions) in cases {
+            let (mut captured, completed) =
+                capture_gpu_case(&runtime, &tokenizer, case, &positions, watchdog).await?;
+            targets.append(&mut captured);
+            expected_completed = expected_completed
+                .checked_add(completed)
+                .ok_or("GPU stage total completion count overflow")?;
+        }
+        Ok::<_, Box<dyn std::error::Error>>(GpuCapture {
+            targets,
+            model_geometry: geometry,
+            gate_identities: [0, 19, 33, 40, 44, 47]
+                .into_iter()
+                .map(|layer| {
+                    (
+                        layer,
+                        GateTensorIdentity::from_gate(layer, &runtime.model.layers[layer].gate),
+                    )
+                })
+                .collect(),
+            model_load,
+            device,
+            background_shutdown: crate::greedy_parity::BackgroundShutdownEvidence::default(),
+            token_loop_snapshot: token_loop.snapshot(),
+            expected_completed_token_steps: u64::try_from(expected_completed)
+                .map_err(|_| "GPU stage completion count does not fit u64")?,
+        })
+    }
+    .await;
+    let shutdown = runtime.shutdown_isolated().await;
+    match (attempt, shutdown) {
+        (Ok(mut capture), Ok(shutdown)) => {
+            capture.background_shutdown = shutdown;
+            Ok(capture)
+        }
+        (Err(error), Ok(_)) => Err(error),
+        (Ok(_), Err(shutdown_error)) => Err(shutdown_error.into()),
+        (Err(error), Err(shutdown_error)) => Err(IsolatedRuntimeShutdownError::new(format!(
+            "{error}; stage diagnostic GPU shutdown also failed: {shutdown_error}"
+        ))
+        .into()),
+    }
+}
+
+fn compare(
+    left_source: &'static str,
+    right_source: &'static str,
+    left: &[f32],
+    right: &[f32],
+) -> Result<VectorNumericalEvidence, Box<dyn std::error::Error>> {
+    Ok(VectorNumericalEvidence::compare(
+        left_source,
+        right_source,
+        left,
+        right,
+    )?)
+}
+
+async fn analyze_target(
+    runtime: &crate::BenchRealRuntime,
+    target: FrozenStageTarget,
+    gpu: &Q4ExpertStageGpuTargetTrace,
+) -> Result<TargetStageAttributionEvidence, Box<dyn std::error::Error>> {
+    if gpu.layer != target.layer
+        || gpu.router_input.len() != runtime.model.config.d_model
+        || gpu.router_input.iter().any(|value| !value.is_finite())
+        || gpu.selected_ids.len() != runtime.model.config.top_k
+        || gpu.selected_weights.len() != runtime.model.config.top_k
+        || gpu.routes.len() != runtime.model.config.top_k
+    {
+        return Err(format!(
+            "target {} GPU stage geometry is incomplete or nonfinite",
+            target.id
+        )
+        .into());
+    }
+    let cpu_route = runtime.model.layers[target.layer]
+        .gate
+        .route(&gpu.router_input);
+    let ordered_equal = cpu_route.experts == gpu.selected_ids;
+    let router = OrderedRouterEvidence {
+        cpu_production_ids: cpu_route.experts.clone(),
+        actual_gpu_ids: gpu.selected_ids.clone(),
+        exact_ordered_equal: ordered_equal,
+        decomposition_valid: ordered_equal,
+        mismatch_not_repaired_or_reordered: true,
+    };
+    let selected_weights = ExactVectorEvidence::new(
+        "actual-production-gpu-selected-weights",
+        &gpu.selected_weights,
+        true,
+    );
+    if !ordered_equal {
+        return Ok(TargetStageAttributionEvidence {
+            target,
+            actual_gpu_selected_weights: selected_weights,
+            router,
+            input_boundary: None,
+            experts: Vec::new(),
+            failure: Some(
+                "same-input CPU production ordered IDs differ from actual GPU ordered IDs; no repair or rank reordering was applied"
+                    .to_string(),
+            ),
+        });
+    }
+    if target
+        .frozen_worst_local_expert
+        .is_some_and(|expert| !gpu.selected_ids.contains(&expert))
+    {
+        return Ok(TargetStageAttributionEvidence {
+            target,
+            actual_gpu_selected_weights: selected_weights,
+            router,
+            input_boundary: None,
+            experts: Vec::new(),
+            failure: Some("frozen worst local expert was not selected at reproduced target".into()),
+        });
+    }
+    let gpu_ranks = pair_routes_by_expert_id(&cpu_route.experts, &gpu.selected_ids)?;
+    let mut experts = Vec::with_capacity(cpu_route.experts.len());
+    let mut input_boundary = None;
+    for (cpu_rank, local_expert_id) in cpu_route.experts.iter().copied().enumerate() {
+        let gpu_rank = gpu_ranks[cpu_rank];
+        let gpu_route = &gpu.routes[gpu_rank];
+        if gpu_route.expert_id != local_expert_id
+            || gpu_route.gate.len() != runtime.model.config.d_ff
+            || gpu_route.up.len() != runtime.model.config.d_ff
+            || gpu_route.gated.len() != runtime.model.config.d_ff
+            || gpu_route.diagnostic_down.len() != runtime.model.config.d_model
+            || gpu_route.production_down.len() != runtime.model.config.d_model
+        {
+            return Err(format!(
+                "target {} expert {local_expert_id} GPU stage geometry is incomplete",
+                target.id
+            )
+            .into());
+        }
+        let global_expert_id = runtime
+            .model
+            .global_expert_id(target.layer, local_expert_id);
+        let bundle = runtime
+            .engine
+            .diagnose_q4_0_expert_stages(
+                global_expert_id,
+                &gpu.router_input,
+                &gpu_route.gate,
+                &gpu_route.up,
+                &gpu_route.gated,
+            )
+            .await?;
+        let effective_input_equal = exact_bits_equal(&gpu.router_input, &bundle.cpu_boundary_input);
+        let current_input_boundary = InputBoundaryEvidence {
+            exact_pre_boundary_gpu_router_input: ExactVectorEvidence::new(
+                "exact-pre-boundary-production-gpu-router-and-expert-input",
+                &gpu.router_input,
+                true,
+            ),
+            effective_gpu_expert_input: ExactVectorEvidence::new(
+                "effective-production-gpu-expert-input",
+                &gpu.router_input,
+                true,
+            ),
+            cpu_boundary_emulated_input: ExactVectorEvidence::new(
+                "cpu-diagnostic-f16-boundary-emulated-expert-input",
+                &bundle.cpu_boundary_input,
+                true,
+            ),
+            effective_input_bit_identical: effective_input_equal,
+            mismatch_cannot_be_coerced_into_equality: true,
+        };
+        if let Some(existing) = &input_boundary {
+            if existing != &current_input_boundary {
+                return Err(
+                    "per-expert CPU input boundary evidence drifted within one target".into(),
+                );
+            }
+        } else {
+            input_boundary = Some(current_input_boundary);
+        }
+        let gate = compare(
+            "cpu-production-candle-raw-gate",
+            "actual-production-gpu-raw-gate",
+            &bundle.cpu_production.gate,
+            &gpu_route.gate,
+        )?;
+        let up = compare(
+            "cpu-production-candle-raw-up",
+            "actual-production-gpu-raw-up",
+            &bundle.cpu_production.up,
+            &gpu_route.up,
+        )?;
+        let gated = compare(
+            "cpu-production-candle-post-swiglu-gated",
+            "actual-production-gpu-post-swiglu-gated",
+            &bundle.cpu_production.gated,
+            &gpu_route.gated,
+        )?;
+        let diagnostic_down = compare(
+            "cpu-production-candle-down",
+            "diagnostic-gpu-down",
+            &bundle.cpu_production.down,
+            &gpu_route.diagnostic_down,
+        )?;
+        let diagnostic_vs_production_gpu_down = compare(
+            "diagnostic-gpu-down",
+            "actual-production-gpu-down",
+            &gpu_route.diagnostic_down,
+            &gpu_route.production_down,
+        )?;
+        let production_down = compare(
+            "cpu-production-candle-down",
+            "actual-production-gpu-down",
+            &bundle.cpu_production.down,
+            &gpu_route.production_down,
+        )?;
+        let final_boundary_equal =
+            exact_bits_equal(&bundle.cpu_effective_output, &gpu_route.production_down);
+        let final_output_boundary = OutputBoundaryEvidence {
+            cpu_pre_output: ExactVectorEvidence::new(
+                "cpu-production-candle-pre-boundary-expert-output",
+                &bundle.cpu_production.down,
+                false,
+            ),
+            cpu_effective_output: ExactVectorEvidence::new(
+                "cpu-diagnostic-f16-boundary-emulated-expert-output",
+                &bundle.cpu_effective_output,
+                true,
+            ),
+            actual_gpu_effective_output: ExactVectorEvidence::new(
+                "actual-production-gpu-expert-output",
+                &gpu_route.production_down,
+                true,
+            ),
+            final_boundary_bit_identical: final_boundary_equal,
+            mismatch_cannot_be_coerced_into_equality: true,
+        };
+        let projection_implied_final = compare(
+            "cpu-production-baseline-down",
+            "gpu-gate-up-through-cpu-production-swiglu-and-down",
+            &bundle.cpu_production.down,
+            &bundle.gpu_gate_up_through_cpu_swiglu_down.down,
+        )?;
+        let swiglu_incremental_final = compare(
+            "gpu-gate-up-through-cpu-production-swiglu-and-down",
+            "actual-gpu-gated-through-cpu-production-down",
+            &bundle.gpu_gate_up_through_cpu_swiglu_down.down,
+            &bundle.gpu_gated_through_cpu_down,
+        )?;
+        let down_incremental_final = compare(
+            "actual-gpu-gated-through-cpu-production-down",
+            "actual-production-gpu-down",
+            &bundle.gpu_gated_through_cpu_down,
+            &gpu_route.production_down,
+        )?;
+        let comparative_error_growth = ComparativeErrorGrowthEvidence {
+            contract: "threshold-free comparative final-output residuals: A-to-B projection contribution, B-to-C SwiGLU increment, C-to-actual-GPU down increment",
+            projection_implied_final_error_strictly_positive:
+                strictly_positive_aggregate_error(&projection_implied_final),
+            swiglu_incremental_final_error_strictly_positive:
+                strictly_positive_aggregate_error(&swiglu_incremental_final),
+            down_incremental_final_error_strictly_positive:
+                strictly_positive_aggregate_error(&down_incremental_final),
+            arbitrary_numerical_threshold_used: false,
+        };
+        let attribution = derive_attribution(
+            effective_input_equal,
+            &gate,
+            &up,
+            &production_down,
+            &projection_implied_final,
+            &swiglu_incremental_final,
+            &down_incremental_final,
+        );
+        let mixed_replay = MixedReplayEvidence {
+            cpu_baseline_vs_actual_gpu: compare(
+                "cpu-production-baseline-down",
+                "actual-production-gpu-down",
+                &bundle.cpu_production.down,
+                &gpu_route.production_down,
+            )?,
+            gpu_gate_up_cpu_swiglu_down_vs_cpu_baseline: projection_implied_final,
+            gpu_gate_up_cpu_swiglu_down_vs_actual_gpu: compare(
+                "gpu-gate-up-through-cpu-production-swiglu-and-down",
+                "actual-production-gpu-down",
+                &bundle.gpu_gate_up_through_cpu_swiglu_down.down,
+                &gpu_route.production_down,
+            )?,
+            gpu_gated_cpu_down_vs_cpu_baseline: compare(
+                "cpu-production-baseline-down",
+                "actual-gpu-gated-through-cpu-production-down",
+                &bundle.cpu_production.down,
+                &bundle.gpu_gated_through_cpu_down,
+            )?,
+            gpu_gated_cpu_down_vs_actual_gpu: down_incremental_final,
+            gpu_gate_up_cpu_swiglu_down_vs_gpu_gated_cpu_down: swiglu_incremental_final,
+            cpu_gated_current_gpu_down_vs_cpu_baseline: compare(
+                "cpu-production-baseline-down",
+                "cpu-gated-through-current-gpu-q4-down-emulator",
+                &bundle.cpu_production.down,
+                &bundle.cpu_gated_through_current_gpu_down,
+            )?,
+            cpu_gated_current_gpu_down_vs_actual_gpu: compare(
+                "cpu-gated-through-current-gpu-q4-down-emulator",
+                "actual-production-gpu-down",
+                &bundle.cpu_gated_through_current_gpu_down,
+                &gpu_route.production_down,
+            )?,
+            gpu_gated_current_gpu_down_vs_cpu_baseline: compare(
+                "cpu-production-baseline-down",
+                "actual-gpu-gated-through-current-gpu-q4-down-emulator",
+                &bundle.cpu_production.down,
+                &bundle.gpu_gated_through_current_gpu_down,
+            )?,
+            gpu_gated_current_gpu_down_vs_actual_gpu: compare(
+                "actual-gpu-gated-through-current-gpu-q4-down-emulator",
+                "actual-production-gpu-down",
+                &bundle.gpu_gated_through_current_gpu_down,
+                &gpu_route.production_down,
+            )?,
+            diagnostic_only_never_fed_to_production: true,
+        };
+        let current_gpu_gate_vs_actual_gpu = compare(
+            "current-gpu-q4-dot-cpu-emulator-gate",
+            "actual-production-gpu-gate",
+            &bundle.current_gpu_emulation.gate,
+            &gpu_route.gate,
+        )?;
+        let current_gpu_up_vs_actual_gpu = compare(
+            "current-gpu-q4-dot-cpu-emulator-up",
+            "actual-production-gpu-up",
+            &bundle.current_gpu_emulation.up,
+            &gpu_route.up,
+        )?;
+        let current_gpu_gated_vs_actual_gpu = compare(
+            "current-gpu-q4-dot-cpu-emulator-gated",
+            "actual-production-gpu-gated",
+            &bundle.current_gpu_emulation.gated,
+            &gpu_route.gated,
+        )?;
+        let current_gpu_down_vs_actual_gpu = compare(
+            "current-gpu-q4-dot-cpu-emulator-down",
+            "actual-production-gpu-down",
+            &bundle.current_gpu_emulation.down,
+            &gpu_route.production_down,
+        )?;
+        let current_gpu_q4_dot_hardware_model_assessment = current_gpu_emulator_assessment(&[
+            &current_gpu_gate_vs_actual_gpu,
+            &current_gpu_up_vs_actual_gpu,
+            &current_gpu_gated_vs_actual_gpu,
+            &current_gpu_down_vs_actual_gpu,
+        ]);
+        let arithmetic_emulators = ArithmeticEmulatorEvidence {
+            current_gpu_q4_dot_status: crate::inference::DiagnosticQ4DotArithmetic::CurrentGpu
+                .status(),
+            current_gpu_q4_dot_hardware_model_assessment,
+            rejected_logical_dequant_q4_dot_status:
+                crate::inference::DiagnosticQ4DotArithmetic::RejectedLogicalDequant.status(),
+            current_gpu_gate_vs_actual_gpu,
+            current_gpu_up_vs_actual_gpu,
+            current_gpu_gated_vs_actual_gpu,
+            current_gpu_down_vs_actual_gpu,
+            rejected_logical_gate_vs_cpu_production: compare(
+                "cpu-production-candle-gate",
+                "rejected-logical-dequant-q4-dot-emulator-gate",
+                &bundle.cpu_production.gate,
+                &bundle.rejected_logical_dequant_emulation.gate,
+            )?,
+            rejected_logical_up_vs_cpu_production: compare(
+                "cpu-production-candle-up",
+                "rejected-logical-dequant-q4-dot-emulator-up",
+                &bundle.cpu_production.up,
+                &bundle.rejected_logical_dequant_emulation.up,
+            )?,
+            rejected_logical_gated_vs_cpu_production: compare(
+                "cpu-production-candle-gated",
+                "rejected-logical-dequant-q4-dot-emulator-gated",
+                &bundle.cpu_production.gated,
+                &bundle.rejected_logical_dequant_emulation.gated,
+            )?,
+            rejected_logical_down_vs_cpu_production: compare(
+                "cpu-production-candle-down",
+                "rejected-logical-dequant-q4-dot-emulator-down",
+                &bundle.cpu_production.down,
+                &bundle.rejected_logical_dequant_emulation.down,
+            )?,
+        };
+        experts.push(ExpertStageAttributionEvidence {
+            rank: cpu_rank + 1,
+            local_expert_id,
+            global_expert_id,
+            canonical_q4_payload_sha256: bundle.canonical_payload_sha256,
+            gpu_route_paired_by_exact_expert_id: true,
+            cpu_production_final_bit_identical_to_ordinary_path: true,
+            final_output_boundary,
+            stage_comparison: StageComparisonEvidence {
+                gate,
+                up,
+                gated_swiglu: gated,
+                diagnostic_down,
+                diagnostic_vs_production_gpu_down,
+                production_down,
+            },
+            mixed_replay,
+            comparative_error_growth,
+            arithmetic_emulators,
+            attribution,
+        });
+    }
+    Ok(TargetStageAttributionEvidence {
+        target,
+        actual_gpu_selected_weights: selected_weights,
+        router,
+        input_boundary,
+        experts,
+        failure: None,
+    })
+}
+
+struct ReferenceCapture {
+    targets: Vec<TargetStageAttributionEvidence>,
+    failure: Option<String>,
+    model_load: crate::greedy_parity::ModelLoadEvidence,
+    background_shutdown: crate::greedy_parity::BackgroundShutdownEvidence,
+}
+
+async fn execute_reference_and_analyze(
+    spec: &ResolvedRealCliSpec,
+    tokenizer: Arc<crate::tokenizer::Tokenizer>,
+    resolved_config_sha256: &str,
+    gpu: &GpuCapture,
+    watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+) -> Result<ReferenceCapture, Box<dyn std::error::Error>> {
+    let runtime = crate::build_isolated_greedy_runtime(
+        spec,
+        RealCliRuntimeMode::IsolatedGreedyParityCpu,
+        tokenizer,
+    )
+    .await?;
+    let attempt = async {
+        runtime.engine.enable_cpu_q4_boundary_emulation()?;
+        let boundary_before = runtime.engine.cpu_q4_boundary_emulation_snapshot();
+        if !boundary_before.enabled || boundary_before.routed_expert_dispatches != 0 {
+            return Err("stage diagnostic CPU boundary emulation did not start clean".into());
+        }
+        let observed_config_sha256 = crate::resolved_real_runtime_identity_sha256(
+            &runtime.cfg,
+            runtime.model.config.architecture,
+            runtime.model.config.first_k_dense_replace,
+            &runtime.model.config.advanced,
+        )?;
+        if observed_config_sha256 != resolved_config_sha256 {
+            return Err("stage diagnostic reference configuration identity drifted".into());
+        }
+        if runtime.model.layers.len() != gpu.model_geometry.num_layers {
+            return Err("stage diagnostic reference layer geometry differs from GPU".into());
+        }
+        for (&layer, gpu_identity) in &gpu.gate_identities {
+            let reference_identity =
+                GateTensorIdentity::from_gate(layer, &runtime.model.layers[layer].gate);
+            if &reference_identity != gpu_identity {
+                return Err(
+                    format!("stage diagnostic gate identity differs at layer {layer}").into(),
+                );
+            }
+        }
+        let model_load = crate::greedy_parity_model_load(&runtime);
+        let mut targets = Vec::with_capacity(FROZEN_TARGETS.len());
+        for target in FROZEN_TARGETS {
+            let gpu_target = gpu.target(target)?;
+            targets.push(
+                crate::with_progress_timeout(
+                    format!("Q4 expert stage CPU analysis {}", target.id),
+                    watchdog,
+                    analyze_target(&runtime, target, gpu_target),
+                )
+                .await?,
+            );
+        }
+        let failures = targets
+            .iter()
+            .filter_map(|target| {
+                target
+                    .failure
+                    .as_ref()
+                    .map(|failure| format!("{}: {failure}", target.target.id))
+            })
+            .collect::<Vec<_>>();
+        Ok::<_, Box<dyn std::error::Error>>(ReferenceCapture {
+            targets,
+            failure: (!failures.is_empty()).then(|| failures.join("; ")),
+            model_load,
+            background_shutdown: crate::greedy_parity::BackgroundShutdownEvidence::default(),
+        })
+    }
+    .await;
+    let shutdown = runtime.shutdown_isolated().await;
+    match (attempt, shutdown) {
+        (Ok(mut capture), Ok(shutdown)) => {
+            capture.background_shutdown = shutdown;
+            Ok(capture)
+        }
+        (Err(error), Ok(_)) => Err(error),
+        (Ok(_), Err(shutdown_error)) => Err(shutdown_error.into()),
+        (Err(error), Err(shutdown_error)) => Err(IsolatedRuntimeShutdownError::new(format!(
+            "{error}; stage diagnostic reference shutdown also failed: {shutdown_error}"
+        ))
+        .into()),
+    }
+}
+
+fn model_load_is_strict(load: &crate::greedy_parity::ModelLoadEvidence) -> bool {
+    load.strict
+        && load.required_tensors > 0
+        && load.loaded_tensors == load.required_tensors
+        && !load.seeded_fallback_remained
+        && load.loader != "seeded"
+}
+
+fn emit_report(
+    report: &Q4ExpertStageAttributionReport,
+    report_out: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if report.qualification_pass() || !report.diagnostic_only {
+        return Err(
+            "Q4 expert stage report must remain diagnostic-only and qualification false".into(),
+        );
+    }
+    if let Some(parent) = report_out.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut json = serde_json::to_vec_pretty(report)?;
+    json.push(b'\n');
+    std::fs::write(report_out, json)?;
+    eprintln!(
+        "GPU-native Q4 expert stage-attribution report written to {}",
+        report_out.display()
+    );
+    Ok(())
+}
+
+pub async fn run_diagnostic(
+    config: PathBuf,
+    cfg: crate::config::Config,
+    expected_adapter_name: String,
+    bea_report: PathBuf,
+    expected_bea_report_sha256: String,
+    report_out: PathBuf,
+    progress_watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use crate::qualification::BuildProvenance;
+
+    // Immutable historical evidence is verified before any runtime or GPU
+    // construction. Hashing and deserialization use the same byte snapshot.
+    let frozen_bea_result_identity =
+        validate_frozen_bea_report(&bea_report, &expected_bea_report_sha256)?;
+    if progress_watchdog.timeout.is_none() {
+        return Err("Q4 expert stage diagnostic requires a positive progress timeout".into());
+    }
+    let build = BuildProvenance::embedded();
+    if build.dirty != Some(false) || build.git_sha.as_deref().is_none_or(|sha| !is_hex(sha, 40)) {
+        return Err("Q4 expert stage diagnostic requires clean embedded Git provenance".into());
+    }
+    let (artifacts, artifact_errors) = crate::qualification_artifacts(&config, &cfg);
+    if !artifact_errors.is_empty() {
+        return Err(format!(
+            "Q4 expert stage diagnostic artifact preflight failed: {}",
+            artifact_errors.join("; ")
+        )
+        .into());
+    }
+    let capacity_bytes = cfg
+        .gpu_cache
+        .vram_capacity_mb
+        .checked_mul(1024 * 1024)
+        .and_then(|bytes| u64::try_from(bytes).ok())
+        .unwrap_or(0);
+    let source_config = crate::gpu_native_greedy_parity::SourceConfigEvidence {
+        real_transformer_enabled: cfg.real_transformer.enabled,
+        gpu_native_enabled: cfg.real_transformer.gpu_native,
+        weights_dir_configured: cfg.real_transformer.weights_dir.is_some(),
+        strict_weights: cfg.real_transformer.strict_weights,
+        allow_seeded_fallback: cfg.real_transformer.allow_seeded_fallback,
+        allow_degraded_experts: cfg.real_transformer.allow_degraded_experts,
+        allow_nonfinite_attention_fallback: cfg.real_transformer.allow_nonfinite_attention_fallback,
+        allow_truncated_expert_payloads: cfg.real_transformer.allow_truncated_expert_payloads,
+        distributed_enabled: cfg.distributed.enabled,
+        gpu_cache_enabled: cfg.gpu_cache.enabled,
+        gpu_expert_capacity_bytes: capacity_bytes,
+        routed_expert_dtype: cfg.model.dtype.as_str().to_string(),
+    };
+    if !source_config.is_strict() {
+        return Err(
+            "Q4 expert stage diagnostic requires strict GPU-native Q4 configuration".into(),
+        );
+    }
+    let expert_metadata =
+        crate::qualification::read_expert_metadata(&cfg.model.data_dir.join("metadata.json"))
+            .map_err(|error| {
+                format!("stage diagnostic expert metadata preflight failed: {error}")
+            })?;
+    if expert_metadata.dtype.as_deref() != Some("q4_0")
+        || expert_metadata.q4_0_layout.as_deref() != Some(crate::inference::Q4_0_LAYOUT_STANDARD_V1)
+        || expert_metadata.explicitly_synthetic
+    {
+        return Err(
+            "Q4 expert stage diagnostic requires canonical nonsynthetic Q4_0 metadata".into(),
+        );
+    }
+    if expected_adapter_name.trim().is_empty() {
+        return Err("Q4 expert stage diagnostic requires a nonempty exact adapter name".into());
+    }
+
+    let mut gpu_spec = crate::resolve_real_cli_spec_from_config(
+        cfg,
+        RealCliRuntimeMode::IsolatedGpuNativeDiagnostic,
+    )?;
+    gpu_spec.cfg.real_transformer.gpu_native = true;
+    gpu_spec.cfg.real_transformer.compute_offload = crate::backend::ComputeOffload::Gpu;
+    let model_identity = crate::greedy_parity_model_identity(&gpu_spec);
+    if !model_identity.is_qwen3_coder_30b_a3b_q4_0() {
+        return Err(
+            "Q4 expert stage diagnostic requires exact Qwen3-Coder 30B-A3B Q4_0 geometry".into(),
+        );
+    }
+    let gpu_resolved_config_sha256 = crate::resolved_real_cli_spec_sha256(&gpu_spec)?;
+    let mut reference_spec = gpu_spec.clone();
+    reference_spec.cfg.real_transformer.gpu_native = false;
+    reference_spec.cfg.real_transformer.compute_offload = crate::backend::ComputeOffload::Cpu;
+    let reference_resolved_config_sha256 = crate::resolved_real_cli_spec_sha256(&reference_spec)?;
+    let tokenizer_path = gpu_spec
+        .cfg
+        .tokenizer
+        .path
+        .as_ref()
+        .ok_or("Q4 expert stage diagnostic requires tokenizer.path")?;
+    let tokenizer = Arc::new(crate::tokenizer::Tokenizer::from_file(tokenizer_path)?);
+
+    let gpu = execute_gpu(
+        &gpu_spec,
+        tokenizer.clone(),
+        &gpu_resolved_config_sha256,
+        &expected_adapter_name,
+        progress_watchdog,
+    )
+    .await?;
+    let reference = execute_reference_and_analyze(
+        &reference_spec,
+        tokenizer,
+        &reference_resolved_config_sha256,
+        &gpu,
+        progress_watchdog,
+    )
+    .await?;
+    let (_, executable_sha256) = crate::current_executable_identity()?;
+    let runtime = DiagnosticRuntimeEvidence {
+        gpu_token_loop: gpu.token_loop_snapshot,
+        gpu_expected_completed_token_steps: gpu.expected_completed_token_steps,
+        reference_background_shutdown: reference.background_shutdown.clone(),
+        gpu_native_background_shutdown: gpu.background_shutdown.clone(),
+    };
+    let mut failures = reference.failure.into_iter().collect::<Vec<_>>();
+    if !model_load_is_strict(&reference.model_load) || !model_load_is_strict(&gpu.model_load) {
+        failures
+            .push("one or both Q4 stage diagnostic runtimes did not load the strict model".into());
+    }
+    if runtime.gpu_token_loop.tokens_completed != runtime.gpu_expected_completed_token_steps
+        || runtime.gpu_token_loop.fatal_failures != 0
+        || runtime.gpu_token_loop.no_progress_failures != 0
+    {
+        failures.push("Q4 stage diagnostic GPU execution did not complete cleanly".into());
+    }
+    if !runtime
+        .reference_background_shutdown
+        .controlled_shutdown_requested
+        || !runtime
+            .reference_background_shutdown
+            .all_runtime_resources_released
+        || !runtime
+            .gpu_native_background_shutdown
+            .controlled_shutdown_requested
+        || !runtime
+            .gpu_native_background_shutdown
+            .all_runtime_resources_released
+    {
+        failures.push("one or both Q4 stage diagnostic runtimes failed controlled shutdown".into());
+    }
+    let failure = (!failures.is_empty()).then(|| failures.join("; "));
+    let report = Q4ExpertStageAttributionReport::new(
+        DiagnosticProvenance {
+            build,
+            executable_sha256,
+            artifacts,
+            gpu_resolved_config_sha256,
+            reference_resolved_config_sha256,
+            model_identity,
+            reference_model_load: reference.model_load,
+            gpu_native_model_load: gpu.model_load,
+            reference_background_shutdown: reference.background_shutdown,
+            gpu_native_background_shutdown: gpu.background_shutdown,
+            expert_metadata,
+            device: gpu.device,
+        },
+        frozen_bea_result_identity,
+        failure,
+        reference.targets,
+        runtime,
+        Vec::new(),
+    );
+    let diagnostic_complete = report.diagnostic_complete;
+    let failure = report.failure.clone();
+    emit_report(&report, &report_out)?;
+    if diagnostic_complete {
+        Ok(())
+    } else {
+        Err(format!(
+            "Q4 expert stage attribution incomplete: {}",
+            failure.unwrap_or_else(|| "required evidence is incomplete".into())
+        )
+        .into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn geometry() -> GpuNativeModelGeometry {
+        GpuNativeModelGeometry {
+            num_layers: 48,
+            d_model: 32,
+            d_ff: 64,
+            num_experts: 128,
+            top_k: 2,
+            num_heads: 4,
+            num_kv_heads: 2,
+            head_dim: 8,
+            rope_dim: 8,
+            vocab_size: 64,
+            max_seq_len: 128,
+            rms_eps: 1.0e-6,
+            rope_base: 1_000_000.0,
+        }
+    }
+
+    fn valid_bea_envelope() -> FrozenBeaEnvelope {
+        let limits = crate::gpu_native_semantic_parity_v2::NumericalLimits::frozen();
+        FrozenBeaEnvelope {
+            schema: crate::gpu_native_v2_holdout_failure_attribution::SCHEMA_VERSION.into(),
+            diagnostic_complete: true,
+            qualification_pass: false,
+            provenance: FrozenProvenanceEnvelope {
+                build: FrozenBuildEnvelope {
+                    git_sha: Some(FROZEN_BEA_BUILD_SHA.into()),
+                },
+            },
+            frozen_v2_result_identity: FrozenV2IdentityEnvelope {
+                report_artifact: FrozenArtifactEnvelope {
+                    sha256:
+                        crate::gpu_native_v2_holdout_failure_attribution::FROZEN_V2_REPORT_SHA256
+                            .into(),
+                },
+                expected_report_sha256_argument:
+                    crate::gpu_native_v2_holdout_failure_attribution::FROZEN_V2_REPORT_SHA256.into(),
+                expected_schema: crate::gpu_native_semantic_parity_v2::SCHEMA_VERSION.into(),
+                frozen_build_sha:
+                    crate::gpu_native_v2_holdout_failure_attribution::FROZEN_V2_BUILD_SHA.into(),
+                qualification_pass: false,
+                holdout_corpus_id: crate::gpu_native_semantic_parity_v2::HOLDOUT_CORPUS_ID.into(),
+                holdout_corpus_sha256: crate::gpu_native_semantic_parity_v2::HOLDOUT_CORPUS_SHA256
+                    .into(),
+                numerical_limits: FrozenNumericalLimitsEnvelope {
+                    max_absolute_error_limit: limits.max_absolute_error_limit,
+                    rms_error_limit: limits.rms_error_limit,
+                    mean_absolute_error_limit: limits.mean_absolute_error_limit,
+                    nonfinite_mismatch_limit: limits.nonfinite_mismatch_limit,
+                    semantic_correctness_not_bit_parity: limits.semantic_correctness_not_bit_parity,
+                },
+                immutable_input_verified: true,
+            },
+        }
+    }
+
+    #[test]
+    fn schema_and_qualification_contract_are_versioned_and_false() {
+        assert_eq!(
+            SCHEMA_VERSION,
+            "mer.gpu-native-q4-expert-stage-attribution.v1"
+        );
+        assert_eq!(MODE, "diagnose-gpu-native-q4-expert-stages");
+        assert!(!QUALIFICATION_PASS);
+        assert!(!ProductionSemanticsEvidence::default().qualification_threshold_introduced);
+    }
+
+    #[test]
+    fn frozen_target_list_is_exactly_q1_through_q4_and_r1_through_r5() {
+        assert_eq!(FROZEN_TARGETS.len(), 9);
+        assert_eq!(
+            FROZEN_TARGETS.map(|target| (
+                target.id,
+                target.case,
+                target.generated_position,
+                target.layer,
+                target.frozen_worst_local_expert,
+            )),
+            [
+                ("Q1", "postgres-window-holdout", 13, 47, Some(28)),
+                ("Q2", "spanish-refactor-holdout", 11, 47, Some(58)),
+                ("Q3", "spanish-refactor-holdout", 13, 47, Some(28)),
+                ("Q4", "spanish-refactor-holdout", 15, 47, Some(116)),
+                ("R1", "rust-ownership-holdout", 1, 0, None),
+                ("R2", "rust-ownership-holdout", 1, 19, None),
+                ("R3", "rust-ownership-holdout", 1, 33, None),
+                ("R4", "rust-ownership-holdout", 1, 40, None),
+                ("R5", "rust-ownership-holdout", 1, 44, None),
+            ]
+        );
+    }
+
+    #[test]
+    fn frozen_bea_envelope_validation_is_fail_closed() {
+        assert!(validate_expected_bea_report_sha_argument(FROZEN_BEA_REPORT_SHA256).is_ok());
+        assert!(validate_expected_bea_report_sha_argument(&"0".repeat(64)).is_err());
+        let mut envelope = valid_bea_envelope();
+        assert!(validate_bea_envelope(&envelope).is_ok());
+        envelope.diagnostic_complete = false;
+        assert!(validate_bea_envelope(&envelope).is_err());
+        envelope = valid_bea_envelope();
+        envelope.schema.push_str("-drift");
+        assert!(validate_bea_envelope(&envelope).is_err());
+        envelope = valid_bea_envelope();
+        envelope.provenance.build.git_sha = Some("0".repeat(40));
+        assert!(validate_bea_envelope(&envelope).is_err());
+        envelope = valid_bea_envelope();
+        envelope.frozen_v2_result_identity.immutable_input_verified = false;
+        assert!(validate_bea_envelope(&envelope).is_err());
+    }
+
+    #[test]
+    fn stage_layout_preserves_route_rank_and_expert_id() {
+        let layout = Q4ExpertStageTraceLayout::try_new(geometry(), &[0, 19]).unwrap();
+        assert_eq!(layout.targets.len(), 2);
+        assert_eq!(layout.stage_elements(), 2 * (3 * 64 + 32));
+        let mut bytes = vec![0u8; layout.total_bytes as usize];
+        for target in &layout.targets {
+            let ids = [17u32, 9u32];
+            for (index, id) in ids.into_iter().enumerate() {
+                let start = target.selected_ids_offset as usize + index * 4;
+                bytes[start..start + 4].copy_from_slice(&id.to_le_bytes());
+            }
+            for index in 0..layout.stage_elements() {
+                let value = (target.layer * 10_000 + index) as f32;
+                let start = target.stages_offset as usize + index * 4;
+                bytes[start..start + 4].copy_from_slice(&value.to_bits().to_le_bytes());
+            }
+        }
+        let trace = layout.parse(&bytes).unwrap();
+        assert_eq!(trace.targets[0].selected_ids, vec![17, 9]);
+        assert_eq!(trace.targets[0].routes[0].expert_id, 17);
+        assert_eq!(trace.targets[0].routes[1].expert_id, 9);
+        assert_eq!(trace.targets[0].routes[0].gate.len(), 64);
+        assert_eq!(trace.targets[0].routes[0].down_len_for_test(), 32);
+    }
+
+    #[test]
+    fn route_pairing_requires_exact_order_and_never_repairs() {
+        assert_eq!(
+            pair_routes_by_expert_id(&[28, 7], &[28, 7]).unwrap(),
+            vec![0, 1]
+        );
+        assert!(pair_routes_by_expert_id(&[28, 7], &[7, 28]).is_err());
+        assert!(pair_routes_by_expert_id(&[28, 7], &[28, 28]).is_err());
+    }
+
+    #[test]
+    fn boundary_equality_is_exact_and_cannot_coerce_mismatch() {
+        assert!(exact_bits_equal(&[1.0, -0.0], &[1.0, -0.0]));
+        assert!(!exact_bits_equal(&[1.0, -0.0], &[1.0, 0.0]));
+        assert!(!exact_bits_equal(&[1.0], &[1.0, 2.0]));
+    }
+
+    #[test]
+    fn non_bit_equal_zero_error_does_not_name_a_stage() {
+        let zero_sign = VectorNumericalEvidence::compare("left", "right", &[-0.0], &[0.0]).unwrap();
+        assert!(!zero_sign.exact_bit_equal);
+        assert_eq!(
+            derive_attribution(
+                true, &zero_sign, &zero_sign, &zero_sign, &zero_sign, &zero_sign, &zero_sign,
+            ),
+            StageAttribution::NoMaterialLocalization
+        );
+    }
+
+    #[test]
+    fn attribution_uses_comparative_replay_growth_without_a_threshold() {
+        let same = VectorNumericalEvidence::compare("left", "right", &[1.0], &[1.0]).unwrap();
+        let drift = VectorNumericalEvidence::compare("left", "right", &[1.0], &[2.0]).unwrap();
+        assert_eq!(
+            derive_attribution(true, &drift, &same, &drift, &drift, &same, &same,),
+            StageAttribution::GateProjectionDrift
+        );
+        assert_eq!(
+            derive_attribution(true, &drift, &same, &drift, &drift, &drift, &same,),
+            StageAttribution::MultiStageDrift
+        );
+    }
+
+    #[test]
+    fn dot_emulator_statuses_are_descriptive_and_rejected() {
+        assert_eq!(
+            crate::inference::DiagnosticQ4DotArithmetic::CurrentGpu.status(),
+            "descriptive-current-production-gpu-q4-arithmetic"
+        );
+        assert_eq!(
+            crate::inference::DiagnosticQ4DotArithmetic::RejectedLogicalDequant.status(),
+            "rejected-software-hypothesis-diagnostic-only-not-production"
+        );
+    }
+}
+
+#[cfg(test)]
+impl Q4ExpertStageGpuRouteTrace {
+    fn down_len_for_test(&self) -> usize {
+        self.diagnostic_down.len()
+    }
+}

--- a/rust-engine/src/gpu_native_real_benchmark.rs
+++ b/rust-engine/src/gpu_native_real_benchmark.rs
@@ -20,10 +20,14 @@ use crate::qualification::{
 use serde::Serialize;
 use std::path::PathBuf;
 
-pub(crate) const SCHEMA: &str = "mer.gpu-native-real-benchmark.v2";
+pub(crate) const SCHEMA: &str = "mer.gpu-native-real-benchmark.v4";
 pub(crate) const MODE: &str = "gpu-native-real-benchmark";
-pub(crate) const OPTIMIZATION: &str = "gpu-native-resumable-recovery-pr1";
-pub(crate) const BASELINE_COMMIT: &str = "db0664159fe4a57e5b630984b9229e233fa21487";
+pub(crate) const OPTIMIZATION: &str = "gpu-native-physical-source-of-truth-pr1bb";
+pub(crate) const IMMEDIATE_COMPARISON_COMMIT: &str = "a39c58062ce167773248d3fa5618ac5fd55e54ba";
+pub(crate) const PR1B_A_EXPERIMENT_COMMIT: &str = "9b1a1da029151dacbb1ad49a562d4eb60e80e260";
+pub(crate) const PR1B_A_EXPERIMENT_REPORT_SHA256: &str =
+    "ac98c83c52df95967a315452517fb2556e82771aa49c5a5b1ab239fa1b3ec4e4";
+pub(crate) const ORIGINAL_BASELINE_COMMIT: &str = "db0664159fe4a57e5b630984b9229e233fa21487";
 
 const EXPECTED_NUM_LAYERS: usize = 48;
 const EXPECTED_NUM_EXPERTS: usize = 128;
@@ -86,7 +90,7 @@ pub(crate) struct ProductionSemantics {
 }
 
 impl ProductionSemantics {
-    pub(crate) const fn resumable_recovery_pr1() -> Self {
+    pub(crate) const fn physical_source_of_truth_pr1bb() -> Self {
         Self {
             production_inference_math_changed: false,
             production_q4_changed: false,
@@ -94,7 +98,7 @@ impl ProductionSemantics {
             production_attention_changed: false,
             production_rmsnorm_changed: false,
             production_lm_head_changed: false,
-            production_residency_policy_changed: false,
+            production_residency_policy_changed: true,
             production_replay_policy_changed: true,
             production_prefetch_policy_changed: false,
             diagnostic_trace_enabled: false,
@@ -720,6 +724,9 @@ impl EngineStorageSnapshot {
 pub(crate) struct GpuNativeResidencyDelta {
     pub(crate) vram_hits: u64,
     pub(crate) vram_misses: u64,
+    pub(crate) physical_current_hits: u64,
+    pub(crate) physical_source_acquisitions: u64,
+    pub(crate) logical_admissions_for_physical_misses: u64,
     pub(crate) ram_to_vram_installs: u64,
     pub(crate) physical_evictions: u64,
     pub(crate) physical_reinstalls: u64,
@@ -738,6 +745,24 @@ fn gpu_native_residency_delta(
     Ok(GpuNativeResidencyDelta {
         vram_hits: checked_delta!(after, before, vram_hits, "gpu-native-residency"),
         vram_misses: checked_delta!(after, before, vram_misses, "gpu-native-residency"),
+        physical_current_hits: checked_delta!(
+            after,
+            before,
+            physical_current_hits,
+            "gpu-native-residency"
+        ),
+        physical_source_acquisitions: checked_delta!(
+            after,
+            before,
+            physical_source_acquisitions,
+            "gpu-native-residency"
+        ),
+        logical_admissions_for_physical_misses: checked_delta!(
+            after,
+            before,
+            logical_admissions_for_physical_misses,
+            "gpu-native-residency"
+        ),
         ram_to_vram_installs: checked_delta!(
             after,
             before,
@@ -1120,7 +1145,10 @@ pub(crate) struct BenchmarkReport {
     pub(crate) schema: &'static str,
     pub(crate) mode: &'static str,
     pub(crate) optimization: &'static str,
-    pub(crate) baseline_commit: &'static str,
+    pub(crate) immediate_comparison_commit: &'static str,
+    pub(crate) pr1b_a_experiment_commit: &'static str,
+    pub(crate) pr1b_a_experiment_report_sha256: &'static str,
+    pub(crate) original_baseline_commit: &'static str,
     pub(crate) benchmark_complete: bool,
     pub(crate) failure: Option<BenchmarkFailure>,
     pub(crate) qualification_pass: bool,
@@ -1158,7 +1186,10 @@ impl BenchmarkReport {
             schema: SCHEMA,
             mode: MODE,
             optimization: OPTIMIZATION,
-            baseline_commit: BASELINE_COMMIT,
+            immediate_comparison_commit: IMMEDIATE_COMPARISON_COMMIT,
+            pr1b_a_experiment_commit: PR1B_A_EXPERIMENT_COMMIT,
+            pr1b_a_experiment_report_sha256: PR1B_A_EXPERIMENT_REPORT_SHA256,
+            original_baseline_commit: ORIGINAL_BASELINE_COMMIT,
             benchmark_complete: false,
             failure: None,
             qualification_pass: false,
@@ -1178,7 +1209,7 @@ impl BenchmarkReport {
             aggregate: None,
             runtime_contract: None,
             production_configuration,
-            production_semantics: ProductionSemantics::resumable_recovery_pr1(),
+            production_semantics: ProductionSemantics::physical_source_of_truth_pr1bb(),
         }
     }
 
@@ -2440,6 +2471,39 @@ mod tests {
     }
 
     #[test]
+    fn physical_source_of_truth_counters_are_reported_without_speculation() {
+        let before = GpuNativeTieredResidencySnapshot {
+            vram_hits: 10,
+            vram_misses: 4,
+            physical_current_hits: 10,
+            physical_source_acquisitions: 4,
+            logical_admissions_for_physical_misses: 3,
+            ram_to_vram_installs: 4,
+            ..GpuNativeTieredResidencySnapshot::default()
+        };
+        let after = GpuNativeTieredResidencySnapshot {
+            vram_hits: 17,
+            vram_misses: 6,
+            physical_current_hits: 17,
+            physical_source_acquisitions: 6,
+            logical_admissions_for_physical_misses: 5,
+            ram_to_vram_installs: 6,
+            ..before.clone()
+        };
+        let delta = gpu_native_residency_delta(&before, &after).unwrap();
+        assert_eq!(delta.vram_hits, 7);
+        assert_eq!(delta.vram_misses, 2);
+        assert_eq!(delta.physical_current_hits, 7);
+        assert_eq!(delta.physical_source_acquisitions, 2);
+        assert_eq!(delta.logical_admissions_for_physical_misses, 2);
+        assert_eq!(delta.ram_to_vram_installs, 2);
+        assert_eq!(delta.speculative_requests, 0);
+        assert_eq!(delta.speculative_vram_hits, 0);
+        assert_eq!(delta.speculative_ram_to_vram_installs, 0);
+        assert_eq!(delta.speculative_dropped_capacity_or_pressure, 0);
+    }
+
+    #[test]
     fn cache_reset_semantics_define_runtime_construction_count() {
         assert_eq!(
             expected_runtime_constructions(crate::BenchRealCacheReset::Keep, 3, 4),
@@ -2795,7 +2859,7 @@ mod tests {
         assert!(!report.production_semantics.production_rmsnorm_changed);
         assert!(!report.production_semantics.production_lm_head_changed);
         assert!(
-            !report
+            report
                 .production_semantics
                 .production_residency_policy_changed
         );
@@ -2810,7 +2874,20 @@ mod tests {
         assert_eq!(json["correctness_qualification_pending"], true);
         assert_eq!(json["schema"], SCHEMA);
         assert_eq!(json["optimization"], OPTIMIZATION);
-        assert_eq!(json["baseline_commit"], BASELINE_COMMIT);
+        assert_eq!(
+            json["immediate_comparison_commit"],
+            IMMEDIATE_COMPARISON_COMMIT
+        );
+        assert_eq!(json["pr1b_a_experiment_commit"], PR1B_A_EXPERIMENT_COMMIT);
+        assert_eq!(
+            json["pr1b_a_experiment_report_sha256"],
+            PR1B_A_EXPERIMENT_REPORT_SHA256
+        );
+        assert_eq!(json["original_baseline_commit"], ORIGINAL_BASELINE_COMMIT);
+        assert_eq!(
+            json["production_semantics"]["production_residency_policy_changed"],
+            true
+        );
         assert_eq!(
             json["production_semantics"]["production_replay_policy_changed"],
             true

--- a/rust-engine/src/gpu_native_real_benchmark.rs
+++ b/rust-engine/src/gpu_native_real_benchmark.rs
@@ -1,0 +1,2582 @@
+//! Benchmark-only reporting and orchestration for the production GPU-native
+//! real-model token loop.
+//!
+//! This module does not define an inference variant. The command path creates
+//! an ordinary [`crate::gpu_native_token_loop::GpuNativeRequestState`] and
+//! calls only [`crate::gpu_native_token_loop::GpuNativeTokenLoop::step_token`].
+
+use crate::backend::{GpuDeviceIdentity, GpuExpertIoSnapshot, GpuExpertMemorySnapshot};
+use crate::engine::RoutedExpertExecutionSnapshot;
+use crate::gpu_native_residency::GpuNativeTieredResidencySnapshot;
+use crate::gpu_native_token_loop::{GpuNativeModelGeometry, GpuNativeTokenLoopSnapshot};
+use crate::greedy_parity::{
+    BackgroundShutdownEvidence, ModelIdentityEvidence, ModelLoadEvidence, RuntimeCacheSnapshot,
+};
+use crate::qualification::{
+    BuildProvenance, ExecutionPlanEvidence, ExpertMetadataEvidence, QualificationArtifacts,
+};
+use serde::Serialize;
+use std::path::PathBuf;
+
+pub(crate) const SCHEMA: &str = "mer.gpu-native-real-benchmark.v1";
+pub(crate) const MODE: &str = "gpu-native-real-benchmark";
+
+const EXPECTED_NUM_LAYERS: usize = 48;
+const EXPECTED_NUM_EXPERTS: usize = 128;
+const EXPECTED_TOP_K: usize = 8;
+const EXPECTED_D_MODEL: usize = 2048;
+const EXPECTED_D_FF: usize = 768;
+
+#[derive(Clone, Debug)]
+pub(crate) struct CommandArgs {
+    pub(crate) config: PathBuf,
+    pub(crate) prompt: Option<String>,
+    pub(crate) request_json: Option<PathBuf>,
+    pub(crate) output_tokens: Option<usize>,
+    pub(crate) warmup_runs: usize,
+    pub(crate) measured_runs: usize,
+    pub(crate) cache_reset: crate::BenchRealCacheReset,
+    pub(crate) greedy: bool,
+    pub(crate) expected_adapter_name: String,
+    pub(crate) report_out: Option<PathBuf>,
+    pub(crate) progress_watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct BenchmarkFailure {
+    pub(crate) stage: String,
+    pub(crate) code: String,
+    pub(crate) detail: String,
+}
+
+impl BenchmarkFailure {
+    pub(crate) fn new(stage: &str, code: &str, detail: impl Into<String>) -> Self {
+        Self {
+            stage: stage.to_string(),
+            code: code.to_string(),
+            detail: detail.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for BenchmarkFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.code, self.detail)
+    }
+}
+
+impl std::error::Error for BenchmarkFailure {}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+pub(crate) struct ProductionSemantics {
+    pub(crate) production_inference_math_changed: bool,
+    pub(crate) production_q4_changed: bool,
+    pub(crate) production_router_changed: bool,
+    pub(crate) production_attention_changed: bool,
+    pub(crate) production_rmsnorm_changed: bool,
+    pub(crate) production_lm_head_changed: bool,
+    pub(crate) production_residency_policy_changed: bool,
+    pub(crate) production_replay_policy_changed: bool,
+    pub(crate) production_prefetch_policy_changed: bool,
+    pub(crate) diagnostic_trace_enabled: bool,
+}
+
+impl ProductionSemantics {
+    pub(crate) const fn baseline() -> Self {
+        Self {
+            production_inference_math_changed: false,
+            production_q4_changed: false,
+            production_router_changed: false,
+            production_attention_changed: false,
+            production_rmsnorm_changed: false,
+            production_lm_head_changed: false,
+            production_residency_policy_changed: false,
+            production_replay_policy_changed: false,
+            production_prefetch_policy_changed: false,
+            diagnostic_trace_enabled: false,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct BenchmarkProvenance {
+    pub(crate) build: BuildProvenance,
+    pub(crate) executable_canonical_path: String,
+    pub(crate) executable_sha256: String,
+    pub(crate) resolved_config_sha256: String,
+    pub(crate) artifacts: QualificationArtifacts,
+    pub(crate) expert_metadata: ExpertMetadataEvidence,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct RequestEvidence {
+    pub(crate) prompt_sha256: String,
+    pub(crate) prompt_token_ids_sha256: String,
+    pub(crate) prompt_token_count: usize,
+    pub(crate) requested_output_tokens: usize,
+    pub(crate) greedy: bool,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub(crate) struct CacheResidencyConfiguration {
+    pub(crate) ram_cache_slots: usize,
+    pub(crate) block_align: usize,
+    pub(crate) direct_io: bool,
+    pub(crate) pipeline_depth: u32,
+    pub(crate) partial_load_fraction: f64,
+    pub(crate) pin_after_observations: u64,
+    pub(crate) packed_blob: Option<String>,
+    pub(crate) packed_manifest: Option<String>,
+    pub(crate) gpu_cache_enabled: bool,
+    pub(crate) gpu_vram_capacity_mb: usize,
+    pub(crate) gpu_vram_anchor_ratio: f32,
+    pub(crate) gpu_promote_after_hits: u64,
+    pub(crate) gpu_cache_dtype: String,
+    pub(crate) gpu_native_max_seq_len: usize,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub(crate) struct PredictorPrefetchConfiguration {
+    pub(crate) predict_fanout: usize,
+    pub(crate) predict_min_prob: f64,
+    pub(crate) max_concurrent_prefetches: usize,
+    pub(crate) max_fetch_yields: usize,
+    pub(crate) locality_enabled: bool,
+    pub(crate) locality_window: usize,
+    pub(crate) locality_threshold_pct: f32,
+    pub(crate) speculator_enabled: bool,
+    pub(crate) speculator_hidden_dim: usize,
+    pub(crate) speculator_top_k: usize,
+    pub(crate) affinity_enabled: bool,
+    pub(crate) affinity_neighbors_k: usize,
+    pub(crate) affinity_decay_epoch: u64,
+    pub(crate) prefetch_governor: bool,
+    pub(crate) prefetch_precision_floor: f64,
+    pub(crate) prefetch_contention_weight: f64,
+    pub(crate) cost_aware_eviction: bool,
+    pub(crate) pregate_enabled: bool,
+    pub(crate) static_residency_fraction: f64,
+    pub(crate) static_residency_warmup_tokens: u64,
+    pub(crate) static_residency_profile: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub(crate) struct ProductionConfiguration {
+    pub(crate) q4_dtype: String,
+    pub(crate) q4_layout: Option<String>,
+    pub(crate) cache_residency: CacheResidencyConfiguration,
+    pub(crate) predictor_prefetch: PredictorPrefetchConfiguration,
+}
+
+impl ProductionConfiguration {
+    pub(crate) fn from_config(
+        cfg: &crate::config::Config,
+        metadata: &ExpertMetadataEvidence,
+    ) -> Self {
+        Self {
+            q4_dtype: cfg.model.dtype.as_str().to_string(),
+            q4_layout: metadata.q4_0_layout.clone(),
+            cache_residency: CacheResidencyConfiguration {
+                ram_cache_slots: cfg.storage.cache_slots,
+                block_align: cfg.storage.block_align,
+                direct_io: !cfg.storage.no_direct,
+                pipeline_depth: cfg.storage.pipeline_depth,
+                partial_load_fraction: cfg.storage.partial_load_fraction,
+                pin_after_observations: cfg.storage.pin_after_observations,
+                packed_blob: cfg
+                    .storage
+                    .packed_blob
+                    .as_ref()
+                    .map(|path| path.display().to_string()),
+                packed_manifest: cfg
+                    .storage
+                    .packed_manifest
+                    .as_ref()
+                    .map(|path| path.display().to_string()),
+                gpu_cache_enabled: cfg.gpu_cache.enabled,
+                gpu_vram_capacity_mb: cfg.gpu_cache.vram_capacity_mb,
+                gpu_vram_anchor_ratio: cfg.gpu_cache.vram_anchor_ratio,
+                gpu_promote_after_hits: cfg.gpu_cache.promote_after_hits,
+                gpu_cache_dtype: cfg.gpu_cache.dtype.clone(),
+                gpu_native_max_seq_len: cfg.real_transformer.gpu_native_max_seq_len,
+            },
+            predictor_prefetch: PredictorPrefetchConfiguration {
+                predict_fanout: cfg.storage.predict_fanout,
+                predict_min_prob: cfg.storage.predict_min_prob,
+                max_concurrent_prefetches: cfg.real_transformer.max_concurrent_prefetches,
+                max_fetch_yields: cfg.real_transformer.max_fetch_yields,
+                locality_enabled: cfg.predictive.locality_enabled,
+                locality_window: cfg.predictive.locality_window,
+                locality_threshold_pct: cfg.predictive.locality_threshold_pct,
+                speculator_enabled: cfg.predictive.speculator_enabled,
+                speculator_hidden_dim: cfg.predictive.speculator_hidden_dim,
+                speculator_top_k: cfg.predictive.speculator_top_k,
+                affinity_enabled: cfg.predictive.affinity_enabled,
+                affinity_neighbors_k: cfg.predictive.affinity_neighbors_k,
+                affinity_decay_epoch: cfg.predictive.affinity_decay_epoch,
+                prefetch_governor: cfg.predictive.prefetch_governor,
+                prefetch_precision_floor: cfg.predictive.prefetch_precision_floor,
+                prefetch_contention_weight: cfg.predictive.prefetch_contention_weight,
+                cost_aware_eviction: cfg.predictive.cost_aware_eviction,
+                pregate_enabled: cfg.predictive.pregate_enabled,
+                static_residency_fraction: cfg.predictive.static_residency_fraction,
+                static_residency_warmup_tokens: cfg.predictive.static_residency_warmup_tokens,
+                static_residency_profile: cfg.predictive.static_residency_profile.clone(),
+            },
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct RuntimeContractInput {
+    pub(crate) real_transformer_enabled: bool,
+    pub(crate) real_transformer_gpu_native: bool,
+    pub(crate) compute_offload: crate::backend::ComputeOffload,
+    pub(crate) legacy_execution_plan: ExecutionPlanEvidence,
+    pub(crate) token_loop_geometry: Option<GpuNativeModelGeometry>,
+    pub(crate) authoritative_device: Option<GpuDeviceIdentity>,
+    pub(crate) model_load: ModelLoadEvidence,
+    pub(crate) routed_failure_policy: crate::engine::RoutedExpertGpuFailurePolicy,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct RuntimeContractEvidence {
+    pub(crate) real_transformer_enabled: bool,
+    pub(crate) real_transformer_gpu_native: bool,
+    pub(crate) compute_offload: String,
+    pub(crate) ordinary_step_token_only: bool,
+    pub(crate) legacy_execution_plan: ExecutionPlanEvidence,
+    pub(crate) token_loop_geometry: GpuNativeModelGeometry,
+    pub(crate) strict_fail_closed_routed_experts: bool,
+}
+
+pub(crate) fn validate_runtime_contract(
+    input: &RuntimeContractInput,
+    expected_adapter_name: &str,
+) -> Result<(RuntimeContractEvidence, GpuDeviceIdentity), BenchmarkFailure> {
+    if expected_adapter_name.trim().is_empty() {
+        return Err(BenchmarkFailure::new(
+            "preflight",
+            "missing-expected-adapter",
+            "bench-gpu-native-real requires a nonempty exact adapter name",
+        ));
+    }
+    if !input.real_transformer_enabled
+        || !input.real_transformer_gpu_native
+        || input.compute_offload != crate::backend::ComputeOffload::Gpu
+    {
+        return Err(BenchmarkFailure::new(
+            "startup",
+            "gpu-native-runtime-contract",
+            format!(
+                "requires real_transformer.enabled=true, gpu_native=true, and compute_offload=gpu; observed enabled={} gpu_native={} compute_offload={:?}",
+                input.real_transformer_enabled,
+                input.real_transformer_gpu_native,
+                input.compute_offload,
+            ),
+        ));
+    }
+
+    // ExecutionPlanEvidence is retained as legacy context evidence. Its CPU
+    // markers are not interpreted as placement of the separate authoritative
+    // GPU-native full-token loop.
+    let plan = &input.legacy_execution_plan;
+    if plan.requested != "gpu"
+        || plan.resolved != "gpu"
+        || plan.embeddings != "cpu"
+        || plan.lm_head != "cpu"
+        || plan.dense_projections != "cpu"
+        || plan.attention != "gpu"
+        || plan.kv != "gpu"
+        || plan.router != "cpu"
+        || plan.routed_experts != "cpu"
+        || plan.routed_expert_dtype != "q4_0"
+        || plan.fallback_occurred
+    {
+        return Err(BenchmarkFailure::new(
+            "startup",
+            "legacy-execution-context-contract",
+            format!(
+                "legacy execution-context evidence drifted from the corrected GPU-native contract: {plan:?}"
+            ),
+        ));
+    }
+
+    let geometry = input.token_loop_geometry.ok_or_else(|| {
+        BenchmarkFailure::new(
+            "startup",
+            "missing-gpu-native-token-loop",
+            "authoritative runtime did not construct gpu_native_token_loop",
+        )
+    })?;
+    if geometry.num_layers != EXPECTED_NUM_LAYERS
+        || geometry.num_experts != EXPECTED_NUM_EXPERTS
+        || geometry.top_k != EXPECTED_TOP_K
+        || geometry.d_model != EXPECTED_D_MODEL
+        || geometry.d_ff != EXPECTED_D_FF
+    {
+        return Err(BenchmarkFailure::new(
+            "startup",
+            "wrong-model-geometry",
+            format!(
+                "expected Qwen geometry layers={EXPECTED_NUM_LAYERS} experts={EXPECTED_NUM_EXPERTS} top_k={EXPECTED_TOP_K} d_model={EXPECTED_D_MODEL} d_ff={EXPECTED_D_FF}; observed {geometry:?}"
+            ),
+        ));
+    }
+
+    let load = &input.model_load;
+    if !load.strict
+        || load.required_tensors == 0
+        || load.loaded_tensors != load.required_tensors
+        || load.seeded_fallback_remained
+        || load.loader == "seeded"
+    {
+        return Err(BenchmarkFailure::new(
+            "startup",
+            "incomplete-model-load",
+            format!("strict real checkpoint load was incomplete: {load:?}"),
+        ));
+    }
+    if input.routed_failure_policy != crate::engine::RoutedExpertGpuFailurePolicy::StrictFailClosed
+    {
+        return Err(BenchmarkFailure::new(
+            "startup",
+            "cpu-fallback-policy-enabled",
+            "routed-expert failure policy was not strict-fail-closed",
+        ));
+    }
+
+    let device = input.authoritative_device.clone().ok_or_else(|| {
+        BenchmarkFailure::new(
+            "startup",
+            "missing-authoritative-adapter",
+            "authoritative GPU device identity was unavailable",
+        )
+    })?;
+    if device.name != expected_adapter_name {
+        return Err(BenchmarkFailure::new(
+            "startup",
+            "wrong-adapter",
+            format!(
+                "selected adapter {:?} did not equal expected adapter {:?}",
+                device.name, expected_adapter_name
+            ),
+        ));
+    }
+    if device.software_adapter || device.device_type.eq_ignore_ascii_case("cpu") {
+        return Err(BenchmarkFailure::new(
+            "startup",
+            "software-adapter",
+            format!("selected adapter is not authoritative hardware: {device:?}"),
+        ));
+    }
+    if device.wgpu_backend != "vulkan"
+        || device.compute_plane != "wgpu-vulkan"
+        || device.driver.trim().is_empty()
+    {
+        return Err(BenchmarkFailure::new(
+            "startup",
+            "wrong-gpu-backend",
+            format!(
+                "requires wgpu_backend=vulkan, compute_plane=wgpu-vulkan, and nonempty driver identity; observed {device:?}"
+            ),
+        ));
+    }
+    if expected_adapter_name == "NVIDIA L4"
+        && (device.name != "NVIDIA L4"
+            || device.vendor_id != 0x10de
+            || device.device_type != "DiscreteGpu")
+    {
+        return Err(BenchmarkFailure::new(
+            "startup",
+            "wrong-l4-hardware",
+            format!("expected an NVIDIA L4 discrete GPU; observed {device:?}"),
+        ));
+    }
+
+    Ok((
+        RuntimeContractEvidence {
+            real_transformer_enabled: input.real_transformer_enabled,
+            real_transformer_gpu_native: input.real_transformer_gpu_native,
+            compute_offload: "gpu".to_string(),
+            ordinary_step_token_only: true,
+            legacy_execution_plan: input.legacy_execution_plan.clone(),
+            token_loop_geometry: geometry,
+            strict_fail_closed_routed_experts: true,
+        },
+        device,
+    ))
+}
+
+pub(crate) fn validate_source_config(cfg: &crate::config::Config) -> Result<(), BenchmarkFailure> {
+    let rt = &cfg.real_transformer;
+    if !rt.enabled
+        || !rt.gpu_native
+        || rt.compute_offload != crate::backend::ComputeOffload::Gpu
+        || rt.weights_dir.is_none()
+        || !rt.strict_weights
+        || rt.allow_seeded_fallback
+        || rt.allow_degraded_experts
+        || rt.allow_nonfinite_attention_fallback
+        || rt.allow_truncated_expert_payloads
+        || cfg.distributed.enabled
+        || !cfg.gpu_cache.enabled
+        || cfg.gpu_cache.vram_capacity_mb == 0
+        || cfg.model.dtype != crate::inference::WeightDtype::Q4_0
+    {
+        return Err(BenchmarkFailure::new(
+            "preflight",
+            "strict-gpu-native-config-required",
+            "requires enabled strict real checkpoint inference, gpu_native=true, compute_offload=gpu, Q4_0 routed experts, enabled nonzero GPU cache, no distributed mode, and every fail-open policy disabled",
+        ));
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy, Debug, Default, Serialize)]
+pub(crate) struct CounterRatios {
+    pub(crate) attempts_per_completed_position: f64,
+    pub(crate) misses_per_completed_position: f64,
+    pub(crate) replays_per_completed_position: f64,
+    pub(crate) submissions_per_completed_position: f64,
+}
+
+impl CounterRatios {
+    fn from_delta(delta: GpuNativeTokenLoopSnapshot) -> Result<Self, BenchmarkFailure> {
+        if delta.tokens_completed == 0 {
+            return Err(BenchmarkFailure::new(
+                "postcondition",
+                "zero-completed-positions",
+                "token-loop counter delta completed zero positions",
+            ));
+        }
+        let completed = delta.tokens_completed as f64;
+        Ok(Self {
+            attempts_per_completed_position: delta.token_attempts as f64 / completed,
+            misses_per_completed_position: delta.residency_miss_attempts as f64 / completed,
+            replays_per_completed_position: delta.replay_attempts as f64 / completed,
+            submissions_per_completed_position: delta.queue_submissions as f64 / completed,
+        })
+    }
+}
+
+macro_rules! checked_delta {
+    ($after:expr, $before:expr, $field:ident, $label:expr) => {
+        $after.$field.checked_sub($before.$field).ok_or_else(|| {
+            BenchmarkFailure::new(
+                "postcondition",
+                "counter-regression",
+                format!("{} counter {} regressed", $label, stringify!($field)),
+            )
+        })?
+    };
+}
+
+pub(crate) fn token_loop_delta(
+    before: GpuNativeTokenLoopSnapshot,
+    after: GpuNativeTokenLoopSnapshot,
+) -> Result<GpuNativeTokenLoopSnapshot, BenchmarkFailure> {
+    Ok(GpuNativeTokenLoopSnapshot {
+        token_attempts: checked_delta!(after, before, token_attempts, "token-loop"),
+        tokens_completed: checked_delta!(after, before, tokens_completed, "token-loop"),
+        warm_tokens_completed: checked_delta!(after, before, warm_tokens_completed, "token-loop"),
+        residency_miss_attempts: checked_delta!(
+            after,
+            before,
+            residency_miss_attempts,
+            "token-loop"
+        ),
+        replay_attempts: checked_delta!(after, before, replay_attempts, "token-loop"),
+        residency_services: checked_delta!(after, before, residency_services, "token-loop"),
+        fatal_failures: checked_delta!(after, before, fatal_failures, "token-loop"),
+        no_progress_failures: checked_delta!(after, before, no_progress_failures, "token-loop"),
+        queue_submissions: checked_delta!(after, before, queue_submissions, "token-loop"),
+        boundary_maps: checked_delta!(after, before, boundary_maps, "token-loop"),
+        boundary_readbacks: checked_delta!(after, before, boundary_readbacks, "token-loop"),
+    })
+}
+
+pub(crate) fn routed_delta(
+    before: RoutedExpertExecutionSnapshot,
+    after: RoutedExpertExecutionSnapshot,
+) -> Result<RoutedExpertExecutionSnapshot, BenchmarkFailure> {
+    Ok(RoutedExpertExecutionSnapshot {
+        selected_routed_experts: checked_delta!(
+            after,
+            before,
+            selected_routed_experts,
+            "routed-execution"
+        ),
+        gpu_dispatch_attempts: checked_delta!(
+            after,
+            before,
+            gpu_dispatch_attempts,
+            "routed-execution"
+        ),
+        gpu_dispatch_successes: checked_delta!(
+            after,
+            before,
+            gpu_dispatch_successes,
+            "routed-execution"
+        ),
+        gpu_dispatch_failures: checked_delta!(
+            after,
+            before,
+            gpu_dispatch_failures,
+            "routed-execution"
+        ),
+        cpu_routed_expert_dispatches: checked_delta!(
+            after,
+            before,
+            cpu_routed_expert_dispatches,
+            "routed-execution"
+        ),
+        gpu_cpu_fallbacks: checked_delta!(after, before, gpu_cpu_fallbacks, "routed-execution"),
+        degraded_expert_substitutions: checked_delta!(
+            after,
+            before,
+            degraded_expert_substitutions,
+            "routed-execution"
+        ),
+    })
+}
+
+fn gpu_io_delta(
+    before: GpuExpertIoSnapshot,
+    after: GpuExpertIoSnapshot,
+) -> Result<GpuExpertIoSnapshot, BenchmarkFailure> {
+    Ok(GpuExpertIoSnapshot {
+        expert_weight_uploads: checked_delta!(
+            after,
+            before,
+            expert_weight_uploads,
+            "gpu-expert-io"
+        ),
+        expert_weight_upload_bytes: checked_delta!(
+            after,
+            before,
+            expert_weight_upload_bytes,
+            "gpu-expert-io"
+        ),
+        hidden_state_uploads: checked_delta!(after, before, hidden_state_uploads, "gpu-expert-io"),
+        hidden_state_upload_bytes: checked_delta!(
+            after,
+            before,
+            hidden_state_upload_bytes,
+            "gpu-expert-io"
+        ),
+        queue_submissions: checked_delta!(after, before, queue_submissions, "gpu-expert-io"),
+        map_requests: checked_delta!(after, before, map_requests, "gpu-expert-io"),
+        readback_completions: checked_delta!(after, before, readback_completions, "gpu-expert-io"),
+        readback_bytes: checked_delta!(after, before, readback_bytes, "gpu-expert-io"),
+    })
+}
+
+#[derive(Clone, Copy, Debug, Default, Serialize)]
+pub(crate) struct EngineStorageSnapshot {
+    pub(crate) ram_hits: u64,
+    pub(crate) ram_misses: u64,
+    pub(crate) nvme_read_operations: u64,
+    pub(crate) nvme_bytes_read: u64,
+    pub(crate) prefetch_completed: u64,
+    pub(crate) predictor_observations: u64,
+    pub(crate) ssd_stall_us: u64,
+}
+
+impl EngineStorageSnapshot {
+    pub(crate) fn from_runtime(runtime: &crate::BenchRealRuntime) -> Self {
+        let report = runtime.engine.report();
+        Self {
+            ram_hits: report.hits,
+            ram_misses: report.misses,
+            nvme_read_operations: report.io_count,
+            nvme_bytes_read: report.bytes_read,
+            prefetch_completed: report.prefetch_completed,
+            predictor_observations: report.predictor_observations,
+            ssd_stall_us: report.predictive.ssd_stall_us,
+        }
+    }
+
+    fn checked_delta(self, before: Self) -> Result<Self, BenchmarkFailure> {
+        Ok(Self {
+            ram_hits: checked_delta!(self, before, ram_hits, "engine-storage"),
+            ram_misses: checked_delta!(self, before, ram_misses, "engine-storage"),
+            nvme_read_operations: checked_delta!(
+                self,
+                before,
+                nvme_read_operations,
+                "engine-storage"
+            ),
+            nvme_bytes_read: checked_delta!(self, before, nvme_bytes_read, "engine-storage"),
+            prefetch_completed: checked_delta!(self, before, prefetch_completed, "engine-storage"),
+            predictor_observations: checked_delta!(
+                self,
+                before,
+                predictor_observations,
+                "engine-storage"
+            ),
+            ssd_stall_us: checked_delta!(self, before, ssd_stall_us, "engine-storage"),
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Serialize)]
+pub(crate) struct GpuNativeResidencyDelta {
+    pub(crate) vram_hits: u64,
+    pub(crate) vram_misses: u64,
+    pub(crate) ram_to_vram_installs: u64,
+    pub(crate) physical_evictions: u64,
+    pub(crate) physical_reinstalls: u64,
+    pub(crate) stale_generation_rejections: u64,
+    pub(crate) demand_requests: u64,
+    pub(crate) speculative_requests: u64,
+    pub(crate) speculative_vram_hits: u64,
+    pub(crate) speculative_ram_to_vram_installs: u64,
+    pub(crate) speculative_dropped_capacity_or_pressure: u64,
+}
+
+fn gpu_native_residency_delta(
+    before: &GpuNativeTieredResidencySnapshot,
+    after: &GpuNativeTieredResidencySnapshot,
+) -> Result<GpuNativeResidencyDelta, BenchmarkFailure> {
+    Ok(GpuNativeResidencyDelta {
+        vram_hits: checked_delta!(after, before, vram_hits, "gpu-native-residency"),
+        vram_misses: checked_delta!(after, before, vram_misses, "gpu-native-residency"),
+        ram_to_vram_installs: checked_delta!(
+            after,
+            before,
+            ram_to_vram_installs,
+            "gpu-native-residency"
+        ),
+        physical_evictions: checked_delta!(
+            after,
+            before,
+            physical_evictions,
+            "gpu-native-residency"
+        ),
+        physical_reinstalls: checked_delta!(
+            after,
+            before,
+            physical_reinstalls,
+            "gpu-native-residency"
+        ),
+        stale_generation_rejections: checked_delta!(
+            after,
+            before,
+            stale_generation_rejections,
+            "gpu-native-residency"
+        ),
+        demand_requests: checked_delta!(after, before, demand_requests, "gpu-native-residency"),
+        speculative_requests: checked_delta!(
+            after,
+            before,
+            speculative_requests,
+            "gpu-native-residency"
+        ),
+        speculative_vram_hits: checked_delta!(
+            after,
+            before,
+            speculative_vram_hits,
+            "gpu-native-residency"
+        ),
+        speculative_ram_to_vram_installs: checked_delta!(
+            after,
+            before,
+            speculative_ram_to_vram_installs,
+            "gpu-native-residency"
+        ),
+        speculative_dropped_capacity_or_pressure: checked_delta!(
+            after,
+            before,
+            speculative_dropped_capacity_or_pressure,
+            "gpu-native-residency"
+        ),
+    })
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct RequestSnapshots {
+    pub(crate) token_loop_before: GpuNativeTokenLoopSnapshot,
+    pub(crate) token_loop_after: GpuNativeTokenLoopSnapshot,
+    pub(crate) token_loop_delta: GpuNativeTokenLoopSnapshot,
+    pub(crate) token_loop_ratios: CounterRatios,
+    pub(crate) routed_execution_before: RoutedExpertExecutionSnapshot,
+    pub(crate) routed_execution_after: RoutedExpertExecutionSnapshot,
+    pub(crate) routed_execution_delta: RoutedExpertExecutionSnapshot,
+    pub(crate) runtime_cache_before: RuntimeCacheSnapshot,
+    pub(crate) runtime_cache_after: RuntimeCacheSnapshot,
+    pub(crate) engine_storage_before: EngineStorageSnapshot,
+    pub(crate) engine_storage_after: EngineStorageSnapshot,
+    pub(crate) engine_storage_delta: EngineStorageSnapshot,
+    pub(crate) gpu_expert_io_before: GpuExpertIoSnapshot,
+    pub(crate) gpu_expert_io_after: GpuExpertIoSnapshot,
+    pub(crate) gpu_expert_io_delta: GpuExpertIoSnapshot,
+    pub(crate) gpu_expert_memory_before: GpuExpertMemorySnapshot,
+    pub(crate) gpu_expert_memory_after: GpuExpertMemorySnapshot,
+    pub(crate) gpu_native_residency_before: GpuNativeTieredResidencySnapshot,
+    pub(crate) gpu_native_residency_after: GpuNativeTieredResidencySnapshot,
+    pub(crate) gpu_native_residency_delta: GpuNativeResidencyDelta,
+}
+
+#[derive(Clone, Copy, Debug, Default, Serialize)]
+pub(crate) struct LatencyStatistics {
+    pub(crate) p50_seconds: f64,
+    pub(crate) p95_seconds: f64,
+    pub(crate) p99_seconds: f64,
+    pub(crate) mean_seconds: f64,
+    pub(crate) min_seconds: f64,
+    pub(crate) max_seconds: f64,
+}
+
+fn finite_positive(value: f64) -> bool {
+    value.is_finite() && value > 0.0
+}
+
+fn percentile(sorted: &[f64], q: f64) -> f64 {
+    if sorted.is_empty() {
+        return 0.0;
+    }
+    let index = ((sorted.len() - 1) as f64 * q.clamp(0.0, 1.0)).round() as usize;
+    sorted[index]
+}
+
+impl LatencyStatistics {
+    fn from_values(values: &[f64]) -> Result<Self, BenchmarkFailure> {
+        if values.is_empty() || values.iter().any(|value| !finite_positive(*value)) {
+            return Err(BenchmarkFailure::new(
+                "postcondition",
+                "invalid-decode-latency",
+                "post-TTFT decode latencies must be nonempty, finite, and positive",
+            ));
+        }
+        let mut sorted = values.to_vec();
+        sorted.sort_by(f64::total_cmp);
+        Ok(Self {
+            p50_seconds: percentile(&sorted, 0.50),
+            p95_seconds: percentile(&sorted, 0.95),
+            p99_seconds: percentile(&sorted, 0.99),
+            mean_seconds: sorted.iter().sum::<f64>() / sorted.len() as f64,
+            min_seconds: sorted[0],
+            max_seconds: *sorted.last().expect("latencies checked nonempty"),
+        })
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct RunTiming {
+    pub(crate) prompt_seconds: f64,
+    pub(crate) time_to_first_token_seconds: f64,
+    pub(crate) decode_generated_tokens: usize,
+    pub(crate) decode_seconds: f64,
+    pub(crate) decode_tps: f64,
+    pub(crate) end_to_end_seconds: f64,
+    pub(crate) end_to_end_generated_tps: f64,
+    pub(crate) post_ttft_decode_token_latencies_seconds: Vec<f64>,
+    pub(crate) post_ttft_decode_token_latency: LatencyStatistics,
+}
+
+impl RunTiming {
+    pub(crate) fn from_measurement(
+        generated_tokens: usize,
+        prompt_seconds: f64,
+        time_to_first_token_seconds: f64,
+        decode_seconds: f64,
+        decode_latencies: Vec<f64>,
+    ) -> Result<Self, BenchmarkFailure> {
+        let decode_generated_tokens = generated_tokens.saturating_sub(1);
+        if generated_tokens < 2
+            || !finite_positive(prompt_seconds)
+            || !finite_positive(time_to_first_token_seconds)
+            || !finite_positive(decode_seconds)
+            || decode_latencies.len() != decode_generated_tokens
+        {
+            return Err(BenchmarkFailure::new(
+                "postcondition",
+                "invalid-measured-duration",
+                format!(
+                    "requires at least two generated tokens and finite positive prompt/TTFT/decode durations with one latency per post-TTFT token; generated={generated_tokens} prompt={prompt_seconds} ttft={time_to_first_token_seconds} decode={decode_seconds} latencies={}",
+                    decode_latencies.len(),
+                ),
+            ));
+        }
+        let end_to_end_seconds = prompt_seconds + decode_seconds;
+        if !finite_positive(end_to_end_seconds) {
+            return Err(BenchmarkFailure::new(
+                "postcondition",
+                "invalid-end-to-end-duration",
+                "end-to-end duration was nonfinite or nonpositive",
+            ));
+        }
+        Ok(Self {
+            prompt_seconds,
+            time_to_first_token_seconds,
+            decode_generated_tokens,
+            decode_seconds,
+            decode_tps: decode_generated_tokens as f64 / decode_seconds,
+            end_to_end_seconds,
+            end_to_end_generated_tps: generated_tokens as f64 / end_to_end_seconds,
+            post_ttft_decode_token_latency: LatencyStatistics::from_values(&decode_latencies)?,
+            post_ttft_decode_token_latencies_seconds: decode_latencies,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct PerRunResult {
+    pub(crate) run_index: usize,
+    pub(crate) prompt_tokens: usize,
+    pub(crate) requested_output_tokens: usize,
+    pub(crate) generated_tokens: usize,
+    pub(crate) generated_token_ids: Vec<u32>,
+    pub(crate) generated_token_ids_sha256: String,
+    pub(crate) generated_text_sha256: String,
+    pub(crate) timing: RunTiming,
+    pub(crate) counters: RequestSnapshots,
+}
+
+#[derive(Clone, Copy, Debug, Default, Serialize)]
+pub(crate) struct DistributionSummary {
+    pub(crate) mean: f64,
+    pub(crate) median: f64,
+    pub(crate) min: f64,
+    pub(crate) max: f64,
+}
+
+fn distribution(values: &[f64]) -> Result<DistributionSummary, BenchmarkFailure> {
+    if values.is_empty() || values.iter().any(|value| !finite_positive(*value)) {
+        return Err(BenchmarkFailure::new(
+            "postcondition",
+            "invalid-aggregate-input",
+            "aggregate inputs must be nonempty, finite, and positive",
+        ));
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_by(f64::total_cmp);
+    Ok(DistributionSummary {
+        mean: sorted.iter().sum::<f64>() / sorted.len() as f64,
+        median: percentile(&sorted, 0.50),
+        min: sorted[0],
+        max: *sorted.last().expect("distribution checked nonempty"),
+    })
+}
+
+#[derive(Clone, Copy, Debug, Default, Serialize)]
+pub(crate) struct TtftAggregate {
+    pub(crate) mean_seconds: f64,
+    pub(crate) median_seconds: f64,
+    pub(crate) p95_seconds: f64,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct Aggregate {
+    pub(crate) decode_tps: DistributionSummary,
+    pub(crate) end_to_end_generated_tps: DistributionSummary,
+    pub(crate) time_to_first_token: TtftAggregate,
+    pub(crate) pooled_post_ttft_decode_token_latency: LatencyStatistics,
+    pub(crate) counter_totals: GpuNativeTokenLoopSnapshot,
+    pub(crate) counter_ratios: CounterRatios,
+}
+
+fn add_counter_totals(
+    total: &mut GpuNativeTokenLoopSnapshot,
+    value: GpuNativeTokenLoopSnapshot,
+) -> Result<(), BenchmarkFailure> {
+    macro_rules! add {
+        ($field:ident) => {
+            total.$field = total.$field.checked_add(value.$field).ok_or_else(|| {
+                BenchmarkFailure::new(
+                    "postcondition",
+                    "counter-overflow",
+                    format!("aggregate counter {} overflowed", stringify!($field)),
+                )
+            })?;
+        };
+    }
+    add!(token_attempts);
+    add!(tokens_completed);
+    add!(warm_tokens_completed);
+    add!(residency_miss_attempts);
+    add!(replay_attempts);
+    add!(residency_services);
+    add!(fatal_failures);
+    add!(no_progress_failures);
+    add!(queue_submissions);
+    add!(boundary_maps);
+    add!(boundary_readbacks);
+    Ok(())
+}
+
+pub(crate) fn aggregate(runs: &[PerRunResult]) -> Result<Aggregate, BenchmarkFailure> {
+    if runs.is_empty() {
+        return Err(BenchmarkFailure::new(
+            "postcondition",
+            "missing-measured-runs",
+            "no measured run results were retained",
+        ));
+    }
+    let decode_tps = runs
+        .iter()
+        .map(|run| run.timing.decode_tps)
+        .collect::<Vec<_>>();
+    let end_to_end = runs
+        .iter()
+        .map(|run| run.timing.end_to_end_generated_tps)
+        .collect::<Vec<_>>();
+    let mut ttft = runs
+        .iter()
+        .map(|run| run.timing.time_to_first_token_seconds)
+        .collect::<Vec<_>>();
+    ttft.sort_by(f64::total_cmp);
+    let mut pooled_latencies = Vec::new();
+    let mut counter_totals = GpuNativeTokenLoopSnapshot::default();
+    for run in runs {
+        pooled_latencies.extend_from_slice(&run.timing.post_ttft_decode_token_latencies_seconds);
+        add_counter_totals(&mut counter_totals, run.counters.token_loop_delta)?;
+    }
+    Ok(Aggregate {
+        decode_tps: distribution(&decode_tps)?,
+        end_to_end_generated_tps: distribution(&end_to_end)?,
+        time_to_first_token: TtftAggregate {
+            mean_seconds: ttft.iter().sum::<f64>() / ttft.len() as f64,
+            median_seconds: percentile(&ttft, 0.50),
+            p95_seconds: percentile(&ttft, 0.95),
+        },
+        pooled_post_ttft_decode_token_latency: LatencyStatistics::from_values(&pooled_latencies)?,
+        counter_ratios: CounterRatios::from_delta(counter_totals)?,
+        counter_totals,
+    })
+}
+
+fn retain_measured_result(
+    retained: &mut Vec<PerRunResult>,
+    result: Result<PerRunResult, BenchmarkFailure>,
+) -> Result<(), BenchmarkFailure> {
+    match result {
+        Ok(run) => {
+            retained.push(run);
+            Ok(())
+        }
+        Err(failure) => Err(failure),
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct RuntimeConstructionTiming {
+    pub(crate) phase: String,
+    pub(crate) run_index: Option<usize>,
+    pub(crate) seconds: f64,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct RuntimeShutdown {
+    pub(crate) phase: String,
+    pub(crate) run_index: Option<usize>,
+    pub(crate) evidence: BackgroundShutdownEvidence,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct BenchmarkReport {
+    pub(crate) schema: &'static str,
+    pub(crate) mode: &'static str,
+    pub(crate) benchmark_complete: bool,
+    pub(crate) failure: Option<BenchmarkFailure>,
+    pub(crate) qualification_pass: bool,
+    pub(crate) correctness_qualification_pending: bool,
+    pub(crate) provenance: BenchmarkProvenance,
+    pub(crate) hardware: Option<GpuDeviceIdentity>,
+    pub(crate) model_identity: ModelIdentityEvidence,
+    pub(crate) model_load: Option<ModelLoadEvidence>,
+    pub(crate) request: RequestEvidence,
+    pub(crate) cache_reset: crate::BenchRealCacheReset,
+    pub(crate) warmup_runs: usize,
+    pub(crate) warmup_runs_completed: usize,
+    pub(crate) measured_runs: usize,
+    pub(crate) runtime_constructions: Vec<RuntimeConstructionTiming>,
+    pub(crate) runtime_shutdowns: Vec<RuntimeShutdown>,
+    pub(crate) per_run_results: Vec<PerRunResult>,
+    pub(crate) aggregate: Option<Aggregate>,
+    pub(crate) runtime_contract: Option<RuntimeContractEvidence>,
+    pub(crate) production_configuration: ProductionConfiguration,
+    pub(crate) production_semantics: ProductionSemantics,
+}
+
+impl BenchmarkReport {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        provenance: BenchmarkProvenance,
+        model_identity: ModelIdentityEvidence,
+        request: RequestEvidence,
+        cache_reset: crate::BenchRealCacheReset,
+        warmup_runs: usize,
+        measured_runs: usize,
+        production_configuration: ProductionConfiguration,
+    ) -> Self {
+        Self {
+            schema: SCHEMA,
+            mode: MODE,
+            benchmark_complete: false,
+            failure: None,
+            qualification_pass: false,
+            correctness_qualification_pending: true,
+            provenance,
+            hardware: None,
+            model_identity,
+            model_load: None,
+            request,
+            cache_reset,
+            warmup_runs,
+            warmup_runs_completed: 0,
+            measured_runs,
+            runtime_constructions: Vec::new(),
+            runtime_shutdowns: Vec::new(),
+            per_run_results: Vec::new(),
+            aggregate: None,
+            runtime_contract: None,
+            production_configuration,
+            production_semantics: ProductionSemantics::baseline(),
+        }
+    }
+
+    pub(crate) fn finish(&mut self) -> Result<(), BenchmarkFailure> {
+        if self.per_run_results.len() != self.measured_runs {
+            return Err(BenchmarkFailure::new(
+                "postcondition",
+                "incomplete-measured-run-set",
+                format!(
+                    "retained {} of {} requested measured runs",
+                    self.per_run_results.len(),
+                    self.measured_runs
+                ),
+            ));
+        }
+        if self.warmup_runs_completed != self.warmup_runs {
+            return Err(BenchmarkFailure::new(
+                "postcondition",
+                "incomplete-warmup-set",
+                format!(
+                    "completed {} of {} requested warmups",
+                    self.warmup_runs_completed, self.warmup_runs
+                ),
+            ));
+        }
+        if self.hardware.is_none() || self.model_load.is_none() || self.runtime_contract.is_none() {
+            return Err(BenchmarkFailure::new(
+                "postcondition",
+                "runtime-evidence-incomplete",
+                "hardware, model-load, or authoritative runtime-contract evidence is missing",
+            ));
+        }
+        self.aggregate = Some(aggregate(&self.per_run_results)?);
+        self.benchmark_complete = true;
+        self.failure = None;
+        Ok(())
+    }
+
+    pub(crate) fn fail(&mut self, failure: BenchmarkFailure) {
+        self.benchmark_complete = false;
+        self.aggregate = None;
+        self.failure = Some(failure);
+    }
+}
+
+pub(crate) fn expected_runtime_constructions(
+    cache_reset: crate::BenchRealCacheReset,
+    warmup_runs: usize,
+    measured_runs: usize,
+) -> usize {
+    match cache_reset {
+        crate::BenchRealCacheReset::Keep => 1,
+        crate::BenchRealCacheReset::FreshRuntime => warmup_runs.saturating_add(measured_runs),
+    }
+}
+
+pub(crate) fn validate_request_postconditions(
+    prompt_tokens: usize,
+    requested_output_tokens: usize,
+    generated_tokens: usize,
+    token_loop: GpuNativeTokenLoopSnapshot,
+    routed: RoutedExpertExecutionSnapshot,
+) -> Result<(), BenchmarkFailure> {
+    let expected_completed = prompt_tokens
+        .checked_add(requested_output_tokens)
+        .and_then(|value| value.checked_sub(1))
+        .ok_or_else(|| {
+            BenchmarkFailure::new(
+                "postcondition",
+                "completed-position-overflow",
+                "expected completed-position count overflowed",
+            )
+        })?;
+    if generated_tokens != requested_output_tokens {
+        return Err(BenchmarkFailure::new(
+            "inference",
+            "incomplete-generation",
+            format!("generated {generated_tokens} of {requested_output_tokens} requested tokens"),
+        ));
+    }
+    if token_loop.tokens_completed != expected_completed as u64
+        || token_loop.fatal_failures != 0
+        || token_loop.no_progress_failures != 0
+    {
+        return Err(BenchmarkFailure::new(
+            "postcondition",
+            "token-loop-postcondition",
+            format!(
+                "expected {expected_completed} completed positions and zero fatal/no-progress failures; observed {token_loop:?}"
+            ),
+        ));
+    }
+    if routed.cpu_routed_expert_dispatches != 0
+        || routed.gpu_cpu_fallbacks != 0
+        || routed.degraded_expert_substitutions != 0
+    {
+        return Err(BenchmarkFailure::new(
+            "postcondition",
+            "fallback-or-degradation",
+            format!("CPU fallback or degraded expert substitution occurred: {routed:?}"),
+        ));
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct OrdinaryStep {
+    token_id: u32,
+    position: usize,
+    sample: bool,
+}
+
+fn next_ordinary_step(
+    prompt_ids: &[u32],
+    generated_ids: &[u32],
+    completed_positions: usize,
+) -> Option<OrdinaryStep> {
+    if completed_positions < prompt_ids.len() {
+        return Some(OrdinaryStep {
+            token_id: prompt_ids[completed_positions],
+            position: completed_positions,
+            sample: completed_positions + 1 == prompt_ids.len(),
+        });
+    }
+    generated_ids.last().copied().map(|token_id| OrdinaryStep {
+        token_id,
+        position: completed_positions,
+        sample: true,
+    })
+}
+
+#[derive(Clone, Debug)]
+struct RequestSnapshotStart {
+    token_loop: GpuNativeTokenLoopSnapshot,
+    routed: RoutedExpertExecutionSnapshot,
+    runtime_cache: RuntimeCacheSnapshot,
+    engine_storage: EngineStorageSnapshot,
+    gpu_expert_io: GpuExpertIoSnapshot,
+    gpu_expert_memory: GpuExpertMemorySnapshot,
+    gpu_native_residency: GpuNativeTieredResidencySnapshot,
+}
+
+impl RequestSnapshotStart {
+    fn capture(runtime: &crate::BenchRealRuntime) -> Result<Self, BenchmarkFailure> {
+        let token_loop = runtime.gpu_native_token_loop.as_ref().ok_or_else(|| {
+            BenchmarkFailure::new(
+                "startup",
+                "missing-gpu-native-token-loop",
+                "request snapshot could not find gpu_native_token_loop",
+            )
+        })?;
+        Ok(Self {
+            token_loop: token_loop.snapshot(),
+            routed: runtime.engine.routed_expert_execution_snapshot(),
+            runtime_cache: crate::greedy_parity_runtime_cache_snapshot(runtime),
+            engine_storage: EngineStorageSnapshot::from_runtime(runtime),
+            gpu_expert_io: runtime.engine.gpu_expert_io_snapshot().ok_or_else(|| {
+                BenchmarkFailure::new(
+                    "startup",
+                    "missing-gpu-io-snapshot",
+                    "authoritative runtime did not expose GPU expert I/O snapshot",
+                )
+            })?,
+            gpu_expert_memory: runtime.engine.gpu_expert_memory_snapshot().ok_or_else(|| {
+                BenchmarkFailure::new(
+                    "startup",
+                    "missing-gpu-memory-snapshot",
+                    "authoritative runtime did not expose GPU expert memory snapshot",
+                )
+            })?,
+            gpu_native_residency: runtime.engine.gpu_native_residency_snapshot().ok_or_else(
+                || {
+                    BenchmarkFailure::new(
+                        "startup",
+                        "missing-gpu-native-residency-snapshot",
+                        "authoritative runtime did not expose GPU-native residency snapshot",
+                    )
+                },
+            )?,
+        })
+    }
+
+    fn finish(
+        self,
+        runtime: &crate::BenchRealRuntime,
+    ) -> Result<RequestSnapshots, BenchmarkFailure> {
+        let token_loop_after = runtime
+            .gpu_native_token_loop
+            .as_ref()
+            .ok_or_else(|| {
+                BenchmarkFailure::new(
+                    "postcondition",
+                    "missing-gpu-native-token-loop",
+                    "gpu_native_token_loop disappeared after request",
+                )
+            })?
+            .snapshot();
+        let routed_after = runtime.engine.routed_expert_execution_snapshot();
+        let engine_storage_after = EngineStorageSnapshot::from_runtime(runtime);
+        let gpu_expert_io_after = runtime.engine.gpu_expert_io_snapshot().ok_or_else(|| {
+            BenchmarkFailure::new(
+                "postcondition",
+                "missing-gpu-io-snapshot",
+                "GPU expert I/O snapshot disappeared after request",
+            )
+        })?;
+        let token_loop_delta = token_loop_delta(self.token_loop, token_loop_after)?;
+        let routed_execution_delta = routed_delta(self.routed, routed_after)?;
+        let gpu_native_residency_after = runtime
+            .engine
+            .gpu_native_residency_snapshot()
+            .ok_or_else(|| {
+                BenchmarkFailure::new(
+                    "postcondition",
+                    "missing-gpu-native-residency-snapshot",
+                    "GPU-native residency snapshot disappeared after request",
+                )
+            })?;
+        let gpu_native_residency_delta =
+            gpu_native_residency_delta(&self.gpu_native_residency, &gpu_native_residency_after)?;
+        Ok(RequestSnapshots {
+            token_loop_before: self.token_loop,
+            token_loop_after,
+            token_loop_delta,
+            token_loop_ratios: CounterRatios::from_delta(token_loop_delta)?,
+            routed_execution_before: self.routed,
+            routed_execution_after: routed_after,
+            routed_execution_delta,
+            runtime_cache_before: self.runtime_cache,
+            runtime_cache_after: crate::greedy_parity_runtime_cache_snapshot(runtime),
+            engine_storage_before: self.engine_storage,
+            engine_storage_after,
+            engine_storage_delta: engine_storage_after.checked_delta(self.engine_storage)?,
+            gpu_expert_io_before: self.gpu_expert_io,
+            gpu_expert_io_after,
+            gpu_expert_io_delta: gpu_io_delta(self.gpu_expert_io, gpu_expert_io_after)?,
+            gpu_expert_memory_before: self.gpu_expert_memory,
+            gpu_expert_memory_after: runtime.engine.gpu_expert_memory_snapshot().ok_or_else(
+                || {
+                    BenchmarkFailure::new(
+                        "postcondition",
+                        "missing-gpu-memory-snapshot",
+                        "GPU expert memory snapshot disappeared after request",
+                    )
+                },
+            )?,
+            gpu_native_residency_before: self.gpu_native_residency,
+            gpu_native_residency_after,
+            gpu_native_residency_delta,
+        })
+    }
+}
+
+pub(crate) async fn execute_request(
+    runtime: &crate::BenchRealRuntime,
+    prompt_ids: &[u32],
+    requested_output_tokens: usize,
+    run_index: usize,
+) -> Result<PerRunResult, Box<dyn std::error::Error>> {
+    if prompt_ids.is_empty() {
+        return Err(BenchmarkFailure::new(
+            "preflight",
+            "empty-prompt-tokenization",
+            "prompt encoded to zero tokens",
+        )
+        .into());
+    }
+    if requested_output_tokens < 2 {
+        return Err(BenchmarkFailure::new(
+            "preflight",
+            "insufficient-output-tokens",
+            "decode throughput requires --output-tokens >= 2",
+        )
+        .into());
+    }
+    let token_loop = runtime.gpu_native_token_loop.as_ref().ok_or_else(|| {
+        BenchmarkFailure::new(
+            "startup",
+            "missing-gpu-native-token-loop",
+            "runtime.gpu_native_token_loop is None",
+        )
+    })?;
+    let required =
+        crate::gpu_native_token_loop::GpuNativeTokenLoop::calculate_required_context_len(
+            0,
+            prompt_ids.len(),
+            requested_output_tokens,
+        )
+        .ok_or_else(|| {
+            BenchmarkFailure::new(
+                "preflight",
+                "context-length-overflow",
+                "prompt plus output token count overflowed context arithmetic",
+            )
+        })?;
+    if required > token_loop.max_seq_len() {
+        return Err(BenchmarkFailure::new(
+            "preflight",
+            "context-limit-exceeded",
+            format!(
+                "request requires {required} positions but gpu_native_max_seq_len is {}",
+                token_loop.max_seq_len()
+            ),
+        )
+        .into());
+    }
+
+    let mut request = token_loop.create_request_state()?;
+    let snapshots = RequestSnapshotStart::capture(runtime)?;
+    let prompt_started = std::time::Instant::now();
+    let mut completed_positions = 0usize;
+    let mut generated_ids = Vec::with_capacity(requested_output_tokens);
+    while completed_positions < prompt_ids.len() {
+        let step = next_ordinary_step(prompt_ids, &generated_ids, completed_positions)
+            .expect("prompt step must exist");
+        let sampled = token_loop
+            .step_token(
+                &runtime.engine,
+                &mut request,
+                step.token_id,
+                step.position,
+                step.sample,
+            )
+            .await?;
+        completed_positions += 1;
+        if step.sample {
+            generated_ids.push(sampled.ok_or_else(|| {
+                BenchmarkFailure::new(
+                    "inference",
+                    "missing-first-generated-token",
+                    "final prompt position produced no sampled token",
+                )
+            })?);
+        } else if sampled.is_some() {
+            return Err(BenchmarkFailure::new(
+                "inference",
+                "unexpected-prefix-sample",
+                "prompt prefix position unexpectedly produced a sampled token",
+            )
+            .into());
+        }
+    }
+    let prompt_seconds = prompt_started.elapsed().as_secs_f64();
+    let time_to_first_token_seconds = prompt_seconds;
+
+    let decode_started = std::time::Instant::now();
+    let mut decode_latencies = Vec::with_capacity(requested_output_tokens - 1);
+    while generated_ids.len() < requested_output_tokens {
+        let step = next_ordinary_step(prompt_ids, &generated_ids, completed_positions)
+            .expect("decode step must exist after first sample");
+        let step_started = std::time::Instant::now();
+        let sampled = token_loop
+            .step_token(
+                &runtime.engine,
+                &mut request,
+                step.token_id,
+                step.position,
+                step.sample,
+            )
+            .await?
+            .ok_or_else(|| {
+                BenchmarkFailure::new(
+                    "inference",
+                    "missing-decode-token",
+                    format!(
+                        "decode position {} produced no sampled token",
+                        step.position
+                    ),
+                )
+            })?;
+        decode_latencies.push(step_started.elapsed().as_secs_f64());
+        generated_ids.push(sampled);
+        completed_positions += 1;
+    }
+    let decode_seconds = decode_started.elapsed().as_secs_f64();
+    let counters = snapshots.finish(runtime)?;
+    validate_request_postconditions(
+        prompt_ids.len(),
+        requested_output_tokens,
+        generated_ids.len(),
+        counters.token_loop_delta,
+        counters.routed_execution_delta,
+    )?;
+    let output_text = runtime.tokenizer.decode(&generated_ids)?;
+    Ok(PerRunResult {
+        run_index,
+        prompt_tokens: prompt_ids.len(),
+        requested_output_tokens,
+        generated_tokens: generated_ids.len(),
+        generated_token_ids_sha256: crate::greedy_parity::token_ids_sha256(&generated_ids),
+        generated_text_sha256: crate::greedy_parity::sha256_hex(output_text.as_bytes()),
+        generated_token_ids: generated_ids,
+        timing: RunTiming::from_measurement(
+            requested_output_tokens,
+            prompt_seconds,
+            time_to_first_token_seconds,
+            decode_seconds,
+            decode_latencies,
+        )?,
+        counters,
+    })
+}
+
+fn is_hex(value: &str, len: usize) -> bool {
+    value.len() == len && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn validate_preflight_provenance(build: &BuildProvenance) -> Result<(), BenchmarkFailure> {
+    if build.dirty != Some(false) || build.git_sha.as_deref().is_none_or(|sha| !is_hex(sha, 40)) {
+        return Err(BenchmarkFailure::new(
+            "preflight",
+            "provenance-unavailable",
+            format!(
+                "requires clean embedded full Git SHA and dirty=false; observed git_sha={:?} dirty={:?}",
+                build.git_sha, build.dirty
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_artifacts(
+    artifacts: &QualificationArtifacts,
+    errors: &[String],
+) -> Result<(), BenchmarkFailure> {
+    if !errors.is_empty()
+        || artifacts.config.is_none()
+        || artifacts.tokenizer.is_none()
+        || artifacts.expert_metadata.is_none()
+        || artifacts.dense_weights_directory.is_none()
+    {
+        return Err(BenchmarkFailure::new(
+            "preflight",
+            "artifact-provenance-unavailable",
+            format!(
+                "config, tokenizer, expert metadata, and dense weights directory identities are mandatory; errors={errors:?} artifacts={artifacts:?}"
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_expert_metadata(metadata: &ExpertMetadataEvidence) -> Result<(), BenchmarkFailure> {
+    if metadata.dtype.as_deref() != Some("q4_0")
+        || metadata.q4_0_layout.as_deref() != Some(crate::inference::Q4_0_LAYOUT_STANDARD_V1)
+        || metadata.explicitly_synthetic
+    {
+        return Err(BenchmarkFailure::new(
+            "preflight",
+            "invalid-expert-metadata",
+            format!("requires canonical nonsynthetic Q4_0 expert metadata; observed {metadata:?}"),
+        ));
+    }
+    Ok(())
+}
+
+fn emit_report(
+    report: &BenchmarkReport,
+    report_out: Option<&std::path::Path>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use std::io::Write as _;
+
+    let mut json = serde_json::to_vec_pretty(report)?;
+    json.push(b'\n');
+    if let Some(path) = report_out {
+        if let Some(parent) = path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+        {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(path, json)?;
+        eprintln!(
+            "GPU-native real-model benchmark report written to {}",
+            path.display()
+        );
+    } else {
+        std::io::stdout().write_all(&json)?;
+    }
+    Ok(())
+}
+
+async fn construct_runtime(
+    spec: &crate::ResolvedRealCliSpec,
+    tokenizer: std::sync::Arc<crate::tokenizer::Tokenizer>,
+    phase: &str,
+    run_index: Option<usize>,
+    report: &mut BenchmarkReport,
+) -> Result<crate::BenchRealRuntime, BenchmarkFailure> {
+    let started = std::time::Instant::now();
+    let runtime = crate::build_isolated_greedy_runtime(
+        spec,
+        crate::RealCliRuntimeMode::IsolatedGpuNativeBenchmark,
+        tokenizer,
+    )
+    .await
+    .map_err(|error| {
+        BenchmarkFailure::new("startup", "runtime-construction-failed", error.to_string())
+    })?;
+    report
+        .runtime_constructions
+        .push(RuntimeConstructionTiming {
+            phase: phase.to_string(),
+            run_index,
+            seconds: started.elapsed().as_secs_f64(),
+        });
+    Ok(runtime)
+}
+
+fn validate_and_record_runtime(
+    runtime: &crate::BenchRealRuntime,
+    resolved_config_sha256: &str,
+    expected_adapter_name: &str,
+    report: &mut BenchmarkReport,
+) -> Result<(), BenchmarkFailure> {
+    let observed_config_sha256 = crate::resolved_real_runtime_identity_sha256(
+        &runtime.cfg,
+        runtime.model.config.architecture,
+        runtime.model.config.first_k_dense_replace,
+        &runtime.model.config.advanced,
+    )
+    .map_err(|error| {
+        BenchmarkFailure::new(
+            "startup",
+            "runtime-config-identity-unavailable",
+            error.to_string(),
+        )
+    })?;
+    if observed_config_sha256 != resolved_config_sha256 {
+        return Err(BenchmarkFailure::new(
+            "startup",
+            "runtime-config-identity-drift",
+            format!(
+                "runtime identity {observed_config_sha256} differs from preflight identity {resolved_config_sha256}"
+            ),
+        ));
+    }
+    let model_load = crate::greedy_parity_model_load(runtime);
+    let input = RuntimeContractInput {
+        real_transformer_enabled: runtime.cfg.real_transformer.enabled,
+        real_transformer_gpu_native: runtime.cfg.real_transformer.gpu_native,
+        compute_offload: runtime.cfg.real_transformer.compute_offload,
+        legacy_execution_plan: runtime.engine.execution_context().plan().into(),
+        token_loop_geometry: runtime
+            .gpu_native_token_loop
+            .as_ref()
+            .map(|token_loop| token_loop.model_geometry()),
+        authoritative_device: runtime.engine.gpu_device_identity(),
+        model_load: model_load.clone(),
+        routed_failure_policy: runtime.engine.routed_expert_gpu_failure_policy(),
+    };
+    let (contract, device) = validate_runtime_contract(&input, expected_adapter_name)?;
+    let token_loop = runtime.gpu_native_token_loop.as_ref().ok_or_else(|| {
+        BenchmarkFailure::new(
+            "startup",
+            "missing-gpu-native-token-loop",
+            "runtime contract passed without gpu_native_token_loop",
+        )
+    })?;
+    if token_loop.snapshot() != GpuNativeTokenLoopSnapshot::default() {
+        return Err(BenchmarkFailure::new(
+            "startup",
+            "nonzero-initial-token-loop-counters",
+            format!(
+                "fresh isolated runtime token-loop counters were not zero: {:?}",
+                token_loop.snapshot()
+            ),
+        ));
+    }
+    if runtime.engine.routed_expert_execution_snapshot() != RoutedExpertExecutionSnapshot::default()
+    {
+        return Err(BenchmarkFailure::new(
+            "startup",
+            "nonzero-initial-routed-counters",
+            "fresh isolated runtime routed-execution counters were not zero",
+        ));
+    }
+    if let Some(previous) = &report.hardware {
+        if previous != &device {
+            return Err(BenchmarkFailure::new(
+                "startup",
+                "adapter-identity-drift",
+                format!(
+                    "fresh runtime adapter identity drifted: before={previous:?} after={device:?}"
+                ),
+            ));
+        }
+    } else {
+        report.hardware = Some(device);
+    }
+    if let Some(previous) = &report.model_load {
+        if previous != &model_load {
+            return Err(BenchmarkFailure::new(
+                "startup",
+                "model-load-identity-drift",
+                format!(
+                    "fresh runtime model load evidence drifted: before={previous:?} after={model_load:?}"
+                ),
+            ));
+        }
+    } else {
+        report.model_load = Some(model_load);
+    }
+    if report.runtime_contract.is_none() {
+        report.runtime_contract = Some(contract);
+    }
+    Ok(())
+}
+
+async fn shutdown_runtime(
+    runtime: crate::BenchRealRuntime,
+    phase: &str,
+    run_index: Option<usize>,
+    report: &mut BenchmarkReport,
+) -> Result<(), BenchmarkFailure> {
+    let evidence = runtime.shutdown_isolated().await.map_err(|error| {
+        BenchmarkFailure::new(
+            "postcondition",
+            "runtime-shutdown-failed",
+            error.to_string(),
+        )
+    })?;
+    if !evidence.controlled_shutdown_requested || !evidence.all_runtime_resources_released {
+        return Err(BenchmarkFailure::new(
+            "postcondition",
+            "runtime-shutdown-incomplete",
+            format!("controlled isolated runtime shutdown was incomplete: {evidence:?}"),
+        ));
+    }
+    report.runtime_shutdowns.push(RuntimeShutdown {
+        phase: phase.to_string(),
+        run_index,
+        evidence,
+    });
+    Ok(())
+}
+
+async fn execute_with_fresh_runtime(
+    spec: &crate::ResolvedRealCliSpec,
+    tokenizer: std::sync::Arc<crate::tokenizer::Tokenizer>,
+    prompt_ids: &[u32],
+    output_tokens: usize,
+    phase: &str,
+    run_index: usize,
+    expected_adapter_name: &str,
+    resolved_config_sha256: &str,
+    watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+    report: &mut BenchmarkReport,
+) -> Result<PerRunResult, BenchmarkFailure> {
+    let runtime = construct_runtime(spec, tokenizer, phase, Some(run_index), report).await?;
+    let validation = validate_and_record_runtime(
+        &runtime,
+        resolved_config_sha256,
+        expected_adapter_name,
+        report,
+    );
+    if let Err(validation_error) = validation {
+        let shutdown = shutdown_runtime(runtime, phase, Some(run_index), report).await;
+        return match shutdown {
+            Ok(()) => Err(validation_error),
+            Err(shutdown_error) => Err(BenchmarkFailure::new(
+                "postcondition",
+                "runtime-validation-and-shutdown-failed",
+                format!("{validation_error}; {shutdown_error}"),
+            )),
+        };
+    }
+    let request_result = crate::with_progress_timeout(
+        format!("bench-gpu-native-real {phase} run {run_index}"),
+        watchdog,
+        execute_request(&runtime, prompt_ids, output_tokens, run_index),
+    )
+    .await
+    .map_err(|error| {
+        BenchmarkFailure::new(
+            "inference",
+            if phase == "measured" {
+                "measured-request-failed"
+            } else {
+                "warmup-request-failed"
+            },
+            error.to_string(),
+        )
+    });
+    let shutdown_result = shutdown_runtime(runtime, phase, Some(run_index), report).await;
+    match (request_result, shutdown_result) {
+        (Ok(result), Ok(())) => Ok(result),
+        (Err(request_error), Ok(())) => Err(request_error),
+        (Ok(_), Err(shutdown_error)) => Err(shutdown_error),
+        (Err(request_error), Err(shutdown_error)) => Err(BenchmarkFailure::new(
+            "postcondition",
+            "request-and-shutdown-failed",
+            format!("{request_error}; {shutdown_error}"),
+        )),
+    }
+}
+
+async fn execute_keep_schedule(
+    args: &CommandArgs,
+    spec: &crate::ResolvedRealCliSpec,
+    tokenizer: std::sync::Arc<crate::tokenizer::Tokenizer>,
+    prompt_ids: &[u32],
+    output_tokens: usize,
+    resolved_config_sha256: &str,
+    report: &mut BenchmarkReport,
+) -> Result<(), BenchmarkFailure> {
+    let runtime = construct_runtime(spec, tokenizer, "shared", None, report).await?;
+    let validation = validate_and_record_runtime(
+        &runtime,
+        resolved_config_sha256,
+        &args.expected_adapter_name,
+        report,
+    );
+    if let Err(validation_error) = validation {
+        let shutdown = shutdown_runtime(runtime, "shared", None, report).await;
+        return match shutdown {
+            Ok(()) => Err(validation_error),
+            Err(shutdown_error) => Err(BenchmarkFailure::new(
+                "postcondition",
+                "runtime-validation-and-shutdown-failed",
+                format!("{validation_error}; {shutdown_error}"),
+            )),
+        };
+    }
+
+    let execution = async {
+        for index in 0..args.warmup_runs {
+            crate::with_progress_timeout(
+                format!("bench-gpu-native-real warmup run {index}"),
+                args.progress_watchdog,
+                execute_request(&runtime, prompt_ids, output_tokens, index),
+            )
+            .await
+            .map_err(|error| {
+                BenchmarkFailure::new("inference", "warmup-request-failed", error.to_string())
+            })?;
+            report.warmup_runs_completed += 1;
+        }
+        for index in 0..args.measured_runs {
+            let measured = crate::with_progress_timeout(
+                format!("bench-gpu-native-real measured run {index}"),
+                args.progress_watchdog,
+                execute_request(&runtime, prompt_ids, output_tokens, index),
+            )
+            .await
+            .map_err(|error| {
+                BenchmarkFailure::new("inference", "measured-request-failed", error.to_string())
+            });
+            retain_measured_result(&mut report.per_run_results, measured)?;
+        }
+        Ok::<(), BenchmarkFailure>(())
+    }
+    .await;
+    let shutdown = shutdown_runtime(runtime, "shared", None, report).await;
+    match (execution, shutdown) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(execution_error), Ok(())) => Err(execution_error),
+        (Ok(()), Err(shutdown_error)) => Err(shutdown_error),
+        (Err(execution_error), Err(shutdown_error)) => Err(BenchmarkFailure::new(
+            "postcondition",
+            "execution-and-shutdown-failed",
+            format!("{execution_error}; {shutdown_error}"),
+        )),
+    }
+}
+
+async fn execute_fresh_schedule(
+    args: &CommandArgs,
+    spec: &crate::ResolvedRealCliSpec,
+    tokenizer: std::sync::Arc<crate::tokenizer::Tokenizer>,
+    prompt_ids: &[u32],
+    output_tokens: usize,
+    resolved_config_sha256: &str,
+    report: &mut BenchmarkReport,
+) -> Result<(), BenchmarkFailure> {
+    for index in 0..args.warmup_runs {
+        let _ = execute_with_fresh_runtime(
+            spec,
+            tokenizer.clone(),
+            prompt_ids,
+            output_tokens,
+            "warmup",
+            index,
+            &args.expected_adapter_name,
+            resolved_config_sha256,
+            args.progress_watchdog,
+            report,
+        )
+        .await?;
+        report.warmup_runs_completed += 1;
+    }
+    for index in 0..args.measured_runs {
+        let measured = execute_with_fresh_runtime(
+            spec,
+            tokenizer.clone(),
+            prompt_ids,
+            output_tokens,
+            "measured",
+            index,
+            &args.expected_adapter_name,
+            resolved_config_sha256,
+            args.progress_watchdog,
+            report,
+        )
+        .await;
+        retain_measured_result(&mut report.per_run_results, measured)?;
+    }
+    Ok(())
+}
+
+pub(crate) async fn run_command(args: CommandArgs) -> Result<(), Box<dyn std::error::Error>> {
+    if !args.greedy {
+        return Err(BenchmarkFailure::new(
+            "preflight",
+            "greedy-required",
+            "bench-gpu-native-real requires the explicit --greedy flag",
+        )
+        .into());
+    }
+    if args.measured_runs == 0 {
+        return Err(BenchmarkFailure::new(
+            "preflight",
+            "measured-runs-required",
+            "bench-gpu-native-real requires --measured-runs > 0",
+        )
+        .into());
+    }
+    if args.expected_adapter_name.trim().is_empty() {
+        return Err(BenchmarkFailure::new(
+            "preflight",
+            "missing-expected-adapter",
+            "bench-gpu-native-real requires --expected-adapter-name",
+        )
+        .into());
+    }
+    let input = crate::load_real_cli_request_input(
+        "bench-gpu-native-real",
+        args.prompt.as_ref(),
+        args.request_json.as_deref(),
+        args.output_tokens,
+    )?;
+    if input.output_tokens < 2 {
+        return Err(BenchmarkFailure::new(
+            "preflight",
+            "insufficient-output-tokens",
+            "bench-gpu-native-real requires --output-tokens >= 2",
+        )
+        .into());
+    }
+
+    let build = BuildProvenance::embedded();
+    validate_preflight_provenance(&build)?;
+    let cfg = crate::config::Config::from_file(&args.config)?;
+    validate_source_config(&cfg)?;
+    let (artifacts, artifact_errors) = crate::qualification_artifacts(&args.config, &cfg);
+    validate_artifacts(&artifacts, &artifact_errors)?;
+    let expert_metadata =
+        crate::qualification::read_expert_metadata(&cfg.model.data_dir.join("metadata.json"))
+            .map_err(|error| {
+                BenchmarkFailure::new("preflight", "expert-metadata-unavailable", error)
+            })?;
+    validate_expert_metadata(&expert_metadata)?;
+
+    let spec = crate::resolve_real_cli_spec_from_config(
+        cfg,
+        crate::RealCliRuntimeMode::IsolatedGpuNativeBenchmark,
+    )?;
+    let model_identity = crate::greedy_parity_model_identity(&spec);
+    if !model_identity.is_qwen3_coder_30b_a3b_q4_0() {
+        return Err(BenchmarkFailure::new(
+            "preflight",
+            "wrong-model-identity",
+            format!(
+                "requires exact Qwen3-Coder 30B-A3B Q4_0 identity; observed {model_identity:?}"
+            ),
+        )
+        .into());
+    }
+    let resolved_config_sha256 = crate::resolved_real_cli_spec_sha256(&spec)?;
+    let tokenizer = crate::load_real_cli_tokenizer(
+        &spec.cfg,
+        crate::RealCliRuntimeMode::IsolatedGpuNativeBenchmark,
+    )?;
+    // Tokenize once and retain this exact caller-owned vector for every
+    // warmup and measured request across either cache policy.
+    let prompt_ids = tokenizer.encode(&input.prompt)?;
+    if prompt_ids.is_empty() {
+        return Err(BenchmarkFailure::new(
+            "preflight",
+            "empty-prompt-tokenization",
+            "prompt encoded to zero tokens",
+        )
+        .into());
+    }
+    let (executable, executable_sha256) = crate::current_executable_identity()?;
+    let executable_canonical_path = std::fs::canonicalize(&executable)
+        .map_err(|error| {
+            BenchmarkFailure::new(
+                "preflight",
+                "executable-provenance-unavailable",
+                format!("failed to canonicalize {}: {error}", executable.display()),
+            )
+        })?
+        .display()
+        .to_string();
+    if !is_hex(&executable_sha256, 64) || !is_hex(&resolved_config_sha256, 64) {
+        return Err(BenchmarkFailure::new(
+            "preflight",
+            "provenance-unavailable",
+            "executable or resolved-config SHA256 was unavailable",
+        )
+        .into());
+    }
+
+    let production_configuration =
+        ProductionConfiguration::from_config(&spec.cfg, &expert_metadata);
+    let mut report = BenchmarkReport::new(
+        BenchmarkProvenance {
+            build,
+            executable_canonical_path,
+            executable_sha256,
+            resolved_config_sha256: resolved_config_sha256.clone(),
+            artifacts,
+            expert_metadata,
+        },
+        model_identity,
+        RequestEvidence {
+            prompt_sha256: crate::greedy_parity::sha256_hex(input.prompt.as_bytes()),
+            prompt_token_ids_sha256: crate::greedy_parity::token_ids_sha256(&prompt_ids),
+            prompt_token_count: prompt_ids.len(),
+            requested_output_tokens: input.output_tokens,
+            greedy: true,
+        },
+        args.cache_reset,
+        args.warmup_runs,
+        args.measured_runs,
+        production_configuration,
+    );
+
+    let execution = match args.cache_reset {
+        crate::BenchRealCacheReset::Keep => {
+            execute_keep_schedule(
+                &args,
+                &spec,
+                tokenizer,
+                &prompt_ids,
+                input.output_tokens,
+                &resolved_config_sha256,
+                &mut report,
+            )
+            .await
+        }
+        crate::BenchRealCacheReset::FreshRuntime => {
+            execute_fresh_schedule(
+                &args,
+                &spec,
+                tokenizer,
+                &prompt_ids,
+                input.output_tokens,
+                &resolved_config_sha256,
+                &mut report,
+            )
+            .await
+        }
+    };
+
+    let completion = execution.and_then(|()| {
+        let expected =
+            expected_runtime_constructions(args.cache_reset, args.warmup_runs, args.measured_runs);
+        if report.runtime_constructions.len() != expected {
+            return Err(BenchmarkFailure::new(
+                "postcondition",
+                "cache-reset-semantics-drift",
+                format!(
+                    "cache mode {:?} constructed {} runtimes, expected {expected}",
+                    args.cache_reset,
+                    report.runtime_constructions.len()
+                ),
+            ));
+        }
+        report.finish()
+    });
+
+    match completion {
+        Ok(()) => emit_report(&report, args.report_out.as_deref()),
+        Err(failure) => {
+            let summary = failure.to_string();
+            report.fail(failure);
+            emit_report(&report, args.report_out.as_deref()).map_err(|emit_error| {
+                format!(
+                    "{summary}; additionally failed to emit benchmark failure report: {emit_error}"
+                )
+            })?;
+            Err(summary.into())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn l4_device() -> GpuDeviceIdentity {
+        GpuDeviceIdentity {
+            name: "NVIDIA L4".into(),
+            vendor_id: 0x10de,
+            device_id: 0x27b8,
+            device_type: "DiscreteGpu".into(),
+            wgpu_backend: "vulkan".into(),
+            driver: "test".into(),
+            driver_info: "test".into(),
+            compute_plane: "wgpu-vulkan".into(),
+            software_adapter: false,
+        }
+    }
+
+    fn qwen_geometry() -> GpuNativeModelGeometry {
+        GpuNativeModelGeometry {
+            num_layers: 48,
+            d_model: 2048,
+            d_ff: 768,
+            num_experts: 128,
+            top_k: 8,
+            num_heads: 64,
+            num_kv_heads: 8,
+            head_dim: 128,
+            rope_dim: 128,
+            vocab_size: 151_936,
+            max_seq_len: 4096,
+            rms_eps: 1e-6,
+            rope_base: 10_000.0,
+        }
+    }
+
+    fn legacy_plan() -> ExecutionPlanEvidence {
+        ExecutionPlanEvidence {
+            context_id: "test".into(),
+            requested: "gpu".into(),
+            resolved: "gpu".into(),
+            embeddings: "cpu".into(),
+            lm_head: "cpu".into(),
+            dense_projections: "cpu".into(),
+            attention: "gpu".into(),
+            kv: "gpu".into(),
+            router: "cpu".into(),
+            routed_experts: "cpu".into(),
+            routed_expert_dtype: "q4_0".into(),
+            fallback_occurred: false,
+            reason: None,
+        }
+    }
+
+    fn strict_load() -> ModelLoadEvidence {
+        ModelLoadEvidence {
+            strict: true,
+            loader: "safetensors".into(),
+            loaded_tensors: 10,
+            required_tensors: 10,
+            optional_probed: 0,
+            optional_loaded: 0,
+            seeded_fallback_remained: false,
+        }
+    }
+
+    fn runtime_contract() -> RuntimeContractInput {
+        RuntimeContractInput {
+            real_transformer_enabled: true,
+            real_transformer_gpu_native: true,
+            compute_offload: crate::backend::ComputeOffload::Gpu,
+            legacy_execution_plan: legacy_plan(),
+            token_loop_geometry: Some(qwen_geometry()),
+            authoritative_device: Some(l4_device()),
+            model_load: strict_load(),
+            routed_failure_policy: crate::engine::RoutedExpertGpuFailurePolicy::StrictFailClosed,
+        }
+    }
+
+    fn empty_snapshots(counter: GpuNativeTokenLoopSnapshot) -> RequestSnapshots {
+        RequestSnapshots {
+            token_loop_before: GpuNativeTokenLoopSnapshot::default(),
+            token_loop_after: counter,
+            token_loop_delta: counter,
+            token_loop_ratios: CounterRatios::from_delta(counter).unwrap(),
+            routed_execution_before: RoutedExpertExecutionSnapshot::default(),
+            routed_execution_after: RoutedExpertExecutionSnapshot::default(),
+            routed_execution_delta: RoutedExpertExecutionSnapshot::default(),
+            runtime_cache_before: RuntimeCacheSnapshot::default(),
+            runtime_cache_after: RuntimeCacheSnapshot::default(),
+            engine_storage_before: EngineStorageSnapshot::default(),
+            engine_storage_after: EngineStorageSnapshot::default(),
+            engine_storage_delta: EngineStorageSnapshot::default(),
+            gpu_expert_io_before: GpuExpertIoSnapshot::default(),
+            gpu_expert_io_after: GpuExpertIoSnapshot::default(),
+            gpu_expert_io_delta: GpuExpertIoSnapshot::default(),
+            gpu_expert_memory_before: GpuExpertMemorySnapshot::default(),
+            gpu_expert_memory_after: GpuExpertMemorySnapshot::default(),
+            gpu_native_residency_before: GpuNativeTieredResidencySnapshot::default(),
+            gpu_native_residency_after: GpuNativeTieredResidencySnapshot::default(),
+            gpu_native_residency_delta: GpuNativeResidencyDelta::default(),
+        }
+    }
+
+    fn run(index: usize, decode_tps_seconds: f64) -> PerRunResult {
+        let counter = GpuNativeTokenLoopSnapshot {
+            token_attempts: 5,
+            tokens_completed: 5,
+            warm_tokens_completed: 5,
+            queue_submissions: 5,
+            boundary_maps: 5,
+            boundary_readbacks: 5,
+            ..GpuNativeTokenLoopSnapshot::default()
+        };
+        PerRunResult {
+            run_index: index,
+            prompt_tokens: 4,
+            requested_output_tokens: 2,
+            generated_tokens: 2,
+            generated_token_ids: vec![7, 8],
+            generated_token_ids_sha256: "a".repeat(64),
+            generated_text_sha256: "b".repeat(64),
+            timing: RunTiming::from_measurement(
+                2,
+                2.0,
+                2.0,
+                decode_tps_seconds,
+                vec![decode_tps_seconds],
+            )
+            .unwrap(),
+            counters: empty_snapshots(counter),
+        }
+    }
+
+    #[test]
+    fn timing_arithmetic_excludes_first_decode_and_includes_all_end_to_end() {
+        let timing = RunTiming::from_measurement(5, 2.0, 2.0, 4.0, vec![1.0; 4]).unwrap();
+        assert_eq!(timing.decode_generated_tokens, 4);
+        assert_eq!(timing.decode_tps, 1.0);
+        assert_eq!(timing.end_to_end_seconds, 6.0);
+        assert_eq!(timing.end_to_end_generated_tps, 5.0 / 6.0);
+    }
+
+    #[test]
+    fn percentile_and_latency_statistics_are_deterministic() {
+        let stats = LatencyStatistics::from_values(&[1.0, 2.0, 3.0, 4.0, 5.0]).unwrap();
+        assert_eq!(stats.p50_seconds, 3.0);
+        assert_eq!(stats.p95_seconds, 5.0);
+        assert_eq!(stats.p99_seconds, 5.0);
+        assert_eq!(stats.mean_seconds, 3.0);
+        assert_eq!(stats.min_seconds, 1.0);
+        assert_eq!(stats.max_seconds, 5.0);
+    }
+
+    #[test]
+    fn counter_delta_and_ratios_are_exact() {
+        let before = GpuNativeTokenLoopSnapshot {
+            token_attempts: 10,
+            tokens_completed: 5,
+            queue_submissions: 10,
+            ..GpuNativeTokenLoopSnapshot::default()
+        };
+        let after = GpuNativeTokenLoopSnapshot {
+            token_attempts: 18,
+            tokens_completed: 9,
+            residency_miss_attempts: 2,
+            replay_attempts: 2,
+            queue_submissions: 18,
+            ..GpuNativeTokenLoopSnapshot::default()
+        };
+        let delta = token_loop_delta(before, after).unwrap();
+        let ratios = CounterRatios::from_delta(delta).unwrap();
+        assert_eq!(delta.token_attempts, 8);
+        assert_eq!(delta.tokens_completed, 4);
+        assert_eq!(ratios.attempts_per_completed_position, 2.0);
+        assert_eq!(ratios.misses_per_completed_position, 0.5);
+        assert_eq!(ratios.replays_per_completed_position, 0.5);
+        assert_eq!(ratios.submissions_per_completed_position, 2.0);
+    }
+
+    #[test]
+    fn cache_reset_semantics_define_runtime_construction_count() {
+        assert_eq!(
+            expected_runtime_constructions(crate::BenchRealCacheReset::Keep, 3, 4),
+            1
+        );
+        assert_eq!(
+            expected_runtime_constructions(crate::BenchRealCacheReset::FreshRuntime, 3, 4),
+            7
+        );
+    }
+
+    #[test]
+    fn aggregate_excludes_unpassed_warmup_and_retains_each_measured_run() {
+        let warmup = run(99, 100.0);
+        let measured = vec![run(0, 1.0), run(1, 2.0)];
+        let aggregate = aggregate(&measured).unwrap();
+        assert_eq!(measured.len(), 2);
+        assert_eq!(aggregate.decode_tps.mean, 0.75);
+        assert_ne!(aggregate.decode_tps.mean, warmup.timing.decode_tps);
+        assert_eq!(aggregate.counter_totals.tokens_completed, 10);
+    }
+
+    #[test]
+    fn zero_or_nonfinite_duration_fails_closed() {
+        assert!(RunTiming::from_measurement(2, 1.0, 1.0, 0.0, vec![0.0]).is_err());
+        assert!(RunTiming::from_measurement(2, f64::NAN, 1.0, 1.0, vec![1.0]).is_err());
+    }
+
+    #[test]
+    fn failed_measured_run_prevents_aggregate_publication() {
+        let mut retained = vec![run(0, 1.0)];
+        let failed = retain_measured_result(
+            &mut retained,
+            Err(BenchmarkFailure::new(
+                "inference",
+                "failed-measured-run",
+                "fixture failure",
+            )),
+        )
+        .unwrap_err();
+        assert_eq!(failed.code, "failed-measured-run");
+        assert_eq!(
+            retained.len(),
+            1,
+            "failed run must not replace or hide prior evidence"
+        );
+    }
+
+    #[test]
+    fn strict_runtime_contract_accepts_corrected_legacy_context() {
+        let (evidence, device) =
+            validate_runtime_contract(&runtime_contract(), "NVIDIA L4").unwrap();
+        assert!(evidence.ordinary_step_token_only);
+        assert_eq!(evidence.legacy_execution_plan.embeddings, "cpu");
+        assert_eq!(device.name, "NVIDIA L4");
+    }
+
+    #[test]
+    fn missing_token_loop_is_rejected() {
+        let mut input = runtime_contract();
+        input.token_loop_geometry = None;
+        assert_eq!(
+            validate_runtime_contract(&input, "NVIDIA L4")
+                .unwrap_err()
+                .code,
+            "missing-gpu-native-token-loop"
+        );
+    }
+
+    #[test]
+    fn wrong_and_software_adapters_are_rejected() {
+        let mut wrong = runtime_contract();
+        wrong.authoritative_device.as_mut().unwrap().name = "other".into();
+        assert_eq!(
+            validate_runtime_contract(&wrong, "NVIDIA L4")
+                .unwrap_err()
+                .code,
+            "wrong-adapter"
+        );
+        let mut software = runtime_contract();
+        software
+            .authoritative_device
+            .as_mut()
+            .unwrap()
+            .software_adapter = true;
+        assert_eq!(
+            validate_runtime_contract(&software, "NVIDIA L4")
+                .unwrap_err()
+                .code,
+            "software-adapter"
+        );
+    }
+
+    #[test]
+    fn wrong_backend_and_incomplete_strict_load_are_rejected() {
+        let mut wrong_backend = runtime_contract();
+        wrong_backend
+            .authoritative_device
+            .as_mut()
+            .unwrap()
+            .wgpu_backend = "metal".into();
+        assert_eq!(
+            validate_runtime_contract(&wrong_backend, "NVIDIA L4")
+                .unwrap_err()
+                .code,
+            "wrong-gpu-backend"
+        );
+
+        let mut incomplete = runtime_contract();
+        incomplete.model_load.loaded_tensors -= 1;
+        assert_eq!(
+            validate_runtime_contract(&incomplete, "NVIDIA L4")
+                .unwrap_err()
+                .code,
+            "incomplete-model-load"
+        );
+    }
+
+    #[test]
+    fn fallback_and_degradation_are_rejected() {
+        let token_loop = GpuNativeTokenLoopSnapshot {
+            tokens_completed: 5,
+            ..GpuNativeTokenLoopSnapshot::default()
+        };
+        let routed = RoutedExpertExecutionSnapshot {
+            gpu_cpu_fallbacks: 1,
+            ..RoutedExpertExecutionSnapshot::default()
+        };
+        assert_eq!(
+            validate_request_postconditions(4, 2, 2, token_loop, routed)
+                .unwrap_err()
+                .code,
+            "fallback-or-degradation"
+        );
+
+        let cpu_dispatch = RoutedExpertExecutionSnapshot {
+            cpu_routed_expert_dispatches: 1,
+            ..RoutedExpertExecutionSnapshot::default()
+        };
+        assert_eq!(
+            validate_request_postconditions(4, 2, 2, token_loop, cpu_dispatch)
+                .unwrap_err()
+                .code,
+            "fallback-or-degradation"
+        );
+
+        let degraded = RoutedExpertExecutionSnapshot {
+            degraded_expert_substitutions: 1,
+            ..RoutedExpertExecutionSnapshot::default()
+        };
+        assert_eq!(
+            validate_request_postconditions(4, 2, 2, token_loop, degraded)
+                .unwrap_err()
+                .code,
+            "fallback-or-degradation"
+        );
+    }
+
+    #[test]
+    fn fatal_no_progress_and_incomplete_generation_are_rejected() {
+        let fatal = GpuNativeTokenLoopSnapshot {
+            tokens_completed: 5,
+            fatal_failures: 1,
+            ..GpuNativeTokenLoopSnapshot::default()
+        };
+        assert_eq!(
+            validate_request_postconditions(
+                4,
+                2,
+                2,
+                fatal,
+                RoutedExpertExecutionSnapshot::default(),
+            )
+            .unwrap_err()
+            .code,
+            "token-loop-postcondition"
+        );
+
+        let no_progress = GpuNativeTokenLoopSnapshot {
+            tokens_completed: 5,
+            no_progress_failures: 1,
+            ..GpuNativeTokenLoopSnapshot::default()
+        };
+        assert_eq!(
+            validate_request_postconditions(
+                4,
+                2,
+                2,
+                no_progress,
+                RoutedExpertExecutionSnapshot::default(),
+            )
+            .unwrap_err()
+            .code,
+            "token-loop-postcondition"
+        );
+
+        let otherwise_valid = GpuNativeTokenLoopSnapshot {
+            tokens_completed: 5,
+            ..GpuNativeTokenLoopSnapshot::default()
+        };
+        assert_eq!(
+            validate_request_postconditions(
+                4,
+                2,
+                1,
+                otherwise_valid,
+                RoutedExpertExecutionSnapshot::default(),
+            )
+            .unwrap_err()
+            .code,
+            "incomplete-generation"
+        );
+    }
+
+    #[test]
+    fn report_flags_are_permanently_nonqualification_and_nondiagnostic() {
+        let report = BenchmarkReport::new(
+            BenchmarkProvenance {
+                build: BuildProvenance {
+                    git_sha: Some("a".repeat(40)),
+                    dirty: Some(false),
+                    package_version: "test".into(),
+                },
+                executable_canonical_path: "/test/bin".into(),
+                executable_sha256: "b".repeat(64),
+                resolved_config_sha256: "c".repeat(64),
+                artifacts: QualificationArtifacts::default(),
+                expert_metadata: ExpertMetadataEvidence {
+                    dtype: Some("q4_0".into()),
+                    q4_0_layout: Some(crate::inference::Q4_0_LAYOUT_STANDARD_V1.into()),
+                    conversion_mode: None,
+                    source: None,
+                    explicitly_synthetic: false,
+                },
+            },
+            ModelIdentityEvidence {
+                architecture: "qwen3_moe".into(),
+                num_layers: 48,
+                num_experts_per_layer: 128,
+                total_experts: 6_144,
+                top_k: 8,
+                d_model: 2_048,
+                d_ff: 768,
+                routed_expert_dtype: "q4_0".into(),
+            },
+            RequestEvidence {
+                prompt_sha256: "d".repeat(64),
+                prompt_token_ids_sha256: "e".repeat(64),
+                prompt_token_count: 2,
+                requested_output_tokens: 2,
+                greedy: true,
+            },
+            crate::BenchRealCacheReset::Keep,
+            0,
+            1,
+            ProductionConfiguration::default(),
+        );
+        assert!(!report.production_semantics.diagnostic_trace_enabled);
+        assert!(
+            !report
+                .production_semantics
+                .production_inference_math_changed
+        );
+        let json = serde_json::to_value(report).unwrap();
+        assert_eq!(json["qualification_pass"], false);
+        assert_eq!(json["correctness_qualification_pending"], true);
+        assert_eq!(
+            json["production_semantics"]["diagnostic_trace_enabled"],
+            false
+        );
+    }
+
+    #[test]
+    fn cli_parses_required_gpu_native_benchmark_surface() {
+        use clap::Parser as _;
+
+        let cli = crate::Cli::try_parse_from([
+            "micro-expert-router",
+            "bench-gpu-native-real",
+            "--config",
+            "config.toml",
+            "--prompt",
+            "hello",
+            "--output-tokens",
+            "8",
+            "--warmup-runs",
+            "2",
+            "--measured-runs",
+            "3",
+            "--cache-reset",
+            "fresh-runtime",
+            "--greedy",
+            "--expected-adapter-name",
+            "NVIDIA L4",
+            "--report-out",
+            "report.json",
+        ])
+        .unwrap();
+        let crate::Cmd::BenchGpuNativeReal {
+            output_tokens,
+            warmup_runs,
+            measured_runs,
+            cache_reset,
+            greedy,
+            expected_adapter_name,
+            report_out,
+            ..
+        } = cli.cmd
+        else {
+            panic!("expected bench-gpu-native-real command")
+        };
+        assert_eq!(output_tokens, Some(8));
+        assert_eq!(warmup_runs, 2);
+        assert_eq!(measured_runs, 3);
+        assert_eq!(cache_reset, crate::BenchRealCacheReset::FreshRuntime);
+        assert!(greedy);
+        assert_eq!(expected_adapter_name, "NVIDIA L4");
+        assert_eq!(report_out, Some(PathBuf::from("report.json")));
+    }
+
+    #[test]
+    fn cli_rejects_missing_required_greedy_flag() {
+        use clap::Parser as _;
+
+        let error = crate::Cli::try_parse_from([
+            "micro-expert-router",
+            "bench-gpu-native-real",
+            "--config",
+            "config.toml",
+            "--prompt",
+            "hello",
+            "--expected-adapter-name",
+            "NVIDIA L4",
+        ])
+        .unwrap_err();
+        assert!(error.to_string().contains("--greedy"));
+    }
+
+    #[test]
+    fn ordinary_step_orchestration_matches_ingest_contract_fixture() {
+        fn sample(token: u32, position: usize) -> u32 {
+            token.wrapping_add(position as u32).wrapping_add(17) % 101
+        }
+        fn ordinary(prompt: &[u32], output_tokens: usize) -> Vec<u32> {
+            let mut generated = Vec::new();
+            let mut completed = 0usize;
+            while generated.len() < output_tokens {
+                let step = next_ordinary_step(prompt, &generated, completed).unwrap();
+                completed += 1;
+                if step.sample {
+                    generated.push(sample(step.token_id, step.position));
+                }
+            }
+            generated
+        }
+        fn ingest_contract(prompt: &[u32], output_tokens: usize) -> Vec<u32> {
+            let mut generated = vec![sample(*prompt.last().unwrap(), prompt.len() - 1)];
+            while generated.len() < output_tokens {
+                let position = prompt.len() + generated.len() - 1;
+                generated.push(sample(*generated.last().unwrap(), position));
+            }
+            generated
+        }
+        let prompt = [3, 5, 8];
+        assert_eq!(ordinary(&prompt, 6), ingest_contract(&prompt, 6));
+    }
+}

--- a/rust-engine/src/gpu_native_real_benchmark.rs
+++ b/rust-engine/src/gpu_native_real_benchmark.rs
@@ -8,7 +8,9 @@
 use crate::backend::{GpuDeviceIdentity, GpuExpertIoSnapshot, GpuExpertMemorySnapshot};
 use crate::engine::RoutedExpertExecutionSnapshot;
 use crate::gpu_native_residency::GpuNativeTieredResidencySnapshot;
-use crate::gpu_native_token_loop::{GpuNativeModelGeometry, GpuNativeTokenLoopSnapshot};
+use crate::gpu_native_token_loop::{
+    GpuNativeModelGeometry, GpuNativeRecoverySnapshot, GpuNativeTokenLoopSnapshot,
+};
 use crate::greedy_parity::{
     BackgroundShutdownEvidence, ModelIdentityEvidence, ModelLoadEvidence, RuntimeCacheSnapshot,
 };
@@ -18,8 +20,10 @@ use crate::qualification::{
 use serde::Serialize;
 use std::path::PathBuf;
 
-pub(crate) const SCHEMA: &str = "mer.gpu-native-real-benchmark.v1";
+pub(crate) const SCHEMA: &str = "mer.gpu-native-real-benchmark.v2";
 pub(crate) const MODE: &str = "gpu-native-real-benchmark";
+pub(crate) const OPTIMIZATION: &str = "gpu-native-resumable-recovery-pr1";
+pub(crate) const BASELINE_COMMIT: &str = "db0664159fe4a57e5b630984b9229e233fa21487";
 
 const EXPECTED_NUM_LAYERS: usize = 48;
 const EXPECTED_NUM_EXPERTS: usize = 128;
@@ -82,7 +86,7 @@ pub(crate) struct ProductionSemantics {
 }
 
 impl ProductionSemantics {
-    pub(crate) const fn baseline() -> Self {
+    pub(crate) const fn resumable_recovery_pr1() -> Self {
         Self {
             production_inference_math_changed: false,
             production_q4_changed: false,
@@ -91,7 +95,7 @@ impl ProductionSemantics {
             production_rmsnorm_changed: false,
             production_lm_head_changed: false,
             production_residency_policy_changed: false,
-            production_replay_policy_changed: false,
+            production_replay_policy_changed: true,
             production_prefetch_policy_changed: false,
             diagnostic_trace_enabled: false,
         }
@@ -460,6 +464,59 @@ impl CounterRatios {
     }
 }
 
+#[derive(Clone, Copy, Debug, Default, Serialize)]
+pub(crate) struct RecoveryRatios {
+    pub(crate) resume_attempts_per_completed_position: f64,
+    pub(crate) recovery_segments_per_completed_position: f64,
+    pub(crate) checkpoint_captures_per_completed_position: f64,
+    pub(crate) checkpoint_restores_per_completed_position: f64,
+    pub(crate) full_token_replays_per_completed_position: f64,
+    pub(crate) layers_encoded_per_completed_position: f64,
+    pub(crate) attention_layers_reexecuted_per_completed_position: f64,
+    pub(crate) expert_layers_reexecuted_per_completed_position: f64,
+    pub(crate) invalid_tail_layers_encoded_per_completed_position: f64,
+    pub(crate) residency_service_us_per_completed_position: f64,
+    pub(crate) boundary_wait_us_per_completed_position: f64,
+}
+
+impl RecoveryRatios {
+    fn from_delta(
+        delta: GpuNativeRecoverySnapshot,
+        completed_positions: u64,
+    ) -> Result<Self, BenchmarkFailure> {
+        if completed_positions == 0 {
+            return Err(BenchmarkFailure::new(
+                "postcondition",
+                "zero-completed-positions",
+                "recovery ratios require at least one completed position",
+            ));
+        }
+        let completed = completed_positions as f64;
+        Ok(Self {
+            resume_attempts_per_completed_position: delta.resume_attempts as f64 / completed,
+            recovery_segments_per_completed_position: delta.recovery_segments as f64 / completed,
+            checkpoint_captures_per_completed_position: delta.checkpoint_captures as f64
+                / completed,
+            checkpoint_restores_per_completed_position: delta.checkpoint_restores as f64
+                / completed,
+            full_token_replays_per_completed_position: delta.full_token_replay_attempts as f64
+                / completed,
+            layers_encoded_per_completed_position: delta.layers_encoded as f64 / completed,
+            attention_layers_reexecuted_per_completed_position: delta.attention_layers_reexecuted
+                as f64
+                / completed,
+            expert_layers_reexecuted_per_completed_position: delta.expert_layers_reexecuted as f64
+                / completed,
+            invalid_tail_layers_encoded_per_completed_position: delta.invalid_tail_layers_encoded
+                as f64
+                / completed,
+            residency_service_us_per_completed_position: delta.residency_service_us as f64
+                / completed,
+            boundary_wait_us_per_completed_position: delta.boundary_wait_us as f64 / completed,
+        })
+    }
+}
+
 macro_rules! checked_delta {
     ($after:expr, $before:expr, $field:ident, $label:expr) => {
         $after.$field.checked_sub($before.$field).ok_or_else(|| {
@@ -493,6 +550,45 @@ pub(crate) fn token_loop_delta(
         queue_submissions: checked_delta!(after, before, queue_submissions, "token-loop"),
         boundary_maps: checked_delta!(after, before, boundary_maps, "token-loop"),
         boundary_readbacks: checked_delta!(after, before, boundary_readbacks, "token-loop"),
+    })
+}
+
+pub(crate) fn recovery_delta(
+    before: GpuNativeRecoverySnapshot,
+    after: GpuNativeRecoverySnapshot,
+) -> Result<GpuNativeRecoverySnapshot, BenchmarkFailure> {
+    Ok(GpuNativeRecoverySnapshot {
+        resume_attempts: checked_delta!(after, before, resume_attempts, "recovery"),
+        recovery_segments: checked_delta!(after, before, recovery_segments, "recovery"),
+        checkpoint_captures: checked_delta!(after, before, checkpoint_captures, "recovery"),
+        checkpoint_restores: checked_delta!(after, before, checkpoint_restores, "recovery"),
+        full_token_replay_attempts: checked_delta!(
+            after,
+            before,
+            full_token_replay_attempts,
+            "recovery"
+        ),
+        layers_encoded: checked_delta!(after, before, layers_encoded, "recovery"),
+        attention_layers_reexecuted: checked_delta!(
+            after,
+            before,
+            attention_layers_reexecuted,
+            "recovery"
+        ),
+        expert_layers_reexecuted: checked_delta!(
+            after,
+            before,
+            expert_layers_reexecuted,
+            "recovery"
+        ),
+        invalid_tail_layers_encoded: checked_delta!(
+            after,
+            before,
+            invalid_tail_layers_encoded,
+            "recovery"
+        ),
+        residency_service_us: checked_delta!(after, before, residency_service_us, "recovery"),
+        boundary_wait_us: checked_delta!(after, before, boundary_wait_us, "recovery"),
     })
 }
 
@@ -700,6 +796,10 @@ pub(crate) struct RequestSnapshots {
     pub(crate) token_loop_after: GpuNativeTokenLoopSnapshot,
     pub(crate) token_loop_delta: GpuNativeTokenLoopSnapshot,
     pub(crate) token_loop_ratios: CounterRatios,
+    pub(crate) recovery_before: GpuNativeRecoverySnapshot,
+    pub(crate) recovery_after: GpuNativeRecoverySnapshot,
+    pub(crate) recovery_delta: GpuNativeRecoverySnapshot,
+    pub(crate) recovery_ratios: RecoveryRatios,
     pub(crate) routed_execution_before: RoutedExpertExecutionSnapshot,
     pub(crate) routed_execution_after: RoutedExpertExecutionSnapshot,
     pub(crate) routed_execution_delta: RoutedExpertExecutionSnapshot,
@@ -875,6 +975,8 @@ pub(crate) struct Aggregate {
     pub(crate) pooled_post_ttft_decode_token_latency: LatencyStatistics,
     pub(crate) counter_totals: GpuNativeTokenLoopSnapshot,
     pub(crate) counter_ratios: CounterRatios,
+    pub(crate) recovery_totals: GpuNativeRecoverySnapshot,
+    pub(crate) recovery_ratios: RecoveryRatios,
 }
 
 fn add_counter_totals(
@@ -906,6 +1008,38 @@ fn add_counter_totals(
     Ok(())
 }
 
+fn add_recovery_totals(
+    total: &mut GpuNativeRecoverySnapshot,
+    value: GpuNativeRecoverySnapshot,
+) -> Result<(), BenchmarkFailure> {
+    macro_rules! add {
+        ($field:ident) => {
+            total.$field = total.$field.checked_add(value.$field).ok_or_else(|| {
+                BenchmarkFailure::new(
+                    "postcondition",
+                    "counter-overflow",
+                    format!(
+                        "aggregate recovery counter {} overflowed",
+                        stringify!($field)
+                    ),
+                )
+            })?;
+        };
+    }
+    add!(resume_attempts);
+    add!(recovery_segments);
+    add!(checkpoint_captures);
+    add!(checkpoint_restores);
+    add!(full_token_replay_attempts);
+    add!(layers_encoded);
+    add!(attention_layers_reexecuted);
+    add!(expert_layers_reexecuted);
+    add!(invalid_tail_layers_encoded);
+    add!(residency_service_us);
+    add!(boundary_wait_us);
+    Ok(())
+}
+
 pub(crate) fn aggregate(runs: &[PerRunResult]) -> Result<Aggregate, BenchmarkFailure> {
     if runs.is_empty() {
         return Err(BenchmarkFailure::new(
@@ -929,9 +1063,11 @@ pub(crate) fn aggregate(runs: &[PerRunResult]) -> Result<Aggregate, BenchmarkFai
     ttft.sort_by(f64::total_cmp);
     let mut pooled_latencies = Vec::new();
     let mut counter_totals = GpuNativeTokenLoopSnapshot::default();
+    let mut recovery_totals = GpuNativeRecoverySnapshot::default();
     for run in runs {
         pooled_latencies.extend_from_slice(&run.timing.post_ttft_decode_token_latencies_seconds);
         add_counter_totals(&mut counter_totals, run.counters.token_loop_delta)?;
+        add_recovery_totals(&mut recovery_totals, run.counters.recovery_delta)?;
     }
     Ok(Aggregate {
         decode_tps: distribution(&decode_tps)?,
@@ -943,6 +1079,11 @@ pub(crate) fn aggregate(runs: &[PerRunResult]) -> Result<Aggregate, BenchmarkFai
         },
         pooled_post_ttft_decode_token_latency: LatencyStatistics::from_values(&pooled_latencies)?,
         counter_ratios: CounterRatios::from_delta(counter_totals)?,
+        recovery_ratios: RecoveryRatios::from_delta(
+            recovery_totals,
+            counter_totals.tokens_completed,
+        )?,
+        recovery_totals,
         counter_totals,
     })
 }
@@ -978,6 +1119,8 @@ pub(crate) struct RuntimeShutdown {
 pub(crate) struct BenchmarkReport {
     pub(crate) schema: &'static str,
     pub(crate) mode: &'static str,
+    pub(crate) optimization: &'static str,
+    pub(crate) baseline_commit: &'static str,
     pub(crate) benchmark_complete: bool,
     pub(crate) failure: Option<BenchmarkFailure>,
     pub(crate) qualification_pass: bool,
@@ -1014,6 +1157,8 @@ impl BenchmarkReport {
         Self {
             schema: SCHEMA,
             mode: MODE,
+            optimization: OPTIMIZATION,
+            baseline_commit: BASELINE_COMMIT,
             benchmark_complete: false,
             failure: None,
             qualification_pass: false,
@@ -1033,7 +1178,7 @@ impl BenchmarkReport {
             aggregate: None,
             runtime_contract: None,
             production_configuration,
-            production_semantics: ProductionSemantics::baseline(),
+            production_semantics: ProductionSemantics::resumable_recovery_pr1(),
         }
     }
 
@@ -1095,6 +1240,7 @@ pub(crate) fn validate_request_postconditions(
     requested_output_tokens: usize,
     generated_tokens: usize,
     token_loop: GpuNativeTokenLoopSnapshot,
+    recovery: GpuNativeRecoverySnapshot,
     routed: RoutedExpertExecutionSnapshot,
 ) -> Result<(), BenchmarkFailure> {
     let expected_completed = prompt_tokens
@@ -1123,6 +1269,26 @@ pub(crate) fn validate_request_postconditions(
             "token-loop-postcondition",
             format!(
                 "expected {expected_completed} completed positions and zero fatal/no-progress failures; observed {token_loop:?}"
+            ),
+        ));
+    }
+    if token_loop.replay_attempts != 0 || recovery.full_token_replay_attempts != 0 {
+        return Err(BenchmarkFailure::new(
+            "postcondition",
+            "full-token-replay-observed",
+            format!(
+                "PR1 requires zero full-token restarts; token_loop.replay_attempts={} recovery.full_token_replay_attempts={}",
+                token_loop.replay_attempts, recovery.full_token_replay_attempts,
+            ),
+        ));
+    }
+    if token_loop.residency_miss_attempts != 0 && recovery.resume_attempts == 0 {
+        return Err(BenchmarkFailure::new(
+            "postcondition",
+            "missing-resume-evidence",
+            format!(
+                "recoverable misses require resumable execution evidence; misses={} recovery={recovery:?}",
+                token_loop.residency_miss_attempts,
             ),
         ));
     }
@@ -1168,6 +1334,7 @@ fn next_ordinary_step(
 #[derive(Clone, Debug)]
 struct RequestSnapshotStart {
     token_loop: GpuNativeTokenLoopSnapshot,
+    recovery: GpuNativeRecoverySnapshot,
     routed: RoutedExpertExecutionSnapshot,
     runtime_cache: RuntimeCacheSnapshot,
     engine_storage: EngineStorageSnapshot,
@@ -1187,6 +1354,7 @@ impl RequestSnapshotStart {
         })?;
         Ok(Self {
             token_loop: token_loop.snapshot(),
+            recovery: token_loop.recovery_snapshot(),
             routed: runtime.engine.routed_expert_execution_snapshot(),
             runtime_cache: crate::greedy_parity_runtime_cache_snapshot(runtime),
             engine_storage: EngineStorageSnapshot::from_runtime(runtime),
@@ -1220,17 +1388,15 @@ impl RequestSnapshotStart {
         self,
         runtime: &crate::BenchRealRuntime,
     ) -> Result<RequestSnapshots, BenchmarkFailure> {
-        let token_loop_after = runtime
-            .gpu_native_token_loop
-            .as_ref()
-            .ok_or_else(|| {
-                BenchmarkFailure::new(
-                    "postcondition",
-                    "missing-gpu-native-token-loop",
-                    "gpu_native_token_loop disappeared after request",
-                )
-            })?
-            .snapshot();
+        let token_loop = runtime.gpu_native_token_loop.as_ref().ok_or_else(|| {
+            BenchmarkFailure::new(
+                "postcondition",
+                "missing-gpu-native-token-loop",
+                "gpu_native_token_loop disappeared after request",
+            )
+        })?;
+        let token_loop_after = token_loop.snapshot();
+        let recovery_after = token_loop.recovery_snapshot();
         let routed_after = runtime.engine.routed_expert_execution_snapshot();
         let engine_storage_after = EngineStorageSnapshot::from_runtime(runtime);
         let gpu_expert_io_after = runtime.engine.gpu_expert_io_snapshot().ok_or_else(|| {
@@ -1241,6 +1407,7 @@ impl RequestSnapshotStart {
             )
         })?;
         let token_loop_delta = token_loop_delta(self.token_loop, token_loop_after)?;
+        let recovery_delta = recovery_delta(self.recovery, recovery_after)?;
         let routed_execution_delta = routed_delta(self.routed, routed_after)?;
         let gpu_native_residency_after = runtime
             .engine
@@ -1259,6 +1426,13 @@ impl RequestSnapshotStart {
             token_loop_after,
             token_loop_delta,
             token_loop_ratios: CounterRatios::from_delta(token_loop_delta)?,
+            recovery_before: self.recovery,
+            recovery_after,
+            recovery_delta,
+            recovery_ratios: RecoveryRatios::from_delta(
+                recovery_delta,
+                token_loop_delta.tokens_completed,
+            )?,
             routed_execution_before: self.routed,
             routed_execution_after: routed_after,
             routed_execution_delta,
@@ -1415,6 +1589,7 @@ pub(crate) async fn execute_request(
         requested_output_tokens,
         generated_ids.len(),
         counters.token_loop_delta,
+        counters.recovery_delta,
         counters.routed_execution_delta,
     )?;
     let output_text = runtime.tokenizer.decode(&generated_ids)?;
@@ -1600,6 +1775,16 @@ fn validate_and_record_runtime(
             format!(
                 "fresh isolated runtime token-loop counters were not zero: {:?}",
                 token_loop.snapshot()
+            ),
+        ));
+    }
+    if token_loop.recovery_snapshot() != GpuNativeRecoverySnapshot::default() {
+        return Err(BenchmarkFailure::new(
+            "startup",
+            "nonzero-initial-recovery-counters",
+            format!(
+                "fresh isolated runtime recovery counters were not zero: {:?}",
+                token_loop.recovery_snapshot()
             ),
         ));
     }
@@ -2117,6 +2302,14 @@ mod tests {
             token_loop_after: counter,
             token_loop_delta: counter,
             token_loop_ratios: CounterRatios::from_delta(counter).unwrap(),
+            recovery_before: GpuNativeRecoverySnapshot::default(),
+            recovery_after: GpuNativeRecoverySnapshot::default(),
+            recovery_delta: GpuNativeRecoverySnapshot::default(),
+            recovery_ratios: RecoveryRatios::from_delta(
+                GpuNativeRecoverySnapshot::default(),
+                counter.tokens_completed,
+            )
+            .unwrap(),
             routed_execution_before: RoutedExpertExecutionSnapshot::default(),
             routed_execution_after: RoutedExpertExecutionSnapshot::default(),
             routed_execution_delta: RoutedExpertExecutionSnapshot::default(),
@@ -2213,6 +2406,40 @@ mod tests {
     }
 
     #[test]
+    fn recovery_delta_and_ratios_are_exact() {
+        let before = GpuNativeRecoverySnapshot {
+            resume_attempts: 2,
+            checkpoint_captures: 10,
+            layers_encoded: 10,
+            residency_service_us: 40,
+            boundary_wait_us: 50,
+            ..GpuNativeRecoverySnapshot::default()
+        };
+        let after = GpuNativeRecoverySnapshot {
+            resume_attempts: 4,
+            recovery_segments: 3,
+            checkpoint_captures: 18,
+            checkpoint_restores: 2,
+            layers_encoded: 20,
+            attention_layers_reexecuted: 2,
+            expert_layers_reexecuted: 4,
+            invalid_tail_layers_encoded: 6,
+            residency_service_us: 140,
+            boundary_wait_us: 250,
+            ..GpuNativeRecoverySnapshot::default()
+        };
+        let delta = recovery_delta(before, after).unwrap();
+        let ratios = RecoveryRatios::from_delta(delta, 2).unwrap();
+        assert_eq!(delta.resume_attempts, 2);
+        assert_eq!(delta.checkpoint_captures, 8);
+        assert_eq!(delta.full_token_replay_attempts, 0);
+        assert_eq!(ratios.resume_attempts_per_completed_position, 1.0);
+        assert_eq!(ratios.checkpoint_captures_per_completed_position, 4.0);
+        assert_eq!(ratios.residency_service_us_per_completed_position, 50.0);
+        assert_eq!(ratios.boundary_wait_us_per_completed_position, 100.0);
+    }
+
+    #[test]
     fn cache_reset_semantics_define_runtime_construction_count() {
         assert_eq!(
             expected_runtime_constructions(crate::BenchRealCacheReset::Keep, 3, 4),
@@ -2227,12 +2454,28 @@ mod tests {
     #[test]
     fn aggregate_excludes_unpassed_warmup_and_retains_each_measured_run() {
         let warmup = run(99, 100.0);
-        let measured = vec![run(0, 1.0), run(1, 2.0)];
+        let mut measured = vec![run(0, 1.0), run(1, 2.0)];
+        let recovery = GpuNativeRecoverySnapshot {
+            resume_attempts: 2,
+            recovery_segments: 3,
+            checkpoint_restores: 2,
+            ..GpuNativeRecoverySnapshot::default()
+        };
+        measured[0].counters.recovery_after = recovery;
+        measured[0].counters.recovery_delta = recovery;
+        measured[0].counters.recovery_ratios = RecoveryRatios::from_delta(recovery, 5).unwrap();
         let aggregate = aggregate(&measured).unwrap();
         assert_eq!(measured.len(), 2);
         assert_eq!(aggregate.decode_tps.mean, 0.75);
         assert_ne!(aggregate.decode_tps.mean, warmup.timing.decode_tps);
         assert_eq!(aggregate.counter_totals.tokens_completed, 10);
+        assert_eq!(aggregate.recovery_totals, recovery);
+        assert_eq!(
+            aggregate
+                .recovery_ratios
+                .resume_attempts_per_completed_position,
+            0.2
+        );
     }
 
     #[test]
@@ -2342,9 +2585,16 @@ mod tests {
             ..RoutedExpertExecutionSnapshot::default()
         };
         assert_eq!(
-            validate_request_postconditions(4, 2, 2, token_loop, routed)
-                .unwrap_err()
-                .code,
+            validate_request_postconditions(
+                4,
+                2,
+                2,
+                token_loop,
+                GpuNativeRecoverySnapshot::default(),
+                routed,
+            )
+            .unwrap_err()
+            .code,
             "fallback-or-degradation"
         );
 
@@ -2353,9 +2603,16 @@ mod tests {
             ..RoutedExpertExecutionSnapshot::default()
         };
         assert_eq!(
-            validate_request_postconditions(4, 2, 2, token_loop, cpu_dispatch)
-                .unwrap_err()
-                .code,
+            validate_request_postconditions(
+                4,
+                2,
+                2,
+                token_loop,
+                GpuNativeRecoverySnapshot::default(),
+                cpu_dispatch,
+            )
+            .unwrap_err()
+            .code,
             "fallback-or-degradation"
         );
 
@@ -2364,9 +2621,16 @@ mod tests {
             ..RoutedExpertExecutionSnapshot::default()
         };
         assert_eq!(
-            validate_request_postconditions(4, 2, 2, token_loop, degraded)
-                .unwrap_err()
-                .code,
+            validate_request_postconditions(
+                4,
+                2,
+                2,
+                token_loop,
+                GpuNativeRecoverySnapshot::default(),
+                degraded,
+            )
+            .unwrap_err()
+            .code,
             "fallback-or-degradation"
         );
     }
@@ -2384,6 +2648,7 @@ mod tests {
                 2,
                 2,
                 fatal,
+                GpuNativeRecoverySnapshot::default(),
                 RoutedExpertExecutionSnapshot::default(),
             )
             .unwrap_err()
@@ -2402,6 +2667,7 @@ mod tests {
                 2,
                 2,
                 no_progress,
+                GpuNativeRecoverySnapshot::default(),
                 RoutedExpertExecutionSnapshot::default(),
             )
             .unwrap_err()
@@ -2419,12 +2685,59 @@ mod tests {
                 2,
                 1,
                 otherwise_valid,
+                GpuNativeRecoverySnapshot::default(),
                 RoutedExpertExecutionSnapshot::default(),
             )
             .unwrap_err()
             .code,
             "incomplete-generation"
         );
+    }
+
+    #[test]
+    fn full_token_replay_is_rejected_but_resumable_miss_is_accepted() {
+        let token_loop = GpuNativeTokenLoopSnapshot {
+            tokens_completed: 5,
+            residency_miss_attempts: 1,
+            replay_attempts: 1,
+            ..GpuNativeTokenLoopSnapshot::default()
+        };
+        assert_eq!(
+            validate_request_postconditions(
+                4,
+                2,
+                2,
+                token_loop,
+                GpuNativeRecoverySnapshot {
+                    resume_attempts: 1,
+                    full_token_replay_attempts: 1,
+                    ..GpuNativeRecoverySnapshot::default()
+                },
+                RoutedExpertExecutionSnapshot::default(),
+            )
+            .unwrap_err()
+            .code,
+            "full-token-replay-observed"
+        );
+
+        let resumable = GpuNativeTokenLoopSnapshot {
+            replay_attempts: 0,
+            ..token_loop
+        };
+        assert!(validate_request_postconditions(
+            4,
+            2,
+            2,
+            resumable,
+            GpuNativeRecoverySnapshot {
+                resume_attempts: 1,
+                recovery_segments: 1,
+                checkpoint_restores: 1,
+                ..GpuNativeRecoverySnapshot::default()
+            },
+            RoutedExpertExecutionSnapshot::default(),
+        )
+        .is_ok());
     }
 
     #[test]
@@ -2476,9 +2789,32 @@ mod tests {
                 .production_semantics
                 .production_inference_math_changed
         );
+        assert!(!report.production_semantics.production_q4_changed);
+        assert!(!report.production_semantics.production_router_changed);
+        assert!(!report.production_semantics.production_attention_changed);
+        assert!(!report.production_semantics.production_rmsnorm_changed);
+        assert!(!report.production_semantics.production_lm_head_changed);
+        assert!(
+            !report
+                .production_semantics
+                .production_residency_policy_changed
+        );
+        assert!(report.production_semantics.production_replay_policy_changed);
+        assert!(
+            !report
+                .production_semantics
+                .production_prefetch_policy_changed
+        );
         let json = serde_json::to_value(report).unwrap();
         assert_eq!(json["qualification_pass"], false);
         assert_eq!(json["correctness_qualification_pending"], true);
+        assert_eq!(json["schema"], SCHEMA);
+        assert_eq!(json["optimization"], OPTIMIZATION);
+        assert_eq!(json["baseline_commit"], BASELINE_COMMIT);
+        assert_eq!(
+            json["production_semantics"]["production_replay_policy_changed"],
+            true
+        );
         assert_eq!(
             json["production_semantics"]["diagnostic_trace_enabled"],
             false

--- a/rust-engine/src/gpu_native_residency.rs
+++ b/rust-engine/src/gpu_native_residency.rs
@@ -1044,6 +1044,46 @@ mod tests {
     }
 
     #[test]
+    fn pre_fix_foreground_admission_self_evicts_a_current_selected_source() {
+        let cache = GpuExpertCache::new(16, 0.0, 0);
+        cache
+            .demand_admit_lru(Arc::new(GpuResident::new(7, vec![1; 8])))
+            .unwrap();
+        let selected_a_generation = cache.current_generation(7).unwrap();
+        cache
+            .demand_admit_lru(Arc::new(GpuResident::new(99, vec![9; 8])))
+            .unwrap();
+
+        let selected_a = GpuNativeDemandExpert::current(7);
+        assert!(cache.contains_generation(7, selected_a_generation));
+
+        // This is the old engine ordering: A was classified as Current, then
+        // selected B was admitted independently. A is the logical LRU even
+        // though non-selected 99 is an eligible victim and A+B fit together.
+        cache
+            .demand_admit_lru(Arc::new(GpuResident::new(8, vec![2; 8])))
+            .unwrap();
+        assert!(!cache.contains_generation(7, selected_a_generation));
+        assert!(cache.contains(99));
+        assert!(cache.contains(8));
+
+        let final_resolution = if cache.contains_generation(7, selected_a_generation) {
+            Ok(())
+        } else {
+            match selected_a {
+                GpuNativeDemandExpert::Current { global_id } => {
+                    Err(GpuNativeTieredResidencyError::DemandSourceMissing { global_id })
+                }
+                GpuNativeDemandExpert::Install { .. } => unreachable!(),
+            }
+        };
+        assert_eq!(
+            final_resolution,
+            Err(GpuNativeTieredResidencyError::DemandSourceMissing { global_id: 7 })
+        );
+    }
+
+    #[test]
     fn model_plan_requires_top_k_slots_per_layer_and_counts_every_arena() {
         let limits = limits();
         let geometry = geometry();

--- a/rust-engine/src/gpu_native_residency.rs
+++ b/rust-engine/src/gpu_native_residency.rs
@@ -83,6 +83,9 @@ pub(crate) enum GpuNativeTieredResidencyError {
         global_id: u32,
         generation: u64,
     },
+    PhysicalIdentityCorrupt {
+        global_id: u32,
+    },
     ResidencyPriorityMismatch,
     Backend(GpuNativeBootstrapError),
 }
@@ -108,6 +111,7 @@ impl fmt::Display for GpuNativeTieredResidencyError {
             Self::NoPhysicalSlot { layer_index } => write!(f, "layer {layer_index} has no free physical expert slot"),
             Self::NoEvictablePhysicalSlot { layer_index } => write!(f, "layer {layer_index} has no physical victim outside the protected demand set"),
             Self::StalePhysicalRequester { global_id, generation } => write!(f, "stale physical requester for global expert {global_id} generation {generation}"),
+            Self::PhysicalIdentityCorrupt { global_id } => write!(f, "GPU-native physical metadata disagrees with the authoritative arena for global expert {global_id}"),
             Self::ResidencyPriorityMismatch => f.write_str("residency request used the wrong demand/speculative priority"),
             Self::Backend(error) => write!(f, "GPU-native residency backend error: {error}"),
         }
@@ -409,6 +413,28 @@ impl Default for LayerResidencyState {
     }
 }
 
+fn touch_physical_record<T: Copy>(residents: &mut LruCache<u32, T>, global_id: u32) -> Option<T> {
+    residents.get(&global_id).copied()
+}
+
+fn validate_physical_install_source(
+    gpu_cache: &GpuExpertCache,
+    global_id: u32,
+    resident: &Arc<ExpertResident>,
+    admission: &GpuAdmission,
+) -> Result<(), GpuNativeTieredResidencyError> {
+    if resident.id != global_id || admission.resident().id != global_id {
+        return Err(GpuNativeTieredResidencyError::DemandSourceIdentityMismatch { global_id });
+    }
+    if !gpu_cache.contains_generation(global_id, admission.generation()) {
+        return Err(GpuNativeTieredResidencyError::LogicalAdmissionStale {
+            global_id,
+            generation: admission.generation(),
+        });
+    }
+    Ok(())
+}
+
 struct LayerResidency {
     arena: Arc<GpuNativeQ4ExpertArena>,
     state: Mutex<LayerResidencyState>,
@@ -418,6 +444,9 @@ struct LayerResidency {
 struct TieredResidencyCounters {
     vram_hits: AtomicU64,
     vram_misses: AtomicU64,
+    physical_current_hits: AtomicU64,
+    physical_source_acquisitions: AtomicU64,
+    logical_admissions_for_physical_misses: AtomicU64,
     ram_to_vram_installs: AtomicU64,
     physical_evictions: AtomicU64,
     physical_reinstalls: AtomicU64,
@@ -446,6 +475,9 @@ pub(crate) struct GpuNativeTieredResidencySnapshot {
     pub(crate) free_physical_slots: usize,
     pub(crate) vram_hits: u64,
     pub(crate) vram_misses: u64,
+    pub(crate) physical_current_hits: u64,
+    pub(crate) physical_source_acquisitions: u64,
+    pub(crate) logical_admissions_for_physical_misses: u64,
     pub(crate) ram_to_vram_installs: u64,
     pub(crate) physical_evictions: u64,
     pub(crate) physical_reinstalls: u64,
@@ -526,8 +558,10 @@ impl GpuNativeTieredResidencyManager {
         )
     }
 
-    /// Read-only tier selection probe for the engine's async demand path.
-    /// A stale logical identity is retired before returning `false`.
+    /// Read-only physical tier-selection probe for the engine's async demand
+    /// path. Host logical-admission LRU state is intentionally not consulted:
+    /// an exact, internally current arena residency owns immutable executable
+    /// bytes for the lifetime of this manager.
     pub(crate) fn has_current_for_demand(
         &self,
         global_id: u32,
@@ -538,6 +572,18 @@ impl GpuNativeTieredResidencyManager {
         Ok(self
             .current_record_locked(global_id, layer, &mut state, false)?
             .is_some())
+    }
+
+    pub(crate) fn record_physical_source_acquisition(&self) {
+        self.counters
+            .physical_source_acquisitions
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn record_logical_admissions_for_physical_misses(&self, count: usize) {
+        self.counters
+            .logical_admissions_for_physical_misses
+            .fetch_add(count as u64, Ordering::Relaxed);
     }
 
     /// VRAM-first speculative probe. It never waits behind a demand mutation;
@@ -629,6 +675,9 @@ impl GpuNativeTieredResidencyManager {
             let global_id = demand.global_id();
             if let Some(record) = self.current_record_locked(global_id, layer, &mut state, true)? {
                 self.counters.vram_hits.fetch_add(1, Ordering::Relaxed);
+                self.counters
+                    .physical_current_hits
+                    .fetch_add(1, Ordering::Relaxed);
                 resolved[index] = Some(record.residency);
             } else {
                 self.counters.vram_misses.fetch_add(1, Ordering::Relaxed);
@@ -752,6 +801,15 @@ impl GpuNativeTieredResidencyManager {
             free_physical_slots: layers.iter().map(|layer| layer.free_slots).sum(),
             vram_hits: self.counters.vram_hits.load(Ordering::Relaxed),
             vram_misses: self.counters.vram_misses.load(Ordering::Relaxed),
+            physical_current_hits: self.counters.physical_current_hits.load(Ordering::Relaxed),
+            physical_source_acquisitions: self
+                .counters
+                .physical_source_acquisitions
+                .load(Ordering::Relaxed),
+            logical_admissions_for_physical_misses: self
+                .counters
+                .logical_admissions_for_physical_misses
+                .load(Ordering::Relaxed),
             ram_to_vram_installs: self.counters.ram_to_vram_installs.load(Ordering::Relaxed),
             physical_evictions: self.counters.physical_evictions.load(Ordering::Relaxed),
             physical_reinstalls: self.counters.physical_reinstalls.load(Ordering::Relaxed),
@@ -780,22 +838,21 @@ impl GpuNativeTieredResidencyManager {
         resident: &Arc<ExpertResident>,
         admission: &GpuAdmission,
     ) -> Result<(), GpuNativeTieredResidencyError> {
-        if resident.id != global_id || admission.resident().id != global_id {
-            return Err(GpuNativeTieredResidencyError::DemandSourceIdentityMismatch { global_id });
-        }
-        if !self
-            .gpu_cache
-            .contains_generation(global_id, admission.generation())
-        {
+        let result = validate_physical_install_source(
+            self.gpu_cache.as_ref(),
+            global_id,
+            resident,
+            admission,
+        );
+        if matches!(
+            result,
+            Err(GpuNativeTieredResidencyError::LogicalAdmissionStale { .. })
+        ) {
             self.counters
                 .stale_generation_rejections
                 .fetch_add(1, Ordering::Relaxed);
-            return Err(GpuNativeTieredResidencyError::LogicalAdmissionStale {
-                global_id,
-                generation: admission.generation(),
-            });
         }
-        Ok(())
+        result
     }
 
     fn current_record_locked(
@@ -808,21 +865,19 @@ impl GpuNativeTieredResidencyManager {
         let Some(record) = state.residents.peek(&global_id).copied() else {
             return Ok(None);
         };
-        if !self
-            .gpu_cache
-            .contains_generation(global_id, record.key.logical_generation())
+        let identity = self.identity(global_id)?;
+        if record.key.layer_index() != identity.layer_index
+            || record.key.expert_id() != identity.local_expert_id
+            || record.residency.key() != record.key
+            || layer.arena.layer_index() != identity.layer_index
+            || !layer
+                .arena
+                .contains_exact_residency(self.executor.context_id(), record.residency)
         {
-            self.retire_metadata_record_locked(global_id, layer, state, false)?;
-            self.counters
-                .stale_generation_rejections
-                .fetch_add(1, Ordering::Relaxed);
-            return Ok(None);
+            return Err(GpuNativeTieredResidencyError::PhysicalIdentityCorrupt { global_id });
         }
         if touch {
-            let record = state
-                .residents
-                .get(&global_id)
-                .copied()
+            let record = touch_physical_record(&mut state.residents, global_id)
                 .expect("peeked current physical record remains under layer lock");
             Ok(Some(record))
         } else {
@@ -967,6 +1022,7 @@ fn oldest_unprotected<T>(cache: &LruCache<u32, T>, protected: &HashSet<u32>) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::buffer_pool::BufferPool;
     use crate::expert_cache::GpuResident;
 
     fn geometry() -> GpuNativeQ4ExpertGeometry {
@@ -1041,6 +1097,38 @@ mod tests {
         assert_eq!(newer_key.logical_generation(), newer.generation());
         assert!(!cache.contains_generation(7, first_key.logical_generation()));
         assert!(cache.contains_generation(7, newer_key.logical_generation()));
+    }
+
+    #[test]
+    fn physical_install_source_requires_current_matching_logical_admission() {
+        let cache = GpuExpertCache::new(8, 0.0, 0);
+        cache
+            .demand_admit_lru(Arc::new(GpuResident::new(7, vec![1; 8])))
+            .unwrap();
+        let admission = cache.current_admission(7).unwrap();
+        let pool = BufferPool::new(2, 8, 4);
+        let resident = Arc::new(ExpertResident::new(7, pool.try_acquire().unwrap()));
+        assert_eq!(
+            validate_physical_install_source(&cache, 7, &resident, &admission),
+            Ok(())
+        );
+
+        let wrong_resident = Arc::new(ExpertResident::new(8, pool.try_acquire().unwrap()));
+        assert_eq!(
+            validate_physical_install_source(&cache, 7, &wrong_resident, &admission),
+            Err(GpuNativeTieredResidencyError::DemandSourceIdentityMismatch { global_id: 7 })
+        );
+
+        cache
+            .demand_admit_lru(Arc::new(GpuResident::new(8, vec![2; 8])))
+            .unwrap();
+        assert_eq!(
+            validate_physical_install_source(&cache, 7, &resident, &admission),
+            Err(GpuNativeTieredResidencyError::LogicalAdmissionStale {
+                global_id: 7,
+                generation: admission.generation(),
+            })
+        );
     }
 
     #[test]
@@ -1187,5 +1275,18 @@ mod tests {
             other_layer.iter().map(|(&id, _)| id).collect::<Vec<_>>(),
             other_before
         );
+    }
+
+    #[test]
+    fn normal_physical_demand_hit_promotes_lru_recency() {
+        let mut residents = LruCache::unbounded();
+        residents.put(7, 70);
+        residents.put(8, 80);
+        assert_eq!(oldest_unprotected(&residents, &HashSet::new()), Some(7));
+
+        assert_eq!(touch_physical_record(&mut residents, 7), Some(70));
+        assert_eq!(oldest_unprotected(&residents, &HashSet::new()), Some(8));
+        assert_eq!(residents.peek(&7), Some(&70));
+        assert_eq!(residents.peek(&8), Some(&80));
     }
 }

--- a/rust-engine/src/gpu_native_router_rank_diagnostics.rs
+++ b/rust-engine/src/gpu_native_router_rank_diagnostics.rs
@@ -1,0 +1,1242 @@
+//! Diagnostic-only attribution for a GPU-native router rank permutation.
+//!
+//! This module owns only typed evidence and hardware-independent analysis.
+//! Production routing and qualification PASS semantics do not depend on it.
+
+use std::cmp::Ordering;
+
+use serde::Serialize;
+
+use crate::backend::GpuDeviceIdentity;
+use crate::gating::{LinearGate, ScoringFunc};
+use crate::gpu_native_token_loop::GpuNativeModelGeometry;
+use crate::greedy_parity::{CorpusEvidence, ModelIdentityEvidence, ModelLoadEvidence};
+use crate::numerical_diagnostics::{FloatEvidence, VectorComparisonEvidence};
+use crate::qualification::{BuildProvenance, ExpertMetadataEvidence, QualificationArtifacts};
+
+pub const SCHEMA_VERSION: &str = "mer.gpu-native-router-rank-divergence.v1";
+pub const MODE: &str = "diagnose-gpu-native-router-rank-divergence";
+pub const LOWER_EXPERT_ID: u32 = 68;
+pub const HIGHER_EXPERT_ID: u32 = 113;
+pub const REQUIRED_TOP_K: usize = 8;
+pub const RANKED_EXPERT_COUNT: usize = 12;
+/// Descriptive evidence only. It is never used by qualification or routing.
+pub const NEAR_TIE_ULP_WINDOW: u32 = 16;
+
+/// Target-layer-only diagnostic staging layout. It is allocated exclusively
+/// by the router-rank diagnostic command.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RouterRankTraceLayout {
+    pub target_layer: usize,
+    pub d_model: usize,
+    pub num_experts: usize,
+    pub top_k: usize,
+    pub router_input_offset: u64,
+    pub router_input_bytes: u64,
+    pub raw_logits_offset: u64,
+    pub raw_logits_bytes: u64,
+    pub selected_ids_offset: u64,
+    pub selected_ids_bytes: u64,
+    pub selected_weights_offset: u64,
+    pub selected_weights_bytes: u64,
+    pub total_bytes: u64,
+}
+
+impl RouterRankTraceLayout {
+    pub fn try_new(geometry: GpuNativeModelGeometry, target_layer: usize) -> Result<Self, String> {
+        if target_layer >= geometry.num_layers
+            || geometry.d_model == 0
+            || geometry.num_experts == 0
+            || geometry.top_k == 0
+            || geometry.top_k > geometry.num_experts
+        {
+            return Err("invalid router-rank trace geometry or target layer".to_string());
+        }
+        let bytes = |elements: usize, label: &str| {
+            elements
+                .checked_mul(std::mem::size_of::<u32>())
+                .and_then(|value| u64::try_from(value).ok())
+                .ok_or_else(|| format!("{label} byte size overflow"))
+        };
+        let router_input_offset = 0;
+        let router_input_bytes = bytes(geometry.d_model, "router input")?;
+        let raw_logits_offset = router_input_bytes;
+        let raw_logits_bytes = bytes(geometry.num_experts, "raw logits")?;
+        let selected_ids_offset = raw_logits_offset
+            .checked_add(raw_logits_bytes)
+            .ok_or("selected IDs offset overflow")?;
+        let selected_ids_bytes = bytes(geometry.top_k, "selected IDs")?;
+        let selected_weights_offset = selected_ids_offset
+            .checked_add(selected_ids_bytes)
+            .ok_or("selected weights offset overflow")?;
+        let selected_weights_bytes = bytes(geometry.top_k, "selected weights")?;
+        let total_bytes = selected_weights_offset
+            .checked_add(selected_weights_bytes)
+            .ok_or("router-rank trace total size overflow")?;
+        Ok(Self {
+            target_layer,
+            d_model: geometry.d_model,
+            num_experts: geometry.num_experts,
+            top_k: geometry.top_k,
+            router_input_offset,
+            router_input_bytes,
+            raw_logits_offset,
+            raw_logits_bytes,
+            selected_ids_offset,
+            selected_ids_bytes,
+            selected_weights_offset,
+            selected_weights_bytes,
+            total_bytes,
+        })
+    }
+
+    pub fn parse(&self, bytes: &[u8]) -> Result<RouterRankGpuTrace, String> {
+        if bytes.len() < self.total_bytes as usize {
+            return Err(format!(
+                "router-rank staging has {} bytes, expected {}",
+                bytes.len(),
+                self.total_bytes
+            ));
+        }
+        let parse_f32 = |offset: u64, count: usize| {
+            bytes[offset as usize..offset as usize + count * 4]
+                .chunks_exact(4)
+                .map(|chunk| f32::from_le_bytes(chunk.try_into().unwrap()))
+                .collect()
+        };
+        let parse_u32 = |offset: u64, count: usize| {
+            bytes[offset as usize..offset as usize + count * 4]
+                .chunks_exact(4)
+                .map(|chunk| u32::from_le_bytes(chunk.try_into().unwrap()))
+                .collect()
+        };
+        Ok(RouterRankGpuTrace {
+            router_input: parse_f32(self.router_input_offset, self.d_model),
+            raw_logits: parse_f32(self.raw_logits_offset, self.num_experts),
+            selected_ids: parse_u32(self.selected_ids_offset, self.top_k),
+            selected_weights: parse_f32(self.selected_weights_offset, self.top_k),
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct RouterRankGpuTrace {
+    pub router_input: Vec<f32>,
+    pub raw_logits: Vec<f32>,
+    pub selected_ids: Vec<u32>,
+    pub selected_weights: Vec<f32>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct DiagnosticProvenance {
+    pub build: BuildProvenance,
+    pub executable_sha256: String,
+    pub artifacts: QualificationArtifacts,
+    pub gpu_resolved_config_sha256: String,
+    pub reference_resolved_config_sha256: String,
+    pub model_identity: ModelIdentityEvidence,
+    pub reference_model_load: ModelLoadEvidence,
+    pub gpu_native_model_load: ModelLoadEvidence,
+    pub reference_background_shutdown: crate::greedy_parity::BackgroundShutdownEvidence,
+    pub gpu_native_background_shutdown: crate::greedy_parity::BackgroundShutdownEvidence,
+    pub expert_metadata: ExpertMetadataEvidence,
+    pub device: GpuDeviceIdentity,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct TargetEvidence {
+    pub case: String,
+    pub generated_position: usize,
+    pub generated_position_zero_based: bool,
+    pub layer: usize,
+    pub expected_reference_ids: Vec<u32>,
+    pub observed_gpu_ids: Vec<u32>,
+    pub top_8_set_match: bool,
+    pub rank_order_match: bool,
+    pub only_internal_rank_change: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct PrefixEvidence {
+    pub corpus: CorpusEvidence,
+    pub prompt_sha256: String,
+    pub prompt_token_ids: Vec<u32>,
+    pub prompt_token_ids_sha256: String,
+    pub reference_preceding_generated_token_ids: Vec<u32>,
+    pub gpu_native_preceding_generated_token_ids: Vec<u32>,
+    pub preceding_generated_prefix_match: bool,
+    pub reference_target_generated_token_id: u32,
+    pub gpu_native_target_generated_token_id: u32,
+    pub target_generated_token_match: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct RouterInputEvidence {
+    pub reference_vector_length: usize,
+    pub gpu_native_vector_length: usize,
+    pub reference_f32_bits_sha256: String,
+    pub gpu_native_f32_bits_sha256: String,
+    pub reference_f32_bits: Vec<u32>,
+    pub gpu_native_f32_bits: Vec<u32>,
+    pub bitwise_equal_element_count: usize,
+    pub comparison: VectorComparisonEvidence,
+    pub worst_index: Option<usize>,
+    pub reference_value_at_worst_index: Option<FloatEvidence>,
+    pub gpu_native_value_at_worst_index: Option<FloatEvidence>,
+}
+
+impl RouterInputEvidence {
+    pub fn compare(reference: &[f32], gpu_native: &[f32]) -> Result<Self, String> {
+        let comparison = crate::numerical_diagnostics::compare_vectors(reference, gpu_native)?;
+        let reference_f32_bits: Vec<u32> = reference.iter().map(|value| value.to_bits()).collect();
+        let gpu_native_f32_bits: Vec<u32> =
+            gpu_native.iter().map(|value| value.to_bits()).collect();
+        let bitwise_equal_element_count = reference_f32_bits
+            .iter()
+            .zip(&gpu_native_f32_bits)
+            .filter(|(reference, gpu)| reference == gpu)
+            .count();
+        let worst_index = comparison.max_error.as_ref().map(|error| error.index);
+        Ok(Self {
+            reference_vector_length: reference.len(),
+            gpu_native_vector_length: gpu_native.len(),
+            reference_f32_bits_sha256: crate::numerical_diagnostics::f32_bits_sha256(
+                &reference_f32_bits,
+            ),
+            gpu_native_f32_bits_sha256: crate::numerical_diagnostics::f32_bits_sha256(
+                &gpu_native_f32_bits,
+            ),
+            reference_f32_bits,
+            gpu_native_f32_bits,
+            bitwise_equal_element_count,
+            worst_index,
+            reference_value_at_worst_index: worst_index
+                .and_then(|index| reference.get(index).copied())
+                .map(FloatEvidence::new),
+            gpu_native_value_at_worst_index: worst_index
+                .and_then(|index| gpu_native.get(index).copied())
+                .map(FloatEvidence::new),
+            comparison,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct GateTensorIdentity {
+    pub canonical_tensor_name: String,
+    pub dtype: String,
+    pub rows: usize,
+    pub cols: usize,
+    pub loaded_f32_bits_sha256: String,
+}
+
+impl GateTensorIdentity {
+    pub fn from_gate(layer: usize, gate: &LinearGate) -> Self {
+        let values = gate.weights.to_f32_vec();
+        let bits: Vec<u32> = values.iter().map(|value| value.to_bits()).collect();
+        Self {
+            canonical_tensor_name: format!("model.layers.{layer}.mlp.gate.weight"),
+            dtype: gate.weights.dtype_name().to_string(),
+            rows: gate.weights.rows(),
+            cols: gate.weights.cols(),
+            loaded_f32_bits_sha256: crate::numerical_diagnostics::f32_bits_sha256(&bits),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct GateIdentityEvidence {
+    pub reference: GateTensorIdentity,
+    pub gpu_native: GateTensorIdentity,
+    pub exact_identity_match: bool,
+}
+
+impl GateIdentityEvidence {
+    pub fn new(reference: GateTensorIdentity, gpu_native: GateTensorIdentity) -> Self {
+        let exact_identity_match = reference == gpu_native;
+        Self {
+            reference,
+            gpu_native,
+            exact_identity_match,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct RankedExpertEvidence {
+    pub expert_id: u32,
+    pub rank: usize,
+    pub raw_logit: FloatEvidence,
+    pub score: FloatEvidence,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct ExpertPairEvidence {
+    pub expert_68_raw_logit: FloatEvidence,
+    pub expert_113_raw_logit: FloatEvidence,
+    pub raw_logit_68_minus_113: FloatEvidence,
+    pub expert_68_score: FloatEvidence,
+    pub expert_113_score: FloatEvidence,
+    pub score_68_minus_113: FloatEvidence,
+    pub expert_68_rank: usize,
+    pub expert_113_rank: usize,
+    pub raw_logit_ulp_distance: Option<u32>,
+    pub score_ulp_distance: Option<u32>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct CutoffMarginEvidence {
+    pub rank_7_expert_id: u32,
+    pub rank_8_expert_id: u32,
+    pub rank_9_expert_id: u32,
+    pub rank_7_minus_rank_8_score: FloatEvidence,
+    pub rank_8_minus_rank_9_score: FloatEvidence,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct RouterEvaluationEvidence {
+    pub source: &'static str,
+    pub score_origin: &'static str,
+    pub raw_logits: Vec<FloatEvidence>,
+    pub scored_probabilities: Vec<FloatEvidence>,
+    pub top_8_ids: Vec<u32>,
+    pub top_8_weights: Vec<FloatEvidence>,
+    pub top_12_ranked_experts: Vec<RankedExpertEvidence>,
+    pub experts_68_and_113: ExpertPairEvidence,
+    pub cutoff_margins: CutoffMarginEvidence,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct SelectedExpertEvidence {
+    pub rank: usize,
+    pub expert_id: u32,
+    pub weight: FloatEvidence,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct ActualGpuRouterEvidence {
+    pub source: &'static str,
+    pub score_origin: &'static str,
+    pub raw_logits: Vec<FloatEvidence>,
+    pub scored_probabilities: Vec<FloatEvidence>,
+    pub top_8_ids: Vec<u32>,
+    pub top_8_weights: Vec<FloatEvidence>,
+    pub production_top_8_selected_experts: Vec<SelectedExpertEvidence>,
+    pub top_12_ranked_experts: Vec<RankedExpertEvidence>,
+    pub experts_68_and_113: ExpertPairEvidence,
+    pub cutoff_margins: CutoffMarginEvidence,
+    pub cpu_top_8_ids_derived_from_exact_gpu_raw_logits: Vec<u32>,
+    pub cpu_top_8_weights_derived_from_exact_gpu_raw_logits: Vec<FloatEvidence>,
+    pub production_top_8_set_matches_cpu_derived_set: bool,
+    pub only_internal_rank_changes: bool,
+    pub selected_weights_paired_with_expert_ids: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct ThreeWayRouterEvidence {
+    pub authoritative_reference: RouterEvaluationEvidence,
+    pub cpu_router_on_exact_gpu_router_input: RouterEvaluationEvidence,
+    pub actual_gpu_router: ActualGpuRouterEvidence,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum PairOrder {
+    Expert68Before113,
+    Expert113Before68,
+    ExactTie,
+    Missing,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Attribution {
+    UpstreamRouterInputDrift,
+    GpuRouterGemvDrift,
+    GpuRouterSoftmaxTopkDrift,
+    ExactTieOrderingDefect,
+    MixedNumericalDrift,
+    Unresolved,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct AttributionEvidence {
+    pub attribution: Attribution,
+    pub smallest_stage_where_order_first_changes: &'static str,
+    pub reference_cpu_order: PairOrder,
+    pub gpu_input_cpu_order: PairOrder,
+    pub gpu_raw_logits_cpu_order: PairOrder,
+    pub actual_gpu_order: PairOrder,
+    pub exact_gpu_raw_and_scored_tie: bool,
+    pub near_tie_ulp_window: u32,
+    pub reference_raw_logit_ulp_distance: Option<u32>,
+    pub cpu_on_gpu_input_raw_logit_ulp_distance: Option<u32>,
+    pub gpu_raw_logit_ulp_distance: Option<u32>,
+    pub minimum_observed_raw_logit_ulp_distance: Option<u32>,
+    pub near_tie_observed: bool,
+    pub explanation: &'static str,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct RouterRankDivergenceReport {
+    pub schema: &'static str,
+    pub mode: &'static str,
+    pub status: &'static str,
+    pub diagnostic_complete: bool,
+    pub qualification_pass: bool,
+    pub failure: Option<String>,
+    pub provenance: DiagnosticProvenance,
+    pub target: TargetEvidence,
+    pub prefix: PrefixEvidence,
+    pub router_input: RouterInputEvidence,
+    pub gate_identity: GateIdentityEvidence,
+    pub evaluations: ThreeWayRouterEvidence,
+    pub attribution: AttributionEvidence,
+}
+
+impl RouterRankDivergenceReport {
+    #[allow(clippy::too_many_arguments)]
+    pub fn build(
+        provenance: DiagnosticProvenance,
+        case: &str,
+        generated_position: usize,
+        layer: usize,
+        prompt_token_ids: Vec<u32>,
+        reference_generated: Vec<u32>,
+        gpu_generated: Vec<u32>,
+        reference_hidden: &[f32],
+        gpu_hidden: &[f32],
+        gate_identity: GateIdentityEvidence,
+        authoritative_reference: RouterEvaluationEvidence,
+        cpu_on_gpu_input: RouterEvaluationEvidence,
+        actual_gpu_router: ActualGpuRouterEvidence,
+    ) -> Result<Self, String> {
+        if reference_generated.len() != generated_position + 1
+            || gpu_generated.len() != generated_position + 1
+        {
+            return Err("target generation evidence is incomplete".to_string());
+        }
+        let reference_preceding = reference_generated[..generated_position].to_vec();
+        let gpu_preceding = gpu_generated[..generated_position].to_vec();
+        let fixed_case = crate::greedy_parity::fixed_case(case)
+            .ok_or_else(|| format!("unknown fixed corpus case {case:?}"))?;
+        let preceding_generated_prefix_match = reference_preceding == gpu_preceding;
+        let failure = if !preceding_generated_prefix_match {
+            Some(
+                "preceding generated token prefix differs; router attribution is invalid"
+                    .to_string(),
+            )
+        } else if !gate_identity.exact_identity_match {
+            Some("reference and GPU runtimes loaded different gate tensors".to_string())
+        } else {
+            None
+        };
+        let target_generated_token_match =
+            reference_generated[generated_position] == gpu_generated[generated_position];
+        let mut attribution = derive_attribution(
+            pair_order_from_ranks(&authoritative_reference.experts_68_and_113),
+            pair_order_from_ranks(&cpu_on_gpu_input.experts_68_and_113),
+            pair_order_from_ranks(&actual_gpu_router.experts_68_and_113),
+            pair_order_from_ids(&actual_gpu_router.top_8_ids),
+            actual_gpu_router
+                .experts_68_and_113
+                .expert_68_raw_logit
+                .bits
+                == actual_gpu_router
+                    .experts_68_and_113
+                    .expert_113_raw_logit
+                    .bits
+                && actual_gpu_router.experts_68_and_113.expert_68_score.bits
+                    == actual_gpu_router.experts_68_and_113.expert_113_score.bits,
+        );
+        let observed_ulp_distances = [
+            authoritative_reference
+                .experts_68_and_113
+                .raw_logit_ulp_distance,
+            cpu_on_gpu_input.experts_68_and_113.raw_logit_ulp_distance,
+            actual_gpu_router.experts_68_and_113.raw_logit_ulp_distance,
+        ];
+        attribution.reference_raw_logit_ulp_distance = observed_ulp_distances[0];
+        attribution.cpu_on_gpu_input_raw_logit_ulp_distance = observed_ulp_distances[1];
+        attribution.gpu_raw_logit_ulp_distance = observed_ulp_distances[2];
+        attribution.minimum_observed_raw_logit_ulp_distance =
+            observed_ulp_distances.into_iter().flatten().min();
+        attribution.near_tie_observed = attribution
+            .minimum_observed_raw_logit_ulp_distance
+            .is_some_and(|distance| distance <= NEAR_TIE_ULP_WINDOW);
+        if failure.is_some() {
+            attribution = derive_attribution(
+                PairOrder::Missing,
+                PairOrder::Missing,
+                PairOrder::Missing,
+                PairOrder::Missing,
+                false,
+            );
+        }
+        Ok(Self {
+            schema: SCHEMA_VERSION,
+            mode: MODE,
+            status: if failure.is_some() {
+                "fail"
+            } else {
+                "diagnostic-only"
+            },
+            diagnostic_complete: failure.is_none(),
+            qualification_pass: false,
+            failure,
+            target: TargetEvidence {
+                case: case.to_string(),
+                generated_position,
+                generated_position_zero_based: true,
+                layer,
+                expected_reference_ids: authoritative_reference.top_8_ids.clone(),
+                observed_gpu_ids: actual_gpu_router.top_8_ids.clone(),
+                top_8_set_match: same_set(
+                    &authoritative_reference.top_8_ids,
+                    &actual_gpu_router.top_8_ids,
+                ),
+                rank_order_match: authoritative_reference.top_8_ids == actual_gpu_router.top_8_ids,
+                only_internal_rank_change: same_set(
+                    &authoritative_reference.top_8_ids,
+                    &actual_gpu_router.top_8_ids,
+                ) && authoritative_reference.top_8_ids
+                    != actual_gpu_router.top_8_ids,
+            },
+            prefix: PrefixEvidence {
+                corpus: CorpusEvidence::fixed(),
+                prompt_sha256: crate::greedy_parity::sha256_hex(fixed_case.prompt.as_bytes()),
+                prompt_token_ids_sha256: crate::greedy_parity::token_ids_sha256(&prompt_token_ids),
+                prompt_token_ids,
+                reference_preceding_generated_token_ids: reference_preceding,
+                gpu_native_preceding_generated_token_ids: gpu_preceding,
+                preceding_generated_prefix_match,
+                reference_target_generated_token_id: reference_generated[generated_position],
+                gpu_native_target_generated_token_id: gpu_generated[generated_position],
+                target_generated_token_match,
+            },
+            router_input: RouterInputEvidence::compare(reference_hidden, gpu_hidden)?,
+            gate_identity,
+            evaluations: ThreeWayRouterEvidence {
+                authoritative_reference,
+                cpu_router_on_exact_gpu_router_input: cpu_on_gpu_input,
+                actual_gpu_router,
+            },
+            attribution,
+            provenance,
+        })
+    }
+}
+
+pub fn validate_target(
+    case: &str,
+    generated_position: usize,
+    layer: usize,
+    expected_adapter_name: &str,
+    geometry: GpuNativeModelGeometry,
+) -> Result<(), String> {
+    if crate::greedy_parity::fixed_case(case).is_none() {
+        return Err(format!("unknown fixed corpus case {case:?}"));
+    }
+    if generated_position >= crate::greedy_parity::OUTPUT_TOKEN_LIMIT {
+        return Err(format!(
+            "generated position {generated_position} is outside fixed output range 0..{}",
+            crate::greedy_parity::OUTPUT_TOKEN_LIMIT
+        ));
+    }
+    if layer >= geometry.num_layers {
+        return Err(format!(
+            "layer {layer} is outside model layer range 0..{}",
+            geometry.num_layers
+        ));
+    }
+    if geometry.num_experts <= HIGHER_EXPERT_ID as usize
+        || geometry.top_k != REQUIRED_TOP_K
+        || geometry.d_model == 0
+    {
+        return Err(format!(
+            "unsupported expert geometry: num_experts={} top_k={} d_model={}",
+            geometry.num_experts, geometry.top_k, geometry.d_model
+        ));
+    }
+    if expected_adapter_name.trim().is_empty() {
+        return Err("expected adapter name must be non-empty".to_string());
+    }
+    Ok(())
+}
+
+pub fn evaluate_cpu_router(
+    source: &'static str,
+    gate: &LinearGate,
+    hidden: &[f32],
+) -> Result<RouterEvaluationEvidence, String> {
+    validate_gate(gate, hidden.len())?;
+    let raw_logits = gate.weights.matvec(hidden);
+    let mut scores = raw_logits.clone();
+    crate::transformer::softmax_inplace(&mut scores);
+    let decision = gate.route(hidden);
+    build_router_evaluation(
+        source,
+        "cpu-production-softmax",
+        raw_logits,
+        scores,
+        decision.experts,
+        decision.weights,
+    )
+}
+
+pub fn evaluate_actual_gpu_router(
+    raw_logits: Vec<f32>,
+    selected_ids: Vec<u32>,
+    selected_weights: Vec<f32>,
+) -> Result<ActualGpuRouterEvidence, String> {
+    if raw_logits.len() <= HIGHER_EXPERT_ID as usize {
+        return Err("GPU raw-logit vector does not include target experts".to_string());
+    }
+    if selected_ids.len() != REQUIRED_TOP_K || selected_weights.len() != REQUIRED_TOP_K {
+        return Err("GPU selected expert result does not have top_k=8".to_string());
+    }
+    validate_finite("GPU raw logits", &raw_logits)?;
+    validate_finite("GPU selected weights", &selected_weights)?;
+    let mut scores = raw_logits.clone();
+    crate::transformer::softmax_inplace(&mut scores);
+    let (derived_ids, derived_weights) = deterministic_top_k(&scores, REQUIRED_TOP_K)?;
+    let (ranked, pair, cutoff) = ranked_evidence(&raw_logits, &scores)?;
+    let production_top_8_set_matches_cpu_derived_set = same_set(&selected_ids, &derived_ids);
+    let only_internal_rank_changes =
+        production_top_8_set_matches_cpu_derived_set && selected_ids != derived_ids;
+    let selected_weights_paired_with_expert_ids = selected_ids
+        .iter()
+        .copied()
+        .collect::<std::collections::HashSet<_>>()
+        .len()
+        == selected_ids.len()
+        && selected_weights
+            .windows(2)
+            .all(|pair| pair[0].total_cmp(&pair[1]) != Ordering::Less);
+    let production_top_8_selected_experts = selected_ids
+        .iter()
+        .copied()
+        .zip(selected_weights.iter().copied())
+        .enumerate()
+        .map(|(rank, (expert_id, weight))| SelectedExpertEvidence {
+            rank: rank + 1,
+            expert_id,
+            weight: FloatEvidence::new(weight),
+        })
+        .collect();
+    Ok(ActualGpuRouterEvidence {
+        source: "gpu-hidden-to-gpu-production-router",
+        score_origin: "cpu-softmax-derived-from-exact-gpu-raw-logits",
+        raw_logits: raw_logits.into_iter().map(FloatEvidence::new).collect(),
+        scored_probabilities: scores.into_iter().map(FloatEvidence::new).collect(),
+        top_8_ids: selected_ids,
+        top_8_weights: selected_weights
+            .into_iter()
+            .map(FloatEvidence::new)
+            .collect(),
+        production_top_8_selected_experts,
+        top_12_ranked_experts: ranked,
+        experts_68_and_113: pair,
+        cutoff_margins: cutoff,
+        cpu_top_8_ids_derived_from_exact_gpu_raw_logits: derived_ids,
+        cpu_top_8_weights_derived_from_exact_gpu_raw_logits: derived_weights
+            .into_iter()
+            .map(FloatEvidence::new)
+            .collect(),
+        production_top_8_set_matches_cpu_derived_set,
+        only_internal_rank_changes,
+        selected_weights_paired_with_expert_ids,
+    })
+}
+
+fn validate_gate(gate: &LinearGate, hidden_len: usize) -> Result<(), String> {
+    if gate.d_model != hidden_len
+        || gate.num_experts <= HIGHER_EXPERT_ID as usize
+        || gate.top_k != REQUIRED_TOP_K
+        || gate.scoring_func != ScoringFunc::Softmax
+        || !gate.normalise_topk
+        || gate.correction_bias.is_some()
+        || gate.n_group > 1
+        || gate.routed_scaling_factor.to_bits() != 1.0f32.to_bits()
+    {
+        return Err("gate does not match the supported Qwen softmax/top-8 contract".to_string());
+    }
+    Ok(())
+}
+
+fn build_router_evaluation(
+    source: &'static str,
+    score_origin: &'static str,
+    raw_logits: Vec<f32>,
+    scores: Vec<f32>,
+    top_ids: Vec<u32>,
+    top_weights: Vec<f32>,
+) -> Result<RouterEvaluationEvidence, String> {
+    if raw_logits.len() != scores.len()
+        || top_ids.len() != REQUIRED_TOP_K
+        || top_weights.len() != REQUIRED_TOP_K
+    {
+        return Err("router evaluation geometry is invalid".to_string());
+    }
+    validate_finite("raw logits", &raw_logits)?;
+    validate_finite("scores", &scores)?;
+    validate_finite("top-k weights", &top_weights)?;
+    let (ranked, pair, cutoff) = ranked_evidence(&raw_logits, &scores)?;
+    Ok(RouterEvaluationEvidence {
+        source,
+        score_origin,
+        raw_logits: raw_logits.into_iter().map(FloatEvidence::new).collect(),
+        scored_probabilities: scores.into_iter().map(FloatEvidence::new).collect(),
+        top_8_ids: top_ids,
+        top_8_weights: top_weights.into_iter().map(FloatEvidence::new).collect(),
+        top_12_ranked_experts: ranked,
+        experts_68_and_113: pair,
+        cutoff_margins: cutoff,
+    })
+}
+
+fn ranked_evidence(
+    raw_logits: &[f32],
+    scores: &[f32],
+) -> Result<
+    (
+        Vec<RankedExpertEvidence>,
+        ExpertPairEvidence,
+        CutoffMarginEvidence,
+    ),
+    String,
+> {
+    if raw_logits.len() != scores.len()
+        || raw_logits.len() <= HIGHER_EXPERT_ID as usize
+        || raw_logits.len() < RANKED_EXPERT_COUNT
+    {
+        return Err("router rank evidence geometry is invalid".to_string());
+    }
+    let mut ranked: Vec<(usize, f32)> = scores.iter().copied().enumerate().collect();
+    ranked.sort_by(|(left_id, left), (right_id, right)| {
+        right.total_cmp(left).then_with(|| left_id.cmp(right_id))
+    });
+    let rank_for = |expert: u32| {
+        ranked
+            .iter()
+            .position(|(id, _)| *id == expert as usize)
+            .map(|rank| rank + 1)
+            .ok_or_else(|| format!("expert {expert} missing from ranking"))
+    };
+    let expert_68_rank = rank_for(LOWER_EXPERT_ID)?;
+    let expert_113_rank = rank_for(HIGHER_EXPERT_ID)?;
+    let logit_68 = raw_logits[LOWER_EXPERT_ID as usize];
+    let logit_113 = raw_logits[HIGHER_EXPERT_ID as usize];
+    let score_68 = scores[LOWER_EXPERT_ID as usize];
+    let score_113 = scores[HIGHER_EXPERT_ID as usize];
+    let top_12_ranked_experts = ranked
+        .iter()
+        .take(RANKED_EXPERT_COUNT)
+        .enumerate()
+        .map(|(rank, (expert_id, score))| RankedExpertEvidence {
+            expert_id: *expert_id as u32,
+            rank: rank + 1,
+            raw_logit: FloatEvidence::new(raw_logits[*expert_id]),
+            score: FloatEvidence::new(*score),
+        })
+        .collect();
+    let rank_7 = ranked[6];
+    let rank_8 = ranked[7];
+    let rank_9 = ranked[8];
+    Ok((
+        top_12_ranked_experts,
+        ExpertPairEvidence {
+            expert_68_raw_logit: FloatEvidence::new(logit_68),
+            expert_113_raw_logit: FloatEvidence::new(logit_113),
+            raw_logit_68_minus_113: FloatEvidence::new(logit_68 - logit_113),
+            expert_68_score: FloatEvidence::new(score_68),
+            expert_113_score: FloatEvidence::new(score_113),
+            score_68_minus_113: FloatEvidence::new(score_68 - score_113),
+            expert_68_rank,
+            expert_113_rank,
+            raw_logit_ulp_distance: ulp_distance(logit_68, logit_113),
+            score_ulp_distance: ulp_distance(score_68, score_113),
+        },
+        CutoffMarginEvidence {
+            rank_7_expert_id: rank_7.0 as u32,
+            rank_8_expert_id: rank_8.0 as u32,
+            rank_9_expert_id: rank_9.0 as u32,
+            rank_7_minus_rank_8_score: FloatEvidence::new(rank_7.1 - rank_8.1),
+            rank_8_minus_rank_9_score: FloatEvidence::new(rank_8.1 - rank_9.1),
+        },
+    ))
+}
+
+fn deterministic_top_k(scores: &[f32], top_k: usize) -> Result<(Vec<u32>, Vec<f32>), String> {
+    validate_finite("scores", scores)?;
+    if top_k == 0 || top_k > scores.len() {
+        return Err("invalid deterministic top-k geometry".to_string());
+    }
+    let mut ranked: Vec<(usize, f32)> = scores.iter().copied().enumerate().collect();
+    ranked.sort_by(|(left_id, left), (right_id, right)| {
+        right.total_cmp(left).then_with(|| left_id.cmp(right_id))
+    });
+    let selected = &ranked[..top_k];
+    let sum: f32 = selected.iter().map(|(_, score)| *score).sum();
+    if !sum.is_finite() || sum <= 0.0 {
+        return Err("selected score sum is nonfinite or nonpositive".to_string());
+    }
+    Ok((
+        selected.iter().map(|(id, _)| *id as u32).collect(),
+        selected.iter().map(|(_, score)| *score / sum).collect(),
+    ))
+}
+
+fn same_set(left: &[u32], right: &[u32]) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+    let mut left = left.to_vec();
+    let mut right = right.to_vec();
+    left.sort_unstable();
+    right.sort_unstable();
+    left == right
+}
+
+fn validate_finite(label: &str, values: &[f32]) -> Result<(), String> {
+    if values.is_empty() || values.iter().any(|value| !value.is_finite()) {
+        return Err(format!("{label} is empty or contains a nonfinite value"));
+    }
+    Ok(())
+}
+
+fn pair_order_from_ranks(pair: &ExpertPairEvidence) -> PairOrder {
+    if pair.expert_68_raw_logit.bits == pair.expert_113_raw_logit.bits
+        && pair.expert_68_score.bits == pair.expert_113_score.bits
+    {
+        PairOrder::ExactTie
+    } else if pair.expert_68_rank < pair.expert_113_rank {
+        PairOrder::Expert68Before113
+    } else {
+        PairOrder::Expert113Before68
+    }
+}
+
+fn pair_order_from_ids(ids: &[u32]) -> PairOrder {
+    match (
+        ids.iter().position(|id| *id == LOWER_EXPERT_ID),
+        ids.iter().position(|id| *id == HIGHER_EXPERT_ID),
+    ) {
+        (Some(left), Some(right)) if left < right => PairOrder::Expert68Before113,
+        (Some(_), Some(_)) => PairOrder::Expert113Before68,
+        _ => PairOrder::Missing,
+    }
+}
+
+pub fn derive_attribution(
+    reference: PairOrder,
+    cpu_on_gpu_input: PairOrder,
+    cpu_on_gpu_logits: PairOrder,
+    actual_gpu: PairOrder,
+    exact_gpu_tie: bool,
+) -> AttributionEvidence {
+    use PairOrder::{Expert113Before68 as Reversed, Expert68Before113 as Expected};
+    let (attribution, stage, explanation) = if exact_gpu_tie && actual_gpu == Reversed {
+        (
+            Attribution::ExactTieOrderingDefect,
+            "gpu-softmax-topk",
+            "captured GPU logits and CPU-derived scores tie exactly, but production GPU order violates the lower-ID tie break",
+        )
+    } else if reference != Expected || actual_gpu != Reversed {
+        (
+            Attribution::Unresolved,
+            "unresolved",
+            "the captured endpoint ordering does not match the target 68-before-113 to 113-before-68 divergence",
+        )
+    } else if cpu_on_gpu_input == Reversed && cpu_on_gpu_logits == Expected {
+        (
+            Attribution::MixedNumericalDrift,
+            "mixed",
+            "GPU input flips the pair, GPU GEMV flips it back, and GPU softmax/top-k flips it again",
+        )
+    } else if cpu_on_gpu_input == Reversed && cpu_on_gpu_logits == Reversed {
+        (
+            Attribution::UpstreamRouterInputDrift,
+            "router-input",
+            "CPU production routing on the exact GPU input already reproduces 113 before 68",
+        )
+    } else if cpu_on_gpu_input == Expected && cpu_on_gpu_logits == Reversed {
+        (
+            Attribution::GpuRouterGemvDrift,
+            "gpu-router-gemv",
+            "CPU routing on the GPU input keeps 68 before 113, while captured GPU GEMV logits reverse them",
+        )
+    } else if cpu_on_gpu_input == Expected && cpu_on_gpu_logits == Expected {
+        (
+            Attribution::GpuRouterSoftmaxTopkDrift,
+            "gpu-softmax-topk",
+            "CPU selection from exact GPU logits keeps 68 before 113, while production GPU selection reverses them",
+        )
+    } else {
+        (
+            Attribution::Unresolved,
+            "unresolved",
+            "one or more intermediate pair orders are tied or unavailable",
+        )
+    };
+    AttributionEvidence {
+        attribution,
+        smallest_stage_where_order_first_changes: stage,
+        reference_cpu_order: reference,
+        gpu_input_cpu_order: cpu_on_gpu_input,
+        gpu_raw_logits_cpu_order: cpu_on_gpu_logits,
+        actual_gpu_order: actual_gpu,
+        exact_gpu_raw_and_scored_tie: exact_gpu_tie,
+        near_tie_ulp_window: NEAR_TIE_ULP_WINDOW,
+        reference_raw_logit_ulp_distance: None,
+        cpu_on_gpu_input_raw_logit_ulp_distance: None,
+        gpu_raw_logit_ulp_distance: None,
+        minimum_observed_raw_logit_ulp_distance: None,
+        near_tie_observed: false,
+        explanation,
+    }
+}
+
+pub fn ulp_distance(left: f32, right: f32) -> Option<u32> {
+    if !left.is_finite() || !right.is_finite() {
+        return None;
+    }
+    let ordered = |value: f32| {
+        let bits = value.to_bits();
+        if bits & 0x8000_0000 != 0 {
+            !bits
+        } else {
+            bits | 0x8000_0000
+        }
+    };
+    Some(ordered(left).abs_diff(ordered(right)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn geometry() -> GpuNativeModelGeometry {
+        GpuNativeModelGeometry {
+            num_layers: 48,
+            d_model: 2048,
+            d_ff: 768,
+            num_experts: 128,
+            top_k: 8,
+            num_heads: 32,
+            num_kv_heads: 4,
+            head_dim: 64,
+            rope_dim: 64,
+            vocab_size: 151_936,
+            max_seq_len: 4096,
+            rms_eps: 1.0e-6,
+            rope_base: 1_000_000.0,
+        }
+    }
+
+    #[test]
+    fn deterministic_top_k_tie_prefers_lower_expert_id() {
+        let mut scores = vec![0.0; 128];
+        for (id, value) in [30, 37, 114, 86, 29, 68, 113, 35]
+            .into_iter()
+            .zip([8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 3.0, 2.0])
+        {
+            scores[id] = value;
+        }
+        let (ids, _) = deterministic_top_k(&scores, 8).unwrap();
+        assert_eq!(ids, vec![30, 37, 114, 86, 29, 68, 113, 35]);
+    }
+
+    #[test]
+    fn target_layer_trace_layout_round_trips_exact_bits() {
+        let mut small = geometry();
+        small.d_model = 4;
+        small.num_experts = 128;
+        let layout = RouterRankTraceLayout::try_new(small, 44).unwrap();
+        assert_eq!(layout.router_input_offset, 0);
+        assert_eq!(layout.router_input_bytes, 16);
+        assert_eq!(layout.raw_logits_offset, 16);
+        assert_eq!(layout.raw_logits_bytes, 512);
+        assert_eq!(layout.selected_ids_offset, 528);
+        assert_eq!(layout.selected_weights_offset, 560);
+        assert_eq!(layout.total_bytes, 592);
+        let mut bytes = vec![0u8; layout.total_bytes as usize];
+        let write_f32 = |bytes: &mut [u8], offset: u64, values: &[f32]| {
+            for (index, value) in values.iter().enumerate() {
+                bytes[offset as usize + index * 4..offset as usize + index * 4 + 4]
+                    .copy_from_slice(&value.to_le_bytes());
+            }
+        };
+        let hidden = [1.0, -0.0, 3.5, -2.0];
+        let logits: Vec<f32> = (0..128).map(|index| index as f32 / 10.0).collect();
+        let ids = [30u32, 37, 114, 86, 29, 113, 68, 35];
+        let weights = [0.3, 0.2, 0.15, 0.12, 0.1, 0.06, 0.04, 0.03];
+        write_f32(&mut bytes, layout.router_input_offset, &hidden);
+        write_f32(&mut bytes, layout.raw_logits_offset, &logits);
+        for (index, value) in ids.iter().enumerate() {
+            bytes[layout.selected_ids_offset as usize + index * 4
+                ..layout.selected_ids_offset as usize + index * 4 + 4]
+                .copy_from_slice(&value.to_le_bytes());
+        }
+        write_f32(&mut bytes, layout.selected_weights_offset, &weights);
+        let trace = layout.parse(&bytes).unwrap();
+        assert_eq!(trace.router_input, hidden);
+        assert_eq!(trace.raw_logits, logits);
+        assert_eq!(trace.selected_ids, ids);
+        assert_eq!(trace.selected_weights, weights);
+    }
+
+    #[test]
+    fn attribution_identifies_upstream_input_flip() {
+        let evidence = derive_attribution(
+            PairOrder::Expert68Before113,
+            PairOrder::Expert113Before68,
+            PairOrder::Expert113Before68,
+            PairOrder::Expert113Before68,
+            false,
+        );
+        assert_eq!(evidence.attribution, Attribution::UpstreamRouterInputDrift);
+    }
+
+    #[test]
+    fn attribution_identifies_gpu_gemv_flip() {
+        let evidence = derive_attribution(
+            PairOrder::Expert68Before113,
+            PairOrder::Expert68Before113,
+            PairOrder::Expert113Before68,
+            PairOrder::Expert113Before68,
+            false,
+        );
+        assert_eq!(evidence.attribution, Attribution::GpuRouterGemvDrift);
+    }
+
+    #[test]
+    fn attribution_identifies_gpu_softmax_topk_flip() {
+        let evidence = derive_attribution(
+            PairOrder::Expert68Before113,
+            PairOrder::Expert68Before113,
+            PairOrder::Expert68Before113,
+            PairOrder::Expert113Before68,
+            false,
+        );
+        assert_eq!(evidence.attribution, Attribution::GpuRouterSoftmaxTopkDrift);
+    }
+
+    #[test]
+    fn attribution_identifies_exact_tie_ordering_defect() {
+        let evidence = derive_attribution(
+            PairOrder::Expert68Before113,
+            PairOrder::Expert68Before113,
+            PairOrder::ExactTie,
+            PairOrder::Expert113Before68,
+            true,
+        );
+        assert_eq!(evidence.attribution, Attribution::ExactTieOrderingDefect);
+    }
+
+    #[test]
+    fn attribution_does_not_hide_multi_stage_flips() {
+        let evidence = derive_attribution(
+            PairOrder::Expert68Before113,
+            PairOrder::Expert113Before68,
+            PairOrder::Expert68Before113,
+            PairOrder::Expert113Before68,
+            false,
+        );
+        assert_eq!(evidence.attribution, Attribution::MixedNumericalDrift);
+    }
+
+    #[test]
+    fn target_validation_fails_closed() {
+        assert!(validate_target("not-a-case", 5, 44, "NVIDIA L4", geometry()).is_err());
+        assert!(validate_target("rust-generation", 16, 44, "NVIDIA L4", geometry()).is_err());
+        assert!(validate_target("rust-generation", 5, 48, "NVIDIA L4", geometry()).is_err());
+        assert!(validate_target("rust-generation", 5, 44, "", geometry()).is_err());
+        let mut bad = geometry();
+        bad.num_experts = 64;
+        assert!(validate_target("rust-generation", 5, 44, "NVIDIA L4", bad).is_err());
+    }
+
+    #[test]
+    fn schema_and_required_router_fields_are_stable() {
+        let mut logits = vec![-10.0; 128];
+        for (id, value) in [30, 37, 114, 86, 29, 68, 113, 35, 12, 13, 14, 15]
+            .into_iter()
+            .zip([
+                12.0, 11.0, 10.0, 9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0,
+            ])
+        {
+            logits[id] = value;
+        }
+        let actual = evaluate_actual_gpu_router(
+            logits,
+            vec![30, 37, 114, 86, 29, 68, 113, 35],
+            vec![0.3, 0.2, 0.15, 0.12, 0.1, 0.06, 0.04, 0.03],
+        )
+        .unwrap();
+        let value = serde_json::to_value(actual).unwrap();
+        assert_eq!(value["raw_logits"].as_array().unwrap().len(), 128);
+        assert_eq!(value["scored_probabilities"].as_array().unwrap().len(), 128);
+        assert_eq!(value["top_8_ids"].as_array().unwrap().len(), 8);
+        assert_eq!(
+            value["production_top_8_selected_experts"]
+                .as_array()
+                .unwrap()
+                .len(),
+            8
+        );
+        assert_eq!(
+            value["production_top_8_selected_experts"][5]["expert_id"],
+            68
+        );
+        assert_eq!(value["top_12_ranked_experts"].as_array().unwrap().len(), 12);
+        assert!(value["experts_68_and_113"]["raw_logit_ulp_distance"].is_number());
+        assert_eq!(SCHEMA_VERSION, "mer.gpu-native-router-rank-divergence.v1");
+    }
+
+    #[test]
+    fn complete_report_serialization_keeps_diagnostic_contract() {
+        let mut logits = vec![-10.0; 128];
+        for (id, value) in [30, 37, 114, 86, 29, 68, 113, 35, 12, 13, 14, 15]
+            .into_iter()
+            .zip([
+                12.0, 11.0, 10.0, 9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0,
+            ])
+        {
+            logits[id] = value;
+        }
+        let mut scores = logits.clone();
+        crate::transformer::softmax_inplace(&mut scores);
+        let (ids, weights) = deterministic_top_k(&scores, 8).unwrap();
+        let reference = build_router_evaluation(
+            "reference-hidden-to-cpu-production-router",
+            "cpu-production-softmax",
+            logits.clone(),
+            scores.clone(),
+            ids.clone(),
+            weights.clone(),
+        )
+        .unwrap();
+        let cpu_on_gpu = build_router_evaluation(
+            "gpu-hidden-to-cpu-production-router",
+            "cpu-production-softmax",
+            logits.clone(),
+            scores,
+            ids,
+            weights,
+        )
+        .unwrap();
+        let actual = evaluate_actual_gpu_router(
+            logits,
+            vec![30, 37, 114, 86, 29, 113, 68, 35],
+            vec![0.3, 0.2, 0.15, 0.12, 0.1, 0.06, 0.04, 0.03],
+        )
+        .unwrap();
+        let gate = GateTensorIdentity {
+            canonical_tensor_name: "model.layers.44.mlp.gate.weight".to_string(),
+            dtype: "f32".to_string(),
+            rows: 128,
+            cols: 2048,
+            loaded_f32_bits_sha256: "a".repeat(64),
+        };
+        let model_load = ModelLoadEvidence {
+            strict: true,
+            loader: "safetensors".to_string(),
+            loaded_tensors: 1,
+            required_tensors: 1,
+            optional_probed: 0,
+            optional_loaded: 0,
+            seeded_fallback_remained: false,
+        };
+        let shutdown = crate::greedy_parity::BackgroundShutdownEvidence {
+            controlled_shutdown_requested: true,
+            all_runtime_resources_released: true,
+            poll_iterations: 1,
+        };
+        let report = RouterRankDivergenceReport::build(
+            DiagnosticProvenance {
+                build: BuildProvenance {
+                    git_sha: Some("b".repeat(40)),
+                    dirty: Some(false),
+                    package_version: "test".to_string(),
+                },
+                executable_sha256: "c".repeat(64),
+                artifacts: QualificationArtifacts::default(),
+                gpu_resolved_config_sha256: "d".repeat(64),
+                reference_resolved_config_sha256: "e".repeat(64),
+                model_identity: ModelIdentityEvidence {
+                    architecture: "qwen3_moe".to_string(),
+                    num_layers: 48,
+                    num_experts_per_layer: 128,
+                    total_experts: 6144,
+                    top_k: 8,
+                    d_model: 2048,
+                    d_ff: 768,
+                    routed_expert_dtype: "q4_0".to_string(),
+                },
+                reference_model_load: model_load.clone(),
+                gpu_native_model_load: model_load,
+                reference_background_shutdown: shutdown,
+                gpu_native_background_shutdown: shutdown,
+                expert_metadata: ExpertMetadataEvidence {
+                    dtype: Some("q4_0".to_string()),
+                    q4_0_layout: Some("standard-v1".to_string()),
+                    conversion_mode: Some("real".to_string()),
+                    source: Some("test".to_string()),
+                    explicitly_synthetic: false,
+                },
+                device: GpuDeviceIdentity {
+                    name: "NVIDIA L4".to_string(),
+                    vendor_id: 0x10de,
+                    device_id: 0,
+                    device_type: "DiscreteGpu".to_string(),
+                    wgpu_backend: "vulkan".to_string(),
+                    driver: "test".to_string(),
+                    driver_info: "test".to_string(),
+                    compute_plane: "wgpu-vulkan".to_string(),
+                    software_adapter: false,
+                },
+            },
+            "rust-generation",
+            5,
+            44,
+            vec![1, 2, 3],
+            vec![10, 11, 12, 13, 14, 15],
+            vec![10, 11, 12, 13, 14, 15],
+            &[1.0, 2.0, 3.0, 4.0],
+            &[1.0, 2.0, 3.0, 4.0],
+            GateIdentityEvidence::new(gate.clone(), gate),
+            reference,
+            cpu_on_gpu,
+            actual,
+        )
+        .unwrap();
+        let value = serde_json::to_value(report).unwrap();
+        assert_eq!(value["schema"], SCHEMA_VERSION);
+        assert_eq!(value["status"], "diagnostic-only");
+        assert_eq!(value["qualification_pass"], false);
+        assert_eq!(value["target"]["top_8_set_match"], true);
+        assert_eq!(value["target"]["only_internal_rank_change"], true);
+        assert_eq!(
+            value["attribution"]["attribution"],
+            "gpu-router-softmax-topk-drift"
+        );
+        assert_eq!(
+            value["router_input"]["reference_f32_bits"]
+                .as_array()
+                .unwrap()
+                .len(),
+            4
+        );
+    }
+
+    #[test]
+    fn ulp_distance_handles_sign_and_adjacent_values() {
+        assert_eq!(
+            ulp_distance(1.0, f32::from_bits(1.0f32.to_bits() + 1)),
+            Some(1)
+        );
+        assert_eq!(ulp_distance(-0.0, 0.0), Some(1));
+        assert_eq!(ulp_distance(f32::NAN, 0.0), None);
+    }
+}

--- a/rust-engine/src/gpu_native_semantic_parity_corpus.rs
+++ b/rust-engine/src/gpu_native_semantic_parity_corpus.rs
@@ -1,0 +1,2564 @@
+//! Diagnostic-only full-corpus GPU-native semantic-parity evidence.
+//!
+//! This module contains only observation layouts, typed report evidence, and
+//! host-side deterministic comparison/aggregation. It is not consulted by
+//! production inference or by any qualification PASS decision.
+
+use std::collections::{BTreeMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use serde::Serialize;
+
+use crate::gpu_native_expert_permutation_semantic_parity::{
+    PermutationOnlyWitness, VectorNumericalEvidence, WeightDeltaEvidence,
+};
+use crate::gpu_native_router_rank_diagnostics::{
+    ActualGpuRouterEvidence, DiagnosticProvenance, RankedExpertEvidence, RouterEvaluationEvidence,
+};
+use crate::gpu_native_token_loop::GpuNativeModelGeometry;
+use crate::greedy_parity::CorpusEvidence;
+use crate::numerical_diagnostics::FloatEvidence;
+
+use crate::{IsolatedRuntimeShutdownError, RealCliRuntimeMode, ResolvedRealCliSpec};
+
+pub const SCHEMA_VERSION: &str = "mer.gpu-native-semantic-parity-corpus.v1";
+pub const MODE: &str = "diagnose-gpu-native-semantic-parity-corpus";
+pub const EXACT_ORDER_SAMPLING_RULE: &str =
+    "first-exact-order-event-per-layer-in-frozen-corpus-order";
+pub const PERCENTILE_CONVENTION: &str =
+    "nearest-rank: sort ascending; rank=max(1,ceil(p*n)); select rank-1";
+
+/// Full-layer staging layout used only by the corpus semantic diagnostic.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct SemanticCorpusTraceLayout {
+    pub num_layers: usize,
+    pub d_model: usize,
+    pub num_experts: usize,
+    pub top_k: usize,
+    pub router_inputs_offset: u64,
+    pub raw_logits_offset: u64,
+    pub selected_ids_offset: u64,
+    pub selected_weights_offset: u64,
+    pub route_outputs_offset: u64,
+    pub routed_moe_outputs_offset: u64,
+    pub router_input_layer_bytes: u64,
+    pub raw_logits_layer_bytes: u64,
+    pub selected_ids_layer_bytes: u64,
+    pub selected_weights_layer_bytes: u64,
+    pub route_outputs_layer_bytes: u64,
+    pub routed_moe_output_layer_bytes: u64,
+    pub total_bytes: u64,
+}
+
+impl SemanticCorpusTraceLayout {
+    pub fn try_new(geometry: GpuNativeModelGeometry) -> Result<Self, String> {
+        if geometry.num_layers == 0
+            || geometry.d_model == 0
+            || geometry.num_experts == 0
+            || geometry.top_k == 0
+            || geometry.top_k > geometry.num_experts
+        {
+            return Err("invalid semantic corpus trace geometry".to_string());
+        }
+        let bytes = |elements: usize, label: &str| {
+            elements
+                .checked_mul(std::mem::size_of::<u32>())
+                .and_then(|value| u64::try_from(value).ok())
+                .ok_or_else(|| format!("{label} byte size overflow"))
+        };
+        let region = |offset: u64, per_layer: u64, label: &str| {
+            per_layer
+                .checked_mul(geometry.num_layers as u64)
+                .and_then(|size| offset.checked_add(size))
+                .ok_or_else(|| format!("{label} region overflow"))
+        };
+
+        let router_input_layer_bytes = bytes(geometry.d_model, "router input")?;
+        let raw_logits_layer_bytes = bytes(geometry.num_experts, "raw logits")?;
+        let selected_ids_layer_bytes = bytes(geometry.top_k, "selected IDs")?;
+        let selected_weights_layer_bytes = bytes(geometry.top_k, "selected weights")?;
+        let route_outputs_layer_bytes = bytes(
+            geometry
+                .top_k
+                .checked_mul(geometry.d_model)
+                .ok_or("route output element count overflow")?,
+            "route outputs",
+        )?;
+        let routed_moe_output_layer_bytes = bytes(geometry.d_model, "routed MoE output")?;
+
+        let router_inputs_offset = 0;
+        let raw_logits_offset = region(
+            router_inputs_offset,
+            router_input_layer_bytes,
+            "router inputs",
+        )?;
+        let selected_ids_offset = region(raw_logits_offset, raw_logits_layer_bytes, "raw logits")?;
+        let selected_weights_offset = region(
+            selected_ids_offset,
+            selected_ids_layer_bytes,
+            "selected IDs",
+        )?;
+        let route_outputs_offset = region(
+            selected_weights_offset,
+            selected_weights_layer_bytes,
+            "selected weights",
+        )?;
+        let routed_moe_outputs_offset = region(
+            route_outputs_offset,
+            route_outputs_layer_bytes,
+            "route outputs",
+        )?;
+        let total_bytes = region(
+            routed_moe_outputs_offset,
+            routed_moe_output_layer_bytes,
+            "routed MoE outputs",
+        )?;
+
+        Ok(Self {
+            num_layers: geometry.num_layers,
+            d_model: geometry.d_model,
+            num_experts: geometry.num_experts,
+            top_k: geometry.top_k,
+            router_inputs_offset,
+            raw_logits_offset,
+            selected_ids_offset,
+            selected_weights_offset,
+            route_outputs_offset,
+            routed_moe_outputs_offset,
+            router_input_layer_bytes,
+            raw_logits_layer_bytes,
+            selected_ids_layer_bytes,
+            selected_weights_layer_bytes,
+            route_outputs_layer_bytes,
+            routed_moe_output_layer_bytes,
+            total_bytes,
+        })
+    }
+
+    fn layer_offset(base: u64, layer_bytes: u64, layer: usize) -> u64 {
+        base + layer_bytes * layer as u64
+    }
+
+    pub fn router_input_offset(&self, layer: usize) -> u64 {
+        Self::layer_offset(
+            self.router_inputs_offset,
+            self.router_input_layer_bytes,
+            layer,
+        )
+    }
+
+    pub fn raw_logits_offset(&self, layer: usize) -> u64 {
+        Self::layer_offset(self.raw_logits_offset, self.raw_logits_layer_bytes, layer)
+    }
+
+    pub fn selected_ids_offset(&self, layer: usize) -> u64 {
+        Self::layer_offset(
+            self.selected_ids_offset,
+            self.selected_ids_layer_bytes,
+            layer,
+        )
+    }
+
+    pub fn selected_weights_offset(&self, layer: usize) -> u64 {
+        Self::layer_offset(
+            self.selected_weights_offset,
+            self.selected_weights_layer_bytes,
+            layer,
+        )
+    }
+
+    pub fn route_outputs_offset(&self, layer: usize) -> u64 {
+        Self::layer_offset(
+            self.route_outputs_offset,
+            self.route_outputs_layer_bytes,
+            layer,
+        )
+    }
+
+    pub fn routed_moe_output_offset(&self, layer: usize) -> u64 {
+        Self::layer_offset(
+            self.routed_moe_outputs_offset,
+            self.routed_moe_output_layer_bytes,
+            layer,
+        )
+    }
+
+    pub fn parse(&self, bytes: &[u8]) -> Result<SemanticCorpusGpuTrace, String> {
+        if bytes.len() < self.total_bytes as usize {
+            return Err(format!(
+                "semantic corpus staging has {} bytes, expected {}",
+                bytes.len(),
+                self.total_bytes
+            ));
+        }
+        let parse_f32 = |offset: u64, count: usize| {
+            bytes[offset as usize..offset as usize + count * 4]
+                .chunks_exact(4)
+                .map(|chunk| f32::from_le_bytes(chunk.try_into().unwrap()))
+                .collect::<Vec<_>>()
+        };
+        let parse_u32 = |offset: u64, count: usize| {
+            bytes[offset as usize..offset as usize + count * 4]
+                .chunks_exact(4)
+                .map(|chunk| u32::from_le_bytes(chunk.try_into().unwrap()))
+                .collect::<Vec<_>>()
+        };
+        let mut layers = Vec::with_capacity(self.num_layers);
+        for layer in 0..self.num_layers {
+            let flat_outputs =
+                parse_f32(self.route_outputs_offset(layer), self.top_k * self.d_model);
+            layers.push(SemanticCorpusGpuLayerTrace {
+                router_input: parse_f32(self.router_input_offset(layer), self.d_model),
+                raw_logits: parse_f32(self.raw_logits_offset(layer), self.num_experts),
+                selected_ids: parse_u32(self.selected_ids_offset(layer), self.top_k),
+                selected_weights: parse_f32(self.selected_weights_offset(layer), self.top_k),
+                route_outputs: flat_outputs
+                    .chunks_exact(self.d_model)
+                    .map(<[f32]>::to_vec)
+                    .collect(),
+                routed_moe_output: parse_f32(self.routed_moe_output_offset(layer), self.d_model),
+            });
+        }
+        Ok(SemanticCorpusGpuTrace { layers })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct SemanticCorpusGpuTrace {
+    pub layers: Vec<SemanticCorpusGpuLayerTrace>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct SemanticCorpusGpuLayerTrace {
+    pub router_input: Vec<f32>,
+    pub raw_logits: Vec<f32>,
+    pub selected_ids: Vec<u32>,
+    pub selected_weights: Vec<f32>,
+    pub route_outputs: Vec<Vec<f32>>,
+    pub routed_moe_output: Vec<f32>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RoutingClassification {
+    ExactOrderMatch,
+    InternalRankPermutation,
+    MembershipMismatch,
+    InvalidNonfiniteIncomplete,
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct EventLocation {
+    pub case: String,
+    pub generated_position: usize,
+    pub layer: usize,
+}
+
+impl EventLocation {
+    pub fn new(case: impl Into<String>, generated_position: usize, layer: usize) -> Self {
+        Self {
+            case: case.into(),
+            generated_position,
+            layer,
+        }
+    }
+}
+
+pub fn classify_routing_event(
+    reference_ids: &[u32],
+    gpu_ids: &[u32],
+    num_experts: usize,
+    required_values_finite: bool,
+) -> RoutingClassification {
+    let structurally_valid = !reference_ids.is_empty()
+        && reference_ids.len() == gpu_ids.len()
+        && unique_valid_ids(reference_ids, num_experts)
+        && unique_valid_ids(gpu_ids, num_experts)
+        && required_values_finite;
+    if !structurally_valid {
+        return RoutingClassification::InvalidNonfiniteIncomplete;
+    }
+    if reference_ids == gpu_ids {
+        RoutingClassification::ExactOrderMatch
+    } else if same_membership(reference_ids, gpu_ids) {
+        RoutingClassification::InternalRankPermutation
+    } else {
+        RoutingClassification::MembershipMismatch
+    }
+}
+
+fn unique_valid_ids(ids: &[u32], num_experts: usize) -> bool {
+    ids.iter().all(|&id| (id as usize) < num_experts)
+        && ids.iter().copied().collect::<HashSet<_>>().len() == ids.len()
+}
+
+pub fn same_membership(left: &[u32], right: &[u32]) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+    let mut left = left.to_vec();
+    let mut right = right.to_vec();
+    left.sort_unstable();
+    right.sort_unstable();
+    left == right
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize)]
+pub struct RankDisplacementEvidence {
+    pub displaced_selected_experts: usize,
+    pub single_transposition: bool,
+    pub multi_rank_change: bool,
+}
+
+pub fn rank_displacement(reference_ids: &[u32], gpu_ids: &[u32]) -> RankDisplacementEvidence {
+    if reference_ids.len() != gpu_ids.len() || !same_membership(reference_ids, gpu_ids) {
+        return RankDisplacementEvidence::default();
+    }
+    let displaced_selected_experts = reference_ids
+        .iter()
+        .zip(gpu_ids)
+        .filter(|(left, right)| left != right)
+        .count();
+    let single_transposition = if displaced_selected_experts == 2 {
+        let changed = reference_ids
+            .iter()
+            .zip(gpu_ids)
+            .enumerate()
+            .filter(|(_, (left, right))| left != right)
+            .map(|(index, _)| index)
+            .collect::<Vec<_>>();
+        reference_ids[changed[0]] == gpu_ids[changed[1]]
+            && reference_ids[changed[1]] == gpu_ids[changed[0]]
+    } else {
+        false
+    };
+    RankDisplacementEvidence {
+        displaced_selected_experts,
+        single_transposition,
+        multi_rank_change: displaced_selected_experts > 0 && !single_transposition,
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct SamplingDecision {
+    pub selected: bool,
+    pub reason: Option<&'static str>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DeterministicEventSampler {
+    exact_layer_selected: Vec<bool>,
+}
+
+impl DeterministicEventSampler {
+    pub fn new(num_layers: usize) -> Self {
+        Self {
+            exact_layer_selected: vec![false; num_layers],
+        }
+    }
+
+    pub fn select(
+        &mut self,
+        layer: usize,
+        classification: RoutingClassification,
+    ) -> SamplingDecision {
+        match classification {
+            RoutingClassification::InternalRankPermutation => SamplingDecision {
+                selected: true,
+                reason: Some("all-internal-rank-permutation-events"),
+            },
+            RoutingClassification::MembershipMismatch => SamplingDecision {
+                selected: true,
+                reason: Some("all-membership-mismatch-events"),
+            },
+            RoutingClassification::ExactOrderMatch
+                if self
+                    .exact_layer_selected
+                    .get(layer)
+                    .is_some_and(|selected| !selected) =>
+            {
+                self.exact_layer_selected[layer] = true;
+                SamplingDecision {
+                    selected: true,
+                    reason: Some(EXACT_ORDER_SAMPLING_RULE),
+                }
+            }
+            RoutingClassification::ExactOrderMatch
+            | RoutingClassification::InvalidNonfiniteIncomplete => SamplingDecision {
+                selected: false,
+                reason: None,
+            },
+        }
+    }
+
+    pub fn layers_with_exact_sample(&self) -> Vec<usize> {
+        self.exact_layer_selected
+            .iter()
+            .enumerate()
+            .filter_map(|(layer, &selected)| selected.then_some(layer))
+            .collect()
+    }
+
+    pub fn layers_without_exact_sample(&self) -> Vec<usize> {
+        self.exact_layer_selected
+            .iter()
+            .enumerate()
+            .filter_map(|(layer, &selected)| (!selected).then_some(layer))
+            .collect()
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct TokenCaseEvidence {
+    pub case: String,
+    pub reference_generated_token_ids: Vec<u32>,
+    pub gpu_generated_token_ids: Vec<u32>,
+    pub exact_match_count: usize,
+    pub mismatch_count: usize,
+    pub first_mismatch_position: Option<usize>,
+}
+
+impl TokenCaseEvidence {
+    pub fn new(case: impl Into<String>, reference: Vec<u32>, gpu: Vec<u32>) -> Self {
+        let compared = reference.len().min(gpu.len());
+        let exact_match_count = reference
+            .iter()
+            .zip(&gpu)
+            .filter(|(left, right)| left == right)
+            .count();
+        let mismatch_count = compared.saturating_sub(exact_match_count)
+            + reference.len().max(gpu.len()).saturating_sub(compared);
+        let first_mismatch_position = (0..reference.len().max(gpu.len()))
+            .find(|&index| reference.get(index) != gpu.get(index));
+        Self {
+            case: case.into(),
+            reference_generated_token_ids: reference,
+            gpu_generated_token_ids: gpu,
+            exact_match_count,
+            mismatch_count,
+            first_mismatch_position,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct GeneratedTokenMismatchEvidence {
+    pub case: String,
+    pub generated_position: usize,
+    pub reference_token_id: Option<u32>,
+    pub gpu_token_id: Option<u32>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct BoundaryRouterView {
+    pub source: &'static str,
+    pub top_12: Vec<RankedExpertEvidence>,
+    pub rank_7_expert_id: u32,
+    pub rank_8_expert_id: u32,
+    pub rank_9_expert_id: u32,
+    pub rank_7_minus_rank_8_score_margin: FloatEvidence,
+    pub rank_8_minus_rank_9_score_margin: FloatEvidence,
+}
+
+impl BoundaryRouterView {
+    pub fn from_cpu(router: &RouterEvaluationEvidence) -> Self {
+        Self {
+            source: router.source,
+            top_12: router.top_12_ranked_experts.clone(),
+            rank_7_expert_id: router.cutoff_margins.rank_7_expert_id,
+            rank_8_expert_id: router.cutoff_margins.rank_8_expert_id,
+            rank_9_expert_id: router.cutoff_margins.rank_9_expert_id,
+            rank_7_minus_rank_8_score_margin: router
+                .cutoff_margins
+                .rank_7_minus_rank_8_score
+                .clone(),
+            rank_8_minus_rank_9_score_margin: router
+                .cutoff_margins
+                .rank_8_minus_rank_9_score
+                .clone(),
+        }
+    }
+
+    pub fn from_gpu(router: &ActualGpuRouterEvidence) -> Self {
+        Self {
+            source: router.source,
+            top_12: router.top_12_ranked_experts.clone(),
+            rank_7_expert_id: router.cutoff_margins.rank_7_expert_id,
+            rank_8_expert_id: router.cutoff_margins.rank_8_expert_id,
+            rank_9_expert_id: router.cutoff_margins.rank_9_expert_id,
+            rank_7_minus_rank_8_score_margin: router
+                .cutoff_margins
+                .rank_7_minus_rank_8_score
+                .clone(),
+            rank_8_minus_rank_9_score_margin: router
+                .cutoff_margins
+                .rank_8_minus_rank_9_score
+                .clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct MembershipBoundaryEvidence {
+    pub selected_membership_equal: bool,
+    pub reference_selected_ids: Vec<u32>,
+    pub gpu_selected_ids: Vec<u32>,
+    pub reference: BoundaryRouterView,
+    pub gpu: BoundaryRouterView,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct CanonicalSelectedWeightEvidence {
+    pub expert_id: u32,
+    pub reference_weight: Option<FloatEvidence>,
+    pub gpu_weight: Option<FloatEvidence>,
+    pub delta: Option<WeightDeltaEvidence>,
+}
+
+pub fn canonical_selected_weight_evidence(
+    reference_ids: &[u32],
+    reference_weights: &[f32],
+    gpu_ids: &[u32],
+    gpu_weights: &[f32],
+    num_experts: usize,
+) -> Result<Vec<CanonicalSelectedWeightEvidence>, String> {
+    let left = canonical_weight_map(reference_ids, reference_weights, num_experts)?;
+    let right = canonical_weight_map(gpu_ids, gpu_weights, num_experts)?;
+    let all_ids = left
+        .keys()
+        .chain(right.keys())
+        .copied()
+        .collect::<std::collections::BTreeSet<_>>();
+    Ok(all_ids
+        .into_iter()
+        .map(|expert_id| {
+            let left_value = left.get(&expert_id).copied();
+            let right_value = right.get(&expert_id).copied();
+            let delta = left_value.zip(right_value).map(|(left, right)| {
+                let absolute = (f64::from(right) - f64::from(left)).abs();
+                WeightDeltaEvidence {
+                    expert_id,
+                    left: FloatEvidence::new(left),
+                    right: FloatEvidence::new(right),
+                    absolute_error: (left.is_finite() && right.is_finite()).then_some(absolute),
+                    relative_error: (left.is_finite() && right.is_finite() && left != 0.0)
+                        .then(|| absolute / f64::from(left).abs())
+                        .filter(|value| value.is_finite()),
+                    ulp_distance: crate::gpu_native_router_rank_diagnostics::ulp_distance(
+                        left, right,
+                    ),
+                }
+            });
+            CanonicalSelectedWeightEvidence {
+                expert_id,
+                reference_weight: left_value.map(FloatEvidence::new),
+                gpu_weight: right_value.map(FloatEvidence::new),
+                delta,
+            }
+        })
+        .collect())
+}
+
+fn canonical_weight_map(
+    ids: &[u32],
+    weights: &[f32],
+    num_experts: usize,
+) -> Result<BTreeMap<u32, f32>, String> {
+    if ids.is_empty() || ids.len() != weights.len() {
+        return Err("selected expert IDs and weights are empty or incomplete".to_string());
+    }
+    if weights.iter().any(|value| !value.is_finite()) {
+        return Err("selected expert weights contain a nonfinite value".to_string());
+    }
+    let mut out = BTreeMap::new();
+    for (&id, &weight) in ids.iter().zip(weights) {
+        if id as usize >= num_experts {
+            return Err(format!("selected expert ID {id} is outside layer geometry"));
+        }
+        if out.insert(id, weight).is_some() {
+            return Err(format!("duplicate selected expert ID {id}"));
+        }
+    }
+    Ok(out)
+}
+
+fn scalar_delta(expert_id: u32, left: f32, right: f32) -> WeightDeltaEvidence {
+    let absolute = (f64::from(right) - f64::from(left)).abs();
+    WeightDeltaEvidence {
+        expert_id,
+        left: FloatEvidence::new(left),
+        right: FloatEvidence::new(right),
+        absolute_error: (left.is_finite() && right.is_finite()).then_some(absolute),
+        relative_error: (left.is_finite() && right.is_finite() && left != 0.0)
+            .then(|| absolute / f64::from(left).abs())
+            .filter(|value| value.is_finite()),
+        ulp_distance: crate::gpu_native_router_rank_diagnostics::ulp_distance(left, right),
+    }
+}
+
+fn common_selected_score_deltas(
+    cpu: &RouterEvaluationEvidence,
+    gpu: &ActualGpuRouterEvidence,
+) -> Vec<WeightDeltaEvidence> {
+    cpu.top_8_ids
+        .iter()
+        .copied()
+        .filter(|id| gpu.top_8_ids.contains(id))
+        .filter_map(|expert_id| {
+            let left = cpu.scored_probabilities.get(expert_id as usize)?.value?;
+            let right = gpu.scored_probabilities.get(expert_id as usize)?.value?;
+            Some(scalar_delta(expert_id, left, right))
+        })
+        .collect()
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct RoutingEventEvidence {
+    pub location: EventLocation,
+    pub classification: RoutingClassification,
+    pub selected_membership_equal: Option<bool>,
+    pub reference_selected_ids: Vec<u32>,
+    pub gpu_selected_ids: Vec<u32>,
+    pub displacement: RankDisplacementEvidence,
+    pub expert_weight_pairing_defect: bool,
+    pub canonical_selected_weights: Option<Vec<CanonicalSelectedWeightEvidence>>,
+    pub boundary: Option<MembershipBoundaryEvidence>,
+    pub numerically_selected: bool,
+    pub numerical_selection_reason: Option<&'static str>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct RouterSameInputEvidence {
+    pub cpu_selected_ids: Vec<u32>,
+    pub gpu_selected_ids: Vec<u32>,
+    pub membership_equal: bool,
+    pub ordered_ids_equal: bool,
+    pub common_expert_score_deltas: Vec<WeightDeltaEvidence>,
+    pub common_expert_weight_deltas: Vec<WeightDeltaEvidence>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct SameInputNumericalEventEvidence {
+    pub location: EventLocation,
+    pub classification: RoutingClassification,
+    pub cpu_vs_gpu_routed_moe: VectorNumericalEvidence,
+    pub reference_vs_gpu_routed_moe_includes_upstream_drift: VectorNumericalEvidence,
+    pub router_same_input: RouterSameInputEvidence,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct PermutationNumericalEventEvidence {
+    pub location: EventLocation,
+    pub witness: PermutationOnlyWitness,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct MetricDistribution {
+    pub count: usize,
+    pub minimum: Option<f64>,
+    pub p50: Option<f64>,
+    pub p95: Option<f64>,
+    pub p99: Option<f64>,
+    pub maximum: Option<f64>,
+    pub event_producing_maximum: Option<EventLocation>,
+}
+
+impl MetricDistribution {
+    fn from_points(points: Vec<(f64, EventLocation)>) -> Self {
+        let mut finite = points
+            .into_iter()
+            .filter(|(value, _)| value.is_finite())
+            .collect::<Vec<_>>();
+        finite.sort_by(|(left, left_location), (right, right_location)| {
+            left.total_cmp(right)
+                .then_with(|| left_location.cmp(right_location))
+        });
+        let percentile = |p: f64| {
+            if finite.is_empty() {
+                None
+            } else {
+                let rank = (p * finite.len() as f64).ceil().max(1.0) as usize;
+                Some(finite[rank - 1].0)
+            }
+        };
+        Self {
+            count: finite.len(),
+            minimum: finite.first().map(|point| point.0),
+            p50: percentile(0.50),
+            p95: percentile(0.95),
+            p99: percentile(0.99),
+            maximum: finite.last().map(|point| point.0),
+            event_producing_maximum: finite.last().map(|point| point.1.clone()),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct NumericalAggregation {
+    pub measured_event_count: usize,
+    pub percentile_convention: &'static str,
+    pub max_absolute_error: MetricDistribution,
+    pub rms_error: MetricDistribution,
+    pub mean_absolute_error: MetricDistribution,
+}
+
+pub fn aggregate_numerics(events: &[SameInputNumericalEventEvidence]) -> NumericalAggregation {
+    aggregate_vector_numerics(
+        events
+            .iter()
+            .map(|event| (&event.location, &event.cpu_vs_gpu_routed_moe)),
+    )
+}
+
+fn aggregate_vector_numerics<'a>(
+    events: impl Iterator<Item = (&'a EventLocation, &'a VectorNumericalEvidence)>,
+) -> NumericalAggregation {
+    let events = events.collect::<Vec<_>>();
+    let points = |extract: fn(&VectorNumericalEvidence) -> Option<f64>| {
+        events
+            .iter()
+            .filter_map(|(location, evidence)| {
+                extract(evidence).map(|value| (value, (*location).clone()))
+            })
+            .collect::<Vec<_>>()
+    };
+    NumericalAggregation {
+        measured_event_count: events.len(),
+        percentile_convention: PERCENTILE_CONVENTION,
+        max_absolute_error: MetricDistribution::from_points(points(|e| e.max_absolute_error)),
+        rms_error: MetricDistribution::from_points(points(|e| e.rms_error)),
+        mean_absolute_error: MetricDistribution::from_points(points(|e| e.mean_absolute_error)),
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct ClassificationNumericalAggregation {
+    pub classification: RoutingClassification,
+    pub summary: NumericalAggregation,
+}
+
+pub fn aggregate_numerics_by_classification(
+    events: &[SameInputNumericalEventEvidence],
+) -> Vec<ClassificationNumericalAggregation> {
+    [
+        RoutingClassification::ExactOrderMatch,
+        RoutingClassification::InternalRankPermutation,
+        RoutingClassification::MembershipMismatch,
+    ]
+    .into_iter()
+    .map(|classification| {
+        let subset = events
+            .iter()
+            .filter(|event| event.classification == classification)
+            .cloned()
+            .collect::<Vec<_>>();
+        ClassificationNumericalAggregation {
+            classification,
+            summary: aggregate_numerics(&subset),
+        }
+    })
+    .collect()
+}
+
+pub fn aggregate_permutation_numerics(
+    events: &[PermutationNumericalEventEvidence],
+) -> NumericalAggregation {
+    aggregate_vector_numerics(
+        events
+            .iter()
+            .map(|event| (&event.location, &event.witness.comparison)),
+    )
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct BoundaryMinimumEvidence {
+    pub margin: Option<FloatEvidence>,
+    pub event: Option<EventLocation>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct BoundarySummary {
+    pub minimum_observed_reference_rank8_minus_rank9_margin: BoundaryMinimumEvidence,
+    pub minimum_observed_gpu_rank8_minus_rank9_margin: BoundaryMinimumEvidence,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
+pub struct RoutingCounters {
+    pub total_routing_events: usize,
+    pub exact_order_match_events: usize,
+    pub internal_rank_permutation_events: usize,
+    pub membership_mismatch_events: usize,
+    pub invalid_events: usize,
+    pub single_transposition_events: usize,
+    pub multi_rank_change_events: usize,
+    pub maximum_displaced_selected_experts: usize,
+    pub event_corresponding_to_maximum_displacement: Option<EventLocation>,
+    pub reference_nonfinite_events: usize,
+    pub gpu_nonfinite_events: usize,
+    pub expert_weight_pairing_defect_events: usize,
+}
+
+impl RoutingCounters {
+    pub fn record(
+        &mut self,
+        event: &RoutingEventEvidence,
+        reference_nonfinite: bool,
+        gpu_nonfinite: bool,
+    ) {
+        self.total_routing_events += 1;
+        match event.classification {
+            RoutingClassification::ExactOrderMatch => self.exact_order_match_events += 1,
+            RoutingClassification::InternalRankPermutation => {
+                self.internal_rank_permutation_events += 1
+            }
+            RoutingClassification::MembershipMismatch => self.membership_mismatch_events += 1,
+            RoutingClassification::InvalidNonfiniteIncomplete => self.invalid_events += 1,
+        }
+        self.single_transposition_events += usize::from(event.displacement.single_transposition);
+        self.multi_rank_change_events += usize::from(event.displacement.multi_rank_change);
+        if event.displacement.displaced_selected_experts > self.maximum_displaced_selected_experts {
+            self.maximum_displaced_selected_experts = event.displacement.displaced_selected_experts;
+            self.event_corresponding_to_maximum_displacement = Some(event.location.clone());
+        }
+        self.reference_nonfinite_events += usize::from(reference_nonfinite);
+        self.gpu_nonfinite_events += usize::from(gpu_nonfinite);
+        self.expert_weight_pairing_defect_events += usize::from(event.expert_weight_pairing_defect);
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct SamplingSummary {
+    pub exact_order_events_total: usize,
+    pub exact_order_events_numerically_sampled: usize,
+    pub exact_order_sampling_rule: &'static str,
+    pub layers_with_exact_order_sample: Vec<usize>,
+    pub layers_without_exact_order_sample: Vec<usize>,
+    pub internal_permutation_events_numerically_measured: usize,
+    pub membership_mismatch_events_numerically_measured: usize,
+    pub maximum_exact_order_samples_for_model: usize,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct TokenSummary {
+    pub case_count: usize,
+    pub requested_generated_tokens: usize,
+    pub completed_generated_tokens: usize,
+    pub exact_generated_token_matches: usize,
+    pub generated_token_mismatches: usize,
+    pub first_generated_token_mismatch: Option<GeneratedTokenMismatchEvidence>,
+}
+
+pub fn summarize_tokens(cases: &[TokenCaseEvidence], requested: usize) -> TokenSummary {
+    let completed_generated_tokens = cases
+        .iter()
+        .map(|case| {
+            case.reference_generated_token_ids
+                .len()
+                .min(case.gpu_generated_token_ids.len())
+        })
+        .sum();
+    let exact_generated_token_matches = cases.iter().map(|case| case.exact_match_count).sum();
+    let generated_token_mismatches = cases.iter().map(|case| case.mismatch_count).sum();
+    let first_generated_token_mismatch = cases.iter().find_map(|case| {
+        case.first_mismatch_position
+            .map(|generated_position| GeneratedTokenMismatchEvidence {
+                case: case.case.clone(),
+                generated_position,
+                reference_token_id: case
+                    .reference_generated_token_ids
+                    .get(generated_position)
+                    .copied(),
+                gpu_token_id: case
+                    .gpu_generated_token_ids
+                    .get(generated_position)
+                    .copied(),
+            })
+    });
+    TokenSummary {
+        case_count: cases.len(),
+        requested_generated_tokens: requested,
+        completed_generated_tokens,
+        exact_generated_token_matches,
+        generated_token_mismatches,
+        first_generated_token_mismatch,
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ProductionSemanticsEvidence {
+    pub production_inference_math_changed: bool,
+    pub production_shader_math_changed: bool,
+    pub production_selected_expert_order_changed: bool,
+    pub production_accumulation_order_changed: bool,
+    pub existing_v1_qualifier_semantics_changed: bool,
+    pub numerical_acceptance_thresholds_introduced: bool,
+    pub cpu_combiner: &'static str,
+    pub gpu_combiner: &'static str,
+    pub canonicalization_scope: &'static str,
+}
+
+impl Default for ProductionSemanticsEvidence {
+    fn default() -> Self {
+        Self {
+            production_inference_math_changed: false,
+            production_shader_math_changed: false,
+            production_selected_expert_order_changed: false,
+            production_accumulation_order_changed: false,
+            existing_v1_qualifier_semantics_changed: false,
+            numerical_acceptance_thresholds_introduced: false,
+            cpu_combiner: "production sequential f32 accumulation",
+            gpu_combiner: "production sequential f32 accumulation",
+            canonicalization_scope: "diagnostic host memory only",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct GlobalSummary {
+    pub routing: RoutingCounters,
+    pub tokens: TokenSummary,
+    pub pairing_defect_count: usize,
+    pub same_input_numerics: NumericalAggregation,
+    pub permutation_only_numerics: NumericalAggregation,
+    pub boundary: BoundarySummary,
+    pub nonfinite_bit_mismatch_count: usize,
+    pub sampling: SamplingSummary,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct SemanticParityCorpusReport {
+    pub schema: &'static str,
+    pub mode: &'static str,
+    pub status: &'static str,
+    pub diagnostic_only: bool,
+    pub diagnostic_complete: bool,
+    qualification_pass: bool,
+    pub failure: Option<String>,
+    pub provenance: DiagnosticProvenance,
+    pub corpus: CorpusEvidence,
+    pub global_summary: GlobalSummary,
+    pub token_cases: Vec<TokenCaseEvidence>,
+    pub routing_events: Vec<RoutingEventEvidence>,
+    pub same_input_numerical_events: Vec<SameInputNumericalEventEvidence>,
+    pub same_input_numerics_by_classification: Vec<ClassificationNumericalAggregation>,
+    pub permutation_only_events: Vec<PermutationNumericalEventEvidence>,
+    pub production_semantics: ProductionSemanticsEvidence,
+    pub observation_seams_not_implemented: Vec<String>,
+}
+
+impl SemanticParityCorpusReport {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        provenance: DiagnosticProvenance,
+        diagnostic_complete: bool,
+        failure: Option<String>,
+        token_cases: Vec<TokenCaseEvidence>,
+        routing_events: Vec<RoutingEventEvidence>,
+        routing_counters: RoutingCounters,
+        sampling: SamplingSummary,
+        boundary: BoundarySummary,
+        same_input_numerical_events: Vec<SameInputNumericalEventEvidence>,
+        permutation_only_events: Vec<PermutationNumericalEventEvidence>,
+        observation_seams_not_implemented: Vec<String>,
+    ) -> Self {
+        let requested =
+            crate::greedy_parity::CORPUS_CASE_COUNT * crate::greedy_parity::OUTPUT_TOKEN_LIMIT;
+        let tokens = summarize_tokens(&token_cases, requested);
+        let same_input_numerics = aggregate_numerics(&same_input_numerical_events);
+        let same_input_numerics_by_classification =
+            aggregate_numerics_by_classification(&same_input_numerical_events);
+        let permutation_only_numerics = aggregate_permutation_numerics(&permutation_only_events);
+        let nonfinite_bit_mismatch_count = same_input_numerical_events
+            .iter()
+            .map(|event| event.cpu_vs_gpu_routed_moe.nonfinite_bit_mismatch_count)
+            .sum();
+        let global_summary = GlobalSummary {
+            pairing_defect_count: routing_counters.expert_weight_pairing_defect_events,
+            routing: routing_counters,
+            tokens,
+            same_input_numerics,
+            permutation_only_numerics,
+            boundary,
+            nonfinite_bit_mismatch_count,
+            sampling,
+        };
+        Self {
+            schema: SCHEMA_VERSION,
+            mode: MODE,
+            status: if diagnostic_complete {
+                "diagnostic-only"
+            } else {
+                "incomplete"
+            },
+            diagnostic_only: true,
+            diagnostic_complete,
+            qualification_pass: false,
+            failure,
+            provenance,
+            corpus: CorpusEvidence::fixed(),
+            global_summary,
+            token_cases,
+            routing_events,
+            same_input_numerical_events,
+            same_input_numerics_by_classification,
+            permutation_only_events,
+            production_semantics: ProductionSemanticsEvidence::default(),
+            observation_seams_not_implemented,
+        }
+    }
+
+    pub fn qualification_pass(&self) -> bool {
+        self.qualification_pass
+    }
+}
+
+struct GpuCaseCapture {
+    case: &'static str,
+    prompt_token_ids: Vec<u32>,
+    generated_token_ids: Vec<u32>,
+    traces: Vec<SemanticCorpusGpuTrace>,
+}
+
+struct GpuCapture {
+    cases: Vec<GpuCaseCapture>,
+    gate_identities: Vec<crate::gpu_native_router_rank_diagnostics::GateTensorIdentity>,
+    model_load: crate::greedy_parity::ModelLoadEvidence,
+    device: crate::backend::GpuDeviceIdentity,
+    model_geometry: GpuNativeModelGeometry,
+    background_shutdown: crate::greedy_parity::BackgroundShutdownEvidence,
+}
+
+struct ReferenceCaseCapture {
+    case: &'static str,
+    generated_token_ids: Vec<u32>,
+    traces: Vec<crate::gpu_native_diagnostics::ModelDiagnosticTrace>,
+}
+
+struct EvidenceCapture {
+    token_cases: Vec<TokenCaseEvidence>,
+    routing_events: Vec<RoutingEventEvidence>,
+    routing_counters: RoutingCounters,
+    sampling: SamplingSummary,
+    boundary: BoundarySummary,
+    same_input_events: Vec<SameInputNumericalEventEvidence>,
+    permutation_events: Vec<PermutationNumericalEventEvidence>,
+    reference_model_load: crate::greedy_parity::ModelLoadEvidence,
+    reference_background_shutdown: crate::greedy_parity::BackgroundShutdownEvidence,
+}
+
+struct PlannedEvent {
+    case_index: usize,
+    generated_position: usize,
+    layer: usize,
+    evidence: RoutingEventEvidence,
+    reference_router: Option<RouterEvaluationEvidence>,
+    actual_gpu_router: Option<ActualGpuRouterEvidence>,
+    reference_nonfinite: bool,
+    gpu_nonfinite: bool,
+}
+
+struct EventPlan {
+    events: Vec<PlannedEvent>,
+    boundary: BoundarySummary,
+    layers_with_exact_sample: Vec<usize>,
+    layers_without_exact_sample: Vec<usize>,
+}
+
+async fn execute_gpu(
+    spec: &ResolvedRealCliSpec,
+    tokenizer: Arc<crate::tokenizer::Tokenizer>,
+    resolved_config_sha256: &str,
+    expected_adapter_name: &str,
+    watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+) -> Result<GpuCapture, Box<dyn std::error::Error>> {
+    let runtime = crate::build_isolated_greedy_runtime(
+        spec,
+        RealCliRuntimeMode::IsolatedGpuNativeDiagnostic,
+        tokenizer.clone(),
+    )
+    .await?;
+    let attempt = async {
+        let observed_config_sha256 = crate::resolved_real_runtime_identity_sha256(
+            &runtime.cfg,
+            runtime.model.config.architecture,
+            runtime.model.config.first_k_dense_replace,
+            &runtime.model.config.advanced,
+        )?;
+        if observed_config_sha256 != resolved_config_sha256 {
+            return Err(format!(
+                "semantic corpus GPU identity {observed_config_sha256} drifted from {resolved_config_sha256}"
+            )
+            .into());
+        }
+        let device = runtime
+            .engine
+            .gpu_device_identity()
+            .ok_or("semantic corpus GPU runtime has no authoritative adapter identity")?;
+        if device.name != expected_adapter_name {
+            return Err(format!(
+                "semantic corpus GPU runtime selected adapter {:?}, expected {:?}",
+                device.name, expected_adapter_name
+            )
+            .into());
+        }
+        if device.software_adapter || device.device_type.eq_ignore_ascii_case("cpu") {
+            return Err(format!(
+                "semantic corpus GPU runtime selected software adapter {:?}",
+                device.name
+            )
+            .into());
+        }
+        let token_loop = runtime
+            .gpu_native_token_loop
+            .as_ref()
+            .ok_or("GPU-native token loop was not initialized")?;
+        let model_geometry = token_loop.model_geometry();
+        if runtime.model.layers.len() != model_geometry.num_layers {
+            return Err("semantic corpus GPU layer geometry is incomplete".into());
+        }
+        let gate_identities = runtime
+            .model
+            .layers
+            .iter()
+            .enumerate()
+            .map(|(layer, plan)| {
+                crate::gpu_native_router_rank_diagnostics::GateTensorIdentity::from_gate(
+                    layer, &plan.gate,
+                )
+            })
+            .collect::<Vec<_>>();
+        let model_load = crate::greedy_parity_model_load(&runtime);
+        if token_loop.snapshot()
+            != crate::gpu_native_token_loop::GpuNativeTokenLoopSnapshot::default()
+        {
+            return Err("semantic corpus GPU token-loop counters did not start at zero".into());
+        }
+        let routed_before = runtime.engine.routed_expert_execution_snapshot();
+        let attention_before = crate::transformer::nonfinite_softmax_fallbacks();
+        let trace_layout = SemanticCorpusTraceLayout::try_new(model_geometry)?;
+        let mut cases = Vec::with_capacity(crate::greedy_parity::CORPUS_CASE_COUNT);
+        let mut expected_completed = 0usize;
+        for fixed in crate::greedy_parity::FIXED_CORPUS {
+            let prompt_token_ids = tokenizer.encode(fixed.prompt)?;
+            if prompt_token_ids.is_empty() {
+                return Err(format!(
+                    "semantic corpus fixed case {:?} encoded to zero tokens",
+                    fixed.name
+                )
+                .into());
+            }
+            let mut request =
+                token_loop.create_semantic_parity_corpus_diagnostic_request_state()?;
+            let staging = token_loop
+                .create_semantic_parity_corpus_diagnostic_staging_buffer(&trace_layout)?;
+            let (generated_token_ids, traces) = crate::with_progress_timeout(
+                format!("GPU-native semantic corpus {} candidate", fixed.name),
+                watchdog,
+                async {
+                    let prefix_count = prompt_token_ids.len().saturating_sub(1);
+                    for (position, &token_id) in
+                        prompt_token_ids[..prefix_count].iter().enumerate()
+                    {
+                        token_loop
+                            .step_token(&runtime.engine, &mut request, token_id, position, false)
+                            .await?;
+                    }
+                    let mut input_token = *prompt_token_ids
+                        .last()
+                        .ok_or("semantic corpus GPU prompt is empty")?;
+                    let mut position = prefix_count;
+                    let mut generated_token_ids =
+                        Vec::with_capacity(crate::greedy_parity::OUTPUT_TOKEN_LIMIT);
+                    let mut traces =
+                        Vec::with_capacity(crate::greedy_parity::OUTPUT_TOKEN_LIMIT);
+                    while generated_token_ids.len() < crate::greedy_parity::OUTPUT_TOKEN_LIMIT {
+                        let (trace, sampled_token, _) = token_loop
+                            .step_token_semantic_parity_corpus_diagnostic(
+                                &runtime.engine,
+                                &mut request,
+                                input_token,
+                                position,
+                                &trace_layout,
+                                &staging,
+                            )
+                            .await?;
+                        if trace.layers.len() != model_geometry.num_layers {
+                            return Err("semantic corpus GPU trace omitted one or more layers".into());
+                        }
+                        generated_token_ids.push(sampled_token);
+                        traces.push(trace);
+                        input_token = sampled_token;
+                        position = position
+                            .checked_add(1)
+                            .ok_or("semantic corpus GPU position overflowed")?;
+                    }
+                    Ok::<_, Box<dyn std::error::Error>>((generated_token_ids, traces))
+                },
+            )
+            .await?;
+            let case_expected = prompt_token_ids
+                .len()
+                .saturating_sub(1)
+                .checked_add(crate::greedy_parity::OUTPUT_TOKEN_LIMIT)
+                .ok_or("semantic corpus expected completion count overflowed")?;
+            if request.committed_position() != case_expected {
+                return Err(format!(
+                    "semantic corpus GPU case {} retired at {}, expected {case_expected}",
+                    fixed.name,
+                    request.committed_position()
+                )
+                .into());
+            }
+            expected_completed = expected_completed
+                .checked_add(case_expected)
+                .ok_or("semantic corpus total completion count overflowed")?;
+            drop(request);
+            drop(staging);
+            cases.push(GpuCaseCapture {
+                case: fixed.name,
+                prompt_token_ids,
+                generated_token_ids,
+                traces,
+            });
+        }
+        let counters_after = token_loop.snapshot();
+        if counters_after.tokens_completed != expected_completed as u64
+            || counters_after.fatal_failures != 0
+            || counters_after.no_progress_failures != 0
+        {
+            return Err(format!(
+                "semantic corpus GPU request/counter evidence is invalid: completed={} expected={} fatal={} no_progress={}",
+                counters_after.tokens_completed,
+                expected_completed,
+                counters_after.fatal_failures,
+                counters_after.no_progress_failures
+            )
+            .into());
+        }
+        let routed_delta = crate::qualification::routed_execution_delta(
+            routed_before,
+            runtime.engine.routed_expert_execution_snapshot(),
+        )
+        .map_err(|failure| failure.detail)?;
+        if routed_delta.degraded_expert_substitutions != 0
+            || routed_delta.gpu_cpu_fallbacks != 0
+            || routed_delta.gpu_dispatch_failures != 0
+            || crate::transformer::nonfinite_softmax_fallbacks().saturating_sub(attention_before)
+                != 0
+        {
+            return Err("semantic corpus GPU run recorded fallback or dispatch failure".into());
+        }
+        Ok::<_, Box<dyn std::error::Error>>(GpuCapture {
+            cases,
+            gate_identities,
+            model_load,
+            device,
+            model_geometry,
+            background_shutdown: crate::greedy_parity::BackgroundShutdownEvidence::default(),
+        })
+    }
+    .await;
+    let shutdown = runtime.shutdown_isolated().await;
+    match (attempt, shutdown) {
+        (Ok(mut capture), Ok(shutdown)) => {
+            capture.background_shutdown = shutdown;
+            Ok(capture)
+        }
+        (Err(error), Ok(_)) => Err(error),
+        (Ok(_), Err(shutdown_error)) => Err(shutdown_error.into()),
+        (Err(error), Err(shutdown_error)) => Err(IsolatedRuntimeShutdownError::new(format!(
+            "{error}; semantic corpus GPU shutdown also failed: {shutdown_error}"
+        ))
+        .into()),
+    }
+}
+
+fn values_finite(values: &[f32]) -> bool {
+    values.iter().all(|value| value.is_finite())
+}
+
+fn update_boundary_minimum(
+    current: &mut Option<(f32, FloatEvidence, EventLocation)>,
+    margin: &FloatEvidence,
+    location: &EventLocation,
+) {
+    let Some(value) = margin.value else {
+        return;
+    };
+    if current
+        .as_ref()
+        .is_none_or(|(observed, _, _)| value.total_cmp(observed).is_lt())
+    {
+        *current = Some((value, margin.clone(), location.clone()));
+    }
+}
+
+fn plan_events(
+    reference_cases: &[ReferenceCaseCapture],
+    gpu: &GpuCapture,
+    gates: &[crate::gating::LinearGate],
+) -> Result<EventPlan, Box<dyn std::error::Error>> {
+    if reference_cases.len() != crate::greedy_parity::CORPUS_CASE_COUNT
+        || gpu.cases.len() != crate::greedy_parity::CORPUS_CASE_COUNT
+        || gates.len() != gpu.model_geometry.num_layers
+    {
+        return Err("semantic corpus case or gate coverage is incomplete".into());
+    }
+    let mut sampler = DeterministicEventSampler::new(gpu.model_geometry.num_layers);
+    let mut events = Vec::with_capacity(
+        crate::greedy_parity::CORPUS_CASE_COUNT
+            * crate::greedy_parity::OUTPUT_TOKEN_LIMIT
+            * gpu.model_geometry.num_layers,
+    );
+    let mut minimum_reference = None;
+    let mut minimum_gpu = None;
+
+    for (case_index, ((reference_case, gpu_case), fixed)) in reference_cases
+        .iter()
+        .zip(&gpu.cases)
+        .zip(crate::greedy_parity::FIXED_CORPUS)
+        .enumerate()
+    {
+        if reference_case.case != fixed.name
+            || gpu_case.case != fixed.name
+            || reference_case.traces.len() != crate::greedy_parity::OUTPUT_TOKEN_LIMIT
+            || gpu_case.traces.len() != crate::greedy_parity::OUTPUT_TOKEN_LIMIT
+        {
+            return Err(format!("semantic corpus case {} coverage drifted", fixed.name).into());
+        }
+        for generated_position in 0..crate::greedy_parity::OUTPUT_TOKEN_LIMIT {
+            let reference_trace = &reference_case.traces[generated_position];
+            let gpu_trace = &gpu_case.traces[generated_position];
+            if reference_trace.layer_selected_ids.len() != gpu.model_geometry.num_layers
+                || reference_trace.layer_selected_weights.len() != gpu.model_geometry.num_layers
+                || reference_trace.layer_router_input.len() != gpu.model_geometry.num_layers
+                || reference_trace.layer_routed_moe_output.len() != gpu.model_geometry.num_layers
+                || gpu_trace.layers.len() != gpu.model_geometry.num_layers
+            {
+                return Err(format!(
+                    "semantic corpus case {} position {generated_position} omitted layer evidence",
+                    fixed.name
+                )
+                .into());
+            }
+            for layer in 0..gpu.model_geometry.num_layers {
+                let location = EventLocation::new(fixed.name, generated_position, layer);
+                let reference_ids = &reference_trace.layer_selected_ids[layer];
+                let reference_weights = &reference_trace.layer_selected_weights[layer];
+                let reference_input = &reference_trace.layer_router_input[layer];
+                let reference_output = &reference_trace.layer_routed_moe_output[layer];
+                let gpu_layer = &gpu_trace.layers[layer];
+                let reference_nonfinite = !values_finite(reference_weights)
+                    || !values_finite(reference_input)
+                    || !values_finite(reference_output);
+                let gpu_nonfinite = !values_finite(&gpu_layer.router_input)
+                    || !values_finite(&gpu_layer.raw_logits)
+                    || !values_finite(&gpu_layer.selected_weights)
+                    || !values_finite(&gpu_layer.routed_moe_output)
+                    || gpu_layer
+                        .route_outputs
+                        .iter()
+                        .any(|output| !values_finite(output));
+                let geometry_complete = reference_ids.len() == gpu.model_geometry.top_k
+                    && reference_weights.len() == gpu.model_geometry.top_k
+                    && reference_input.len() == gpu.model_geometry.d_model
+                    && reference_output.len() == gpu.model_geometry.d_model
+                    && gpu_layer.selected_ids.len() == gpu.model_geometry.top_k
+                    && gpu_layer.selected_weights.len() == gpu.model_geometry.top_k
+                    && gpu_layer.router_input.len() == gpu.model_geometry.d_model
+                    && gpu_layer.raw_logits.len() == gpu.model_geometry.num_experts
+                    && gpu_layer.route_outputs.len() == gpu.model_geometry.top_k
+                    && gpu_layer
+                        .route_outputs
+                        .iter()
+                        .all(|output| output.len() == gpu.model_geometry.d_model)
+                    && gpu_layer.routed_moe_output.len() == gpu.model_geometry.d_model;
+                let mut classification = classify_routing_event(
+                    reference_ids,
+                    &gpu_layer.selected_ids,
+                    gpu.model_geometry.num_experts,
+                    geometry_complete && !reference_nonfinite && !gpu_nonfinite,
+                );
+                let reference_router =
+                    if classification == RoutingClassification::InvalidNonfiniteIncomplete {
+                        None
+                    } else {
+                        crate::gpu_native_router_rank_diagnostics::evaluate_cpu_router(
+                            "reference-hidden-to-cpu-production-router",
+                            &gates[layer],
+                            reference_input,
+                        )
+                        .ok()
+                    };
+                let actual_gpu_router =
+                    if classification == RoutingClassification::InvalidNonfiniteIncomplete {
+                        None
+                    } else {
+                        crate::gpu_native_router_rank_diagnostics::evaluate_actual_gpu_router(
+                            gpu_layer.raw_logits.clone(),
+                            gpu_layer.selected_ids.clone(),
+                            gpu_layer.selected_weights.clone(),
+                        )
+                        .ok()
+                    };
+                if reference_router.is_none() || actual_gpu_router.is_none() {
+                    classification = RoutingClassification::InvalidNonfiniteIncomplete;
+                }
+                let canonical_selected_weights = if matches!(
+                    classification,
+                    RoutingClassification::InternalRankPermutation
+                        | RoutingClassification::MembershipMismatch
+                ) {
+                    canonical_selected_weight_evidence(
+                        reference_ids,
+                        reference_weights,
+                        &gpu_layer.selected_ids,
+                        &gpu_layer.selected_weights,
+                        gpu.model_geometry.num_experts,
+                    )
+                    .ok()
+                } else {
+                    None
+                };
+                let gpu_pairing_structurally_valid = canonical_selected_weight_evidence(
+                    &gpu_layer.selected_ids,
+                    &gpu_layer.selected_weights,
+                    &gpu_layer.selected_ids,
+                    &gpu_layer.selected_weights,
+                    gpu.model_geometry.num_experts,
+                )
+                .is_ok();
+                let expert_weight_pairing_defect = !gpu_pairing_structurally_valid
+                    || actual_gpu_router
+                        .as_ref()
+                        .is_some_and(|router| !router.selected_weights_paired_with_expert_ids);
+                let displacement = rank_displacement(reference_ids, &gpu_layer.selected_ids);
+                let boundary = if matches!(
+                    classification,
+                    RoutingClassification::InternalRankPermutation
+                        | RoutingClassification::MembershipMismatch
+                ) {
+                    reference_router
+                        .as_ref()
+                        .zip(actual_gpu_router.as_ref())
+                        .map(|(reference, actual)| MembershipBoundaryEvidence {
+                            selected_membership_equal: same_membership(
+                                reference_ids,
+                                &gpu_layer.selected_ids,
+                            ),
+                            reference_selected_ids: reference_ids.clone(),
+                            gpu_selected_ids: gpu_layer.selected_ids.clone(),
+                            reference: BoundaryRouterView::from_cpu(reference),
+                            gpu: BoundaryRouterView::from_gpu(actual),
+                        })
+                } else {
+                    None
+                };
+                if let Some(router) = &reference_router {
+                    update_boundary_minimum(
+                        &mut minimum_reference,
+                        &router.cutoff_margins.rank_8_minus_rank_9_score,
+                        &location,
+                    );
+                }
+                if let Some(router) = &actual_gpu_router {
+                    update_boundary_minimum(
+                        &mut minimum_gpu,
+                        &router.cutoff_margins.rank_8_minus_rank_9_score,
+                        &location,
+                    );
+                }
+                let sampling = sampler.select(layer, classification);
+                events.push(PlannedEvent {
+                    case_index,
+                    generated_position,
+                    layer,
+                    evidence: RoutingEventEvidence {
+                        location,
+                        classification,
+                        selected_membership_equal: (classification
+                            != RoutingClassification::InvalidNonfiniteIncomplete)
+                            .then(|| same_membership(reference_ids, &gpu_layer.selected_ids)),
+                        reference_selected_ids: reference_ids.clone(),
+                        gpu_selected_ids: gpu_layer.selected_ids.clone(),
+                        displacement,
+                        expert_weight_pairing_defect,
+                        canonical_selected_weights,
+                        boundary,
+                        numerically_selected: sampling.selected,
+                        numerical_selection_reason: sampling.reason,
+                    },
+                    reference_router,
+                    actual_gpu_router,
+                    reference_nonfinite,
+                    gpu_nonfinite,
+                });
+            }
+        }
+    }
+
+    let boundary_minimum = |minimum: Option<(f32, FloatEvidence, EventLocation)>| match minimum {
+        Some((_, margin, event)) => BoundaryMinimumEvidence {
+            margin: Some(margin),
+            event: Some(event),
+        },
+        None => BoundaryMinimumEvidence {
+            margin: None,
+            event: None,
+        },
+    };
+    Ok(EventPlan {
+        events,
+        boundary: BoundarySummary {
+            minimum_observed_reference_rank8_minus_rank9_margin: boundary_minimum(
+                minimum_reference,
+            ),
+            minimum_observed_gpu_rank8_minus_rank9_margin: boundary_minimum(minimum_gpu),
+        },
+        layers_with_exact_sample: sampler.layers_with_exact_sample(),
+        layers_without_exact_sample: sampler.layers_without_exact_sample(),
+    })
+}
+
+async fn execute_reference_and_evidence(
+    spec: &ResolvedRealCliSpec,
+    tokenizer: Arc<crate::tokenizer::Tokenizer>,
+    resolved_config_sha256: &str,
+    gpu: &GpuCapture,
+    watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+) -> Result<EvidenceCapture, Box<dyn std::error::Error>> {
+    let runtime = crate::build_isolated_greedy_runtime(
+        spec,
+        RealCliRuntimeMode::IsolatedGreedyParityCpu,
+        tokenizer.clone(),
+    )
+    .await?;
+    let attempt = async {
+        runtime.engine.enable_cpu_q4_boundary_emulation()?;
+        let observed_config_sha256 = crate::resolved_real_runtime_identity_sha256(
+            &runtime.cfg,
+            runtime.model.config.architecture,
+            runtime.model.config.first_k_dense_replace,
+            &runtime.model.config.advanced,
+        )?;
+        if observed_config_sha256 != resolved_config_sha256 {
+            return Err(format!(
+                "semantic corpus reference identity {observed_config_sha256} drifted from {resolved_config_sha256}"
+            )
+            .into());
+        }
+        if runtime.model.layers.len() != gpu.model_geometry.num_layers {
+            return Err("semantic corpus reference layer geometry is incomplete".into());
+        }
+        let gates = runtime
+            .model
+            .layers
+            .iter()
+            .map(|layer| layer.gate.clone())
+            .collect::<Vec<_>>();
+        let reference_gate_identities = gates
+            .iter()
+            .enumerate()
+            .map(|(layer, gate)| {
+                crate::gpu_native_router_rank_diagnostics::GateTensorIdentity::from_gate(
+                    layer, gate,
+                )
+            })
+            .collect::<Vec<_>>();
+        if reference_gate_identities != gpu.gate_identities {
+            return Err("semantic corpus reference and GPU gate tensor identities differ".into());
+        }
+        let model_load = crate::greedy_parity_model_load(&runtime);
+        let boundary_before = runtime.engine.cpu_q4_boundary_emulation_snapshot();
+        if !boundary_before.enabled || boundary_before.routed_expert_dispatches != 0 {
+            return Err("semantic corpus reference boundary emulation did not start clean".into());
+        }
+        let routed_before = runtime.engine.routed_expert_execution_snapshot();
+        let attention_before = crate::transformer::nonfinite_softmax_fallbacks();
+        let mut reference_cases = Vec::with_capacity(crate::greedy_parity::CORPUS_CASE_COUNT);
+        for (case_index, fixed) in crate::greedy_parity::FIXED_CORPUS.into_iter().enumerate() {
+            let prompt_token_ids = tokenizer.encode(fixed.prompt)?;
+            if prompt_token_ids != gpu.cases[case_index].prompt_token_ids {
+                return Err(format!(
+                    "semantic corpus tokenizer identity drifted for case {}",
+                    fixed.name
+                )
+                .into());
+            }
+            let (generated_token_ids, traces) = crate::with_progress_timeout(
+                format!("semantic corpus {} authoritative reference", fixed.name),
+                watchdog,
+                async {
+                    let mut kv = runtime.model.fresh_kv_caches();
+                    let prefix_count = prompt_token_ids.len().saturating_sub(1);
+                    for (position, &token_id) in
+                        prompt_token_ids[..prefix_count].iter().enumerate()
+                    {
+                        runtime
+                            .model
+                            .forward_token_hidden(
+                                &runtime.engine,
+                                token_id,
+                                position,
+                                &mut kv,
+                            )
+                            .await?;
+                    }
+                    let mut input_token = *prompt_token_ids
+                        .last()
+                        .ok_or("semantic corpus reference prompt is empty")?;
+                    let mut position = prefix_count;
+                    let mut generated_token_ids =
+                        Vec::with_capacity(crate::greedy_parity::OUTPUT_TOKEN_LIMIT);
+                    let mut traces =
+                        Vec::with_capacity(crate::greedy_parity::OUTPUT_TOKEN_LIMIT);
+                    while generated_token_ids.len() < crate::greedy_parity::OUTPUT_TOKEN_LIMIT {
+                        let trace = runtime
+                            .model
+                            .forward_token_diagnostic_trace(
+                                &runtime.engine,
+                                input_token,
+                                position,
+                                &mut kv,
+                                None,
+                            )
+                            .await?;
+                        input_token = trace.sampled_token;
+                        generated_token_ids.push(trace.sampled_token);
+                        traces.push(trace);
+                        position = position
+                            .checked_add(1)
+                            .ok_or("semantic corpus reference position overflowed")?;
+                    }
+                    Ok::<_, Box<dyn std::error::Error>>((generated_token_ids, traces))
+                },
+            )
+            .await?;
+            reference_cases.push(ReferenceCaseCapture {
+                case: fixed.name,
+                generated_token_ids,
+                traces,
+            });
+        }
+
+        let mut plan = plan_events(&reference_cases, gpu, &gates)?;
+        let mut same_input_events = Vec::new();
+        for planned in plan
+            .events
+            .iter_mut()
+            .filter(|event| event.evidence.numerically_selected)
+        {
+            let gpu_layer = &gpu.cases[planned.case_index].traces[planned.generated_position]
+                .layers[planned.layer];
+            let reference_trace =
+                &reference_cases[planned.case_index].traces[planned.generated_position];
+            let cpu_router = crate::gpu_native_router_rank_diagnostics::evaluate_cpu_router(
+                "gpu-hidden-to-cpu-production-router",
+                &gates[planned.layer],
+                &gpu_layer.router_input,
+            )?;
+            let routing = gates[planned.layer].route(&gpu_layer.router_input);
+            let routing_matches_evaluation = routing.experts == cpu_router.top_8_ids
+                && routing
+                    .weights
+                    .iter()
+                    .map(|value| value.to_bits())
+                    .eq(cpu_router.top_8_weights.iter().map(|value| value.bits));
+            if !routing_matches_evaluation {
+                planned.evidence.expert_weight_pairing_defect = true;
+            }
+            let global_ids = routing
+                .experts
+                .iter()
+                .map(|&expert| runtime.model.global_expert_id(planned.layer, expert))
+                .collect::<Vec<_>>();
+            let token_index = (planned.case_index as u64)
+                .wrapping_mul(crate::greedy_parity::OUTPUT_TOKEN_LIMIT as u64)
+                .wrapping_add(planned.generated_position as u64)
+                .wrapping_mul(gpu.model_geometry.num_layers as u64)
+                .wrapping_add(planned.layer as u64);
+            let expert_outputs = runtime
+                .engine
+                .moe_step_with_timing(
+                    token_index,
+                    planned.layer as u32,
+                    &gpu_layer.router_input,
+                    &global_ids,
+                    None,
+                )
+                .await?;
+            if expert_outputs.len() != routing.experts.len()
+                || expert_outputs
+                    .iter()
+                    .any(|output| output.len() != gpu.model_geometry.d_model)
+            {
+                planned.evidence.expert_weight_pairing_defect = true;
+                return Err(format!(
+                    "same-input CPU expert output coverage is incomplete at {:?}",
+                    planned.evidence.location
+                )
+                .into());
+            }
+            let cpu_routed_moe_output =
+                crate::inference::combine_outputs(&expert_outputs, &routing.weights);
+            let canonical = canonical_selected_weight_evidence(
+                &routing.experts,
+                &routing.weights,
+                &gpu_layer.selected_ids,
+                &gpu_layer.selected_weights,
+                gpu.model_geometry.num_experts,
+            )?;
+            let common_expert_weight_deltas = canonical
+                .into_iter()
+                .filter_map(|item| item.delta)
+                .collect::<Vec<_>>();
+            let actual_gpu_router = planned
+                .actual_gpu_router
+                .as_ref()
+                .ok_or("selected semantic corpus event is missing actual GPU router evidence")?;
+            if actual_gpu_router.top_8_ids != gpu_layer.selected_ids
+                || !actual_gpu_router.selected_weights_paired_with_expert_ids
+            {
+                planned.evidence.expert_weight_pairing_defect = true;
+            }
+            let stored_reference_router = planned
+                .reference_router
+                .as_ref()
+                .ok_or("selected semantic corpus event is missing reference router evidence")?;
+            if stored_reference_router.top_8_ids
+                != reference_trace.layer_selected_ids[planned.layer]
+            {
+                planned.evidence.expert_weight_pairing_defect = true;
+            }
+            same_input_events.push(SameInputNumericalEventEvidence {
+                location: planned.evidence.location.clone(),
+                classification: planned.evidence.classification,
+                cpu_vs_gpu_routed_moe: VectorNumericalEvidence::compare(
+                    "cpu-production-routed-moe-on-exact-gpu-input",
+                    "actual-production-gpu-routed-moe-on-exact-gpu-input",
+                    &cpu_routed_moe_output,
+                    &gpu_layer.routed_moe_output,
+                )?,
+                reference_vs_gpu_routed_moe_includes_upstream_drift:
+                    VectorNumericalEvidence::compare(
+                        "authoritative-cpu-reference-routed-moe-includes-upstream-drift",
+                        "actual-production-gpu-routed-moe",
+                        &reference_trace.layer_routed_moe_output[planned.layer],
+                        &gpu_layer.routed_moe_output,
+                    )?,
+                router_same_input: RouterSameInputEvidence {
+                    cpu_selected_ids: cpu_router.top_8_ids.clone(),
+                    gpu_selected_ids: gpu_layer.selected_ids.clone(),
+                    membership_equal: same_membership(
+                        &cpu_router.top_8_ids,
+                        &gpu_layer.selected_ids,
+                    ),
+                    ordered_ids_equal: cpu_router.top_8_ids == gpu_layer.selected_ids,
+                    common_expert_score_deltas: common_selected_score_deltas(
+                        &cpu_router,
+                        actual_gpu_router,
+                    ),
+                    common_expert_weight_deltas,
+                },
+            });
+        }
+
+        let mut permutation_events = Vec::new();
+        for planned in plan.events.iter().filter(|event| {
+            event.evidence.classification == RoutingClassification::InternalRankPermutation
+        }) {
+            let gpu_layer = &gpu.cases[planned.case_index].traces[planned.generated_position]
+                .layers[planned.layer];
+            permutation_events.push(PermutationNumericalEventEvidence {
+                location: planned.evidence.location.clone(),
+                witness: crate::gpu_native_expert_permutation_semantic_parity::permutation_only_witness(
+                    &gpu_layer.selected_ids,
+                    &gpu_layer.selected_weights,
+                    &gpu_layer.route_outputs,
+                )?,
+            });
+        }
+
+        let boundary_after = runtime.engine.cpu_q4_boundary_emulation_snapshot();
+        if !boundary_after.enabled || boundary_after.routed_expert_dispatches == 0 {
+            return Err("semantic corpus reference did not exercise the Hybrid F16 boundary".into());
+        }
+        let routed_delta = crate::qualification::routed_execution_delta(
+            routed_before,
+            runtime.engine.routed_expert_execution_snapshot(),
+        )
+        .map_err(|failure| failure.detail)?;
+        if routed_delta.degraded_expert_substitutions != 0
+            || crate::transformer::nonfinite_softmax_fallbacks().saturating_sub(attention_before)
+                != 0
+        {
+            return Err("semantic corpus reference recorded degraded or nonfinite fallback".into());
+        }
+
+        let token_cases = reference_cases
+            .iter()
+            .zip(&gpu.cases)
+            .map(|(reference, gpu_case)| {
+                TokenCaseEvidence::new(
+                    reference.case,
+                    reference.generated_token_ids.clone(),
+                    gpu_case.generated_token_ids.clone(),
+                )
+            })
+            .collect::<Vec<_>>();
+        let mut routing_counters = RoutingCounters::default();
+        for event in &plan.events {
+            routing_counters.record(
+                &event.evidence,
+                event.reference_nonfinite,
+                event.gpu_nonfinite,
+            );
+        }
+        let exact_sampled = same_input_events
+            .iter()
+            .filter(|event| event.classification == RoutingClassification::ExactOrderMatch)
+            .count();
+        let internal_measured = same_input_events
+            .iter()
+            .filter(|event| {
+                event.classification == RoutingClassification::InternalRankPermutation
+            })
+            .count();
+        let membership_measured = same_input_events
+            .iter()
+            .filter(|event| event.classification == RoutingClassification::MembershipMismatch)
+            .count();
+        if internal_measured != routing_counters.internal_rank_permutation_events
+            || membership_measured != routing_counters.membership_mismatch_events
+            || permutation_events.len() != routing_counters.internal_rank_permutation_events
+        {
+            return Err("semantic corpus mandatory anomaly sampling coverage is incomplete".into());
+        }
+        let sampling = SamplingSummary {
+            exact_order_events_total: routing_counters.exact_order_match_events,
+            exact_order_events_numerically_sampled: exact_sampled,
+            exact_order_sampling_rule: EXACT_ORDER_SAMPLING_RULE,
+            layers_with_exact_order_sample: plan.layers_with_exact_sample,
+            layers_without_exact_order_sample: plan.layers_without_exact_sample,
+            internal_permutation_events_numerically_measured: internal_measured,
+            membership_mismatch_events_numerically_measured: membership_measured,
+            maximum_exact_order_samples_for_model: gpu.model_geometry.num_layers,
+        };
+        Ok::<_, Box<dyn std::error::Error>>(EvidenceCapture {
+            token_cases,
+            routing_events: plan
+                .events
+                .into_iter()
+                .map(|event| event.evidence)
+                .collect(),
+            routing_counters,
+            sampling,
+            boundary: plan.boundary,
+            same_input_events,
+            permutation_events,
+            reference_model_load: model_load,
+            reference_background_shutdown:
+                crate::greedy_parity::BackgroundShutdownEvidence::default(),
+        })
+    }
+    .await;
+    let shutdown = runtime.shutdown_isolated().await;
+    match (attempt, shutdown) {
+        (Ok(mut capture), Ok(shutdown)) => {
+            capture.reference_background_shutdown = shutdown;
+            Ok(capture)
+        }
+        (Err(error), Ok(_)) => Err(error),
+        (Ok(_), Err(shutdown_error)) => Err(shutdown_error.into()),
+        (Err(error), Err(shutdown_error)) => Err(IsolatedRuntimeShutdownError::new(format!(
+            "{error}; semantic corpus reference shutdown also failed: {shutdown_error}"
+        ))
+        .into()),
+    }
+}
+
+fn emit_report(
+    report: &SemanticParityCorpusReport,
+    report_out: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if report.qualification_pass() {
+        return Err("semantic corpus diagnostic cannot claim qualification PASS".into());
+    }
+    if let Some(parent) = report_out.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut json = serde_json::to_vec_pretty(report)?;
+    json.push(b'\n');
+    std::fs::write(report_out, json)?;
+    eprintln!(
+        "GPU-native semantic-parity corpus diagnostic report written to {}",
+        report_out.display()
+    );
+    Ok(())
+}
+
+pub async fn run_diagnostic(
+    config: PathBuf,
+    cfg: crate::config::Config,
+    expected_adapter_name: String,
+    report_out: PathBuf,
+    progress_watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use crate::qualification::BuildProvenance;
+
+    let provenance = BuildProvenance::embedded();
+    let (artifacts, artifact_errors) = crate::qualification_artifacts(&config, &cfg);
+    if !artifact_errors.is_empty() {
+        return Err(format!(
+            "semantic corpus diagnostic artifact preflight failed: {}",
+            artifact_errors.join("; ")
+        )
+        .into());
+    }
+    if progress_watchdog.timeout.is_none() {
+        return Err("semantic corpus diagnostic requires a positive progress timeout".into());
+    }
+    if provenance.dirty != Some(false)
+        || provenance
+            .git_sha
+            .as_deref()
+            .is_none_or(|sha| sha.len() != 40 || !sha.bytes().all(|byte| byte.is_ascii_hexdigit()))
+    {
+        return Err(
+            "semantic corpus diagnostic requires clean embedded 40-hex Git provenance".into(),
+        );
+    }
+    if CorpusEvidence::fixed().sha256
+        != "ea7fdda4f08cde2fe3658165054d80099948f66ae8cba1c904ca41102f0aadc7"
+    {
+        return Err("semantic corpus identity drifted from the frozen contract".into());
+    }
+    let capacity_bytes = cfg
+        .gpu_cache
+        .vram_capacity_mb
+        .checked_mul(1024 * 1024)
+        .and_then(|bytes| u64::try_from(bytes).ok())
+        .unwrap_or(0);
+    let source_config = crate::gpu_native_greedy_parity::SourceConfigEvidence {
+        real_transformer_enabled: cfg.real_transformer.enabled,
+        gpu_native_enabled: cfg.real_transformer.gpu_native,
+        weights_dir_configured: cfg.real_transformer.weights_dir.is_some(),
+        strict_weights: cfg.real_transformer.strict_weights,
+        allow_seeded_fallback: cfg.real_transformer.allow_seeded_fallback,
+        allow_degraded_experts: cfg.real_transformer.allow_degraded_experts,
+        allow_nonfinite_attention_fallback: cfg.real_transformer.allow_nonfinite_attention_fallback,
+        allow_truncated_expert_payloads: cfg.real_transformer.allow_truncated_expert_payloads,
+        distributed_enabled: cfg.distributed.enabled,
+        gpu_cache_enabled: cfg.gpu_cache.enabled,
+        gpu_expert_capacity_bytes: capacity_bytes,
+        routed_expert_dtype: cfg.model.dtype.as_str().to_string(),
+    };
+    if !source_config.is_strict() {
+        return Err(
+            "semantic corpus diagnostic requires the strict GPU-native Q4 qualifier configuration"
+                .into(),
+        );
+    }
+    let expert_metadata =
+        crate::qualification::read_expert_metadata(&cfg.model.data_dir.join("metadata.json"))
+            .map_err(|error| {
+                format!("semantic corpus expert metadata preflight failed: {error}")
+            })?;
+    if expert_metadata.q4_0_layout.as_deref() != Some(crate::inference::Q4_0_LAYOUT_STANDARD_V1)
+        || expert_metadata.explicitly_synthetic
+    {
+        return Err(
+            "semantic corpus diagnostic requires canonical nonsynthetic Q4_0 metadata".into(),
+        );
+    }
+    if expected_adapter_name.trim().is_empty() {
+        return Err("semantic corpus diagnostic requires a nonempty exact adapter name".into());
+    }
+
+    let mut gpu_spec = crate::resolve_real_cli_spec_from_config(
+        cfg,
+        RealCliRuntimeMode::IsolatedGpuNativeDiagnostic,
+    )?;
+    gpu_spec.cfg.real_transformer.gpu_native = true;
+    gpu_spec.cfg.real_transformer.compute_offload = crate::backend::ComputeOffload::Gpu;
+    let model_identity = crate::greedy_parity_model_identity(&gpu_spec);
+    if !model_identity.is_qwen3_coder_30b_a3b_q4_0() {
+        return Err(
+            "semantic corpus diagnostic requires exact Qwen3-Coder 30B-A3B Q4_0 geometry".into(),
+        );
+    }
+    let gpu_resolved_config_sha256 = crate::resolved_real_cli_spec_sha256(&gpu_spec)?;
+    let mut reference_spec = gpu_spec.clone();
+    reference_spec.cfg.real_transformer.gpu_native = false;
+    reference_spec.cfg.real_transformer.compute_offload = crate::backend::ComputeOffload::Cpu;
+    let reference_resolved_config_sha256 = crate::resolved_real_cli_spec_sha256(&reference_spec)?;
+    let tokenizer = crate::load_real_cli_tokenizer(
+        &gpu_spec.cfg,
+        RealCliRuntimeMode::IsolatedGpuNativeDiagnostic,
+    )?;
+
+    let gpu = execute_gpu(
+        &gpu_spec,
+        tokenizer.clone(),
+        &gpu_resolved_config_sha256,
+        &expected_adapter_name,
+        progress_watchdog,
+    )
+    .await?;
+    if gpu.model_geometry.num_layers != 48
+        || gpu.model_geometry.num_experts != 128
+        || gpu.model_geometry.top_k != 8
+        || gpu.model_geometry.d_model != 2048
+        || gpu.model_geometry.d_ff != 768
+    {
+        return Err("semantic corpus GPU runtime geometry drifted after strict startup".into());
+    }
+    let evidence = execute_reference_and_evidence(
+        &reference_spec,
+        tokenizer,
+        &reference_resolved_config_sha256,
+        &gpu,
+        progress_watchdog,
+    )
+    .await?;
+    let expected_routing_events = crate::greedy_parity::CORPUS_CASE_COUNT
+        * crate::greedy_parity::OUTPUT_TOKEN_LIMIT
+        * gpu.model_geometry.num_layers;
+    if evidence.routing_events.len() != expected_routing_events
+        || evidence.routing_counters.total_routing_events != expected_routing_events
+    {
+        return Err(format!(
+            "semantic corpus routing coverage is incomplete: observed {} expected {expected_routing_events}",
+            evidence.routing_events.len()
+        )
+        .into());
+    }
+    let (_, executable_sha256) = crate::current_executable_identity()?;
+    let report = SemanticParityCorpusReport::new(
+        DiagnosticProvenance {
+            build: provenance,
+            executable_sha256,
+            artifacts,
+            gpu_resolved_config_sha256,
+            reference_resolved_config_sha256,
+            model_identity,
+            reference_model_load: evidence.reference_model_load,
+            gpu_native_model_load: gpu.model_load,
+            reference_background_shutdown: evidence.reference_background_shutdown,
+            gpu_native_background_shutdown: gpu.background_shutdown,
+            expert_metadata,
+            device: gpu.device,
+        },
+        true,
+        None,
+        evidence.token_cases,
+        evidence.routing_events,
+        evidence.routing_counters,
+        evidence.sampling,
+        evidence.boundary,
+        evidence.same_input_events,
+        evidence.permutation_events,
+        Vec::new(),
+    );
+    emit_report(&report, &report_out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn geometry() -> GpuNativeModelGeometry {
+        GpuNativeModelGeometry {
+            num_layers: 3,
+            d_model: 4,
+            d_ff: 8,
+            num_experts: 12,
+            top_k: 3,
+            num_heads: 2,
+            num_kv_heads: 1,
+            head_dim: 2,
+            rope_dim: 2,
+            vocab_size: 32,
+            max_seq_len: 64,
+            rms_eps: 1.0e-6,
+            rope_base: 1_000_000.0,
+        }
+    }
+
+    fn event(
+        case: &str,
+        position: usize,
+        layer: usize,
+        classification: RoutingClassification,
+        displacement: RankDisplacementEvidence,
+        pairing_defect: bool,
+    ) -> RoutingEventEvidence {
+        RoutingEventEvidence {
+            location: EventLocation::new(case, position, layer),
+            classification,
+            selected_membership_equal: Some(
+                classification != RoutingClassification::MembershipMismatch,
+            ),
+            reference_selected_ids: vec![1, 2, 3],
+            gpu_selected_ids: vec![1, 2, 3],
+            displacement,
+            expert_weight_pairing_defect: pairing_defect,
+            canonical_selected_weights: None,
+            boundary: None,
+            numerically_selected: false,
+            numerical_selection_reason: None,
+        }
+    }
+
+    #[test]
+    fn full_layer_trace_layout_round_trips_every_observation() {
+        let layout = SemanticCorpusTraceLayout::try_new(geometry()).unwrap();
+        let mut bytes = vec![0u8; layout.total_bytes as usize];
+        let write_f32 = |bytes: &mut [u8], offset: u64, values: &[f32]| {
+            for (index, value) in values.iter().enumerate() {
+                bytes[offset as usize + index * 4..offset as usize + index * 4 + 4]
+                    .copy_from_slice(&value.to_le_bytes());
+            }
+        };
+        for layer in 0..layout.num_layers {
+            write_f32(
+                &mut bytes,
+                layout.router_input_offset(layer),
+                &[layer as f32, 2.0, 3.0, 4.0],
+            );
+            write_f32(
+                &mut bytes,
+                layout.raw_logits_offset(layer),
+                &(0..12).map(|id| id as f32).collect::<Vec<_>>(),
+            );
+            for (rank, id) in [9u32, 2, 5].iter().enumerate() {
+                let offset = layout.selected_ids_offset(layer) as usize + rank * 4;
+                bytes[offset..offset + 4].copy_from_slice(&id.to_le_bytes());
+            }
+            write_f32(
+                &mut bytes,
+                layout.selected_weights_offset(layer),
+                &[0.5, 0.3, 0.2],
+            );
+            write_f32(
+                &mut bytes,
+                layout.route_outputs_offset(layer),
+                &(0..12).map(|index| index as f32).collect::<Vec<_>>(),
+            );
+            write_f32(
+                &mut bytes,
+                layout.routed_moe_output_offset(layer),
+                &[5.0, 6.0, 7.0, 8.0],
+            );
+        }
+        let trace = layout.parse(&bytes).unwrap();
+        assert_eq!(trace.layers.len(), 3);
+        assert_eq!(trace.layers[2].router_input[0], 2.0);
+        assert_eq!(trace.layers[1].selected_ids, [9, 2, 5]);
+        assert_eq!(trace.layers[0].route_outputs[2], [8.0, 9.0, 10.0, 11.0]);
+    }
+
+    #[test]
+    fn routing_classification_is_exact_and_fail_closed() {
+        assert_eq!(
+            classify_routing_event(&[1, 2, 3], &[1, 2, 3], 12, true),
+            RoutingClassification::ExactOrderMatch
+        );
+        assert_eq!(
+            classify_routing_event(&[1, 2, 3], &[1, 3, 2], 12, true),
+            RoutingClassification::InternalRankPermutation
+        );
+        assert_eq!(
+            classify_routing_event(&[1, 2, 3], &[1, 3, 4], 12, true),
+            RoutingClassification::MembershipMismatch
+        );
+        for (left, right, finite) in [
+            (&[1, 2][..], &[1, 2, 3][..], true),
+            (&[1, 2, 2][..], &[1, 2, 3][..], true),
+            (&[1, 2, 12][..], &[1, 2, 3][..], true),
+            (&[1, 2, 3][..], &[1, 2, 3][..], false),
+        ] {
+            assert_eq!(
+                classify_routing_event(left, right, 12, finite),
+                RoutingClassification::InvalidNonfiniteIncomplete
+            );
+        }
+    }
+
+    #[test]
+    fn displacement_distinguishes_transposition_and_multi_rank_change() {
+        let transposition = rank_displacement(&[1, 2, 3, 4], &[1, 3, 2, 4]);
+        assert_eq!(transposition.displaced_selected_experts, 2);
+        assert!(transposition.single_transposition);
+        assert!(!transposition.multi_rank_change);
+        let multi = rank_displacement(&[1, 2, 3, 4], &[2, 3, 1, 4]);
+        assert_eq!(multi.displaced_selected_experts, 3);
+        assert!(!multi.single_transposition);
+        assert!(multi.multi_rank_change);
+    }
+
+    #[test]
+    fn canonicalization_preserves_pairing_and_rejects_defects() {
+        let evidence = canonical_selected_weight_evidence(
+            &[9, 2, 5],
+            &[0.1, 0.2, 0.7],
+            &[2, 5, 9],
+            &[0.2, 0.7, 0.1],
+            12,
+        )
+        .unwrap();
+        let by_id = evidence
+            .into_iter()
+            .map(|item| (item.expert_id, item))
+            .collect::<BTreeMap<_, _>>();
+        assert_eq!(
+            by_id[&9].gpu_weight.as_ref().unwrap().bits,
+            0.1f32.to_bits()
+        );
+        assert_eq!(
+            by_id[&2].gpu_weight.as_ref().unwrap().bits,
+            0.2f32.to_bits()
+        );
+        assert!(canonical_selected_weight_evidence(
+            &[1, 1, 2],
+            &[0.5, 0.3, 0.2],
+            &[1, 2, 3],
+            &[0.5, 0.3, 0.2],
+            12,
+        )
+        .unwrap_err()
+        .contains("duplicate"));
+        assert!(canonical_selected_weight_evidence(
+            &[1, 2, 12],
+            &[0.5, 0.3, 0.2],
+            &[1, 2, 3],
+            &[0.5, 0.3, 0.2],
+            12,
+        )
+        .unwrap_err()
+        .contains("outside"));
+    }
+
+    #[test]
+    fn deterministic_sampling_selects_first_exact_per_layer_and_all_anomalies() {
+        let classifications = [
+            (0, RoutingClassification::ExactOrderMatch),
+            (0, RoutingClassification::ExactOrderMatch),
+            (1, RoutingClassification::InternalRankPermutation),
+            (1, RoutingClassification::ExactOrderMatch),
+            (2, RoutingClassification::MembershipMismatch),
+            (2, RoutingClassification::InvalidNonfiniteIncomplete),
+        ];
+        let run = || {
+            let mut sampler = DeterministicEventSampler::new(4);
+            let decisions = classifications
+                .into_iter()
+                .map(|(layer, class)| sampler.select(layer, class).selected)
+                .collect::<Vec<_>>();
+            (decisions, sampler)
+        };
+        let (first, sampler) = run();
+        let (second, _) = run();
+        assert_eq!(first, [true, false, true, true, true, false]);
+        assert_eq!(first, second);
+        assert_eq!(sampler.layers_with_exact_sample(), [0, 1]);
+        assert_eq!(sampler.layers_without_exact_sample(), [2, 3]);
+    }
+
+    #[test]
+    fn routing_counters_retain_maximum_displacement_event() {
+        let mut counters = RoutingCounters::default();
+        let first = event(
+            "a",
+            0,
+            1,
+            RoutingClassification::InternalRankPermutation,
+            rank_displacement(&[1, 2, 3], &[1, 3, 2]),
+            false,
+        );
+        let second = event(
+            "a",
+            0,
+            2,
+            RoutingClassification::InternalRankPermutation,
+            rank_displacement(&[1, 2, 3], &[2, 3, 1]),
+            true,
+        );
+        counters.record(&first, false, false);
+        counters.record(&second, true, false);
+        assert_eq!(counters.internal_rank_permutation_events, 2);
+        assert_eq!(counters.single_transposition_events, 1);
+        assert_eq!(counters.multi_rank_change_events, 1);
+        assert_eq!(counters.maximum_displaced_selected_experts, 3);
+        assert_eq!(
+            counters.event_corresponding_to_maximum_displacement,
+            Some(second.location)
+        );
+        assert_eq!(counters.reference_nonfinite_events, 1);
+        assert_eq!(counters.expert_weight_pairing_defect_events, 1);
+    }
+
+    #[test]
+    fn token_parity_retains_first_mismatch_and_incomplete_lengths() {
+        let first = TokenCaseEvidence::new("a", vec![1, 2, 3], vec![1, 9, 3]);
+        let second = TokenCaseEvidence::new("b", vec![4, 5, 6], vec![4, 5]);
+        assert_eq!(first.exact_match_count, 2);
+        assert_eq!(first.mismatch_count, 1);
+        assert_eq!(first.first_mismatch_position, Some(1));
+        assert_eq!(second.first_mismatch_position, Some(2));
+        let summary = summarize_tokens(&[first, second], 6);
+        assert_eq!(summary.completed_generated_tokens, 5);
+        assert_eq!(summary.exact_generated_token_matches, 4);
+        assert_eq!(summary.generated_token_mismatches, 2);
+        assert_eq!(
+            summary
+                .first_generated_token_mismatch
+                .unwrap()
+                .generated_position,
+            1
+        );
+    }
+
+    #[test]
+    fn numerical_aggregation_uses_deterministic_nearest_rank_percentiles() {
+        let events = (1..=100)
+            .map(|index| SameInputNumericalEventEvidence {
+                location: EventLocation::new("a", 0, index),
+                classification: RoutingClassification::ExactOrderMatch,
+                cpu_vs_gpu_routed_moe: VectorNumericalEvidence::compare(
+                    "cpu",
+                    "gpu",
+                    &[0.0],
+                    &[index as f32],
+                )
+                .unwrap(),
+                reference_vs_gpu_routed_moe_includes_upstream_drift:
+                    VectorNumericalEvidence::compare("reference", "gpu", &[0.0], &[index as f32])
+                        .unwrap(),
+                router_same_input: RouterSameInputEvidence {
+                    cpu_selected_ids: vec![1],
+                    gpu_selected_ids: vec![1],
+                    membership_equal: true,
+                    ordered_ids_equal: true,
+                    common_expert_score_deltas: Vec::new(),
+                    common_expert_weight_deltas: Vec::new(),
+                },
+            })
+            .collect::<Vec<_>>();
+        let summary = aggregate_numerics(&events);
+        assert_eq!(summary.max_absolute_error.minimum, Some(1.0));
+        assert_eq!(summary.max_absolute_error.p50, Some(50.0));
+        assert_eq!(summary.max_absolute_error.p95, Some(95.0));
+        assert_eq!(summary.max_absolute_error.p99, Some(99.0));
+        assert_eq!(summary.max_absolute_error.maximum, Some(100.0));
+        assert_eq!(
+            summary
+                .max_absolute_error
+                .event_producing_maximum
+                .unwrap()
+                .layer,
+            100
+        );
+    }
+
+    #[test]
+    fn permutation_accumulation_uses_frozen_outputs_and_can_differ_in_f32() {
+        let outputs = vec![
+            vec![-16_777_216.0, 1.0],
+            vec![16_777_216.0, 2.0],
+            vec![1.0, 3.0],
+        ];
+        let witness =
+            crate::gpu_native_expert_permutation_semantic_parity::permutation_only_witness(
+                &[9, 2, 5],
+                &[1.0; 3],
+                &outputs,
+            )
+            .unwrap();
+        assert_eq!(
+            witness.frozen_expert_outputs_in_production_rank_order.len(),
+            3
+        );
+        assert_eq!(witness.comparison.exact_bit_equal_element_count, 1);
+        assert!(!witness.comparison.exact_bit_equal);
+        let exact = crate::gpu_native_expert_permutation_semantic_parity::permutation_only_witness(
+            &[1, 2],
+            &[0.5, 0.5],
+            &[vec![1.0], vec![1.0]],
+        )
+        .unwrap();
+        assert!(exact.comparison.exact_bit_equal);
+    }
+
+    #[test]
+    fn schema_corpus_and_qualification_false_are_stable() {
+        assert_eq!(SCHEMA_VERSION, "mer.gpu-native-semantic-parity-corpus.v1");
+        assert_eq!(MODE, "diagnose-gpu-native-semantic-parity-corpus");
+        let corpus = serde_json::to_value(CorpusEvidence::fixed()).unwrap();
+        assert_eq!(corpus["id"], crate::greedy_parity::CORPUS_ID);
+        assert_eq!(corpus["version"], 1);
+        assert_eq!(corpus["case_count"], 4);
+        assert_eq!(corpus["output_token_limit"], 16);
+        assert_eq!(
+            corpus["sha256"],
+            "ea7fdda4f08cde2fe3658165054d80099948f66ae8cba1c904ca41102f0aadc7"
+        );
+        #[derive(Serialize)]
+        struct Contract {
+            qualification_pass: bool,
+        }
+        let value = serde_json::to_value(Contract {
+            qualification_pass: false,
+        })
+        .unwrap();
+        assert_eq!(value["qualification_pass"], false);
+    }
+
+    #[test]
+    fn complete_report_serializes_provenance_summary_and_hardcoded_false() {
+        let model_load = crate::greedy_parity::ModelLoadEvidence {
+            strict: true,
+            loader: "safetensors".to_string(),
+            loaded_tensors: 1,
+            required_tensors: 1,
+            optional_probed: 0,
+            optional_loaded: 0,
+            seeded_fallback_remained: false,
+        };
+        let shutdown = crate::greedy_parity::BackgroundShutdownEvidence {
+            controlled_shutdown_requested: true,
+            all_runtime_resources_released: true,
+            poll_iterations: 1,
+        };
+        let report = SemanticParityCorpusReport::new(
+            DiagnosticProvenance {
+                build: crate::qualification::BuildProvenance {
+                    git_sha: Some("a".repeat(40)),
+                    dirty: Some(false),
+                    package_version: "test".to_string(),
+                },
+                executable_sha256: "b".repeat(64),
+                artifacts: crate::qualification::QualificationArtifacts::default(),
+                gpu_resolved_config_sha256: "c".repeat(64),
+                reference_resolved_config_sha256: "d".repeat(64),
+                model_identity: crate::greedy_parity::ModelIdentityEvidence {
+                    architecture: "qwen3_moe".to_string(),
+                    num_layers: 48,
+                    num_experts_per_layer: 128,
+                    total_experts: 6144,
+                    top_k: 8,
+                    d_model: 2048,
+                    d_ff: 768,
+                    routed_expert_dtype: "q4_0".to_string(),
+                },
+                reference_model_load: model_load.clone(),
+                gpu_native_model_load: model_load,
+                reference_background_shutdown: shutdown.clone(),
+                gpu_native_background_shutdown: shutdown,
+                expert_metadata: crate::qualification::ExpertMetadataEvidence {
+                    dtype: Some("q4_0".to_string()),
+                    q4_0_layout: Some("standard-v1".to_string()),
+                    conversion_mode: Some("real".to_string()),
+                    source: Some("test".to_string()),
+                    explicitly_synthetic: false,
+                },
+                device: crate::backend::GpuDeviceIdentity {
+                    name: "NVIDIA L4".to_string(),
+                    vendor_id: 0x10de,
+                    device_id: 0,
+                    device_type: "DiscreteGpu".to_string(),
+                    wgpu_backend: "vulkan".to_string(),
+                    driver: "test".to_string(),
+                    driver_info: "test".to_string(),
+                    compute_plane: "wgpu-vulkan".to_string(),
+                    software_adapter: false,
+                },
+            },
+            true,
+            None,
+            Vec::new(),
+            Vec::new(),
+            RoutingCounters::default(),
+            SamplingSummary {
+                exact_order_events_total: 0,
+                exact_order_events_numerically_sampled: 0,
+                exact_order_sampling_rule: EXACT_ORDER_SAMPLING_RULE,
+                layers_with_exact_order_sample: Vec::new(),
+                layers_without_exact_order_sample: (0..48).collect(),
+                internal_permutation_events_numerically_measured: 0,
+                membership_mismatch_events_numerically_measured: 0,
+                maximum_exact_order_samples_for_model: 48,
+            },
+            BoundarySummary {
+                minimum_observed_reference_rank8_minus_rank9_margin: BoundaryMinimumEvidence {
+                    margin: None,
+                    event: None,
+                },
+                minimum_observed_gpu_rank8_minus_rank9_margin: BoundaryMinimumEvidence {
+                    margin: None,
+                    event: None,
+                },
+            },
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+        assert!(!report.qualification_pass());
+        let value = serde_json::to_value(report).unwrap();
+        assert_eq!(value["schema"], SCHEMA_VERSION);
+        assert_eq!(value["mode"], MODE);
+        assert_eq!(value["qualification_pass"], false);
+        assert_eq!(value["diagnostic_only"], true);
+        assert_eq!(value["provenance"]["build"]["dirty"], false);
+        assert!(value["global_summary"]["routing"].is_object());
+        assert_eq!(
+            value["global_summary"]["sampling"]["maximum_exact_order_samples_for_model"],
+            48
+        );
+    }
+
+    #[test]
+    fn pairing_defect_is_detected_when_rank_weights_are_repaired_incorrectly() {
+        let mut logits = vec![-10.0; 128];
+        let ids = vec![30, 37, 114, 86, 29, 113, 68, 35];
+        for (rank, id) in ids.iter().copied().enumerate() {
+            logits[id as usize] = 10.0 - rank as f32;
+        }
+        let correct = crate::gpu_native_router_rank_diagnostics::evaluate_actual_gpu_router(
+            logits.clone(),
+            ids.clone(),
+            vec![0.30, 0.20, 0.15, 0.12, 0.10, 0.06, 0.04, 0.03],
+        )
+        .unwrap();
+        assert!(correct.selected_weights_paired_with_expert_ids);
+        let defect = crate::gpu_native_router_rank_diagnostics::evaluate_actual_gpu_router(
+            logits,
+            ids,
+            vec![0.20, 0.30, 0.15, 0.12, 0.10, 0.06, 0.04, 0.03],
+        )
+        .unwrap();
+        assert!(!defect.selected_weights_paired_with_expert_ids);
+    }
+
+    #[test]
+    fn vector_evidence_covers_relative_ulp_and_nonfinite_behavior() {
+        let evidence = VectorNumericalEvidence::compare(
+            "left",
+            "right",
+            &[0.0, f32::from_bits(1), f32::NAN],
+            &[1.0, 1.0, f32::NAN],
+        )
+        .unwrap();
+        assert_eq!(evidence.relative_error_defined_element_count, 1);
+        assert_eq!(evidence.left_nonfinite_count, 1);
+        assert_eq!(evidence.right_nonfinite_count, 1);
+        assert_eq!(
+            crate::gpu_native_router_rank_diagnostics::ulp_distance(
+                1.0,
+                f32::from_bits(1.0f32.to_bits() + 1),
+            ),
+            Some(1)
+        );
+    }
+}

--- a/rust-engine/src/gpu_native_semantic_parity_corpus.rs
+++ b/rust-engine/src/gpu_native_semantic_parity_corpus.rs
@@ -28,6 +28,8 @@ pub const EXACT_ORDER_SAMPLING_RULE: &str =
     "first-exact-order-event-per-layer-in-frozen-corpus-order";
 pub const PERCENTILE_CONVENTION: &str =
     "nearest-rank: sort ascending; rank=max(1,ceil(p*n)); select rank-1";
+pub const POST_GENERATED_TOKEN_DIVERGENCE_INVALID_REASON: &str =
+    "post-generated-token-divergence-noncomparable";
 
 /// Full-layer staging layout used only by the corpus semantic diagnostic.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -429,8 +431,7 @@ impl TokenCaseEvidence {
             .count();
         let mismatch_count = compared.saturating_sub(exact_match_count)
             + reference.len().max(gpu.len()).saturating_sub(compared);
-        let first_mismatch_position = (0..reference.len().max(gpu.len()))
-            .find(|&index| reference.get(index) != gpu.get(index));
+        let first_mismatch_position = first_generated_token_mismatch_position(&reference, &gpu);
         Self {
             case: case.into(),
             reference_generated_token_ids: reference,
@@ -440,6 +441,19 @@ impl TokenCaseEvidence {
             first_mismatch_position,
         }
     }
+}
+
+pub fn first_generated_token_mismatch_position(reference: &[u32], gpu: &[u32]) -> Option<usize> {
+    (0..reference.len().max(gpu.len())).find(|&index| reference.get(index) != gpu.get(index))
+}
+
+fn post_generated_token_divergence_invalid_reason(
+    first_mismatch_position: Option<usize>,
+    generated_position: usize,
+) -> Option<&'static str> {
+    first_mismatch_position
+        .is_some_and(|mismatch_position| generated_position > mismatch_position)
+        .then_some(POST_GENERATED_TOKEN_DIVERGENCE_INVALID_REASON)
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
@@ -617,6 +631,7 @@ fn common_selected_score_deltas(
 pub struct RoutingEventEvidence {
     pub location: EventLocation,
     pub classification: RoutingClassification,
+    pub invalid_reason: Option<&'static str>,
     pub selected_membership_equal: Option<bool>,
     pub reference_selected_ids: Vec<u32>,
     pub gpu_selected_ids: Vec<u32>,
@@ -1294,6 +1309,17 @@ fn update_boundary_minimum(
     }
 }
 
+fn update_boundary_minimum_if_comparable(
+    current: &mut Option<(f32, FloatEvidence, EventLocation)>,
+    margin: &FloatEvidence,
+    location: &EventLocation,
+    semantically_comparable: bool,
+) {
+    if semantically_comparable {
+        update_boundary_minimum(current, margin, location);
+    }
+}
+
 fn plan_events(
     reference_cases: &[ReferenceCaseCapture],
     gpu: &GpuCapture,
@@ -1327,7 +1353,16 @@ fn plan_events(
         {
             return Err(format!("semantic corpus case {} coverage drifted", fixed.name).into());
         }
+        let first_mismatch_position = first_generated_token_mismatch_position(
+            &reference_case.generated_token_ids,
+            &gpu_case.generated_token_ids,
+        );
         for generated_position in 0..crate::greedy_parity::OUTPUT_TOKEN_LIMIT {
+            let invalid_reason = post_generated_token_divergence_invalid_reason(
+                first_mismatch_position,
+                generated_position,
+            );
+            let semantically_comparable = invalid_reason.is_none();
             let reference_trace = &reference_case.traces[generated_position];
             let gpu_trace = &gpu_case.traces[generated_position];
             if reference_trace.layer_selected_ids.len() != gpu.model_geometry.num_layers
@@ -1374,12 +1409,16 @@ fn plan_events(
                         .iter()
                         .all(|output| output.len() == gpu.model_geometry.d_model)
                     && gpu_layer.routed_moe_output.len() == gpu.model_geometry.d_model;
-                let mut classification = classify_routing_event(
-                    reference_ids,
-                    &gpu_layer.selected_ids,
-                    gpu.model_geometry.num_experts,
-                    geometry_complete && !reference_nonfinite && !gpu_nonfinite,
-                );
+                let mut classification = if semantically_comparable {
+                    classify_routing_event(
+                        reference_ids,
+                        &gpu_layer.selected_ids,
+                        gpu.model_geometry.num_experts,
+                        geometry_complete && !reference_nonfinite && !gpu_nonfinite,
+                    )
+                } else {
+                    RoutingClassification::InvalidNonfiniteIncomplete
+                };
                 let reference_router =
                     if classification == RoutingClassification::InvalidNonfiniteIncomplete {
                         None
@@ -1421,19 +1460,23 @@ fn plan_events(
                 } else {
                     None
                 };
-                let gpu_pairing_structurally_valid = canonical_selected_weight_evidence(
-                    &gpu_layer.selected_ids,
-                    &gpu_layer.selected_weights,
-                    &gpu_layer.selected_ids,
-                    &gpu_layer.selected_weights,
-                    gpu.model_geometry.num_experts,
-                )
-                .is_ok();
-                let expert_weight_pairing_defect = !gpu_pairing_structurally_valid
-                    || actual_gpu_router
-                        .as_ref()
-                        .is_some_and(|router| !router.selected_weights_paired_with_expert_ids);
-                let displacement = rank_displacement(reference_ids, &gpu_layer.selected_ids);
+                let expert_weight_pairing_defect = semantically_comparable
+                    && (canonical_selected_weight_evidence(
+                        &gpu_layer.selected_ids,
+                        &gpu_layer.selected_weights,
+                        &gpu_layer.selected_ids,
+                        &gpu_layer.selected_weights,
+                        gpu.model_geometry.num_experts,
+                    )
+                    .is_err()
+                        || actual_gpu_router
+                            .as_ref()
+                            .is_some_and(|router| !router.selected_weights_paired_with_expert_ids));
+                let displacement = if semantically_comparable {
+                    rank_displacement(reference_ids, &gpu_layer.selected_ids)
+                } else {
+                    RankDisplacementEvidence::default()
+                };
                 let boundary = if matches!(
                     classification,
                     RoutingClassification::InternalRankPermutation
@@ -1456,17 +1499,19 @@ fn plan_events(
                     None
                 };
                 if let Some(router) = &reference_router {
-                    update_boundary_minimum(
+                    update_boundary_minimum_if_comparable(
                         &mut minimum_reference,
                         &router.cutoff_margins.rank_8_minus_rank_9_score,
                         &location,
+                        semantically_comparable,
                     );
                 }
                 if let Some(router) = &actual_gpu_router {
-                    update_boundary_minimum(
+                    update_boundary_minimum_if_comparable(
                         &mut minimum_gpu,
                         &router.cutoff_margins.rank_8_minus_rank_9_score,
                         &location,
+                        semantically_comparable,
                     );
                 }
                 let sampling = sampler.select(layer, classification);
@@ -1477,6 +1522,7 @@ fn plan_events(
                     evidence: RoutingEventEvidence {
                         location,
                         classification,
+                        invalid_reason,
                         selected_membership_equal: (classification
                             != RoutingClassification::InvalidNonfiniteIncomplete)
                             .then(|| same_membership(reference_ids, &gpu_layer.selected_ids)),
@@ -2097,9 +2143,10 @@ mod tests {
         RoutingEventEvidence {
             location: EventLocation::new(case, position, layer),
             classification,
-            selected_membership_equal: Some(
-                classification != RoutingClassification::MembershipMismatch,
-            ),
+            invalid_reason: None,
+            selected_membership_equal: (classification
+                != RoutingClassification::InvalidNonfiniteIncomplete)
+                .then_some(classification != RoutingClassification::MembershipMismatch),
             reference_selected_ids: vec![1, 2, 3],
             gpu_selected_ids: vec![1, 2, 3],
             displacement,
@@ -2109,6 +2156,134 @@ mod tests {
             numerically_selected: false,
             numerical_selection_reason: None,
         }
+    }
+
+    fn comparable_positions(reference: &[u32], gpu: &[u32]) -> Vec<bool> {
+        let first_mismatch_position = first_generated_token_mismatch_position(reference, gpu);
+        (0..crate::greedy_parity::OUTPUT_TOKEN_LIMIT)
+            .map(|generated_position| {
+                post_generated_token_divergence_invalid_reason(
+                    first_mismatch_position,
+                    generated_position,
+                )
+                .is_none()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn no_token_mismatch_keeps_every_routing_position_comparable() {
+        let tokens = (0..crate::greedy_parity::OUTPUT_TOKEN_LIMIT as u32).collect::<Vec<_>>();
+        assert_eq!(comparable_positions(&tokens, &tokens), vec![true; 16]);
+    }
+
+    #[test]
+    fn mismatch_at_zero_keeps_zero_comparable_and_invalidates_later_positions() {
+        let reference = (0..crate::greedy_parity::OUTPUT_TOKEN_LIMIT as u32).collect::<Vec<_>>();
+        let mut gpu = reference.clone();
+        gpu[0] = 100;
+        let comparable = comparable_positions(&reference, &gpu);
+        assert!(comparable[0]);
+        assert!(comparable[1..].iter().all(|value| !value));
+    }
+
+    #[test]
+    fn interior_token_mismatch_keeps_mismatch_position_comparable() {
+        let reference = (0..crate::greedy_parity::OUTPUT_TOKEN_LIMIT as u32).collect::<Vec<_>>();
+        let mut gpu = reference.clone();
+        gpu[5] = 100;
+        let comparable = comparable_positions(&reference, &gpu);
+        assert!(comparable[..=5].iter().all(|value| *value));
+        assert!(comparable[6..].iter().all(|value| !value));
+    }
+
+    #[test]
+    fn final_token_mismatch_keeps_all_routing_positions_comparable() {
+        let reference = (0..crate::greedy_parity::OUTPUT_TOKEN_LIMIT as u32).collect::<Vec<_>>();
+        let mut gpu = reference.clone();
+        gpu[15] = 100;
+        assert_eq!(
+            comparable_positions(&reference, &gpu),
+            vec![true; crate::greedy_parity::OUTPUT_TOKEN_LIMIT]
+        );
+    }
+
+    #[test]
+    fn post_divergence_records_remain_complete_invalid_unsampled_and_boundary_excluded() {
+        let first_mismatch_position = Some(1);
+        let mut sampler = DeterministicEventSampler::new(48);
+        let mut counters = RoutingCounters::default();
+        let mut boundary_minimum = None;
+        let mut sampled_post_divergence = 0usize;
+        let mut serialized_reason = None;
+
+        for case_index in 0..4 {
+            for generated_position in 0..16 {
+                let invalid_reason = post_generated_token_divergence_invalid_reason(
+                    first_mismatch_position,
+                    generated_position,
+                );
+                let semantically_comparable = invalid_reason.is_none();
+                for layer in 0..48 {
+                    let candidate = if generated_position == 0 {
+                        RoutingClassification::ExactOrderMatch
+                    } else {
+                        RoutingClassification::MembershipMismatch
+                    };
+                    let classification = if semantically_comparable {
+                        candidate
+                    } else {
+                        RoutingClassification::InvalidNonfiniteIncomplete
+                    };
+                    let sampling = sampler.select(layer, classification);
+                    if !semantically_comparable {
+                        sampled_post_divergence += usize::from(sampling.selected);
+                    }
+                    let mut evidence = event(
+                        &format!("case-{case_index}"),
+                        generated_position,
+                        layer,
+                        classification,
+                        RankDisplacementEvidence::default(),
+                        false,
+                    );
+                    evidence.invalid_reason = invalid_reason;
+                    evidence.numerically_selected = sampling.selected;
+                    evidence.numerical_selection_reason = sampling.reason;
+                    counters.record(&evidence, false, false);
+                    if serialized_reason.is_none() && invalid_reason.is_some() {
+                        serialized_reason = Some(serde_json::to_value(&evidence).unwrap());
+                    }
+                }
+                let margin = if generated_position == 0 {
+                    1.0
+                } else if generated_position == 1 {
+                    0.5
+                } else {
+                    -100.0
+                };
+                update_boundary_minimum_if_comparable(
+                    &mut boundary_minimum,
+                    &FloatEvidence::new(margin),
+                    &EventLocation::new(format!("case-{case_index}"), generated_position, 0),
+                    semantically_comparable,
+                );
+            }
+        }
+
+        assert_eq!(counters.total_routing_events, 4 * 16 * 48);
+        assert_eq!(counters.exact_order_match_events, 4 * 48);
+        assert_eq!(counters.membership_mismatch_events, 4 * 48);
+        assert_eq!(counters.internal_rank_permutation_events, 0);
+        assert_eq!(counters.invalid_events, 4 * 14 * 48);
+        assert_eq!(sampled_post_divergence, 0);
+        let (_, margin, event) = boundary_minimum.unwrap();
+        assert_eq!(margin.value, Some(0.5));
+        assert_eq!(event.generated_position, 1);
+        assert_eq!(
+            serialized_reason.unwrap()["invalid_reason"],
+            POST_GENERATED_TOKEN_DIVERGENCE_INVALID_REASON
+        );
     }
 
     #[test]
@@ -2307,17 +2482,18 @@ mod tests {
         assert_eq!(first.mismatch_count, 1);
         assert_eq!(first.first_mismatch_position, Some(1));
         assert_eq!(second.first_mismatch_position, Some(2));
+        assert_eq!(
+            first_generated_token_mismatch_position(&[4, 5, 6], &[4, 5]),
+            Some(2)
+        );
         let summary = summarize_tokens(&[first, second], 6);
         assert_eq!(summary.completed_generated_tokens, 5);
         assert_eq!(summary.exact_generated_token_matches, 4);
         assert_eq!(summary.generated_token_mismatches, 2);
-        assert_eq!(
-            summary
-                .first_generated_token_mismatch
-                .unwrap()
-                .generated_position,
-            1
-        );
+        let mismatch = summary.first_generated_token_mismatch.unwrap();
+        assert_eq!(mismatch.generated_position, 1);
+        assert_eq!(mismatch.reference_token_id, Some(2));
+        assert_eq!(mismatch.gpu_token_id, Some(9));
     }
 
     #[test]

--- a/rust-engine/src/gpu_native_semantic_parity_v2.rs
+++ b/rust-engine/src/gpu_native_semantic_parity_v2.rs
@@ -1,0 +1,2396 @@
+//! Versioned GPU-native semantic correctness qualification over an independent
+//! frozen holdout corpus.
+//!
+//! This module is qualification-only. It reuses the existing semantic survey's
+//! observation types and the production execution paths, but owns an
+//! independent corpus, report schema, and PASS derivation. It is never
+//! consulted by ordinary inference or by the historical v1 qualifier.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+use crate::gpu_native_expert_permutation_semantic_parity::{
+    VectorNumericalEvidence, WeightDeltaEvidence,
+};
+use crate::gpu_native_router_rank_diagnostics::{
+    ActualGpuRouterEvidence, DiagnosticProvenance, RouterEvaluationEvidence,
+};
+use crate::gpu_native_semantic_parity_corpus::{
+    aggregate_numerics, aggregate_numerics_by_classification, aggregate_permutation_numerics,
+    canonical_selected_weight_evidence, rank_displacement, same_membership, BoundaryRouterView,
+    ClassificationNumericalAggregation, DeterministicEventSampler, EventLocation,
+    MembershipBoundaryEvidence, NumericalAggregation, PermutationNumericalEventEvidence,
+    RankDisplacementEvidence, RouterSameInputEvidence, RoutingClassification, RoutingCounters,
+    RoutingEventEvidence, SameInputNumericalEventEvidence, SamplingSummary, SemanticCorpusGpuTrace,
+    SemanticCorpusTraceLayout, TokenCaseEvidence, TokenSummary,
+};
+use crate::gpu_native_token_loop::{GpuNativeModelGeometry, GpuNativeTokenLoopSnapshot};
+use crate::qualification::QualificationStatus;
+use crate::{IsolatedRuntimeShutdownError, RealCliRuntimeMode, ResolvedRealCliSpec};
+
+pub const SCHEMA_VERSION: &str = "mer.gpu-native-semantic-parity.v2";
+pub const MODE: &str = "qualify-gpu-native-semantic-parity-v2";
+
+pub const CALIBRATION_CORPUS_ID: &str = "qwen3-coder-30b-a3b-greedy-v1";
+pub const CALIBRATION_CORPUS_VERSION: u32 = 1;
+pub const CALIBRATION_CORPUS_SHA256: &str =
+    "ea7fdda4f08cde2fe3658165054d80099948f66ae8cba1c904ca41102f0aadc7";
+
+pub const HOLDOUT_CORPUS_ID: &str = "qwen3-coder-30b-a3b-greedy-v2-holdout";
+pub const HOLDOUT_CORPUS_VERSION: u32 = 1;
+pub const HOLDOUT_CORPUS_CASE_COUNT: usize = 4;
+pub const OUTPUT_TOKEN_LIMIT: usize = 16;
+pub const HOLDOUT_CORPUS_SHA256: &str =
+    "0a680d4e96937782cdb14d48e3609b095368cf69295e1bc794e6354c9eb6513d";
+
+pub const MAX_ABSOLUTE_ERROR_LIMIT: f64 = 0.020;
+pub const RMS_ERROR_LIMIT: f64 = 0.001;
+pub const MEAN_ABSOLUTE_ERROR_LIMIT: f64 = 0.00075;
+pub const NONFINITE_MISMATCH_LIMIT: usize = 0;
+pub const EXACT_ORDER_SAMPLING_RULE: &str =
+    "first-exact-order-event-per-layer-in-frozen-corpus-order";
+const POST_GENERATED_TOKEN_DIVERGENCE_INVALID_REASON: &str =
+    "post-generated-token-divergence-noncomparable";
+const STRUCTURAL_INVALID_REASON: &str = "routing-structure-nonfinite-or-incomplete";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct HoldoutCase {
+    pub name: &'static str,
+    pub prompt: &'static str,
+}
+
+pub const HOLDOUT_CORPUS: [HoldoutCase; HOLDOUT_CORPUS_CASE_COUNT] = [
+    HoldoutCase {
+        name: "rust-ownership-holdout",
+        prompt: "Fix the Rust function below so it compiles without cloning the input.\nReturn only the corrected function followed by one short explanation.\n\nfn first_word(s: String) -> &str {\n    s.split_whitespace().next().unwrap_or(\"\")\n}",
+    },
+    HoldoutCase {
+        name: "python-async-holdout",
+        prompt: "Find the concurrency bug in this Python asyncio code and provide the\nminimal corrected version.\n\nasync def load_all(urls):\n    tasks = []\n    for url in urls:\n        tasks.append(asyncio.create_task(fetch(url)))\n    for task in tasks:\n        return await task",
+    },
+    HoldoutCase {
+        name: "postgres-window-holdout",
+        prompt: "Write a PostgreSQL query that returns each customer's most recent order,\nincluding customer_id, order_id, ordered_at, and total, with exactly one\nrow per customer. Use a window function.",
+    },
+    HoldoutCase {
+        name: "spanish-refactor-holdout",
+        prompt: "En Rust, refactoriza esta función para evitar una asignación innecesaria\nsin cambiar su comportamiento. Devuelve primero el código y luego una\nexplicación breve.\n\nfn normalize(name: &str) -> String {\n    let value = name.to_string();\n    value.trim().to_lowercase()\n}",
+    },
+];
+
+fn hash_len_prefixed(hasher: &mut Sha256, bytes: &[u8]) {
+    hasher.update((bytes.len() as u64).to_le_bytes());
+    hasher.update(bytes);
+}
+
+pub fn holdout_corpus_sha256() -> String {
+    let mut hasher = Sha256::new();
+    hash_len_prefixed(&mut hasher, HOLDOUT_CORPUS_ID.as_bytes());
+    hasher.update(HOLDOUT_CORPUS_VERSION.to_le_bytes());
+    hasher.update((OUTPUT_TOKEN_LIMIT as u64).to_le_bytes());
+    for case in HOLDOUT_CORPUS {
+        hash_len_prefixed(&mut hasher, case.name.as_bytes());
+        hash_len_prefixed(&mut hasher, case.prompt.as_bytes());
+    }
+    format!("{:x}", hasher.finalize())
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct CorpusIdentityEvidence {
+    pub id: &'static str,
+    pub version: u32,
+    pub sha256: String,
+    pub case_count: usize,
+    pub output_token_limit: usize,
+    pub role: &'static str,
+}
+
+impl CorpusIdentityEvidence {
+    pub fn calibration() -> Self {
+        Self {
+            id: CALIBRATION_CORPUS_ID,
+            version: CALIBRATION_CORPUS_VERSION,
+            sha256: CALIBRATION_CORPUS_SHA256.to_string(),
+            case_count: crate::greedy_parity::CORPUS_CASE_COUNT,
+            output_token_limit: crate::greedy_parity::OUTPUT_TOKEN_LIMIT,
+            role: "frozen-calibration-evidence-only-not-v2-pass",
+        }
+    }
+
+    pub fn holdout() -> Self {
+        Self {
+            id: HOLDOUT_CORPUS_ID,
+            version: HOLDOUT_CORPUS_VERSION,
+            sha256: holdout_corpus_sha256(),
+            case_count: HOLDOUT_CORPUS_CASE_COUNT,
+            output_token_limit: OUTPUT_TOKEN_LIMIT,
+            role: "independent-v2-qualification-holdout",
+        }
+    }
+
+    fn is_exact_holdout(&self) -> bool {
+        self == &Self::holdout() && self.sha256 == HOLDOUT_CORPUS_SHA256
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Serialize)]
+pub struct NumericalLimits {
+    pub max_absolute_error_limit: f64,
+    pub rms_error_limit: f64,
+    pub mean_absolute_error_limit: f64,
+    pub nonfinite_mismatch_limit: usize,
+    pub semantic_correctness_not_bit_parity: bool,
+}
+
+impl NumericalLimits {
+    pub const fn frozen() -> Self {
+        Self {
+            max_absolute_error_limit: MAX_ABSOLUTE_ERROR_LIMIT,
+            rms_error_limit: RMS_ERROR_LIMIT,
+            mean_absolute_error_limit: MEAN_ABSOLUTE_ERROR_LIMIT,
+            nonfinite_mismatch_limit: NONFINITE_MISMATCH_LIMIT,
+            semantic_correctness_not_bit_parity: true,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ProductionSemanticsEvidence {
+    pub production_inference_math_changed: bool,
+    pub production_shader_math_changed: bool,
+    pub production_router_math_changed: bool,
+    pub production_selected_expert_order_changed: bool,
+    pub production_accumulation_order_changed: bool,
+    pub existing_v1_qualifier_semantics_changed: bool,
+    pub existing_semantic_corpus_survey_changed: bool,
+    pub frozen_v2_numerical_limits_changed: bool,
+    pub frozen_v2_holdout_prompts_changed: bool,
+    pub cpu_combiner: &'static str,
+    pub gpu_combiner: &'static str,
+    pub canonicalization_scope: &'static str,
+}
+
+impl Default for ProductionSemanticsEvidence {
+    fn default() -> Self {
+        Self {
+            production_inference_math_changed: false,
+            production_shader_math_changed: false,
+            production_router_math_changed: false,
+            production_selected_expert_order_changed: false,
+            production_accumulation_order_changed: false,
+            existing_v1_qualifier_semantics_changed: false,
+            existing_semantic_corpus_survey_changed: false,
+            frozen_v2_numerical_limits_changed: false,
+            frozen_v2_holdout_prompts_changed: false,
+            cpu_combiner: "production-cpu-sequential-selected-expert-order",
+            gpu_combiner: "production-gpu-existing-selected-expert-order",
+            canonicalization_scope:
+                "qualification-host-evidence-only-no-production-canonicalization",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct SameInputRouterEventEvidence {
+    pub location: EventLocation,
+    pub cpu_production_router_on_exact_gpu_input: Option<RouterSameInputEvidence>,
+    pub evaluation_error: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+pub struct SameInputRouterSummary {
+    pub same_input_router_events_total: usize,
+    pub same_input_router_ordered_equal: usize,
+    pub same_input_router_ordered_mismatch: usize,
+    pub first_same_input_mismatch: Option<SameInputRouterEventEvidence>,
+}
+
+impl SameInputRouterSummary {
+    fn from_events(events: &[SameInputRouterEventEvidence]) -> Self {
+        let same_input_router_ordered_equal = events
+            .iter()
+            .filter(|event| {
+                event
+                    .cpu_production_router_on_exact_gpu_input
+                    .as_ref()
+                    .is_some_and(|evidence| evidence.ordered_ids_equal)
+                    && event.evaluation_error.is_none()
+            })
+            .count();
+        let first_same_input_mismatch = events.iter().find_map(|event| {
+            (event.evaluation_error.is_some()
+                || event
+                    .cpu_production_router_on_exact_gpu_input
+                    .as_ref()
+                    .is_none_or(|evidence| !evidence.ordered_ids_equal))
+            .then(|| event.clone())
+        });
+        Self {
+            same_input_router_events_total: events.len(),
+            same_input_router_ordered_equal,
+            same_input_router_ordered_mismatch: events
+                .len()
+                .saturating_sub(same_input_router_ordered_equal),
+            first_same_input_mismatch,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
+pub struct RuntimeCompletionEvidence {
+    pub gpu_expected_completed_token_steps: u64,
+    pub gpu_token_loop: GpuNativeTokenLoopSnapshot,
+    pub reference_routed_execution: crate::engine::RoutedExpertExecutionSnapshot,
+    pub gpu_native_routed_execution: crate::engine::RoutedExpertExecutionSnapshot,
+    pub reference_nonfinite_attention_fallbacks: u64,
+    pub gpu_native_nonfinite_attention_fallbacks: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct QualificationGates {
+    pub exact_provenance: bool,
+    pub frozen_holdout_corpus_identity: bool,
+    pub exact_model_geometry: bool,
+    pub strict_model_load: bool,
+    pub complete_exact_greedy_token_parity: bool,
+    pub routing_structural_validity: bool,
+    pub same_input_gpu_router_ordered_ids_exact: bool,
+    pub same_input_routed_moe_numerical_limits: bool,
+    pub deterministic_numerical_sampling_complete: bool,
+    pub no_fallback_or_degradation: bool,
+    pub residency_and_execution_completion: bool,
+    pub controlled_shutdown: bool,
+    pub observation_completeness: bool,
+}
+
+impl QualificationGates {
+    pub fn qualification_pass(&self) -> bool {
+        self.exact_provenance
+            && self.frozen_holdout_corpus_identity
+            && self.exact_model_geometry
+            && self.strict_model_load
+            && self.complete_exact_greedy_token_parity
+            && self.routing_structural_validity
+            && self.same_input_gpu_router_ordered_ids_exact
+            && self.same_input_routed_moe_numerical_limits
+            && self.deterministic_numerical_sampling_complete
+            && self.no_fallback_or_degradation
+            && self.residency_and_execution_completion
+            && self.controlled_shutdown
+            && self.observation_completeness
+    }
+
+    fn failed_criteria(&self) -> Vec<&'static str> {
+        let values = [
+            ("exact-provenance", self.exact_provenance),
+            (
+                "frozen-holdout-corpus-identity",
+                self.frozen_holdout_corpus_identity,
+            ),
+            ("exact-model-geometry", self.exact_model_geometry),
+            ("strict-model-load", self.strict_model_load),
+            (
+                "complete-exact-greedy-token-parity",
+                self.complete_exact_greedy_token_parity,
+            ),
+            (
+                "routing-structural-validity",
+                self.routing_structural_validity,
+            ),
+            (
+                "same-input-gpu-router-ordered-ids-exact",
+                self.same_input_gpu_router_ordered_ids_exact,
+            ),
+            (
+                "same-input-routed-moe-numerical-limits",
+                self.same_input_routed_moe_numerical_limits,
+            ),
+            (
+                "deterministic-numerical-sampling-complete",
+                self.deterministic_numerical_sampling_complete,
+            ),
+            (
+                "no-fallback-or-degradation",
+                self.no_fallback_or_degradation,
+            ),
+            (
+                "residency-and-execution-completion",
+                self.residency_and_execution_completion,
+            ),
+            ("controlled-shutdown", self.controlled_shutdown),
+            ("observation-completeness", self.observation_completeness),
+        ];
+        values
+            .into_iter()
+            .filter_map(|(criterion, passed)| (!passed).then_some(criterion))
+            .collect()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct V2GlobalSummary {
+    pub routing: RoutingCounters,
+    pub tokens: TokenSummary,
+    pub same_input_router: SameInputRouterSummary,
+    pub cross_backend_membership_drift_events: usize,
+    pub same_input_numerics: NumericalAggregation,
+    pub permutation_only_numerics: NumericalAggregation,
+    pub nonfinite_mismatch_count: usize,
+    pub sampling: SamplingSummary,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct SemanticParityV2Report {
+    pub schema: &'static str,
+    pub mode: &'static str,
+    pub status: QualificationStatus,
+    pub qualification_pass: bool,
+    pub failed_criteria: Vec<&'static str>,
+    pub expected_adapter_name: String,
+    pub calibration_corpus: CorpusIdentityEvidence,
+    pub holdout_corpus: CorpusIdentityEvidence,
+    pub numerical_limits: NumericalLimits,
+    pub provenance: DiagnosticProvenance,
+    pub gates: QualificationGates,
+    pub global_summary: V2GlobalSummary,
+    pub token_cases: Vec<TokenCaseEvidence>,
+    pub routing_events: Vec<RoutingEventEvidence>,
+    pub same_input_router_events: Vec<SameInputRouterEventEvidence>,
+    pub same_input_numerical_events: Vec<SameInputNumericalEventEvidence>,
+    pub same_input_numerics_by_classification: Vec<ClassificationNumericalAggregation>,
+    pub permutation_only_events: Vec<PermutationNumericalEventEvidence>,
+    pub runtime_completion: RuntimeCompletionEvidence,
+    pub production_semantics: ProductionSemanticsEvidence,
+    pub observation_seams_not_implemented: Vec<String>,
+}
+
+fn is_hex(value: &str, length: usize) -> bool {
+    value.len() == length && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn artifact_is_exact(artifact: Option<&crate::qualification::ArtifactDigest>) -> bool {
+    artifact.is_some_and(|artifact| {
+        !artifact.canonical_path.is_empty()
+            && artifact.byte_length > 0
+            && is_hex(&artifact.sha256, 64)
+    })
+}
+
+fn exact_provenance_pass(provenance: &DiagnosticProvenance, expected_adapter_name: &str) -> bool {
+    provenance.build.dirty == Some(false)
+        && provenance
+            .build
+            .git_sha
+            .as_deref()
+            .is_some_and(|sha| is_hex(sha, 40))
+        && !provenance.build.package_version.is_empty()
+        && is_hex(&provenance.executable_sha256, 64)
+        && artifact_is_exact(provenance.artifacts.config.as_ref())
+        && artifact_is_exact(provenance.artifacts.tokenizer.as_ref())
+        && artifact_is_exact(provenance.artifacts.expert_metadata.as_ref())
+        && is_hex(&provenance.gpu_resolved_config_sha256, 64)
+        && is_hex(&provenance.reference_resolved_config_sha256, 64)
+        && !expected_adapter_name.trim().is_empty()
+        && provenance.device.name == expected_adapter_name
+        && !provenance.device.software_adapter
+        && !provenance.device.device_type.eq_ignore_ascii_case("cpu")
+        && !provenance.device.wgpu_backend.is_empty()
+        && !provenance.device.driver.is_empty()
+}
+
+fn exact_model_geometry_pass(provenance: &DiagnosticProvenance) -> bool {
+    provenance.model_identity.is_qwen3_coder_30b_a3b_q4_0()
+        && provenance.expert_metadata.dtype.as_deref() == Some("q4_0")
+        && provenance.expert_metadata.q4_0_layout.as_deref()
+            == Some(crate::inference::Q4_0_LAYOUT_STANDARD_V1)
+        && !provenance.expert_metadata.explicitly_synthetic
+}
+
+fn model_load_is_strict(load: &crate::greedy_parity::ModelLoadEvidence) -> bool {
+    load.strict
+        && load.loaded_tensors == load.required_tensors
+        && load.required_tensors > 0
+        && !load.seeded_fallback_remained
+        && load.loader != "seeded"
+}
+
+fn token_parity_pass(cases: &[TokenCaseEvidence]) -> bool {
+    cases.len() == HOLDOUT_CORPUS_CASE_COUNT
+        && cases.iter().zip(HOLDOUT_CORPUS).all(|(case, fixed)| {
+            case.case == fixed.name
+                && case.reference_generated_token_ids.len() == OUTPUT_TOKEN_LIMIT
+                && case.gpu_generated_token_ids.len() == OUTPUT_TOKEN_LIMIT
+                && case.reference_generated_token_ids == case.gpu_generated_token_ids
+                && case.exact_match_count == OUTPUT_TOKEN_LIMIT
+                && case.mismatch_count == 0
+                && case.first_mismatch_position.is_none()
+        })
+}
+
+fn routing_structural_pass(counters: &RoutingCounters, expected_events: usize) -> bool {
+    counters.total_routing_events == expected_events
+        && counters.invalid_events == 0
+        && counters.reference_nonfinite_events == 0
+        && counters.gpu_nonfinite_events == 0
+        && counters.expert_weight_pairing_defect_events == 0
+}
+
+fn same_input_router_pass(events: &[SameInputRouterEventEvidence], expected_events: usize) -> bool {
+    events.len() == expected_events
+        && events.iter().all(|event| {
+            event.evaluation_error.is_none()
+                && event
+                    .cpu_production_router_on_exact_gpu_input
+                    .as_ref()
+                    .is_some_and(|evidence| evidence.ordered_ids_equal)
+        })
+}
+
+fn numerical_event_within_limits(event: &SameInputNumericalEventEvidence) -> bool {
+    let evidence = &event.cpu_vs_gpu_routed_moe;
+    evidence
+        .max_absolute_error
+        .is_some_and(|value| value <= MAX_ABSOLUTE_ERROR_LIMIT)
+        && evidence
+            .rms_error
+            .is_some_and(|value| value <= RMS_ERROR_LIMIT)
+        && evidence
+            .mean_absolute_error
+            .is_some_and(|value| value <= MEAN_ABSOLUTE_ERROR_LIMIT)
+        && evidence.nonfinite_bit_mismatch_count == NONFINITE_MISMATCH_LIMIT
+}
+
+fn numerical_sampling_complete(
+    routing: &RoutingCounters,
+    sampling: &SamplingSummary,
+    numerical_events: &[SameInputNumericalEventEvidence],
+    permutation_events: &[PermutationNumericalEventEvidence],
+    num_layers: usize,
+) -> bool {
+    sampling.exact_order_sampling_rule == EXACT_ORDER_SAMPLING_RULE
+        && sampling.layers_with_exact_order_sample == (0..num_layers).collect::<Vec<_>>()
+        && sampling.layers_without_exact_order_sample.is_empty()
+        && sampling.exact_order_events_numerically_sampled == num_layers
+        && sampling.internal_permutation_events_numerically_measured
+            == routing.internal_rank_permutation_events
+        && sampling.membership_mismatch_events_numerically_measured
+            == routing.membership_mismatch_events
+        && numerical_events.len()
+            == num_layers
+                + routing.internal_rank_permutation_events
+                + routing.membership_mismatch_events
+        && permutation_events.len() == routing.internal_rank_permutation_events
+}
+
+fn no_fallback_or_degradation_pass(runtime: &RuntimeCompletionEvidence) -> bool {
+    runtime
+        .gpu_native_routed_execution
+        .cpu_routed_expert_dispatches
+        == 0
+        && runtime.gpu_native_routed_execution.gpu_cpu_fallbacks == 0
+        && runtime
+            .gpu_native_routed_execution
+            .degraded_expert_substitutions
+            == 0
+        && runtime.reference_routed_execution.gpu_cpu_fallbacks == 0
+        && runtime
+            .reference_routed_execution
+            .degraded_expert_substitutions
+            == 0
+        && runtime.reference_nonfinite_attention_fallbacks == 0
+        && runtime.gpu_native_nonfinite_attention_fallbacks == 0
+}
+
+fn residency_and_execution_completion_pass(runtime: &RuntimeCompletionEvidence) -> bool {
+    runtime.gpu_expected_completed_token_steps > 0
+        && runtime.gpu_token_loop.tokens_completed == runtime.gpu_expected_completed_token_steps
+        && runtime.gpu_token_loop.fatal_failures == 0
+        && runtime.gpu_token_loop.no_progress_failures == 0
+        && runtime.gpu_native_routed_execution.gpu_dispatch_failures == 0
+}
+
+fn controlled_shutdown_pass(provenance: &DiagnosticProvenance) -> bool {
+    provenance
+        .reference_background_shutdown
+        .controlled_shutdown_requested
+        && provenance
+            .reference_background_shutdown
+            .all_runtime_resources_released
+        && provenance
+            .gpu_native_background_shutdown
+            .controlled_shutdown_requested
+        && provenance
+            .gpu_native_background_shutdown
+            .all_runtime_resources_released
+}
+
+#[allow(clippy::too_many_arguments)]
+fn derive_gates(
+    provenance: &DiagnosticProvenance,
+    expected_adapter_name: &str,
+    holdout: &CorpusIdentityEvidence,
+    token_cases: &[TokenCaseEvidence],
+    routing_events: &[RoutingEventEvidence],
+    routing: &RoutingCounters,
+    sampling: &SamplingSummary,
+    same_input_router_events: &[SameInputRouterEventEvidence],
+    numerical_events: &[SameInputNumericalEventEvidence],
+    permutation_events: &[PermutationNumericalEventEvidence],
+    runtime: &RuntimeCompletionEvidence,
+    observation_seams_not_implemented: &[String],
+) -> QualificationGates {
+    let expected_events = HOLDOUT_CORPUS_CASE_COUNT * OUTPUT_TOKEN_LIMIT * 48;
+    let observation_completeness = observation_seams_not_implemented.is_empty()
+        && routing.total_routing_events == expected_events
+        && routing_events.len() == expected_events
+        && same_input_router_events.len() == expected_events
+        && token_cases.len() == HOLDOUT_CORPUS_CASE_COUNT;
+    QualificationGates {
+        exact_provenance: exact_provenance_pass(provenance, expected_adapter_name),
+        frozen_holdout_corpus_identity: holdout.is_exact_holdout(),
+        exact_model_geometry: exact_model_geometry_pass(provenance),
+        strict_model_load: model_load_is_strict(&provenance.reference_model_load)
+            && model_load_is_strict(&provenance.gpu_native_model_load),
+        complete_exact_greedy_token_parity: token_parity_pass(token_cases),
+        routing_structural_validity: routing_structural_pass(routing, expected_events),
+        same_input_gpu_router_ordered_ids_exact: same_input_router_pass(
+            same_input_router_events,
+            expected_events,
+        ),
+        same_input_routed_moe_numerical_limits: !numerical_events.is_empty()
+            && numerical_events.iter().all(numerical_event_within_limits),
+        deterministic_numerical_sampling_complete: numerical_sampling_complete(
+            routing,
+            sampling,
+            numerical_events,
+            permutation_events,
+            48,
+        ),
+        no_fallback_or_degradation: no_fallback_or_degradation_pass(runtime),
+        residency_and_execution_completion: residency_and_execution_completion_pass(runtime),
+        controlled_shutdown: controlled_shutdown_pass(provenance),
+        observation_completeness,
+    }
+}
+
+impl SemanticParityV2Report {
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        expected_adapter_name: String,
+        provenance: DiagnosticProvenance,
+        token_cases: Vec<TokenCaseEvidence>,
+        routing_events: Vec<RoutingEventEvidence>,
+        routing_counters: RoutingCounters,
+        sampling: SamplingSummary,
+        same_input_router_events: Vec<SameInputRouterEventEvidence>,
+        same_input_numerical_events: Vec<SameInputNumericalEventEvidence>,
+        permutation_only_events: Vec<PermutationNumericalEventEvidence>,
+        runtime_completion: RuntimeCompletionEvidence,
+        observation_seams_not_implemented: Vec<String>,
+    ) -> Self {
+        let holdout_corpus = CorpusIdentityEvidence::holdout();
+        let gates = derive_gates(
+            &provenance,
+            &expected_adapter_name,
+            &holdout_corpus,
+            &token_cases,
+            &routing_events,
+            &routing_counters,
+            &sampling,
+            &same_input_router_events,
+            &same_input_numerical_events,
+            &permutation_only_events,
+            &runtime_completion,
+            &observation_seams_not_implemented,
+        );
+        let qualification_pass = gates.qualification_pass();
+        let tokens = crate::gpu_native_semantic_parity_corpus::summarize_tokens(
+            &token_cases,
+            HOLDOUT_CORPUS_CASE_COUNT * OUTPUT_TOKEN_LIMIT,
+        );
+        let same_input_router = SameInputRouterSummary::from_events(&same_input_router_events);
+        let same_input_numerics = aggregate_numerics(&same_input_numerical_events);
+        let permutation_only_numerics = aggregate_permutation_numerics(&permutation_only_events);
+        let nonfinite_mismatch_count = same_input_numerical_events
+            .iter()
+            .map(|event| event.cpu_vs_gpu_routed_moe.nonfinite_bit_mismatch_count)
+            .sum();
+        let same_input_numerics_by_classification =
+            aggregate_numerics_by_classification(&same_input_numerical_events);
+        let failed_criteria = gates.failed_criteria();
+        Self {
+            schema: SCHEMA_VERSION,
+            mode: MODE,
+            status: if qualification_pass {
+                QualificationStatus::Pass
+            } else {
+                QualificationStatus::Fail
+            },
+            qualification_pass,
+            failed_criteria,
+            expected_adapter_name,
+            calibration_corpus: CorpusIdentityEvidence::calibration(),
+            holdout_corpus,
+            numerical_limits: NumericalLimits::frozen(),
+            provenance,
+            gates,
+            global_summary: V2GlobalSummary {
+                cross_backend_membership_drift_events: routing_counters.membership_mismatch_events,
+                routing: routing_counters,
+                tokens,
+                same_input_router,
+                same_input_numerics,
+                permutation_only_numerics,
+                nonfinite_mismatch_count,
+                sampling,
+            },
+            token_cases,
+            routing_events,
+            same_input_router_events,
+            same_input_numerical_events,
+            same_input_numerics_by_classification,
+            permutation_only_events,
+            runtime_completion,
+            production_semantics: ProductionSemanticsEvidence::default(),
+            observation_seams_not_implemented,
+        }
+    }
+}
+
+struct GpuCaseCapture {
+    case: &'static str,
+    prompt_token_ids: Vec<u32>,
+    generated_token_ids: Vec<u32>,
+    traces: Vec<SemanticCorpusGpuTrace>,
+}
+
+struct GpuCapture {
+    cases: Vec<GpuCaseCapture>,
+    gate_identities: Vec<crate::gpu_native_router_rank_diagnostics::GateTensorIdentity>,
+    model_load: crate::greedy_parity::ModelLoadEvidence,
+    device: crate::backend::GpuDeviceIdentity,
+    model_geometry: GpuNativeModelGeometry,
+    background_shutdown: crate::greedy_parity::BackgroundShutdownEvidence,
+    expected_completed_token_steps: u64,
+    token_loop_snapshot: GpuNativeTokenLoopSnapshot,
+    routed_execution: crate::engine::RoutedExpertExecutionSnapshot,
+    nonfinite_attention_fallbacks: u64,
+}
+
+struct ReferenceCaseCapture {
+    case: &'static str,
+    generated_token_ids: Vec<u32>,
+    traces: Vec<crate::gpu_native_diagnostics::ModelDiagnosticTrace>,
+}
+
+struct EvidenceCapture {
+    token_cases: Vec<TokenCaseEvidence>,
+    routing_events: Vec<RoutingEventEvidence>,
+    routing_counters: RoutingCounters,
+    sampling: SamplingSummary,
+    same_input_router_events: Vec<SameInputRouterEventEvidence>,
+    same_input_events: Vec<SameInputNumericalEventEvidence>,
+    permutation_events: Vec<PermutationNumericalEventEvidence>,
+    reference_model_load: crate::greedy_parity::ModelLoadEvidence,
+    reference_background_shutdown: crate::greedy_parity::BackgroundShutdownEvidence,
+    reference_routed_execution: crate::engine::RoutedExpertExecutionSnapshot,
+    reference_nonfinite_attention_fallbacks: u64,
+}
+
+struct PlannedEvent {
+    case_index: usize,
+    generated_position: usize,
+    layer: usize,
+    evidence: RoutingEventEvidence,
+    actual_gpu_router: Option<ActualGpuRouterEvidence>,
+    reference_nonfinite: bool,
+    gpu_nonfinite: bool,
+}
+
+struct EventPlan {
+    events: Vec<PlannedEvent>,
+    layers_with_exact_sample: Vec<usize>,
+    layers_without_exact_sample: Vec<usize>,
+}
+
+async fn execute_gpu(
+    spec: &ResolvedRealCliSpec,
+    tokenizer: Arc<crate::tokenizer::Tokenizer>,
+    resolved_config_sha256: &str,
+    expected_adapter_name: &str,
+    watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+) -> Result<GpuCapture, Box<dyn std::error::Error>> {
+    let runtime = crate::build_isolated_greedy_runtime(
+        spec,
+        RealCliRuntimeMode::IsolatedGpuNativeDiagnostic,
+        tokenizer.clone(),
+    )
+    .await?;
+    let attempt = async {
+        let observed_config_sha256 = crate::resolved_real_runtime_identity_sha256(
+            &runtime.cfg,
+            runtime.model.config.architecture,
+            runtime.model.config.first_k_dense_replace,
+            &runtime.model.config.advanced,
+        )?;
+        if observed_config_sha256 != resolved_config_sha256 {
+            return Err(format!(
+                "v2 GPU identity {observed_config_sha256} drifted from {resolved_config_sha256}"
+            )
+            .into());
+        }
+        let device = runtime
+            .engine
+            .gpu_device_identity()
+            .ok_or("v2 GPU runtime has no authoritative adapter identity")?;
+        if device.name != expected_adapter_name {
+            return Err(format!(
+                "v2 GPU runtime selected adapter {:?}, expected {:?}",
+                device.name, expected_adapter_name
+            )
+            .into());
+        }
+        if device.software_adapter || device.device_type.eq_ignore_ascii_case("cpu") {
+            return Err(
+                format!("v2 GPU runtime selected software adapter {:?}", device.name).into(),
+            );
+        }
+        let token_loop = runtime
+            .gpu_native_token_loop
+            .as_ref()
+            .ok_or("v2 GPU-native token loop was not initialized")?;
+        let model_geometry = token_loop.model_geometry();
+        if runtime.model.layers.len() != model_geometry.num_layers {
+            return Err("v2 GPU layer geometry is incomplete".into());
+        }
+        let gate_identities = runtime
+            .model
+            .layers
+            .iter()
+            .enumerate()
+            .map(|(layer, plan)| {
+                crate::gpu_native_router_rank_diagnostics::GateTensorIdentity::from_gate(
+                    layer, &plan.gate,
+                )
+            })
+            .collect::<Vec<_>>();
+        let model_load = crate::greedy_parity_model_load(&runtime);
+        if token_loop.snapshot() != GpuNativeTokenLoopSnapshot::default() {
+            return Err("v2 GPU token-loop counters did not start at zero".into());
+        }
+        let routed_before = runtime.engine.routed_expert_execution_snapshot();
+        let attention_before = crate::transformer::nonfinite_softmax_fallbacks();
+        let trace_layout = SemanticCorpusTraceLayout::try_new(model_geometry)?;
+        let mut cases = Vec::with_capacity(HOLDOUT_CORPUS_CASE_COUNT);
+        let mut expected_completed = 0usize;
+        for fixed in HOLDOUT_CORPUS {
+            let prompt_token_ids = tokenizer.encode(fixed.prompt)?;
+            if prompt_token_ids.is_empty() {
+                return Err(
+                    format!("v2 holdout case {:?} encoded to zero tokens", fixed.name).into(),
+                );
+            }
+            let mut request =
+                token_loop.create_semantic_parity_corpus_diagnostic_request_state()?;
+            let staging = token_loop
+                .create_semantic_parity_corpus_diagnostic_staging_buffer(&trace_layout)?;
+            let (generated_token_ids, traces) = crate::with_progress_timeout(
+                format!("GPU-native semantic parity v2 {} candidate", fixed.name),
+                watchdog,
+                async {
+                    let prefix_count = prompt_token_ids.len().saturating_sub(1);
+                    for (position, &token_id) in prompt_token_ids[..prefix_count].iter().enumerate()
+                    {
+                        token_loop
+                            .step_token(&runtime.engine, &mut request, token_id, position, false)
+                            .await?;
+                    }
+                    let mut input_token = *prompt_token_ids
+                        .last()
+                        .ok_or("v2 GPU holdout prompt is empty")?;
+                    let mut position = prefix_count;
+                    let mut generated_token_ids = Vec::with_capacity(OUTPUT_TOKEN_LIMIT);
+                    let mut traces = Vec::with_capacity(OUTPUT_TOKEN_LIMIT);
+                    while generated_token_ids.len() < OUTPUT_TOKEN_LIMIT {
+                        let (trace, sampled_token, _) = token_loop
+                            .step_token_semantic_parity_corpus_diagnostic(
+                                &runtime.engine,
+                                &mut request,
+                                input_token,
+                                position,
+                                &trace_layout,
+                                &staging,
+                            )
+                            .await?;
+                        if trace.layers.len() != model_geometry.num_layers {
+                            return Err("v2 GPU trace omitted one or more layers".into());
+                        }
+                        generated_token_ids.push(sampled_token);
+                        traces.push(trace);
+                        input_token = sampled_token;
+                        position = position
+                            .checked_add(1)
+                            .ok_or("v2 GPU position overflowed")?;
+                    }
+                    Ok::<_, Box<dyn std::error::Error>>((generated_token_ids, traces))
+                },
+            )
+            .await?;
+            let case_expected = prompt_token_ids
+                .len()
+                .saturating_sub(1)
+                .checked_add(OUTPUT_TOKEN_LIMIT)
+                .ok_or("v2 GPU expected completion count overflowed")?;
+            if request.committed_position() != case_expected {
+                return Err(format!(
+                    "v2 GPU case {} retired at {}, expected {case_expected}",
+                    fixed.name,
+                    request.committed_position()
+                )
+                .into());
+            }
+            expected_completed = expected_completed
+                .checked_add(case_expected)
+                .ok_or("v2 GPU total completion count overflowed")?;
+            drop(request);
+            drop(staging);
+            cases.push(GpuCaseCapture {
+                case: fixed.name,
+                prompt_token_ids,
+                generated_token_ids,
+                traces,
+            });
+        }
+        let token_loop_snapshot = token_loop.snapshot();
+        let routed_execution = crate::qualification::routed_execution_delta(
+            routed_before,
+            runtime.engine.routed_expert_execution_snapshot(),
+        )
+        .map_err(|failure| failure.detail)?;
+        Ok::<_, Box<dyn std::error::Error>>(GpuCapture {
+            cases,
+            gate_identities,
+            model_load,
+            device,
+            model_geometry,
+            background_shutdown: crate::greedy_parity::BackgroundShutdownEvidence::default(),
+            expected_completed_token_steps: u64::try_from(expected_completed)
+                .map_err(|_| "v2 GPU completion count does not fit u64")?,
+            token_loop_snapshot,
+            routed_execution,
+            nonfinite_attention_fallbacks: crate::transformer::nonfinite_softmax_fallbacks()
+                .saturating_sub(attention_before),
+        })
+    }
+    .await;
+    let shutdown = runtime.shutdown_isolated().await;
+    match (attempt, shutdown) {
+        (Ok(mut capture), Ok(shutdown)) => {
+            capture.background_shutdown = shutdown;
+            Ok(capture)
+        }
+        (Err(error), Ok(_)) => Err(error),
+        (Ok(_), Err(shutdown_error)) => Err(shutdown_error.into()),
+        (Err(error), Err(shutdown_error)) => Err(IsolatedRuntimeShutdownError::new(format!(
+            "{error}; v2 GPU shutdown also failed: {shutdown_error}"
+        ))
+        .into()),
+    }
+}
+
+fn values_finite(values: &[f32]) -> bool {
+    values.iter().all(|value| value.is_finite())
+}
+
+fn first_generated_token_mismatch_position(reference: &[u32], gpu: &[u32]) -> Option<usize> {
+    (0..reference.len().max(gpu.len())).find(|&index| reference.get(index) != gpu.get(index))
+}
+
+fn post_generated_token_divergence_invalid_reason(
+    first_mismatch_position: Option<usize>,
+    generated_position: usize,
+) -> Option<&'static str> {
+    first_mismatch_position
+        .is_some_and(|mismatch_position| generated_position > mismatch_position)
+        .then_some(POST_GENERATED_TOKEN_DIVERGENCE_INVALID_REASON)
+}
+
+fn scalar_delta(expert_id: u32, left: f32, right: f32) -> WeightDeltaEvidence {
+    let absolute = (f64::from(right) - f64::from(left)).abs();
+    WeightDeltaEvidence {
+        expert_id,
+        left: crate::numerical_diagnostics::FloatEvidence::new(left),
+        right: crate::numerical_diagnostics::FloatEvidence::new(right),
+        absolute_error: (left.is_finite() && right.is_finite()).then_some(absolute),
+        relative_error: (left.is_finite() && right.is_finite() && left != 0.0)
+            .then(|| absolute / f64::from(left).abs())
+            .filter(|value| value.is_finite()),
+        ulp_distance: crate::gpu_native_router_rank_diagnostics::ulp_distance(left, right),
+    }
+}
+
+fn common_selected_score_deltas(
+    cpu: &RouterEvaluationEvidence,
+    gpu: &ActualGpuRouterEvidence,
+) -> Vec<WeightDeltaEvidence> {
+    cpu.top_8_ids
+        .iter()
+        .copied()
+        .filter(|id| gpu.top_8_ids.contains(id))
+        .filter_map(|expert_id| {
+            let left = cpu.scored_probabilities.get(expert_id as usize)?.value?;
+            let right = gpu.scored_probabilities.get(expert_id as usize)?.value?;
+            Some(scalar_delta(expert_id, left, right))
+        })
+        .collect()
+}
+
+fn plan_events(
+    reference_cases: &[ReferenceCaseCapture],
+    gpu: &GpuCapture,
+    gates: &[crate::gating::LinearGate],
+) -> Result<EventPlan, Box<dyn std::error::Error>> {
+    if reference_cases.len() != HOLDOUT_CORPUS_CASE_COUNT
+        || gpu.cases.len() != HOLDOUT_CORPUS_CASE_COUNT
+        || gates.len() != gpu.model_geometry.num_layers
+    {
+        return Err("v2 case or gate coverage is incomplete".into());
+    }
+    let mut sampler = DeterministicEventSampler::new(gpu.model_geometry.num_layers);
+    let mut events = Vec::with_capacity(
+        HOLDOUT_CORPUS_CASE_COUNT * OUTPUT_TOKEN_LIMIT * gpu.model_geometry.num_layers,
+    );
+    for (case_index, ((reference_case, gpu_case), fixed)) in reference_cases
+        .iter()
+        .zip(&gpu.cases)
+        .zip(HOLDOUT_CORPUS)
+        .enumerate()
+    {
+        if reference_case.case != fixed.name
+            || gpu_case.case != fixed.name
+            || reference_case.traces.len() != OUTPUT_TOKEN_LIMIT
+            || gpu_case.traces.len() != OUTPUT_TOKEN_LIMIT
+        {
+            return Err(format!("v2 holdout case {} coverage drifted", fixed.name).into());
+        }
+        let first_mismatch_position = first_generated_token_mismatch_position(
+            &reference_case.generated_token_ids,
+            &gpu_case.generated_token_ids,
+        );
+        for generated_position in 0..OUTPUT_TOKEN_LIMIT {
+            let divergence_reason = post_generated_token_divergence_invalid_reason(
+                first_mismatch_position,
+                generated_position,
+            );
+            let semantically_comparable = divergence_reason.is_none();
+            let reference_trace = &reference_case.traces[generated_position];
+            let gpu_trace = &gpu_case.traces[generated_position];
+            if reference_trace.layer_selected_ids.len() != gpu.model_geometry.num_layers
+                || reference_trace.layer_selected_weights.len() != gpu.model_geometry.num_layers
+                || reference_trace.layer_router_input.len() != gpu.model_geometry.num_layers
+                || reference_trace.layer_routed_moe_output.len() != gpu.model_geometry.num_layers
+                || gpu_trace.layers.len() != gpu.model_geometry.num_layers
+            {
+                return Err(format!(
+                    "v2 case {} position {generated_position} omitted layer evidence",
+                    fixed.name
+                )
+                .into());
+            }
+            for layer in 0..gpu.model_geometry.num_layers {
+                let location = EventLocation::new(fixed.name, generated_position, layer);
+                let reference_ids = &reference_trace.layer_selected_ids[layer];
+                let reference_weights = &reference_trace.layer_selected_weights[layer];
+                let reference_input = &reference_trace.layer_router_input[layer];
+                let reference_output = &reference_trace.layer_routed_moe_output[layer];
+                let gpu_layer = &gpu_trace.layers[layer];
+                let reference_nonfinite = !values_finite(reference_weights)
+                    || !values_finite(reference_input)
+                    || !values_finite(reference_output);
+                let gpu_nonfinite = !values_finite(&gpu_layer.router_input)
+                    || !values_finite(&gpu_layer.raw_logits)
+                    || !values_finite(&gpu_layer.selected_weights)
+                    || !values_finite(&gpu_layer.routed_moe_output)
+                    || gpu_layer
+                        .route_outputs
+                        .iter()
+                        .any(|output| !values_finite(output));
+                let geometry_complete = reference_ids.len() == gpu.model_geometry.top_k
+                    && reference_weights.len() == gpu.model_geometry.top_k
+                    && reference_input.len() == gpu.model_geometry.d_model
+                    && reference_output.len() == gpu.model_geometry.d_model
+                    && gpu_layer.selected_ids.len() == gpu.model_geometry.top_k
+                    && gpu_layer.selected_weights.len() == gpu.model_geometry.top_k
+                    && gpu_layer.router_input.len() == gpu.model_geometry.d_model
+                    && gpu_layer.raw_logits.len() == gpu.model_geometry.num_experts
+                    && gpu_layer.route_outputs.len() == gpu.model_geometry.top_k
+                    && gpu_layer
+                        .route_outputs
+                        .iter()
+                        .all(|output| output.len() == gpu.model_geometry.d_model)
+                    && gpu_layer.routed_moe_output.len() == gpu.model_geometry.d_model;
+                let reference_router = (semantically_comparable
+                    && geometry_complete
+                    && !reference_nonfinite
+                    && !gpu_nonfinite)
+                    .then(|| {
+                        crate::gpu_native_router_rank_diagnostics::evaluate_cpu_router(
+                            "reference-hidden-to-cpu-production-router",
+                            &gates[layer],
+                            reference_input,
+                        )
+                    })
+                    .transpose()
+                    .ok()
+                    .flatten();
+                let actual_gpu_router = (geometry_complete && !gpu_nonfinite)
+                    .then(|| {
+                        crate::gpu_native_router_rank_diagnostics::evaluate_actual_gpu_router(
+                            gpu_layer.raw_logits.clone(),
+                            gpu_layer.selected_ids.clone(),
+                            gpu_layer.selected_weights.clone(),
+                        )
+                    })
+                    .transpose()
+                    .ok()
+                    .flatten();
+                let mut classification = if semantically_comparable {
+                    crate::gpu_native_semantic_parity_corpus::classify_routing_event(
+                        reference_ids,
+                        &gpu_layer.selected_ids,
+                        gpu.model_geometry.num_experts,
+                        geometry_complete && !reference_nonfinite && !gpu_nonfinite,
+                    )
+                } else {
+                    RoutingClassification::InvalidNonfiniteIncomplete
+                };
+                if semantically_comparable
+                    && (reference_router.is_none() || actual_gpu_router.is_none())
+                {
+                    classification = RoutingClassification::InvalidNonfiniteIncomplete;
+                }
+                let reference_pairing_valid = canonical_selected_weight_evidence(
+                    reference_ids,
+                    reference_weights,
+                    reference_ids,
+                    reference_weights,
+                    gpu.model_geometry.num_experts,
+                )
+                .is_ok()
+                    && reference_router.as_ref().is_none_or(|router| {
+                        router.top_8_ids == *reference_ids
+                            && router
+                                .top_8_weights
+                                .iter()
+                                .map(|value| value.bits)
+                                .eq(reference_weights.iter().map(|value| value.to_bits()))
+                    });
+                let gpu_pairing_valid = canonical_selected_weight_evidence(
+                    &gpu_layer.selected_ids,
+                    &gpu_layer.selected_weights,
+                    &gpu_layer.selected_ids,
+                    &gpu_layer.selected_weights,
+                    gpu.model_geometry.num_experts,
+                )
+                .is_ok()
+                    && actual_gpu_router
+                        .as_ref()
+                        .is_some_and(|router| router.selected_weights_paired_with_expert_ids);
+                let expert_weight_pairing_defect =
+                    semantically_comparable && (!reference_pairing_valid || !gpu_pairing_valid);
+                let canonical_selected_weights = matches!(
+                    classification,
+                    RoutingClassification::InternalRankPermutation
+                        | RoutingClassification::MembershipMismatch
+                )
+                .then(|| {
+                    canonical_selected_weight_evidence(
+                        reference_ids,
+                        reference_weights,
+                        &gpu_layer.selected_ids,
+                        &gpu_layer.selected_weights,
+                        gpu.model_geometry.num_experts,
+                    )
+                })
+                .transpose()
+                .ok()
+                .flatten();
+                let displacement = if semantically_comparable {
+                    rank_displacement(reference_ids, &gpu_layer.selected_ids)
+                } else {
+                    RankDisplacementEvidence::default()
+                };
+                let boundary = if matches!(
+                    classification,
+                    RoutingClassification::InternalRankPermutation
+                        | RoutingClassification::MembershipMismatch
+                ) {
+                    reference_router
+                        .as_ref()
+                        .zip(actual_gpu_router.as_ref())
+                        .map(|(reference, actual)| MembershipBoundaryEvidence {
+                            selected_membership_equal: same_membership(
+                                reference_ids,
+                                &gpu_layer.selected_ids,
+                            ),
+                            reference_selected_ids: reference_ids.clone(),
+                            gpu_selected_ids: gpu_layer.selected_ids.clone(),
+                            reference: BoundaryRouterView::from_cpu(reference),
+                            gpu: BoundaryRouterView::from_gpu(actual),
+                        })
+                } else {
+                    None
+                };
+                let sampling = sampler.select(layer, classification);
+                events.push(PlannedEvent {
+                    case_index,
+                    generated_position,
+                    layer,
+                    evidence: RoutingEventEvidence {
+                        location,
+                        classification,
+                        invalid_reason: divergence_reason.or_else(|| {
+                            (classification == RoutingClassification::InvalidNonfiniteIncomplete)
+                                .then_some(STRUCTURAL_INVALID_REASON)
+                        }),
+                        selected_membership_equal: (classification
+                            != RoutingClassification::InvalidNonfiniteIncomplete)
+                            .then(|| same_membership(reference_ids, &gpu_layer.selected_ids)),
+                        reference_selected_ids: reference_ids.clone(),
+                        gpu_selected_ids: gpu_layer.selected_ids.clone(),
+                        displacement,
+                        expert_weight_pairing_defect,
+                        canonical_selected_weights,
+                        boundary,
+                        numerically_selected: sampling.selected,
+                        numerical_selection_reason: sampling.reason,
+                    },
+                    actual_gpu_router,
+                    reference_nonfinite,
+                    gpu_nonfinite,
+                });
+            }
+        }
+    }
+    Ok(EventPlan {
+        events,
+        layers_with_exact_sample: sampler.layers_with_exact_sample(),
+        layers_without_exact_sample: sampler.layers_without_exact_sample(),
+    })
+}
+
+fn evaluate_same_input_router(
+    gate: &crate::gating::LinearGate,
+    gpu_layer: &crate::gpu_native_semantic_parity_corpus::SemanticCorpusGpuLayerTrace,
+    actual_gpu_router: Option<&ActualGpuRouterEvidence>,
+    num_experts: usize,
+) -> Result<RouterSameInputEvidence, String> {
+    let cpu_router = crate::gpu_native_router_rank_diagnostics::evaluate_cpu_router(
+        "gpu-hidden-to-cpu-production-router",
+        gate,
+        &gpu_layer.router_input,
+    )?;
+    let routing = gate.route(&gpu_layer.router_input);
+    let routing_matches_evaluation = routing.experts == cpu_router.top_8_ids
+        && routing
+            .weights
+            .iter()
+            .map(|value| value.to_bits())
+            .eq(cpu_router.top_8_weights.iter().map(|value| value.bits));
+    if !routing_matches_evaluation {
+        return Err("CPU production route disagrees with same-input router evaluation".to_string());
+    }
+    let actual_gpu_router = actual_gpu_router
+        .ok_or_else(|| "actual GPU production router evidence is unavailable".to_string())?;
+    if actual_gpu_router.top_8_ids != gpu_layer.selected_ids
+        || !actual_gpu_router.selected_weights_paired_with_expert_ids
+    {
+        return Err("actual GPU router evidence is invalid or unpaired".to_string());
+    }
+    let canonical = canonical_selected_weight_evidence(
+        &routing.experts,
+        &routing.weights,
+        &gpu_layer.selected_ids,
+        &gpu_layer.selected_weights,
+        num_experts,
+    )?;
+    Ok(RouterSameInputEvidence {
+        cpu_selected_ids: cpu_router.top_8_ids.clone(),
+        gpu_selected_ids: gpu_layer.selected_ids.clone(),
+        membership_equal: same_membership(&cpu_router.top_8_ids, &gpu_layer.selected_ids),
+        ordered_ids_equal: cpu_router.top_8_ids == gpu_layer.selected_ids,
+        common_expert_score_deltas: common_selected_score_deltas(&cpu_router, actual_gpu_router),
+        common_expert_weight_deltas: canonical
+            .into_iter()
+            .filter_map(|item| item.delta)
+            .collect(),
+    })
+}
+
+async fn execute_reference_and_evidence(
+    spec: &ResolvedRealCliSpec,
+    tokenizer: Arc<crate::tokenizer::Tokenizer>,
+    resolved_config_sha256: &str,
+    gpu: &GpuCapture,
+    watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+) -> Result<EvidenceCapture, Box<dyn std::error::Error>> {
+    let runtime = crate::build_isolated_greedy_runtime(
+        spec,
+        RealCliRuntimeMode::IsolatedGreedyParityCpu,
+        tokenizer.clone(),
+    )
+    .await?;
+    let attempt = async {
+        runtime.engine.enable_cpu_q4_boundary_emulation()?;
+        let observed_config_sha256 = crate::resolved_real_runtime_identity_sha256(
+            &runtime.cfg,
+            runtime.model.config.architecture,
+            runtime.model.config.first_k_dense_replace,
+            &runtime.model.config.advanced,
+        )?;
+        if observed_config_sha256 != resolved_config_sha256 {
+            return Err(format!(
+                "v2 reference identity {observed_config_sha256} drifted from {resolved_config_sha256}"
+            )
+            .into());
+        }
+        if runtime.model.layers.len() != gpu.model_geometry.num_layers {
+            return Err("v2 reference layer geometry is incomplete".into());
+        }
+        let gates = runtime
+            .model
+            .layers
+            .iter()
+            .map(|layer| layer.gate.clone())
+            .collect::<Vec<_>>();
+        let reference_gate_identities = gates
+            .iter()
+            .enumerate()
+            .map(|(layer, gate)| {
+                crate::gpu_native_router_rank_diagnostics::GateTensorIdentity::from_gate(
+                    layer, gate,
+                )
+            })
+            .collect::<Vec<_>>();
+        if reference_gate_identities != gpu.gate_identities {
+            return Err("v2 reference and GPU gate tensor identities differ".into());
+        }
+        let model_load = crate::greedy_parity_model_load(&runtime);
+        let boundary_before = runtime.engine.cpu_q4_boundary_emulation_snapshot();
+        if !boundary_before.enabled || boundary_before.routed_expert_dispatches != 0 {
+            return Err("v2 reference boundary emulation did not start clean".into());
+        }
+        let routed_before = runtime.engine.routed_expert_execution_snapshot();
+        let attention_before = crate::transformer::nonfinite_softmax_fallbacks();
+        let mut reference_cases = Vec::with_capacity(HOLDOUT_CORPUS_CASE_COUNT);
+        for (case_index, fixed) in HOLDOUT_CORPUS.into_iter().enumerate() {
+            let prompt_token_ids = tokenizer.encode(fixed.prompt)?;
+            if prompt_token_ids != gpu.cases[case_index].prompt_token_ids {
+                return Err(
+                    format!("v2 tokenizer identity drifted for case {}", fixed.name).into(),
+                );
+            }
+            let (generated_token_ids, traces) = crate::with_progress_timeout(
+                format!("semantic parity v2 {} authoritative reference", fixed.name),
+                watchdog,
+                async {
+                    let mut kv = runtime.model.fresh_kv_caches();
+                    let prefix_count = prompt_token_ids.len().saturating_sub(1);
+                    for (position, &token_id) in
+                        prompt_token_ids[..prefix_count].iter().enumerate()
+                    {
+                        runtime
+                            .model
+                            .forward_token_hidden(
+                                &runtime.engine,
+                                token_id,
+                                position,
+                                &mut kv,
+                            )
+                            .await?;
+                    }
+                    let mut input_token = *prompt_token_ids
+                        .last()
+                        .ok_or("v2 reference holdout prompt is empty")?;
+                    let mut position = prefix_count;
+                    let mut generated_token_ids = Vec::with_capacity(OUTPUT_TOKEN_LIMIT);
+                    let mut traces = Vec::with_capacity(OUTPUT_TOKEN_LIMIT);
+                    while generated_token_ids.len() < OUTPUT_TOKEN_LIMIT {
+                        let trace = runtime
+                            .model
+                            .forward_token_diagnostic_trace(
+                                &runtime.engine,
+                                input_token,
+                                position,
+                                &mut kv,
+                                None,
+                            )
+                            .await?;
+                        input_token = trace.sampled_token;
+                        generated_token_ids.push(trace.sampled_token);
+                        traces.push(trace);
+                        position = position
+                            .checked_add(1)
+                            .ok_or("v2 reference position overflowed")?;
+                    }
+                    Ok::<_, Box<dyn std::error::Error>>((generated_token_ids, traces))
+                },
+            )
+            .await?;
+            reference_cases.push(ReferenceCaseCapture {
+                case: fixed.name,
+                generated_token_ids,
+                traces,
+            });
+        }
+
+        let mut plan = plan_events(&reference_cases, gpu, &gates)?;
+        let same_input_router_events = plan
+            .events
+            .iter()
+            .map(|planned| {
+                let gpu_layer = &gpu.cases[planned.case_index].traces
+                    [planned.generated_position]
+                    .layers[planned.layer];
+                match evaluate_same_input_router(
+                    &gates[planned.layer],
+                    gpu_layer,
+                    planned.actual_gpu_router.as_ref(),
+                    gpu.model_geometry.num_experts,
+                ) {
+                    Ok(evidence) => SameInputRouterEventEvidence {
+                        location: planned.evidence.location.clone(),
+                        cpu_production_router_on_exact_gpu_input: Some(evidence),
+                        evaluation_error: None,
+                    },
+                    Err(error) => SameInputRouterEventEvidence {
+                        location: planned.evidence.location.clone(),
+                        cpu_production_router_on_exact_gpu_input: None,
+                        evaluation_error: Some(error),
+                    },
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let mut same_input_events = Vec::new();
+        for (event_index, planned) in plan
+            .events
+            .iter_mut()
+            .enumerate()
+            .filter(|(_, event)| event.evidence.numerically_selected)
+        {
+            let gpu_layer = &gpu.cases[planned.case_index].traces[planned.generated_position]
+                .layers[planned.layer];
+            let reference_trace =
+                &reference_cases[planned.case_index].traces[planned.generated_position];
+            let Some(router_same_input) = same_input_router_events[event_index]
+                .cpu_production_router_on_exact_gpu_input
+                .clone()
+            else {
+                continue;
+            };
+            let routing = gates[planned.layer].route(&gpu_layer.router_input);
+            let global_ids = routing
+                .experts
+                .iter()
+                .map(|&expert| runtime.model.global_expert_id(planned.layer, expert))
+                .collect::<Vec<_>>();
+            let token_index = (planned.case_index as u64)
+                .wrapping_mul(OUTPUT_TOKEN_LIMIT as u64)
+                .wrapping_add(planned.generated_position as u64)
+                .wrapping_mul(gpu.model_geometry.num_layers as u64)
+                .wrapping_add(planned.layer as u64);
+            let expert_outputs = runtime
+                .engine
+                .moe_step_with_timing(
+                    token_index,
+                    planned.layer as u32,
+                    &gpu_layer.router_input,
+                    &global_ids,
+                    None,
+                )
+                .await?;
+            if expert_outputs.len() != routing.experts.len()
+                || expert_outputs
+                    .iter()
+                    .any(|output| output.len() != gpu.model_geometry.d_model)
+            {
+                planned.evidence.expert_weight_pairing_defect = true;
+                continue;
+            }
+            let cpu_routed_moe_output =
+                crate::inference::combine_outputs(&expert_outputs, &routing.weights);
+            same_input_events.push(SameInputNumericalEventEvidence {
+                location: planned.evidence.location.clone(),
+                classification: planned.evidence.classification,
+                cpu_vs_gpu_routed_moe: VectorNumericalEvidence::compare(
+                    "cpu-production-routed-moe-on-exact-gpu-input",
+                    "actual-production-gpu-routed-moe-on-exact-gpu-input",
+                    &cpu_routed_moe_output,
+                    &gpu_layer.routed_moe_output,
+                )?,
+                reference_vs_gpu_routed_moe_includes_upstream_drift:
+                    VectorNumericalEvidence::compare(
+                        "authoritative-cpu-reference-routed-moe-includes-upstream-drift",
+                        "actual-production-gpu-routed-moe",
+                        &reference_trace.layer_routed_moe_output[planned.layer],
+                        &gpu_layer.routed_moe_output,
+                    )?,
+                router_same_input,
+            });
+        }
+
+        let mut permutation_events = Vec::new();
+        for planned in plan.events.iter().filter(|event| {
+            event.evidence.classification == RoutingClassification::InternalRankPermutation
+        }) {
+            let gpu_layer = &gpu.cases[planned.case_index].traces[planned.generated_position]
+                .layers[planned.layer];
+            permutation_events.push(PermutationNumericalEventEvidence {
+                location: planned.evidence.location.clone(),
+                witness:
+                    crate::gpu_native_expert_permutation_semantic_parity::permutation_only_witness(
+                        &gpu_layer.selected_ids,
+                        &gpu_layer.selected_weights,
+                        &gpu_layer.route_outputs,
+                    )?,
+            });
+        }
+
+        let boundary_after = runtime.engine.cpu_q4_boundary_emulation_snapshot();
+        if !boundary_after.enabled || boundary_after.routed_expert_dispatches == 0 {
+            return Err("v2 reference did not exercise the Hybrid F16 boundary".into());
+        }
+        let reference_routed_execution = crate::qualification::routed_execution_delta(
+            routed_before,
+            runtime.engine.routed_expert_execution_snapshot(),
+        )
+        .map_err(|failure| failure.detail)?;
+        let reference_nonfinite_attention_fallbacks =
+            crate::transformer::nonfinite_softmax_fallbacks().saturating_sub(attention_before);
+        let token_cases = reference_cases
+            .iter()
+            .zip(&gpu.cases)
+            .map(|(reference, gpu_case)| {
+                TokenCaseEvidence::new(
+                    reference.case,
+                    reference.generated_token_ids.clone(),
+                    gpu_case.generated_token_ids.clone(),
+                )
+            })
+            .collect::<Vec<_>>();
+        let mut routing_counters = RoutingCounters::default();
+        for event in &plan.events {
+            routing_counters.record(
+                &event.evidence,
+                event.reference_nonfinite,
+                event.gpu_nonfinite,
+            );
+        }
+        let exact_sampled = same_input_events
+            .iter()
+            .filter(|event| event.classification == RoutingClassification::ExactOrderMatch)
+            .count();
+        let internal_measured = same_input_events
+            .iter()
+            .filter(|event| {
+                event.classification == RoutingClassification::InternalRankPermutation
+            })
+            .count();
+        let membership_measured = same_input_events
+            .iter()
+            .filter(|event| event.classification == RoutingClassification::MembershipMismatch)
+            .count();
+        let sampling = SamplingSummary {
+            exact_order_events_total: routing_counters.exact_order_match_events,
+            exact_order_events_numerically_sampled: exact_sampled,
+            exact_order_sampling_rule: EXACT_ORDER_SAMPLING_RULE,
+            layers_with_exact_order_sample: plan.layers_with_exact_sample,
+            layers_without_exact_order_sample: plan.layers_without_exact_sample,
+            internal_permutation_events_numerically_measured: internal_measured,
+            membership_mismatch_events_numerically_measured: membership_measured,
+            maximum_exact_order_samples_for_model: gpu.model_geometry.num_layers,
+        };
+        Ok::<_, Box<dyn std::error::Error>>(EvidenceCapture {
+            token_cases,
+            routing_events: plan
+                .events
+                .into_iter()
+                .map(|event| event.evidence)
+                .collect(),
+            routing_counters,
+            sampling,
+            same_input_router_events,
+            same_input_events,
+            permutation_events,
+            reference_model_load: model_load,
+            reference_background_shutdown:
+                crate::greedy_parity::BackgroundShutdownEvidence::default(),
+            reference_routed_execution,
+            reference_nonfinite_attention_fallbacks,
+        })
+    }
+    .await;
+    let shutdown = runtime.shutdown_isolated().await;
+    match (attempt, shutdown) {
+        (Ok(mut capture), Ok(shutdown)) => {
+            capture.reference_background_shutdown = shutdown;
+            Ok(capture)
+        }
+        (Err(error), Ok(_)) => Err(error),
+        (Ok(_), Err(shutdown_error)) => Err(shutdown_error.into()),
+        (Err(error), Err(shutdown_error)) => Err(IsolatedRuntimeShutdownError::new(format!(
+            "{error}; v2 reference shutdown also failed: {shutdown_error}"
+        ))
+        .into()),
+    }
+}
+
+fn emit_report(
+    report: &SemanticParityV2Report,
+    report_out: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if report.qualification_pass != report.gates.qualification_pass() {
+        return Err("v2 serialized qualification PASS disagrees with frozen gates".into());
+    }
+    if let Some(parent) = report_out.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut json = serde_json::to_vec_pretty(report)?;
+    json.push(b'\n');
+    std::fs::write(report_out, json)?;
+    eprintln!(
+        "GPU-native semantic parity v2 qualification report written to {}",
+        report_out.display()
+    );
+    Ok(())
+}
+
+pub async fn run_qualification(
+    config: PathBuf,
+    cfg: crate::config::Config,
+    expected_adapter_name: String,
+    report_out: PathBuf,
+    progress_watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use crate::qualification::BuildProvenance;
+
+    let build = BuildProvenance::embedded();
+    let (artifacts, artifact_errors) = crate::qualification_artifacts(&config, &cfg);
+    if !artifact_errors.is_empty() {
+        return Err(format!(
+            "v2 qualification artifact preflight failed: {}",
+            artifact_errors.join("; ")
+        )
+        .into());
+    }
+    if progress_watchdog.timeout.is_none() {
+        return Err("v2 qualification requires a positive progress timeout".into());
+    }
+    if build.dirty != Some(false) || build.git_sha.as_deref().is_none_or(|sha| !is_hex(sha, 40)) {
+        return Err("v2 qualification requires clean embedded 40-hex Git provenance".into());
+    }
+    if crate::greedy_parity::CorpusEvidence::fixed().sha256 != CALIBRATION_CORPUS_SHA256 {
+        return Err("v2 calibration corpus identity drifted from the frozen contract".into());
+    }
+    if holdout_corpus_sha256() != HOLDOUT_CORPUS_SHA256 {
+        return Err("v2 holdout corpus identity drifted from the frozen contract".into());
+    }
+    let capacity_bytes = cfg
+        .gpu_cache
+        .vram_capacity_mb
+        .checked_mul(1024 * 1024)
+        .and_then(|bytes| u64::try_from(bytes).ok())
+        .unwrap_or(0);
+    let source_config = crate::gpu_native_greedy_parity::SourceConfigEvidence {
+        real_transformer_enabled: cfg.real_transformer.enabled,
+        gpu_native_enabled: cfg.real_transformer.gpu_native,
+        weights_dir_configured: cfg.real_transformer.weights_dir.is_some(),
+        strict_weights: cfg.real_transformer.strict_weights,
+        allow_seeded_fallback: cfg.real_transformer.allow_seeded_fallback,
+        allow_degraded_experts: cfg.real_transformer.allow_degraded_experts,
+        allow_nonfinite_attention_fallback: cfg.real_transformer.allow_nonfinite_attention_fallback,
+        allow_truncated_expert_payloads: cfg.real_transformer.allow_truncated_expert_payloads,
+        distributed_enabled: cfg.distributed.enabled,
+        gpu_cache_enabled: cfg.gpu_cache.enabled,
+        gpu_expert_capacity_bytes: capacity_bytes,
+        routed_expert_dtype: cfg.model.dtype.as_str().to_string(),
+    };
+    if !source_config.is_strict() {
+        return Err("v2 qualification requires the strict GPU-native Q4 configuration".into());
+    }
+    let expert_metadata =
+        crate::qualification::read_expert_metadata(&cfg.model.data_dir.join("metadata.json"))
+            .map_err(|error| format!("v2 expert metadata preflight failed: {error}"))?;
+    if expert_metadata.q4_0_layout.as_deref() != Some(crate::inference::Q4_0_LAYOUT_STANDARD_V1)
+        || expert_metadata.dtype.as_deref() != Some("q4_0")
+        || expert_metadata.explicitly_synthetic
+    {
+        return Err("v2 qualification requires canonical nonsynthetic Q4_0 metadata".into());
+    }
+    if expected_adapter_name.trim().is_empty() {
+        return Err("v2 qualification requires a nonempty exact adapter name".into());
+    }
+
+    let mut gpu_spec = crate::resolve_real_cli_spec_from_config(
+        cfg,
+        RealCliRuntimeMode::IsolatedGpuNativeDiagnostic,
+    )?;
+    gpu_spec.cfg.real_transformer.gpu_native = true;
+    gpu_spec.cfg.real_transformer.compute_offload = crate::backend::ComputeOffload::Gpu;
+    let model_identity = crate::greedy_parity_model_identity(&gpu_spec);
+    if !model_identity.is_qwen3_coder_30b_a3b_q4_0() {
+        return Err("v2 qualification requires exact Qwen3-Coder 30B-A3B Q4_0 geometry".into());
+    }
+    let gpu_resolved_config_sha256 = crate::resolved_real_cli_spec_sha256(&gpu_spec)?;
+    let mut reference_spec = gpu_spec.clone();
+    reference_spec.cfg.real_transformer.gpu_native = false;
+    reference_spec.cfg.real_transformer.compute_offload = crate::backend::ComputeOffload::Cpu;
+    let reference_resolved_config_sha256 = crate::resolved_real_cli_spec_sha256(&reference_spec)?;
+    let tokenizer_path = gpu_spec
+        .cfg
+        .tokenizer
+        .path
+        .as_ref()
+        .ok_or("v2 qualification requires tokenizer.path")?;
+    let tokenizer = crate::tokenizer::Tokenizer::from_file(tokenizer_path)
+        .map(Arc::new)
+        .map_err(|error| {
+            format!(
+                "v2 qualification failed to load tokenizer {}: {error}",
+                tokenizer_path.display()
+            )
+        })?;
+
+    let gpu = execute_gpu(
+        &gpu_spec,
+        tokenizer.clone(),
+        &gpu_resolved_config_sha256,
+        &expected_adapter_name,
+        progress_watchdog,
+    )
+    .await?;
+    if gpu.model_geometry.num_layers != 48
+        || gpu.model_geometry.num_experts != 128
+        || gpu.model_geometry.top_k != 8
+        || gpu.model_geometry.d_model != 2048
+        || gpu.model_geometry.d_ff != 768
+    {
+        return Err("v2 GPU runtime geometry drifted after strict startup".into());
+    }
+    let evidence = execute_reference_and_evidence(
+        &reference_spec,
+        tokenizer,
+        &reference_resolved_config_sha256,
+        &gpu,
+        progress_watchdog,
+    )
+    .await?;
+    let expected_routing_events =
+        HOLDOUT_CORPUS_CASE_COUNT * OUTPUT_TOKEN_LIMIT * gpu.model_geometry.num_layers;
+    if evidence.routing_events.len() != expected_routing_events
+        || evidence.routing_counters.total_routing_events != expected_routing_events
+        || evidence.same_input_router_events.len() != expected_routing_events
+    {
+        return Err(format!(
+            "v2 observation coverage is incomplete: routing={} same-input={} expected={expected_routing_events}",
+            evidence.routing_events.len(),
+            evidence.same_input_router_events.len()
+        )
+        .into());
+    }
+    let (_, executable_sha256) = crate::current_executable_identity()?;
+    let runtime_completion = RuntimeCompletionEvidence {
+        gpu_expected_completed_token_steps: gpu.expected_completed_token_steps,
+        gpu_token_loop: gpu.token_loop_snapshot,
+        reference_routed_execution: evidence.reference_routed_execution,
+        gpu_native_routed_execution: gpu.routed_execution,
+        reference_nonfinite_attention_fallbacks: evidence.reference_nonfinite_attention_fallbacks,
+        gpu_native_nonfinite_attention_fallbacks: gpu.nonfinite_attention_fallbacks,
+    };
+    let report = SemanticParityV2Report::new(
+        expected_adapter_name.clone(),
+        DiagnosticProvenance {
+            build,
+            executable_sha256,
+            artifacts,
+            gpu_resolved_config_sha256,
+            reference_resolved_config_sha256,
+            model_identity,
+            reference_model_load: evidence.reference_model_load,
+            gpu_native_model_load: gpu.model_load,
+            reference_background_shutdown: evidence.reference_background_shutdown,
+            gpu_native_background_shutdown: gpu.background_shutdown,
+            expert_metadata,
+            device: gpu.device,
+        },
+        evidence.token_cases,
+        evidence.routing_events,
+        evidence.routing_counters,
+        evidence.sampling,
+        evidence.same_input_router_events,
+        evidence.same_input_events,
+        evidence.permutation_events,
+        runtime_completion,
+        Vec::new(),
+    );
+    let qualification_pass = report.qualification_pass;
+    let failed_criteria = report.failed_criteria.join(", ");
+    emit_report(&report, &report_out)?;
+    if qualification_pass {
+        Ok(())
+    } else {
+        Err(format!("v2 qualification FAIL: {failed_criteria}").into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn artifact(label: &str) -> crate::qualification::ArtifactDigest {
+        crate::qualification::ArtifactDigest {
+            configured_path: format!("/{label}"),
+            canonical_path: format!("/canonical/{label}"),
+            byte_length: 1,
+            sha256: "a".repeat(64),
+        }
+    }
+
+    fn strict_model_load() -> crate::greedy_parity::ModelLoadEvidence {
+        crate::greedy_parity::ModelLoadEvidence {
+            strict: true,
+            loader: "safetensors".to_string(),
+            loaded_tensors: 435,
+            required_tensors: 435,
+            optional_probed: 0,
+            optional_loaded: 0,
+            seeded_fallback_remained: false,
+        }
+    }
+
+    fn released_shutdown() -> crate::greedy_parity::BackgroundShutdownEvidence {
+        crate::greedy_parity::BackgroundShutdownEvidence {
+            controlled_shutdown_requested: true,
+            all_runtime_resources_released: true,
+            poll_iterations: 1,
+        }
+    }
+
+    fn passing_provenance() -> DiagnosticProvenance {
+        DiagnosticProvenance {
+            build: crate::qualification::BuildProvenance {
+                git_sha: Some("b".repeat(40)),
+                dirty: Some(false),
+                package_version: "0.1.0".to_string(),
+            },
+            executable_sha256: "c".repeat(64),
+            artifacts: crate::qualification::QualificationArtifacts {
+                config: Some(artifact("config.toml")),
+                tokenizer: Some(artifact("tokenizer.json")),
+                expert_metadata: Some(artifact("metadata.json")),
+                ..crate::qualification::QualificationArtifacts::default()
+            },
+            gpu_resolved_config_sha256: "d".repeat(64),
+            reference_resolved_config_sha256: "e".repeat(64),
+            model_identity: crate::greedy_parity::ModelIdentityEvidence {
+                architecture: "qwen3_moe".to_string(),
+                num_layers: 48,
+                num_experts_per_layer: 128,
+                total_experts: 6144,
+                top_k: 8,
+                d_model: 2048,
+                d_ff: 768,
+                routed_expert_dtype: "q4_0".to_string(),
+            },
+            reference_model_load: strict_model_load(),
+            gpu_native_model_load: strict_model_load(),
+            reference_background_shutdown: released_shutdown(),
+            gpu_native_background_shutdown: released_shutdown(),
+            expert_metadata: crate::qualification::ExpertMetadataEvidence {
+                dtype: Some("q4_0".to_string()),
+                q4_0_layout: Some(crate::inference::Q4_0_LAYOUT_STANDARD_V1.to_string()),
+                conversion_mode: Some("real".to_string()),
+                source: Some("test".to_string()),
+                explicitly_synthetic: false,
+            },
+            device: crate::backend::GpuDeviceIdentity {
+                name: "NVIDIA L4".to_string(),
+                vendor_id: 0x10de,
+                device_id: 0x27b8,
+                device_type: "DiscreteGpu".to_string(),
+                wgpu_backend: "vulkan".to_string(),
+                driver: "580.173.02".to_string(),
+                driver_info: "test".to_string(),
+                compute_plane: "wgpu-vulkan".to_string(),
+                software_adapter: false,
+            },
+        }
+    }
+
+    fn passing_token_cases() -> Vec<TokenCaseEvidence> {
+        HOLDOUT_CORPUS
+            .iter()
+            .enumerate()
+            .map(|(case_index, case)| {
+                let ids = (0..OUTPUT_TOKEN_LIMIT)
+                    .map(|position| (case_index * OUTPUT_TOKEN_LIMIT + position) as u32)
+                    .collect::<Vec<_>>();
+                TokenCaseEvidence::new(case.name, ids.clone(), ids)
+            })
+            .collect()
+    }
+
+    fn router_same_input(cpu: &[u32], gpu: &[u32]) -> RouterSameInputEvidence {
+        RouterSameInputEvidence {
+            cpu_selected_ids: cpu.to_vec(),
+            gpu_selected_ids: gpu.to_vec(),
+            membership_equal: same_membership(cpu, gpu),
+            ordered_ids_equal: cpu == gpu,
+            common_expert_score_deltas: Vec::new(),
+            common_expert_weight_deltas: Vec::new(),
+        }
+    }
+
+    fn same_input_router_event(index: usize) -> SameInputRouterEventEvidence {
+        let ids = [0, 1, 2, 3, 4, 5, 6, 7];
+        SameInputRouterEventEvidence {
+            location: EventLocation::new("rust-ownership-holdout", index / 48, index % 48),
+            cpu_production_router_on_exact_gpu_input: Some(router_same_input(&ids, &ids)),
+            evaluation_error: None,
+        }
+    }
+
+    fn routing_event(index: usize) -> RoutingEventEvidence {
+        RoutingEventEvidence {
+            location: EventLocation::new("rust-ownership-holdout", index / 48, index % 48),
+            classification: RoutingClassification::ExactOrderMatch,
+            invalid_reason: None,
+            selected_membership_equal: Some(true),
+            reference_selected_ids: vec![0, 1, 2, 3, 4, 5, 6, 7],
+            gpu_selected_ids: vec![0, 1, 2, 3, 4, 5, 6, 7],
+            displacement: RankDisplacementEvidence::default(),
+            expert_weight_pairing_defect: false,
+            canonical_selected_weights: None,
+            boundary: None,
+            numerically_selected: index < 48,
+            numerical_selection_reason: (index < 48).then_some(EXACT_ORDER_SAMPLING_RULE),
+        }
+    }
+
+    fn numerical_event(
+        layer: usize,
+        classification: RoutingClassification,
+    ) -> SameInputNumericalEventEvidence {
+        SameInputNumericalEventEvidence {
+            location: EventLocation::new("rust-ownership-holdout", 0, layer),
+            classification,
+            cpu_vs_gpu_routed_moe: VectorNumericalEvidence::compare("cpu", "gpu", &[0.0], &[0.0])
+                .unwrap(),
+            reference_vs_gpu_routed_moe_includes_upstream_drift: VectorNumericalEvidence::compare(
+                "reference",
+                "gpu",
+                &[0.0],
+                &[0.0],
+            )
+            .unwrap(),
+            router_same_input: router_same_input(&[0, 1], &[0, 1]),
+        }
+    }
+
+    fn numerical_with_metrics(
+        max_absolute: f64,
+        rms: f64,
+        mean_absolute: f64,
+        nonfinite_mismatches: usize,
+    ) -> SameInputNumericalEventEvidence {
+        let mut event = numerical_event(0, RoutingClassification::ExactOrderMatch);
+        event.cpu_vs_gpu_routed_moe.max_absolute_error = Some(max_absolute);
+        event.cpu_vs_gpu_routed_moe.rms_error = Some(rms);
+        event.cpu_vs_gpu_routed_moe.mean_absolute_error = Some(mean_absolute);
+        event.cpu_vs_gpu_routed_moe.nonfinite_bit_mismatch_count = nonfinite_mismatches;
+        event
+    }
+
+    fn passing_routing_counters() -> RoutingCounters {
+        RoutingCounters {
+            total_routing_events: HOLDOUT_CORPUS_CASE_COUNT * OUTPUT_TOKEN_LIMIT * 48,
+            exact_order_match_events: HOLDOUT_CORPUS_CASE_COUNT * OUTPUT_TOKEN_LIMIT * 48,
+            ..RoutingCounters::default()
+        }
+    }
+
+    fn passing_sampling() -> SamplingSummary {
+        SamplingSummary {
+            exact_order_events_total: HOLDOUT_CORPUS_CASE_COUNT * OUTPUT_TOKEN_LIMIT * 48,
+            exact_order_events_numerically_sampled: 48,
+            exact_order_sampling_rule: EXACT_ORDER_SAMPLING_RULE,
+            layers_with_exact_order_sample: (0..48).collect(),
+            layers_without_exact_order_sample: Vec::new(),
+            internal_permutation_events_numerically_measured: 0,
+            membership_mismatch_events_numerically_measured: 0,
+            maximum_exact_order_samples_for_model: 48,
+        }
+    }
+
+    fn passing_runtime() -> RuntimeCompletionEvidence {
+        RuntimeCompletionEvidence {
+            gpu_expected_completed_token_steps: 64,
+            gpu_token_loop: GpuNativeTokenLoopSnapshot {
+                tokens_completed: 64,
+                ..GpuNativeTokenLoopSnapshot::default()
+            },
+            ..RuntimeCompletionEvidence::default()
+        }
+    }
+
+    fn all_gates_pass() -> QualificationGates {
+        QualificationGates {
+            exact_provenance: true,
+            frozen_holdout_corpus_identity: true,
+            exact_model_geometry: true,
+            strict_model_load: true,
+            complete_exact_greedy_token_parity: true,
+            routing_structural_validity: true,
+            same_input_gpu_router_ordered_ids_exact: true,
+            same_input_routed_moe_numerical_limits: true,
+            deterministic_numerical_sampling_complete: true,
+            no_fallback_or_degradation: true,
+            residency_and_execution_completion: true,
+            controlled_shutdown: true,
+            observation_completeness: true,
+        }
+    }
+
+    #[test]
+    fn schema_mode_and_frozen_limits_are_exact() {
+        assert_eq!(SCHEMA_VERSION, "mer.gpu-native-semantic-parity.v2");
+        assert_eq!(MODE, "qualify-gpu-native-semantic-parity-v2");
+        assert_eq!(MAX_ABSOLUTE_ERROR_LIMIT, 0.020);
+        assert_eq!(RMS_ERROR_LIMIT, 0.001);
+        assert_eq!(MEAN_ABSOLUTE_ERROR_LIMIT, 0.00075);
+        assert_eq!(NONFINITE_MISMATCH_LIMIT, 0);
+    }
+
+    #[test]
+    fn calibration_and_holdout_identities_are_distinct() {
+        let calibration = CorpusIdentityEvidence::calibration();
+        let holdout = CorpusIdentityEvidence::holdout();
+        assert_ne!(calibration.id, holdout.id);
+        assert_ne!(calibration.sha256, holdout.sha256);
+        assert_eq!(calibration.sha256, CALIBRATION_CORPUS_SHA256);
+    }
+
+    #[test]
+    fn holdout_case_order_prompts_and_token_limit_are_frozen() {
+        assert_eq!(HOLDOUT_CORPUS.len(), 4);
+        assert_eq!(OUTPUT_TOKEN_LIMIT, 16);
+        assert_eq!(
+            HOLDOUT_CORPUS.map(|case| case.name),
+            [
+                "rust-ownership-holdout",
+                "python-async-holdout",
+                "postgres-window-holdout",
+                "spanish-refactor-holdout",
+            ]
+        );
+        assert_eq!(
+            HOLDOUT_CORPUS[0].prompt,
+            "Fix the Rust function below so it compiles without cloning the input.\nReturn only the corrected function followed by one short explanation.\n\nfn first_word(s: String) -> &str {\n    s.split_whitespace().next().unwrap_or(\"\")\n}"
+        );
+        assert_eq!(
+            HOLDOUT_CORPUS[1].prompt,
+            "Find the concurrency bug in this Python asyncio code and provide the\nminimal corrected version.\n\nasync def load_all(urls):\n    tasks = []\n    for url in urls:\n        tasks.append(asyncio.create_task(fetch(url)))\n    for task in tasks:\n        return await task"
+        );
+        assert_eq!(
+            HOLDOUT_CORPUS[2].prompt,
+            "Write a PostgreSQL query that returns each customer's most recent order,\nincluding customer_id, order_id, ordered_at, and total, with exactly one\nrow per customer. Use a window function."
+        );
+        assert_eq!(
+            HOLDOUT_CORPUS[3].prompt,
+            "En Rust, refactoriza esta función para evitar una asignación innecesaria\nsin cambiar su comportamiento. Devuelve primero el código y luego una\nexplicación breve.\n\nfn normalize(name: &str) -> String {\n    let value = name.to_string();\n    value.trim().to_lowercase()\n}"
+        );
+    }
+
+    #[test]
+    fn holdout_sha_is_deterministic_and_frozen() {
+        assert_eq!(holdout_corpus_sha256(), HOLDOUT_CORPUS_SHA256);
+        assert_eq!(
+            CorpusIdentityEvidence::holdout().sha256,
+            HOLDOUT_CORPUS_SHA256
+        );
+    }
+
+    #[test]
+    fn token_mismatch_and_incomplete_generation_fail() {
+        let mut mismatch = passing_token_cases();
+        mismatch[0].gpu_generated_token_ids[3] ^= 1;
+        mismatch[0] = TokenCaseEvidence::new(
+            mismatch[0].case.clone(),
+            mismatch[0].reference_generated_token_ids.clone(),
+            mismatch[0].gpu_generated_token_ids.clone(),
+        );
+        assert!(!token_parity_pass(&mismatch));
+
+        let mut incomplete = passing_token_cases();
+        incomplete[1].gpu_generated_token_ids.pop();
+        incomplete[1] = TokenCaseEvidence::new(
+            incomplete[1].case.clone(),
+            incomplete[1].reference_generated_token_ids.clone(),
+            incomplete[1].gpu_generated_token_ids.clone(),
+        );
+        assert!(!token_parity_pass(&incomplete));
+    }
+
+    #[test]
+    fn invalid_duplicate_out_of_range_and_nonfinite_routing_fail() {
+        use crate::gpu_native_semantic_parity_corpus::classify_routing_event;
+        assert_eq!(
+            classify_routing_event(&[1, 1], &[1, 2], 128, true),
+            RoutingClassification::InvalidNonfiniteIncomplete
+        );
+        assert_eq!(
+            classify_routing_event(&[1, 128], &[1, 2], 128, true),
+            RoutingClassification::InvalidNonfiniteIncomplete
+        );
+        assert_eq!(
+            classify_routing_event(&[1, 2], &[1, 2], 128, false),
+            RoutingClassification::InvalidNonfiniteIncomplete
+        );
+    }
+
+    #[test]
+    fn pairing_defect_fails_structural_gate() {
+        let mut counters = passing_routing_counters();
+        counters.expert_weight_pairing_defect_events = 1;
+        assert!(!routing_structural_pass(
+            &counters,
+            HOLDOUT_CORPUS_CASE_COUNT * OUTPUT_TOKEN_LIMIT * 48
+        ));
+    }
+
+    #[test]
+    fn same_input_ordered_match_passes_router_gate() {
+        let event = SameInputRouterEventEvidence {
+            location: EventLocation::new("case", 0, 0),
+            cpu_production_router_on_exact_gpu_input: Some(router_same_input(
+                &[1, 2, 3],
+                &[1, 2, 3],
+            )),
+            evaluation_error: None,
+        };
+        assert!(same_input_router_pass(&[event], 1));
+    }
+
+    #[test]
+    fn same_input_membership_same_but_order_different_fails_router_gate() {
+        let event = SameInputRouterEventEvidence {
+            location: EventLocation::new("case", 0, 0),
+            cpu_production_router_on_exact_gpu_input: Some(router_same_input(
+                &[1, 2, 3],
+                &[1, 3, 2],
+            )),
+            evaluation_error: None,
+        };
+        assert!(
+            event
+                .cpu_production_router_on_exact_gpu_input
+                .as_ref()
+                .unwrap()
+                .membership_equal
+        );
+        assert!(!same_input_router_pass(&[event], 1));
+    }
+
+    #[test]
+    fn same_input_membership_difference_fails_router_gate() {
+        let event = SameInputRouterEventEvidence {
+            location: EventLocation::new("case", 0, 0),
+            cpu_production_router_on_exact_gpu_input: Some(router_same_input(
+                &[1, 2, 3],
+                &[1, 2, 4],
+            )),
+            evaluation_error: None,
+        };
+        assert!(!same_input_router_pass(&[event], 1));
+    }
+
+    #[test]
+    fn cross_backend_membership_drift_is_not_an_independent_fail_gate() {
+        let mut counters = passing_routing_counters();
+        counters.exact_order_match_events -= 1;
+        counters.membership_mismatch_events = 1;
+        assert!(routing_structural_pass(
+            &counters,
+            HOLDOUT_CORPUS_CASE_COUNT * OUTPUT_TOKEN_LIMIT * 48
+        ));
+        let same_input = SameInputRouterEventEvidence {
+            location: EventLocation::new("case", 0, 0),
+            cpu_production_router_on_exact_gpu_input: Some(router_same_input(
+                &[1, 2, 3],
+                &[1, 2, 3],
+            )),
+            evaluation_error: None,
+        };
+        assert!(same_input_router_pass(&[same_input], 1));
+    }
+
+    #[test]
+    fn numerical_max_absolute_boundary_is_inclusive_and_excess_fails() {
+        assert!(numerical_event_within_limits(&numerical_with_metrics(
+            0.020, 0.0, 0.0, 0
+        )));
+        assert!(!numerical_event_within_limits(&numerical_with_metrics(
+            0.020_000_1,
+            0.0,
+            0.0,
+            0
+        )));
+    }
+
+    #[test]
+    fn numerical_rms_boundary_is_inclusive_and_excess_fails() {
+        assert!(numerical_event_within_limits(&numerical_with_metrics(
+            0.0, 0.001, 0.0, 0
+        )));
+        assert!(!numerical_event_within_limits(&numerical_with_metrics(
+            0.0,
+            0.001_000_1,
+            0.0,
+            0
+        )));
+    }
+
+    #[test]
+    fn numerical_mean_absolute_boundary_is_inclusive_and_excess_fails() {
+        assert!(numerical_event_within_limits(&numerical_with_metrics(
+            0.0, 0.0, 0.00075, 0
+        )));
+        assert!(!numerical_event_within_limits(&numerical_with_metrics(
+            0.0,
+            0.0,
+            0.000_750_1,
+            0
+        )));
+    }
+
+    #[test]
+    fn numerical_nonfinite_mismatch_fails() {
+        assert!(!numerical_event_within_limits(&numerical_with_metrics(
+            0.0, 0.0, 0.0, 1
+        )));
+    }
+
+    #[test]
+    fn deterministic_sampler_selects_first_exact_per_layer_and_all_anomalies() {
+        let mut sampler = DeterministicEventSampler::new(2);
+        assert!(
+            sampler
+                .select(0, RoutingClassification::ExactOrderMatch)
+                .selected
+        );
+        assert!(
+            !sampler
+                .select(0, RoutingClassification::ExactOrderMatch)
+                .selected
+        );
+        assert!(
+            sampler
+                .select(0, RoutingClassification::MembershipMismatch)
+                .selected
+        );
+        assert!(
+            sampler
+                .select(1, RoutingClassification::InternalRankPermutation)
+                .selected
+        );
+        assert!(
+            sampler
+                .select(1, RoutingClassification::ExactOrderMatch)
+                .selected
+        );
+        assert_eq!(sampler.layers_with_exact_sample(), vec![0, 1]);
+    }
+
+    #[test]
+    fn every_membership_drift_and_internal_permutation_must_be_measured() {
+        let routing = RoutingCounters {
+            total_routing_events: 5,
+            exact_order_match_events: 3,
+            internal_rank_permutation_events: 1,
+            membership_mismatch_events: 1,
+            ..RoutingCounters::default()
+        };
+        let mut sampling = SamplingSummary {
+            exact_order_events_total: 3,
+            exact_order_events_numerically_sampled: 3,
+            exact_order_sampling_rule: EXACT_ORDER_SAMPLING_RULE,
+            layers_with_exact_order_sample: vec![0, 1, 2],
+            layers_without_exact_order_sample: Vec::new(),
+            internal_permutation_events_numerically_measured: 1,
+            membership_mismatch_events_numerically_measured: 1,
+            maximum_exact_order_samples_for_model: 3,
+        };
+        let numerical = vec![
+            numerical_event(0, RoutingClassification::ExactOrderMatch),
+            numerical_event(1, RoutingClassification::ExactOrderMatch),
+            numerical_event(2, RoutingClassification::ExactOrderMatch),
+            numerical_event(0, RoutingClassification::InternalRankPermutation),
+            numerical_event(0, RoutingClassification::MembershipMismatch),
+        ];
+        let permutation = vec![PermutationNumericalEventEvidence {
+            location: EventLocation::new("case", 0, 0),
+            witness:
+                crate::gpu_native_expert_permutation_semantic_parity::permutation_only_witness(
+                    &[2, 1],
+                    &[0.5, 0.5],
+                    &[vec![1.0], vec![2.0]],
+                )
+                .unwrap(),
+        }];
+        assert!(numerical_sampling_complete(
+            &routing,
+            &sampling,
+            &numerical,
+            &permutation,
+            3
+        ));
+        sampling.membership_mismatch_events_numerically_measured = 0;
+        assert!(!numerical_sampling_complete(
+            &routing,
+            &sampling,
+            &numerical,
+            &permutation,
+            3
+        ));
+        sampling.membership_mismatch_events_numerically_measured = 1;
+        sampling.internal_permutation_events_numerically_measured = 0;
+        assert!(!numerical_sampling_complete(
+            &routing,
+            &sampling,
+            &numerical,
+            &permutation,
+            3
+        ));
+    }
+
+    #[test]
+    fn cpu_fallback_and_degraded_substitution_fail() {
+        let mut runtime = passing_runtime();
+        runtime
+            .gpu_native_routed_execution
+            .cpu_routed_expert_dispatches = 1;
+        assert!(!no_fallback_or_degradation_pass(&runtime));
+        runtime
+            .gpu_native_routed_execution
+            .cpu_routed_expert_dispatches = 0;
+        runtime
+            .gpu_native_routed_execution
+            .degraded_expert_substitutions = 1;
+        assert!(!no_fallback_or_degradation_pass(&runtime));
+    }
+
+    #[test]
+    fn residency_failure_or_incomplete_execution_fails() {
+        let mut runtime = passing_runtime();
+        assert!(residency_and_execution_completion_pass(&runtime));
+        runtime.gpu_token_loop.no_progress_failures = 1;
+        assert!(!residency_and_execution_completion_pass(&runtime));
+        runtime.gpu_token_loop.no_progress_failures = 0;
+        runtime.gpu_native_routed_execution.gpu_dispatch_failures = 1;
+        assert!(!residency_and_execution_completion_pass(&runtime));
+        runtime.gpu_native_routed_execution.gpu_dispatch_failures = 0;
+        runtime.gpu_token_loop.tokens_completed = 63;
+        assert!(!residency_and_execution_completion_pass(&runtime));
+    }
+
+    #[test]
+    fn both_controlled_shutdown_witnesses_are_required() {
+        let mut provenance = passing_provenance();
+        assert!(controlled_shutdown_pass(&provenance));
+        provenance
+            .reference_background_shutdown
+            .all_runtime_resources_released = false;
+        assert!(!controlled_shutdown_pass(&provenance));
+        provenance.reference_background_shutdown = released_shutdown();
+        provenance
+            .gpu_native_background_shutdown
+            .controlled_shutdown_requested = false;
+        assert!(!controlled_shutdown_pass(&provenance));
+    }
+
+    #[test]
+    fn qualification_pass_cannot_survive_any_failed_criterion() {
+        let gates = all_gates_pass();
+        assert!(gates.qualification_pass());
+        macro_rules! assert_field_fails {
+            ($field:ident) => {{
+                let mut failed = gates.clone();
+                failed.$field = false;
+                assert!(!failed.qualification_pass(), stringify!($field));
+            }};
+        }
+        assert_field_fails!(exact_provenance);
+        assert_field_fails!(frozen_holdout_corpus_identity);
+        assert_field_fails!(exact_model_geometry);
+        assert_field_fails!(strict_model_load);
+        assert_field_fails!(complete_exact_greedy_token_parity);
+        assert_field_fails!(routing_structural_validity);
+        assert_field_fails!(same_input_gpu_router_ordered_ids_exact);
+        assert_field_fails!(same_input_routed_moe_numerical_limits);
+        assert_field_fails!(deterministic_numerical_sampling_complete);
+        assert_field_fails!(no_fallback_or_degradation);
+        assert_field_fails!(residency_and_execution_completion);
+        assert_field_fails!(controlled_shutdown);
+        assert_field_fails!(observation_completeness);
+    }
+
+    #[test]
+    fn complete_report_can_pass_only_from_frozen_v2_evidence() {
+        let expected_events = HOLDOUT_CORPUS_CASE_COUNT * OUTPUT_TOKEN_LIMIT * 48;
+        let report = SemanticParityV2Report::new(
+            "NVIDIA L4".to_string(),
+            passing_provenance(),
+            passing_token_cases(),
+            (0..expected_events).map(routing_event).collect(),
+            passing_routing_counters(),
+            passing_sampling(),
+            (0..expected_events).map(same_input_router_event).collect(),
+            (0..48)
+                .map(|layer| numerical_event(layer, RoutingClassification::ExactOrderMatch))
+                .collect(),
+            Vec::new(),
+            passing_runtime(),
+            Vec::new(),
+        );
+        assert!(report.qualification_pass);
+        assert_eq!(report.status, QualificationStatus::Pass);
+        assert_eq!(report.schema, SCHEMA_VERSION);
+        assert_eq!(
+            report
+                .global_summary
+                .same_input_router
+                .same_input_router_events_total,
+            expected_events
+        );
+        assert_eq!(
+            report.global_summary.cross_backend_membership_drift_events,
+            0
+        );
+        assert!(report.failed_criteria.is_empty());
+        assert!(
+            !report
+                .production_semantics
+                .production_inference_math_changed
+        );
+        assert!(!report.production_semantics.production_shader_math_changed);
+        assert!(
+            !report
+                .production_semantics
+                .existing_v1_qualifier_semantics_changed
+        );
+    }
+}

--- a/rust-engine/src/gpu_native_spanish_first_token_attribution.rs
+++ b/rust-engine/src/gpu_native_spanish_first_token_attribution.rs
@@ -1,0 +1,3348 @@
+//! Diagnostic-only three-plane attribution of the frozen Spanish first-token
+//! divergence. This module consumes three immutable historical reports, then
+//! runs one caller-tokenized prompt through isolated exact-f32 CPU,
+//! historical-f16 CPU, and production GPU-native runtimes.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+use crate::gpu_native_expert_permutation_semantic_parity::VectorNumericalEvidence;
+use crate::gpu_native_router_rank_diagnostics::{
+    ActualGpuRouterEvidence, RouterEvaluationEvidence,
+};
+use crate::numerical_diagnostics::FloatEvidence;
+use crate::{IsolatedRuntimeShutdownError, RealCliRuntimeMode, ResolvedRealCliSpec};
+
+pub const SCHEMA_VERSION: &str = "mer.gpu-native-spanish-first-token-attribution.v1";
+pub const MODE: &str = "diagnose-gpu-native-spanish-first-token-attribution";
+pub const QUALIFICATION_PASS: bool = false;
+
+pub const FROZEN_V2_REPORT_SHA256: &str =
+    "9629de35a18f4457bbe38aeeaeb208fd979bb08e9d2eccb283437d6c16a5c4ad";
+pub const FROZEN_STAGE_REPORT_SHA256: &str =
+    "f81827b39d2ece62b9c1af432f71ca70045fe41c13e6e6ac15b03d460246365d";
+pub const FROZEN_BOUNDARY_AUDIT_REPORT_SHA256: &str =
+    "8bd568eb41510eae5541bd0829e939e4426cfdf04548677b026a28021c4cf3f1";
+pub const FROZEN_BOUNDARY_AUDIT_LOG_SHA256: &str =
+    "66bbcb9d3d6ad96de1251545b6fce32a556cf7734d52719854a74d462edea5b1";
+pub const FROZEN_BOUNDARY_AUDIT_SUMMARY_SHA256: &str =
+    "b88c6c1733185be6034b737355eb402e5c791376603b4b0d525eb66ac2008856";
+pub const FROZEN_V2_BUILD_SHA: &str = "300448ac3da48ac74ef86fcd2c62ffca27ffa634";
+pub const FROZEN_STAGE_BUILD_SHA: &str = "987e7e4b8791dc70f75b62a772e89ad9f1948ec5";
+pub const FROZEN_BOUNDARY_AUDIT_BUILD_SHA: &str = "7d54f6671c71a6c1686a5fccd70059e24314460d";
+
+pub const TARGET_CASE: &str = "spanish-refactor-holdout";
+pub const TARGET_GENERATED_POSITION: usize = 0;
+pub const HISTORICAL_F16_CPU_TOKEN: u32 = 54_275;
+pub const FROZEN_GPU_TOKEN: u32 = 54_275;
+pub const EXACT_F32_CPU_TOKEN: u32 = 140_003;
+pub const REQUIRED_ADAPTER_NAME: &str = "NVIDIA L4";
+
+const EXPECTED_NUM_LAYERS: usize = 48;
+const EXPECTED_NUM_EXPERTS: usize = 128;
+const EXPECTED_TOP_K: usize = 8;
+const EXPECTED_D_MODEL: usize = 2_048;
+const EXPECTED_D_FF: usize = 768;
+
+fn is_hex(value: &str, length: usize) -> bool {
+    value.len() == length && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct FrozenBuildEnvelope {
+    git_sha: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct FrozenProvenanceEnvelope {
+    build: FrozenBuildEnvelope,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct FrozenCorpusEnvelope {
+    id: String,
+    version: u32,
+    sha256: String,
+    case_count: usize,
+    output_token_limit: usize,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct FrozenTokenCaseEnvelope {
+    case: String,
+    reference_generated_token_ids: Vec<u32>,
+    gpu_generated_token_ids: Vec<u32>,
+    exact_match_count: usize,
+    mismatch_count: usize,
+    first_mismatch_position: Option<usize>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize)]
+struct FrozenNumericalLimitsEnvelope {
+    max_absolute_error_limit: f64,
+    rms_error_limit: f64,
+    mean_absolute_error_limit: f64,
+    nonfinite_mismatch_limit: usize,
+    semantic_correctness_not_bit_parity: bool,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct FrozenV2Envelope {
+    schema: String,
+    qualification_pass: bool,
+    provenance: FrozenProvenanceEnvelope,
+    holdout_corpus: FrozenCorpusEnvelope,
+    numerical_limits: FrozenNumericalLimitsEnvelope,
+    token_cases: Vec<FrozenTokenCaseEnvelope>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize)]
+struct FrozenStageTargetIdentity {
+    id: String,
+    case: String,
+    generated_position: usize,
+    layer: usize,
+    frozen_worst_local_expert: Option<u32>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct FrozenStageTargetEnvelope {
+    target: FrozenStageTargetIdentity,
+    experts: Vec<serde_json::Value>,
+    failure: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct FrozenStageEnvelope {
+    schema: String,
+    diagnostic_complete: bool,
+    qualification_pass: bool,
+    failure: Option<String>,
+    provenance: FrozenProvenanceEnvelope,
+    frozen_targets: Vec<FrozenStageTargetIdentity>,
+    targets: Vec<FrozenStageTargetEnvelope>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize)]
+struct FrozenImprovementEnvelope {
+    exact_f32_error_smaller_than_old_f16_error_maxabs: bool,
+    exact_f32_error_smaller_than_old_f16_error_rms: bool,
+    exact_f32_error_smaller_than_old_f16_error_meanabs: bool,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize)]
+struct FrozenBoundaryExpertEnvelope {
+    improvement: FrozenImprovementEnvelope,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize)]
+struct FrozenPartAAggregationEnvelope {
+    expert_record_count: usize,
+    exact_f32_smaller_than_old_f16_maxabs_count: usize,
+    exact_f32_smaller_than_old_f16_rms_count: usize,
+    exact_f32_smaller_than_old_f16_meanabs_count: usize,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct FrozenCpuTokenCaseEnvelope {
+    case: String,
+    requested_tokens: usize,
+    completed_tokens: usize,
+    exact_token_matches: usize,
+    mismatch_count: usize,
+    first_mismatch_position: Option<usize>,
+    corrected_ordinary_f32_cpu_token_ids: Vec<u32>,
+    frozen_gpu_token_ids: Vec<u32>,
+    historical_old_boundary_cpu_reference_token_ids: Vec<u32>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize)]
+struct FrozenRustPositionOneEnvelope {
+    historical_old_cpu_token_id: u32,
+    frozen_gpu_token_id: u32,
+    new_ordinary_f32_cpu_token_id: u32,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize)]
+struct FrozenPartBEnvelope {
+    requested_tokens: usize,
+    completed_tokens: usize,
+    exact_token_matches: usize,
+    mismatch_count: usize,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct FrozenArtifactEnvelope {
+    sha256: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct FrozenBoundaryInputsEnvelope {
+    v2_report: FrozenArtifactEnvelope,
+    stage_report: FrozenArtifactEnvelope,
+    exact_expert_identity_count: usize,
+    immutable_inputs_verified_before_runtime: bool,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize)]
+struct FrozenProductionSemanticsEnvelope {
+    diagnostic_only: bool,
+    production_inference_changed: bool,
+    production_q4_changed: bool,
+    production_q4_wgsl_changed: bool,
+    production_router_changed: bool,
+    production_attention_changed: bool,
+    v1_changed: bool,
+    v2_changed: bool,
+    v2_limits_changed: bool,
+    v2_corpus_or_prompts_changed: bool,
+    production_correction_made_or_justified: bool,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct FrozenBoundaryEnvelope {
+    schema: String,
+    diagnostic_only: bool,
+    diagnostic_complete: bool,
+    qualification_pass: bool,
+    failure: Option<String>,
+    provenance: FrozenProvenanceEnvelope,
+    frozen_inputs: FrozenBoundaryInputsEnvelope,
+    expert_records: Vec<FrozenBoundaryExpertEnvelope>,
+    part_a_aggregation: FrozenPartAAggregationEnvelope,
+    corrected_cpu_token_cases: Vec<FrozenCpuTokenCaseEnvelope>,
+    rust_ownership_position_one: FrozenRustPositionOneEnvelope,
+    part_b_token_summary: FrozenPartBEnvelope,
+    production_semantics: FrozenProductionSemanticsEnvelope,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct FrozenSpanishTargetIdentity {
+    pub case: &'static str,
+    pub generated_position: usize,
+    pub historical_f16_boundary_cpu_token: u32,
+    pub frozen_gpu_token: u32,
+    pub corrected_exact_f32_cpu_token: u32,
+    pub later_generated_positions_in_scope: bool,
+}
+
+impl Default for FrozenSpanishTargetIdentity {
+    fn default() -> Self {
+        Self {
+            case: TARGET_CASE,
+            generated_position: TARGET_GENERATED_POSITION,
+            historical_f16_boundary_cpu_token: HISTORICAL_F16_CPU_TOKEN,
+            frozen_gpu_token: FROZEN_GPU_TOKEN,
+            corrected_exact_f32_cpu_token: EXACT_F32_CPU_TOKEN,
+            later_generated_positions_in_scope: false,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct FrozenEvidencePreflight {
+    pub v2_report: crate::qualification::ArtifactDigest,
+    pub expected_v2_report_sha256_argument: String,
+    pub stage_report: crate::qualification::ArtifactDigest,
+    pub expected_stage_report_sha256_argument: String,
+    pub boundary_audit_report: crate::qualification::ArtifactDigest,
+    pub expected_boundary_audit_report_sha256_argument: String,
+    pub boundary_audit_log_sha256: &'static str,
+    pub boundary_audit_summary_sha256: &'static str,
+    pub reports_read_once: bool,
+    pub hash_and_deserialization_used_same_snapshots: bool,
+    pub verified_before_runtime_construction: bool,
+    pub exact_72_of_72_improvement_all_three_metrics: bool,
+    pub rust_corrected_position_one_is_8822: bool,
+    pub rust_corrected_stream_matches_gpu_16_of_16: bool,
+    pub spanish_corrected_stream_mismatch_count: usize,
+    pub spanish_first_mismatch_position: usize,
+}
+
+struct FrozenInputs {
+    identity: FrozenEvidencePreflight,
+}
+
+fn validate_expected_sha(value: &str, frozen: &str, label: &str) -> Result<(), String> {
+    if !is_hex(value, 64) || !value.eq_ignore_ascii_case(frozen) {
+        return Err(format!("{label} expected SHA must equal frozen {frozen}"));
+    }
+    Ok(())
+}
+
+fn artifact_from_snapshot(
+    path: &Path,
+    bytes: &[u8],
+) -> Result<crate::qualification::ArtifactDigest, Box<dyn std::error::Error>> {
+    Ok(crate::qualification::ArtifactDigest {
+        configured_path: path.display().to_string(),
+        canonical_path: std::fs::canonicalize(path)?.display().to_string(),
+        byte_length: u64::try_from(bytes.len()).map_err(|_| "report byte length overflow")?,
+        sha256: crate::greedy_parity::sha256_hex(bytes),
+    })
+}
+
+fn validate_artifact_hash(
+    artifact: &crate::qualification::ArtifactDigest,
+    argument: &str,
+    frozen: &str,
+    label: &str,
+) -> Result<(), String> {
+    if !artifact.sha256.eq_ignore_ascii_case(argument)
+        || !artifact.sha256.eq_ignore_ascii_case(frozen)
+    {
+        return Err(format!(
+            "frozen {label} SHA differs: observed {} expected {frozen}",
+            artifact.sha256
+        ));
+    }
+    Ok(())
+}
+
+fn validate_v2(envelope: &FrozenV2Envelope) -> Result<(), String> {
+    use crate::gpu_native_semantic_parity_v2 as v2;
+    if envelope.schema != v2::SCHEMA_VERSION
+        || envelope.qualification_pass
+        || envelope.provenance.build.git_sha.as_deref() != Some(FROZEN_V2_BUILD_SHA)
+    {
+        return Err("frozen v2 schema/build/qualification identity differs".into());
+    }
+    let corpus = &envelope.holdout_corpus;
+    if corpus.id != v2::HOLDOUT_CORPUS_ID
+        || corpus.version != v2::HOLDOUT_CORPUS_VERSION
+        || corpus.sha256 != v2::HOLDOUT_CORPUS_SHA256
+        || corpus.case_count != v2::HOLDOUT_CORPUS_CASE_COUNT
+        || corpus.output_token_limit != v2::OUTPUT_TOKEN_LIMIT
+        || envelope.token_cases.len() != v2::HOLDOUT_CORPUS_CASE_COUNT
+    {
+        return Err("frozen v2 corpus identity differs".into());
+    }
+    let limits = envelope.numerical_limits;
+    if limits.max_absolute_error_limit.to_bits() != v2::MAX_ABSOLUTE_ERROR_LIMIT.to_bits()
+        || limits.rms_error_limit.to_bits() != v2::RMS_ERROR_LIMIT.to_bits()
+        || limits.mean_absolute_error_limit.to_bits() != v2::MEAN_ABSOLUTE_ERROR_LIMIT.to_bits()
+        || limits.nonfinite_mismatch_limit != v2::NONFINITE_MISMATCH_LIMIT
+        || !limits.semantic_correctness_not_bit_parity
+    {
+        return Err("frozen v2 numerical limits differ".into());
+    }
+    for (observed, expected) in envelope.token_cases.iter().zip(v2::HOLDOUT_CORPUS) {
+        if observed.case != expected.name
+            || observed.reference_generated_token_ids.len() != v2::OUTPUT_TOKEN_LIMIT
+            || observed.gpu_generated_token_ids.len() != v2::OUTPUT_TOKEN_LIMIT
+        {
+            return Err(format!("frozen v2 case {} is incomplete", expected.name));
+        }
+        let recomputed = crate::gpu_native_semantic_parity_corpus::TokenCaseEvidence::new(
+            observed.case.clone(),
+            observed.reference_generated_token_ids.clone(),
+            observed.gpu_generated_token_ids.clone(),
+        );
+        if observed.exact_match_count != recomputed.exact_match_count
+            || observed.mismatch_count != recomputed.mismatch_count
+            || observed.first_mismatch_position != recomputed.first_mismatch_position
+        {
+            return Err(format!(
+                "frozen v2 comparison drifted for {}",
+                expected.name
+            ));
+        }
+    }
+    let spanish = envelope
+        .token_cases
+        .iter()
+        .find(|case| case.case == TARGET_CASE)
+        .ok_or("frozen v2 Spanish case is missing")?;
+    if spanish.reference_generated_token_ids.first() != Some(&HISTORICAL_F16_CPU_TOKEN)
+        || spanish.gpu_generated_token_ids.first() != Some(&FROZEN_GPU_TOKEN)
+    {
+        return Err("frozen v2 Spanish first-token identity differs".into());
+    }
+    Ok(())
+}
+
+fn expected_stage_targets() -> Vec<FrozenStageTargetIdentity> {
+    crate::gpu_native_q4_expert_stage_attribution::FROZEN_TARGETS
+        .into_iter()
+        .map(|target| FrozenStageTargetIdentity {
+            id: target.id.to_string(),
+            case: target.case.to_string(),
+            generated_position: target.generated_position,
+            layer: target.layer,
+            frozen_worst_local_expert: target.frozen_worst_local_expert,
+        })
+        .collect()
+}
+
+fn validate_stage(envelope: &FrozenStageEnvelope) -> Result<(), String> {
+    let expected = expected_stage_targets();
+    if envelope.schema != crate::gpu_native_q4_expert_stage_attribution::SCHEMA_VERSION
+        || !envelope.diagnostic_complete
+        || envelope.qualification_pass
+        || envelope.failure.is_some()
+        || envelope.provenance.build.git_sha.as_deref() != Some(FROZEN_STAGE_BUILD_SHA)
+        || envelope.frozen_targets != expected
+        || envelope.targets.len() != expected.len()
+    {
+        return Err("frozen stage report top-level identity differs".into());
+    }
+    let mut records = 0usize;
+    for (observed, expected) in envelope.targets.iter().zip(expected) {
+        if observed.target != expected || observed.failure.is_some() || observed.experts.len() != 8
+        {
+            return Err(format!("frozen stage target {} differs", expected.id));
+        }
+        records += observed.experts.len();
+    }
+    if records != 72 {
+        return Err("frozen stage report does not contain exactly 72 expert records".into());
+    }
+    Ok(())
+}
+
+fn validate_boundary(envelope: &FrozenBoundaryEnvelope) -> Result<(), String> {
+    if envelope.schema != crate::gpu_native_f32_reference_boundary_audit::SCHEMA_VERSION
+        || !envelope.diagnostic_only
+        || !envelope.diagnostic_complete
+        || envelope.qualification_pass
+        || envelope.failure.is_some()
+        || envelope.provenance.build.git_sha.as_deref() != Some(FROZEN_BOUNDARY_AUDIT_BUILD_SHA)
+    {
+        return Err("frozen boundary-audit top-level identity differs".into());
+    }
+    if !envelope
+        .frozen_inputs
+        .v2_report
+        .sha256
+        .eq_ignore_ascii_case(FROZEN_V2_REPORT_SHA256)
+        || !envelope
+            .frozen_inputs
+            .stage_report
+            .sha256
+            .eq_ignore_ascii_case(FROZEN_STAGE_REPORT_SHA256)
+        || envelope.frozen_inputs.exact_expert_identity_count != 72
+        || !envelope
+            .frozen_inputs
+            .immutable_inputs_verified_before_runtime
+    {
+        return Err("frozen boundary-audit input identity differs".into());
+    }
+    let aggregation = envelope.part_a_aggregation;
+    if envelope.expert_records.len() != 72
+        || aggregation.expert_record_count != 72
+        || aggregation.exact_f32_smaller_than_old_f16_maxabs_count != 72
+        || aggregation.exact_f32_smaller_than_old_f16_rms_count != 72
+        || aggregation.exact_f32_smaller_than_old_f16_meanabs_count != 72
+        || envelope.expert_records.iter().any(|record| {
+            !record
+                .improvement
+                .exact_f32_error_smaller_than_old_f16_error_maxabs
+                || !record
+                    .improvement
+                    .exact_f32_error_smaller_than_old_f16_error_rms
+                || !record
+                    .improvement
+                    .exact_f32_error_smaller_than_old_f16_error_meanabs
+        })
+    {
+        return Err("frozen boundary-audit 72/72 improvement identity differs".into());
+    }
+    if envelope.corrected_cpu_token_cases.len() != 4 {
+        return Err("frozen boundary-audit token-case count differs".into());
+    }
+    for (case, expected) in envelope
+        .corrected_cpu_token_cases
+        .iter()
+        .zip(crate::gpu_native_semantic_parity_v2::HOLDOUT_CORPUS)
+    {
+        if case.case != expected.name {
+            return Err("frozen boundary-audit token-case order/identity differs".into());
+        }
+        if case.requested_tokens != 16
+            || case.completed_tokens != 16
+            || case.corrected_ordinary_f32_cpu_token_ids.len() != 16
+            || case.frozen_gpu_token_ids.len() != 16
+            || case.historical_old_boundary_cpu_reference_token_ids.len() != 16
+        {
+            return Err(format!(
+                "frozen boundary-audit case {} is incomplete",
+                case.case
+            ));
+        }
+        let expected_exact = usize::from(case.case != TARGET_CASE) * 16;
+        let expected_mismatch = usize::from(case.case == TARGET_CASE) * 16;
+        let recomputed_exact = case
+            .corrected_ordinary_f32_cpu_token_ids
+            .iter()
+            .zip(&case.frozen_gpu_token_ids)
+            .filter(|(cpu, gpu)| cpu == gpu)
+            .count();
+        let recomputed_first_mismatch = case
+            .corrected_ordinary_f32_cpu_token_ids
+            .iter()
+            .zip(&case.frozen_gpu_token_ids)
+            .position(|(cpu, gpu)| cpu != gpu);
+        if case.exact_token_matches != expected_exact
+            || case.mismatch_count != expected_mismatch
+            || case.exact_token_matches != recomputed_exact
+            || case.mismatch_count != 16 - recomputed_exact
+            || case.first_mismatch_position != recomputed_first_mismatch
+        {
+            return Err(format!(
+                "frozen boundary-audit case {} counts differ",
+                case.case
+            ));
+        }
+    }
+    let spanish = envelope
+        .corrected_cpu_token_cases
+        .iter()
+        .find(|case| case.case == TARGET_CASE)
+        .ok_or("frozen boundary-audit Spanish case is missing")?;
+    if spanish.first_mismatch_position != Some(0)
+        || spanish.corrected_ordinary_f32_cpu_token_ids.first() != Some(&EXACT_F32_CPU_TOKEN)
+        || spanish.frozen_gpu_token_ids.first() != Some(&FROZEN_GPU_TOKEN)
+        || spanish
+            .historical_old_boundary_cpu_reference_token_ids
+            .first()
+            != Some(&HISTORICAL_F16_CPU_TOKEN)
+    {
+        return Err("frozen boundary-audit Spanish target differs".into());
+    }
+    let rust = envelope
+        .corrected_cpu_token_cases
+        .iter()
+        .find(|case| case.case == "rust-ownership-holdout")
+        .ok_or("frozen boundary-audit Rust case is missing")?;
+    if rust.corrected_ordinary_f32_cpu_token_ids != rust.frozen_gpu_token_ids
+        || rust.corrected_ordinary_f32_cpu_token_ids.get(1) != Some(&8_822)
+        || envelope
+            .rust_ownership_position_one
+            .historical_old_cpu_token_id
+            != 785
+        || envelope.rust_ownership_position_one.frozen_gpu_token_id != 8_822
+        || envelope
+            .rust_ownership_position_one
+            .new_ordinary_f32_cpu_token_id
+            != 8_822
+        || envelope.part_b_token_summary.requested_tokens != 64
+        || envelope.part_b_token_summary.completed_tokens != 64
+        || envelope.part_b_token_summary.exact_token_matches != 48
+        || envelope.part_b_token_summary.mismatch_count != 16
+    {
+        return Err("frozen boundary-audit corrected Rust/summary identity differs".into());
+    }
+    let semantics = envelope.production_semantics;
+    if !semantics.diagnostic_only
+        || semantics.production_inference_changed
+        || semantics.production_q4_changed
+        || semantics.production_q4_wgsl_changed
+        || semantics.production_router_changed
+        || semantics.production_attention_changed
+        || semantics.v1_changed
+        || semantics.v2_changed
+        || semantics.v2_limits_changed
+        || semantics.v2_corpus_or_prompts_changed
+        || semantics.production_correction_made_or_justified
+    {
+        return Err("frozen boundary-audit production-semantics identity differs".into());
+    }
+    Ok(())
+}
+
+impl FrozenInputs {
+    #[allow(clippy::too_many_arguments)]
+    fn read_and_validate(
+        v2_path: &Path,
+        expected_v2: &str,
+        stage_path: &Path,
+        expected_stage: &str,
+        boundary_path: &Path,
+        expected_boundary: &str,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        validate_expected_sha(expected_v2, FROZEN_V2_REPORT_SHA256, "v2 report")?;
+        validate_expected_sha(expected_stage, FROZEN_STAGE_REPORT_SHA256, "stage report")?;
+        validate_expected_sha(
+            expected_boundary,
+            FROZEN_BOUNDARY_AUDIT_REPORT_SHA256,
+            "boundary-audit report",
+        )?;
+
+        // Each supplied report is read exactly once. Hashing and typed
+        // deserialization both consume these same immutable byte snapshots.
+        let v2_bytes = std::fs::read(v2_path)?;
+        let stage_bytes = std::fs::read(stage_path)?;
+        let boundary_bytes = std::fs::read(boundary_path)?;
+        let v2_artifact = artifact_from_snapshot(v2_path, &v2_bytes)?;
+        let stage_artifact = artifact_from_snapshot(stage_path, &stage_bytes)?;
+        let boundary_artifact = artifact_from_snapshot(boundary_path, &boundary_bytes)?;
+        validate_artifact_hash(
+            &v2_artifact,
+            expected_v2,
+            FROZEN_V2_REPORT_SHA256,
+            "v2 report",
+        )?;
+        validate_artifact_hash(
+            &stage_artifact,
+            expected_stage,
+            FROZEN_STAGE_REPORT_SHA256,
+            "stage report",
+        )?;
+        validate_artifact_hash(
+            &boundary_artifact,
+            expected_boundary,
+            FROZEN_BOUNDARY_AUDIT_REPORT_SHA256,
+            "boundary-audit report",
+        )?;
+        let v2: FrozenV2Envelope = serde_json::from_slice(&v2_bytes)
+            .map_err(|error| format!("malformed frozen v2 report: {error}"))?;
+        let stage: FrozenStageEnvelope = serde_json::from_slice(&stage_bytes)
+            .map_err(|error| format!("malformed frozen stage report: {error}"))?;
+        let boundary: FrozenBoundaryEnvelope = serde_json::from_slice(&boundary_bytes)
+            .map_err(|error| format!("malformed frozen boundary-audit report: {error}"))?;
+        validate_v2(&v2)?;
+        validate_stage(&stage)?;
+        validate_boundary(&boundary)?;
+        Ok(Self {
+            identity: FrozenEvidencePreflight {
+                v2_report: v2_artifact,
+                expected_v2_report_sha256_argument: expected_v2.to_ascii_lowercase(),
+                stage_report: stage_artifact,
+                expected_stage_report_sha256_argument: expected_stage.to_ascii_lowercase(),
+                boundary_audit_report: boundary_artifact,
+                expected_boundary_audit_report_sha256_argument: expected_boundary
+                    .to_ascii_lowercase(),
+                boundary_audit_log_sha256: FROZEN_BOUNDARY_AUDIT_LOG_SHA256,
+                boundary_audit_summary_sha256: FROZEN_BOUNDARY_AUDIT_SUMMARY_SHA256,
+                reports_read_once: true,
+                hash_and_deserialization_used_same_snapshots: true,
+                verified_before_runtime_construction: true,
+                exact_72_of_72_improvement_all_three_metrics: true,
+                rust_corrected_position_one_is_8822: true,
+                rust_corrected_stream_matches_gpu_16_of_16: true,
+                spanish_corrected_stream_mismatch_count: 16,
+                spanish_first_mismatch_position: 0,
+            },
+        })
+    }
+}
+
+fn canonical_output_path(path: &Path) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    if path.exists() {
+        return Ok(std::fs::canonicalize(path)?);
+    }
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()?.join(path)
+    };
+    let mut existing = absolute.as_path();
+    let mut missing = Vec::new();
+    while !existing.exists() {
+        missing.push(
+            existing
+                .file_name()
+                .ok_or("report output path has no existing ancestor")?
+                .to_os_string(),
+        );
+        existing = existing
+            .parent()
+            .ok_or("report output path has no existing ancestor")?;
+    }
+    let mut canonical = std::fs::canonicalize(existing)?;
+    for component in missing.into_iter().rev() {
+        canonical.push(component);
+    }
+    Ok(canonical)
+}
+
+fn output_conflicts_with_input(
+    report_out: &Path,
+    frozen: &FrozenEvidencePreflight,
+) -> Result<bool, Box<dyn std::error::Error>> {
+    let output = canonical_output_path(report_out)?;
+    Ok([
+        &frozen.v2_report.canonical_path,
+        &frozen.stage_report.canonical_path,
+        &frozen.boundary_audit_report.canonical_path,
+    ]
+    .into_iter()
+    .any(|input| output == PathBuf::from(input)))
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct SharedTokenizationEvidence {
+    pub case: &'static str,
+    pub prompt_sha256: String,
+    pub prompt_token_ids: Vec<u32>,
+    pub prompt_token_ids_sha256: String,
+    pub tokenized_exactly_once: bool,
+    pub caller_owned_tokenization_shared_by_all_planes: bool,
+    pub per_plane_retokenization_performed: bool,
+}
+
+fn shared_tokenization(
+    tokenizer: &crate::tokenizer::Tokenizer,
+) -> Result<(Arc<Vec<u32>>, SharedTokenizationEvidence), Box<dyn std::error::Error>> {
+    let fixed = crate::gpu_native_semantic_parity_v2::HOLDOUT_CORPUS
+        .into_iter()
+        .find(|case| case.name == TARGET_CASE)
+        .ok_or("frozen Spanish holdout prompt is missing")?;
+    let ids = Arc::new(tokenizer.encode(fixed.prompt)?);
+    if ids.is_empty() {
+        return Err("frozen Spanish prompt encoded to zero tokens".into());
+    }
+    let evidence = SharedTokenizationEvidence {
+        case: TARGET_CASE,
+        prompt_sha256: crate::greedy_parity::sha256_hex(fixed.prompt.as_bytes()),
+        prompt_token_ids: ids.as_ref().clone(),
+        prompt_token_ids_sha256: crate::greedy_parity::token_ids_sha256(&ids),
+        tokenized_exactly_once: true,
+        caller_owned_tokenization_shared_by_all_planes: true,
+        per_plane_retokenization_performed: false,
+    };
+    Ok((ids, evidence))
+}
+
+fn shared_plane_token_ids(token_ids: &Arc<Vec<u32>>) -> [Arc<Vec<u32>>; 3] {
+    [token_ids.clone(), token_ids.clone(), token_ids.clone()]
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ExactVectorTraceEvidence {
+    pub source: String,
+    pub vector_length: usize,
+    pub f32_bits_sha256: String,
+    pub f32_bits: Vec<u32>,
+    pub nonfinite_count: usize,
+}
+
+impl ExactVectorTraceEvidence {
+    fn new(source: impl Into<String>, values: &[f32], retain_bits: bool) -> Self {
+        let bits = values
+            .iter()
+            .map(|value| value.to_bits())
+            .collect::<Vec<_>>();
+        Self {
+            source: source.into(),
+            vector_length: values.len(),
+            f32_bits_sha256: crate::numerical_diagnostics::f32_bits_sha256(&bits),
+            f32_bits: retain_bits.then_some(bits).unwrap_or_default(),
+            nonfinite_count: values.iter().filter(|value| !value.is_finite()).count(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct FullTraceLayerEvidence {
+    pub layer: usize,
+    pub pre_attention_residual: ExactVectorTraceEvidence,
+    pub post_attention: ExactVectorTraceEvidence,
+    pub router_input: ExactVectorTraceEvidence,
+    pub selected_expert_ids: Vec<u32>,
+    pub selected_weights: ExactVectorTraceEvidence,
+    pub routed_moe_output: ExactVectorTraceEvidence,
+    pub post_moe_residual: ExactVectorTraceEvidence,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct PlaneFullTraceEvidence {
+    pub plane: &'static str,
+    pub embedding: ExactVectorTraceEvidence,
+    pub layers: Vec<FullTraceLayerEvidence>,
+    pub final_hidden: ExactVectorTraceEvidence,
+    pub final_rmsnorm: ExactVectorTraceEvidence,
+    pub full_lm_head_logits: ExactVectorTraceEvidence,
+    pub greedy_argmax: u32,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct ThreeWayVectorComparison {
+    pub exact_f32_cpu_vs_gpu: VectorNumericalEvidence,
+    pub historical_f16_cpu_vs_gpu: VectorNumericalEvidence,
+    pub exact_f32_cpu_vs_historical_f16_cpu: VectorNumericalEvidence,
+}
+
+fn three_way_compare(
+    _label: &str,
+    exact: &[f32],
+    historical: &[f32],
+    gpu: &[f32],
+) -> Result<ThreeWayVectorComparison, String> {
+    let exact_source = "EXACT_F32_CPU";
+    let historical_source = "HISTORICAL_F16_CPU";
+    let gpu_source = "GPU_NATIVE";
+    Ok(ThreeWayVectorComparison {
+        exact_f32_cpu_vs_gpu: VectorNumericalEvidence::compare(
+            exact_source,
+            gpu_source,
+            exact,
+            gpu,
+        )?,
+        historical_f16_cpu_vs_gpu: VectorNumericalEvidence::compare(
+            historical_source,
+            gpu_source,
+            historical,
+            gpu,
+        )?,
+        exact_f32_cpu_vs_historical_f16_cpu: VectorNumericalEvidence::compare(
+            exact_source,
+            historical_source,
+            exact,
+            historical,
+        )?,
+    })
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct PrefillPositionSummary {
+    pub position: usize,
+    pub token_id: u32,
+    pub final_hidden: ThreeWayVectorComparison,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ThreeWaySelectedIds {
+    pub exact_f32_cpu: Vec<u32>,
+    pub historical_f16_cpu: Vec<u32>,
+    pub gpu_native: Vec<u32>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct ThreeWayLayerTraceComparison {
+    pub layer: usize,
+    pub pre_attention_residual: ThreeWayVectorComparison,
+    pub post_attention: ThreeWayVectorComparison,
+    pub router_input: ThreeWayVectorComparison,
+    pub selected_ids: ThreeWaySelectedIds,
+    pub selected_weights: ThreeWayVectorComparison,
+    pub routed_moe_output: ThreeWayVectorComparison,
+    pub post_moe_residual: ThreeWayVectorComparison,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct FinalPositionTraceComparison {
+    pub embedding: ThreeWayVectorComparison,
+    pub layers: Vec<ThreeWayLayerTraceComparison>,
+    pub final_hidden: ThreeWayVectorComparison,
+    pub final_rmsnorm: ThreeWayVectorComparison,
+    pub full_lm_head_logits: ThreeWayVectorComparison,
+    pub greedy_argmax_exact_f32_cpu: u32,
+    pub greedy_argmax_historical_f16_cpu: u32,
+    pub greedy_argmax_gpu_native: u32,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum DistanceRelation {
+    HistoricalF16Closer,
+    ExactF32Closer,
+    Equal,
+    Unavailable,
+}
+
+fn distance_relation(historical: Option<f64>, exact: Option<f64>) -> DistanceRelation {
+    match historical.zip(exact) {
+        Some((historical, exact)) if historical.is_finite() && exact.is_finite() => {
+            match historical.total_cmp(&exact) {
+                std::cmp::Ordering::Less => DistanceRelation::HistoricalF16Closer,
+                std::cmp::Ordering::Greater => DistanceRelation::ExactF32Closer,
+                std::cmp::Ordering::Equal => DistanceRelation::Equal,
+            }
+        }
+        _ => DistanceRelation::Unavailable,
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct CompensationStageEvidence {
+    pub stage: String,
+    pub maxabs: DistanceRelation,
+    pub rms: DistanceRelation,
+    pub meanabs: DistanceRelation,
+}
+
+impl CompensationStageEvidence {
+    fn from_comparison(stage: impl Into<String>, comparison: &ThreeWayVectorComparison) -> Self {
+        Self {
+            stage: stage.into(),
+            maxabs: distance_relation(
+                comparison.historical_f16_cpu_vs_gpu.max_absolute_error,
+                comparison.exact_f32_cpu_vs_gpu.max_absolute_error,
+            ),
+            rms: distance_relation(
+                comparison.historical_f16_cpu_vs_gpu.rms_error,
+                comparison.exact_f32_cpu_vs_gpu.rms_error,
+            ),
+            meanabs: distance_relation(
+                comparison.historical_f16_cpu_vs_gpu.mean_absolute_error,
+                comparison.exact_f32_cpu_vs_gpu.mean_absolute_error,
+            ),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct HistoricalF16CompensationAnalysis {
+    pub descriptive_only: bool,
+    pub numerical_threshold_used: bool,
+    pub historical_f16_is_correct_reference_claimed: bool,
+    pub stages: Vec<CompensationStageEvidence>,
+    pub first_stage_historical_f16_closer_maxabs: Option<String>,
+    pub first_stage_historical_f16_farther_maxabs: Option<String>,
+}
+
+fn compensation_analysis(
+    trace: &FinalPositionTraceComparison,
+) -> HistoricalF16CompensationAnalysis {
+    let mut stages = vec![CompensationStageEvidence::from_comparison(
+        "embedding",
+        &trace.embedding,
+    )];
+    for layer in &trace.layers {
+        stages.push(CompensationStageEvidence::from_comparison(
+            format!("layer-{}-pre-attention-residual", layer.layer),
+            &layer.pre_attention_residual,
+        ));
+        stages.push(CompensationStageEvidence::from_comparison(
+            format!("layer-{}-post-attention", layer.layer),
+            &layer.post_attention,
+        ));
+        stages.push(CompensationStageEvidence::from_comparison(
+            format!("layer-{}-router-input", layer.layer),
+            &layer.router_input,
+        ));
+        stages.push(CompensationStageEvidence::from_comparison(
+            format!("layer-{}-selected-weights", layer.layer),
+            &layer.selected_weights,
+        ));
+        stages.push(CompensationStageEvidence::from_comparison(
+            format!("layer-{}-routed-moe", layer.layer),
+            &layer.routed_moe_output,
+        ));
+        stages.push(CompensationStageEvidence::from_comparison(
+            format!("layer-{}-post-moe", layer.layer),
+            &layer.post_moe_residual,
+        ));
+    }
+    stages.push(CompensationStageEvidence::from_comparison(
+        "final-hidden",
+        &trace.final_hidden,
+    ));
+    stages.push(CompensationStageEvidence::from_comparison(
+        "final-rmsnorm",
+        &trace.final_rmsnorm,
+    ));
+    stages.push(CompensationStageEvidence::from_comparison(
+        "lm-head-logits",
+        &trace.full_lm_head_logits,
+    ));
+    let first_stage_historical_f16_closer_maxabs = stages
+        .iter()
+        .find(|stage| stage.maxabs == DistanceRelation::HistoricalF16Closer)
+        .map(|stage| stage.stage.clone());
+    let first_stage_historical_f16_farther_maxabs = stages
+        .iter()
+        .find(|stage| stage.maxabs == DistanceRelation::ExactF32Closer)
+        .map(|stage| stage.stage.clone());
+    HistoricalF16CompensationAnalysis {
+        descriptive_only: true,
+        numerical_threshold_used: false,
+        historical_f16_is_correct_reference_claimed: false,
+        stages,
+        first_stage_historical_f16_closer_maxabs,
+        first_stage_historical_f16_farther_maxabs,
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SameInputRouterStage {
+    ExactOrderedMatch,
+    GpuRouterGemvDrift,
+    GpuRouterSoftmaxTopkDrift,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct RouterLayerAttributionEvidence {
+    pub layer: usize,
+    pub three_plane_selected_ids: ThreeWaySelectedIds,
+    pub exact_f32_cpu_selected_weights: ExactVectorTraceEvidence,
+    pub historical_f16_cpu_selected_weights: ExactVectorTraceEvidence,
+    pub gpu_native_selected_weights: ExactVectorTraceEvidence,
+    pub cpu_production_router_on_exact_gpu_input: RouterEvaluationEvidence,
+    pub actual_gpu_production_router: ActualGpuRouterEvidence,
+    pub same_input_cpu_vs_gpu_raw_logits: VectorNumericalEvidence,
+    pub same_input_ordered_ids_equal: bool,
+    pub same_input_stage: SameInputRouterStage,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct RouterAttributionEvidence {
+    pub layers: Vec<RouterLayerAttributionEvidence>,
+    pub first_same_input_ordered_id_mismatch_layer: Option<usize>,
+    pub known_postgres_defect_preserved_as_separate: bool,
+    pub known_postgres_defect: &'static str,
+}
+
+fn router_layer_evidence(
+    layer: usize,
+    exact_trace: &crate::gpu_native_diagnostics::ModelDiagnosticTrace,
+    historical_trace: &crate::gpu_native_diagnostics::ModelDiagnosticTrace,
+    gpu_trace: &crate::gpu_native_diagnostics::GpuNativeDiagnosticTrace,
+    gpu_semantic: &crate::gpu_native_semantic_parity_corpus::SemanticCorpusGpuTrace,
+    gate: &crate::gating::LinearGate,
+) -> Result<RouterLayerAttributionEvidence, String> {
+    let semantic = gpu_semantic
+        .layers
+        .get(layer)
+        .ok_or("GPU semantic router layer is missing")?;
+    if gpu_trace.layer_router_input.get(layer) != Some(&semantic.router_input)
+        || gpu_trace.layer_selected_ids.get(layer) != Some(&semantic.selected_ids)
+        || gpu_trace.layer_selected_weights.get(layer) != Some(&semantic.selected_weights)
+    {
+        return Err(format!(
+            "GPU full and semantic traces disagree at router layer {layer}"
+        ));
+    }
+    let cpu = crate::gpu_native_router_rank_diagnostics::evaluate_cpu_router(
+        "cpu-production-router-on-exact-gpu-router-input",
+        gate,
+        &semantic.router_input,
+    )?;
+    let actual = crate::gpu_native_router_rank_diagnostics::evaluate_actual_gpu_router(
+        semantic.raw_logits.clone(),
+        semantic.selected_ids.clone(),
+        semantic.selected_weights.clone(),
+    )?;
+    let cpu_raw = cpu
+        .raw_logits
+        .iter()
+        .map(|value| f32::from_bits(value.bits))
+        .collect::<Vec<_>>();
+    let same_input_ordered_ids_equal = cpu.top_8_ids == actual.top_8_ids;
+    let same_input_stage = derive_same_input_router_stage(
+        &cpu.top_8_ids,
+        &actual.cpu_top_8_ids_derived_from_exact_gpu_raw_logits,
+        &actual.top_8_ids,
+    );
+    Ok(RouterLayerAttributionEvidence {
+        layer,
+        three_plane_selected_ids: ThreeWaySelectedIds {
+            exact_f32_cpu: exact_trace.layer_selected_ids[layer].clone(),
+            historical_f16_cpu: historical_trace.layer_selected_ids[layer].clone(),
+            gpu_native: semantic.selected_ids.clone(),
+        },
+        exact_f32_cpu_selected_weights: ExactVectorTraceEvidence::new(
+            format!("exact-f32-cpu-layer-{layer}-selected-weights"),
+            &exact_trace.layer_selected_weights[layer],
+            true,
+        ),
+        historical_f16_cpu_selected_weights: ExactVectorTraceEvidence::new(
+            format!("historical-f16-cpu-layer-{layer}-selected-weights"),
+            &historical_trace.layer_selected_weights[layer],
+            true,
+        ),
+        gpu_native_selected_weights: ExactVectorTraceEvidence::new(
+            format!("production-gpu-native-layer-{layer}-selected-weights"),
+            &semantic.selected_weights,
+            true,
+        ),
+        same_input_cpu_vs_gpu_raw_logits: VectorNumericalEvidence::compare(
+            "cpu-production-router-raw-logits-on-exact-gpu-input",
+            "actual-production-gpu-router-raw-logits",
+            &cpu_raw,
+            &semantic.raw_logits,
+        )?,
+        cpu_production_router_on_exact_gpu_input: cpu,
+        actual_gpu_production_router: actual,
+        same_input_ordered_ids_equal,
+        same_input_stage,
+    })
+}
+
+fn derive_same_input_router_stage(
+    cpu_on_gpu_input_ids: &[u32],
+    cpu_from_gpu_raw_ids: &[u32],
+    actual_gpu_ids: &[u32],
+) -> SameInputRouterStage {
+    if cpu_on_gpu_input_ids == actual_gpu_ids {
+        SameInputRouterStage::ExactOrderedMatch
+    } else if cpu_from_gpu_raw_ids == actual_gpu_ids {
+        SameInputRouterStage::GpuRouterGemvDrift
+    } else {
+        SameInputRouterStage::GpuRouterSoftmaxTopkDrift
+    }
+}
+
+fn router_attribution(
+    exact_trace: &crate::gpu_native_diagnostics::ModelDiagnosticTrace,
+    historical_trace: &crate::gpu_native_diagnostics::ModelDiagnosticTrace,
+    gpu_trace: &crate::gpu_native_diagnostics::GpuNativeDiagnosticTrace,
+    gpu_semantic: &crate::gpu_native_semantic_parity_corpus::SemanticCorpusGpuTrace,
+    model: &crate::model::RealModel,
+) -> Result<RouterAttributionEvidence, String> {
+    let mut layers = Vec::with_capacity(EXPECTED_NUM_LAYERS);
+    for layer in 0..EXPECTED_NUM_LAYERS {
+        layers.push(router_layer_evidence(
+            layer,
+            exact_trace,
+            historical_trace,
+            gpu_trace,
+            gpu_semantic,
+            &model.layers[layer].gate,
+        )?);
+    }
+    let first_same_input_ordered_id_mismatch_layer = layers
+        .iter()
+        .find(|layer| !layer.same_input_ordered_ids_equal)
+        .map(|layer| layer.layer);
+    Ok(RouterAttributionEvidence {
+        layers,
+        first_same_input_ordered_id_mismatch_layer,
+        known_postgres_defect_preserved_as_separate: true,
+        known_postgres_defect:
+            "postgres-window-holdout generated-position-11 layer-38 CPU-same-input-107 GPU-95 gpu-router-gemv-drift",
+    })
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct SameInputExpertEvidence {
+    pub production_rank: usize,
+    pub local_expert_id: u32,
+    pub global_expert_id: u32,
+    pub three_way_output: ThreeWayVectorComparison,
+    pub historical_f16_vs_exact_f32_relation_maxabs: DistanceRelation,
+    pub historical_f16_vs_exact_f32_relation_rms: DistanceRelation,
+    pub historical_f16_vs_exact_f32_relation_meanabs: DistanceRelation,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct SameInputExpertLayerEvidence {
+    pub layer: usize,
+    pub exact_gpu_f32_input: ExactVectorTraceEvidence,
+    pub gpu_selected_expert_ids: Vec<u32>,
+    pub gpu_selected_weights: ExactVectorTraceEvidence,
+    pub per_expert_in_gpu_production_rank_order: Vec<SameInputExpertEvidence>,
+    pub three_way_outputs_combined_with_actual_gpu_weights: ThreeWayVectorComparison,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct SameInputExpertBoundaryEvidence {
+    pub exact_gpu_f32_input_supplied_to_both_cpu_replays_without_pre_rounding: bool,
+    pub exact_f32_cpu_boundary_emulation_enabled: bool,
+    pub historical_f16_cpu_boundary_emulation_enabled: bool,
+    pub actual_gpu_expert_outputs_observed: bool,
+    pub current_gpu_arithmetic_emulator_used: bool,
+    pub emulator_not_needed_reason: &'static str,
+    pub selected_expert_execution_count: usize,
+    pub exact_f32_closer_than_historical_f16_maxabs_count: usize,
+    pub exact_f32_closer_than_historical_f16_rms_count: usize,
+    pub exact_f32_closer_than_historical_f16_meanabs_count: usize,
+    pub historical_f16_closer_than_exact_f32_maxabs_count: usize,
+    pub historical_f16_closer_than_exact_f32_rms_count: usize,
+    pub historical_f16_closer_than_exact_f32_meanabs_count: usize,
+    pub mere_bit_inequality_promoted_to_defect: bool,
+    pub layers: Vec<SameInputExpertLayerEvidence>,
+}
+
+async fn replay_historical_same_input_experts(
+    runtime: &crate::BenchRealRuntime,
+    gpu_semantic: &crate::gpu_native_semantic_parity_corpus::SemanticCorpusGpuTrace,
+) -> Result<Vec<Vec<Vec<f32>>>, Box<dyn std::error::Error>> {
+    let mut layers = Vec::with_capacity(EXPECTED_NUM_LAYERS);
+    for (layer, gpu) in gpu_semantic.layers.iter().enumerate() {
+        if gpu.selected_ids.len() != EXPECTED_TOP_K || gpu.router_input.len() != EXPECTED_D_MODEL {
+            return Err(format!(
+                "GPU expert trace geometry is incomplete for historical replay at layer {layer}"
+            )
+            .into());
+        }
+        let global_ids = gpu
+            .selected_ids
+            .iter()
+            .map(|expert| runtime.model.global_expert_id(layer, *expert))
+            .collect::<Vec<_>>();
+        let token_index = (layer as u64).wrapping_add(0x4849_5354_5350_4100);
+        let outputs = runtime
+            .engine
+            .moe_step_with_timing(
+                token_index,
+                layer as u32,
+                &gpu.router_input,
+                &global_ids,
+                None,
+            )
+            .await?;
+        if outputs.len() != EXPECTED_TOP_K
+            || outputs
+                .iter()
+                .any(|output| output.len() != EXPECTED_D_MODEL)
+        {
+            return Err(format!(
+                "historical-f16 same-input expert replay is incomplete at layer {layer}"
+            )
+            .into());
+        }
+        layers.push(outputs);
+    }
+    Ok(layers)
+}
+
+async fn same_input_expert_boundary(
+    runtime: &crate::BenchRealRuntime,
+    gpu_semantic: &crate::gpu_native_semantic_parity_corpus::SemanticCorpusGpuTrace,
+    historical_outputs: &[Vec<Vec<f32>>],
+) -> Result<SameInputExpertBoundaryEvidence, Box<dyn std::error::Error>> {
+    if historical_outputs.len() != EXPECTED_NUM_LAYERS {
+        return Err("historical same-input expert replay omitted one or more layers".into());
+    }
+    let mut layers = Vec::with_capacity(EXPECTED_NUM_LAYERS);
+    let mut exact_closer_maxabs = 0usize;
+    let mut exact_closer_rms = 0usize;
+    let mut exact_closer_meanabs = 0usize;
+    let mut historical_closer_maxabs = 0usize;
+    let mut historical_closer_rms = 0usize;
+    let mut historical_closer_meanabs = 0usize;
+    for (layer, gpu) in gpu_semantic.layers.iter().enumerate() {
+        if gpu.selected_ids.len() != EXPECTED_TOP_K
+            || gpu.selected_weights.len() != EXPECTED_TOP_K
+            || gpu.route_outputs.len() != EXPECTED_TOP_K
+            || gpu
+                .route_outputs
+                .iter()
+                .any(|output| output.len() != EXPECTED_D_MODEL)
+            || historical_outputs[layer].len() != EXPECTED_TOP_K
+            || historical_outputs[layer]
+                .iter()
+                .any(|output| output.len() != EXPECTED_D_MODEL)
+        {
+            return Err(format!("GPU expert trace geometry is incomplete at layer {layer}").into());
+        }
+        let global_ids = gpu
+            .selected_ids
+            .iter()
+            .map(|expert| runtime.model.global_expert_id(layer, *expert))
+            .collect::<Vec<_>>();
+        let token_index = (layer as u64).wrapping_add(0x5350_414e_4953_4800);
+        let cpu_outputs = runtime
+            .engine
+            .moe_step_with_timing(
+                token_index,
+                layer as u32,
+                &gpu.router_input,
+                &global_ids,
+                None,
+            )
+            .await?;
+        if cpu_outputs.len() != EXPECTED_TOP_K
+            || cpu_outputs
+                .iter()
+                .any(|output| output.len() != EXPECTED_D_MODEL)
+        {
+            return Err(
+                format!("CPU same-input expert replay is incomplete at layer {layer}").into(),
+            );
+        }
+        let mut per_expert = Vec::with_capacity(EXPECTED_TOP_K);
+        for rank in 0..EXPECTED_TOP_K {
+            let comparison = three_way_compare(
+                "same-input-expert-output",
+                &cpu_outputs[rank],
+                &historical_outputs[layer][rank],
+                &gpu.route_outputs[rank],
+            )?;
+            let maxabs = distance_relation(
+                comparison.historical_f16_cpu_vs_gpu.max_absolute_error,
+                comparison.exact_f32_cpu_vs_gpu.max_absolute_error,
+            );
+            let rms = distance_relation(
+                comparison.historical_f16_cpu_vs_gpu.rms_error,
+                comparison.exact_f32_cpu_vs_gpu.rms_error,
+            );
+            let meanabs = distance_relation(
+                comparison.historical_f16_cpu_vs_gpu.mean_absolute_error,
+                comparison.exact_f32_cpu_vs_gpu.mean_absolute_error,
+            );
+            exact_closer_maxabs += usize::from(maxabs == DistanceRelation::ExactF32Closer);
+            exact_closer_rms += usize::from(rms == DistanceRelation::ExactF32Closer);
+            exact_closer_meanabs += usize::from(meanabs == DistanceRelation::ExactF32Closer);
+            historical_closer_maxabs +=
+                usize::from(maxabs == DistanceRelation::HistoricalF16Closer);
+            historical_closer_rms += usize::from(rms == DistanceRelation::HistoricalF16Closer);
+            historical_closer_meanabs +=
+                usize::from(meanabs == DistanceRelation::HistoricalF16Closer);
+            per_expert.push(SameInputExpertEvidence {
+                production_rank: rank + 1,
+                local_expert_id: gpu.selected_ids[rank],
+                global_expert_id: global_ids[rank],
+                three_way_output: comparison,
+                historical_f16_vs_exact_f32_relation_maxabs: maxabs,
+                historical_f16_vs_exact_f32_relation_rms: rms,
+                historical_f16_vs_exact_f32_relation_meanabs: meanabs,
+            });
+        }
+        let cpu_combined = crate::inference::combine_outputs(&cpu_outputs, &gpu.selected_weights);
+        let historical_combined =
+            crate::inference::combine_outputs(&historical_outputs[layer], &gpu.selected_weights);
+        layers.push(SameInputExpertLayerEvidence {
+            layer,
+            exact_gpu_f32_input: ExactVectorTraceEvidence::new(
+                format!("layer-{layer}-exact-actual-gpu-f32-expert-input"),
+                &gpu.router_input,
+                true,
+            ),
+            gpu_selected_expert_ids: gpu.selected_ids.clone(),
+            gpu_selected_weights: ExactVectorTraceEvidence::new(
+                format!("layer-{layer}-actual-gpu-selected-weights"),
+                &gpu.selected_weights,
+                true,
+            ),
+            per_expert_in_gpu_production_rank_order: per_expert,
+            three_way_outputs_combined_with_actual_gpu_weights: three_way_compare(
+                "same-input-expert-outputs-combined-with-actual-gpu-weights",
+                &cpu_combined,
+                &historical_combined,
+                &gpu.routed_moe_output,
+            )?,
+        });
+    }
+    Ok(SameInputExpertBoundaryEvidence {
+        exact_gpu_f32_input_supplied_to_both_cpu_replays_without_pre_rounding: true,
+        exact_f32_cpu_boundary_emulation_enabled: false,
+        historical_f16_cpu_boundary_emulation_enabled: true,
+        actual_gpu_expert_outputs_observed: true,
+        current_gpu_arithmetic_emulator_used: false,
+        emulator_not_needed_reason:
+            "actual production GPU per-expert outputs were captured in the same final-prompt traversal",
+        selected_expert_execution_count: layers.len() * EXPECTED_TOP_K,
+        exact_f32_closer_than_historical_f16_maxabs_count: exact_closer_maxabs,
+        exact_f32_closer_than_historical_f16_rms_count: exact_closer_rms,
+        exact_f32_closer_than_historical_f16_meanabs_count: exact_closer_meanabs,
+        historical_f16_closer_than_exact_f32_maxabs_count: historical_closer_maxabs,
+        historical_f16_closer_than_exact_f32_rms_count: historical_closer_rms,
+        historical_f16_closer_than_exact_f32_meanabs_count: historical_closer_meanabs,
+        mere_bit_inequality_promoted_to_defect: false,
+        layers,
+    })
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct RankedTokenEvidence {
+    pub token_id: u32,
+    pub rank: usize,
+    pub raw_logit: FloatEvidence,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct CandidateTokenEvidence {
+    pub token_id: u32,
+    pub competing_token_id: u32,
+    pub rank: usize,
+    pub raw_logit: FloatEvidence,
+    pub margin_over_competing_candidate: FloatEvidence,
+    pub ulp_distance_to_competing_candidate: Option<u32>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct LogitViewEvidence {
+    pub source: &'static str,
+    pub argmax: u32,
+    pub top_12: Vec<RankedTokenEvidence>,
+    pub candidates_140003_and_54275: Vec<CandidateTokenEvidence>,
+}
+
+fn ranked_logit_indices(logits: &[f32]) -> Result<Vec<usize>, String> {
+    if logits.is_empty() || logits.iter().any(|value| !value.is_finite()) {
+        return Err("LM-head logits are empty or nonfinite".into());
+    }
+    let mut ranked = (0..logits.len()).collect::<Vec<_>>();
+    ranked.sort_by(|left, right| {
+        logits[*right]
+            .total_cmp(&logits[*left])
+            .then_with(|| left.cmp(right))
+    });
+    Ok(ranked)
+}
+
+fn deterministic_argmax(logits: &[f32]) -> Result<u32, String> {
+    u32::try_from(ranked_logit_indices(logits)?[0])
+        .map_err(|_| "argmax token ID does not fit u32".into())
+}
+
+fn logit_view(source: &'static str, logits: &[f32]) -> Result<LogitViewEvidence, String> {
+    let ranked = ranked_logit_indices(logits)?;
+    let candidate = |token_id: u32, competing_token_id: u32| {
+        let token = token_id as usize;
+        let competing = competing_token_id as usize;
+        if token >= logits.len() || competing >= logits.len() {
+            return Err("explicit Spanish token candidate is outside vocabulary".to_string());
+        }
+        let rank = ranked
+            .iter()
+            .position(|candidate| *candidate == token)
+            .ok_or("candidate token missing from LM-head ranking")?
+            + 1;
+        Ok(CandidateTokenEvidence {
+            token_id,
+            competing_token_id,
+            rank,
+            raw_logit: FloatEvidence::new(logits[token]),
+            margin_over_competing_candidate: FloatEvidence::new(logits[token] - logits[competing]),
+            ulp_distance_to_competing_candidate:
+                crate::gpu_native_router_rank_diagnostics::ulp_distance(
+                    logits[token],
+                    logits[competing],
+                ),
+        })
+    };
+    Ok(LogitViewEvidence {
+        source,
+        argmax: u32::try_from(ranked[0]).map_err(|_| "argmax token ID overflow")?,
+        top_12: ranked
+            .iter()
+            .take(12)
+            .enumerate()
+            .map(|(rank, token)| RankedTokenEvidence {
+                token_id: *token as u32,
+                rank: rank + 1,
+                raw_logit: FloatEvidence::new(logits[*token]),
+            })
+            .collect(),
+        candidates_140003_and_54275: vec![
+            candidate(EXACT_F32_CPU_TOKEN, FROZEN_GPU_TOKEN)?,
+            candidate(FROZEN_GPU_TOKEN, EXACT_F32_CPU_TOKEN)?,
+        ],
+    })
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct SameInputFinalRmsnormEvidence {
+    pub cpu_production_on_exact_gpu_final_hidden_vs_actual_gpu_final_rmsnorm:
+        VectorNumericalEvidence,
+    pub cpu_production_final_rmsnorm: ExactVectorTraceEvidence,
+    pub actual_gpu_final_rmsnorm: ExactVectorTraceEvidence,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct SameInputLmHeadEvidence {
+    pub cpu_production_on_exact_gpu_final_rmsnorm_vs_actual_gpu_logits: VectorNumericalEvidence,
+    pub cpu_same_input_argmax: u32,
+    pub gpu_logits_deterministic_argmax: u32,
+    pub actual_gpu_greedy_argmax: u32,
+    pub views: Vec<LogitViewEvidence>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct DownstreamCounterfactuals {
+    cpu_argmax_on_cpu_norm_of_gpu_hidden: u32,
+    cpu_argmax_on_actual_gpu_norm: u32,
+    deterministic_argmax_on_actual_gpu_logits: u32,
+}
+
+fn same_input_downstream(
+    model: &crate::model::RealModel,
+    exact_trace: &crate::gpu_native_diagnostics::ModelDiagnosticTrace,
+    historical_trace: &crate::gpu_native_diagnostics::ModelDiagnosticTrace,
+    gpu_trace: &crate::gpu_native_diagnostics::GpuNativeDiagnosticTrace,
+) -> Result<
+    (
+        SameInputFinalRmsnormEvidence,
+        SameInputLmHeadEvidence,
+        DownstreamCounterfactuals,
+    ),
+    String,
+> {
+    let gpu_hidden = gpu_trace
+        .layer_post_moe
+        .last()
+        .ok_or("GPU final hidden is missing")?;
+    let cpu_norm_on_gpu_hidden = model.diagnostic_final_rms_norm(gpu_hidden);
+    let cpu_logits_on_cpu_norm = model.diagnostic_greedy_logits(&cpu_norm_on_gpu_hidden);
+    let cpu_logits_on_gpu_norm = model.diagnostic_greedy_logits(&gpu_trace.final_norm);
+    let cpu_argmax_on_cpu_norm_of_gpu_hidden = deterministic_argmax(&cpu_logits_on_cpu_norm)?;
+    let cpu_argmax_on_actual_gpu_norm = deterministic_argmax(&cpu_logits_on_gpu_norm)?;
+    let deterministic_argmax_on_actual_gpu_logits = deterministic_argmax(&gpu_trace.logits)?;
+    Ok((
+        SameInputFinalRmsnormEvidence {
+            cpu_production_on_exact_gpu_final_hidden_vs_actual_gpu_final_rmsnorm:
+                VectorNumericalEvidence::compare(
+                    "cpu-production-final-rmsnorm-on-exact-actual-gpu-final-hidden",
+                    "actual-production-gpu-final-rmsnorm",
+                    &cpu_norm_on_gpu_hidden,
+                    &gpu_trace.final_norm,
+                )?,
+            cpu_production_final_rmsnorm: ExactVectorTraceEvidence::new(
+                "cpu-production-final-rmsnorm-on-exact-actual-gpu-final-hidden",
+                &cpu_norm_on_gpu_hidden,
+                true,
+            ),
+            actual_gpu_final_rmsnorm: ExactVectorTraceEvidence::new(
+                "actual-production-gpu-final-rmsnorm",
+                &gpu_trace.final_norm,
+                true,
+            ),
+        },
+        SameInputLmHeadEvidence {
+            cpu_production_on_exact_gpu_final_rmsnorm_vs_actual_gpu_logits:
+                VectorNumericalEvidence::compare(
+                    "cpu-production-lm-head-on-exact-actual-gpu-final-rmsnorm",
+                    "actual-production-gpu-lm-head-logits",
+                    &cpu_logits_on_gpu_norm,
+                    &gpu_trace.logits,
+                )?,
+            cpu_same_input_argmax: cpu_argmax_on_actual_gpu_norm,
+            gpu_logits_deterministic_argmax: deterministic_argmax_on_actual_gpu_logits,
+            actual_gpu_greedy_argmax: gpu_trace.sampled_token,
+            views: vec![
+                logit_view("exact-f32-cpu-plane", &exact_trace.logits)?,
+                logit_view("historical-f16-cpu-plane", &historical_trace.logits)?,
+                logit_view("actual-production-gpu-native-plane", &gpu_trace.logits)?,
+                logit_view(
+                    "cpu-production-lm-head-on-cpu-rmsnorm-of-exact-gpu-hidden",
+                    &cpu_logits_on_cpu_norm,
+                )?,
+                logit_view(
+                    "cpu-production-lm-head-on-exact-actual-gpu-final-rmsnorm",
+                    &cpu_logits_on_gpu_norm,
+                )?,
+            ],
+        },
+        DownstreamCounterfactuals {
+            cpu_argmax_on_cpu_norm_of_gpu_hidden,
+            cpu_argmax_on_actual_gpu_norm,
+            deterministic_argmax_on_actual_gpu_logits,
+        },
+    ))
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "kebab-case")]
+#[allow(dead_code)]
+pub enum AttributionCategory {
+    UpstreamPrefillDrift,
+    AttentionDrift,
+    RouterGemvDrift,
+    RoutedMoeDrift,
+    FinalRmsnormDrift,
+    LmHeadGemvDrift,
+    GreedyCutoffDrift,
+    NumericalCompensation,
+    MultiStageDrift,
+    Unresolved,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ConservativeAttributionEvidence {
+    pub primary: AttributionCategory,
+    pub supporting_classifications: Vec<AttributionCategory>,
+    pub classification_uses_hidden_numerical_threshold: bool,
+    pub mere_bit_inequality_promoted_to_causal_attribution: bool,
+    pub no_production_correction_justified: bool,
+}
+
+fn derive_attribution(
+    exact_token: u32,
+    historical_token: u32,
+    gpu_token: u32,
+    downstream: &DownstreamCounterfactuals,
+    router: &RouterAttributionEvidence,
+) -> ConservativeAttributionEvidence {
+    let mut causal = BTreeSet::new();
+    if downstream.cpu_argmax_on_cpu_norm_of_gpu_hidden != exact_token {
+        causal.insert(AttributionCategory::UpstreamPrefillDrift);
+    }
+    if downstream.cpu_argmax_on_actual_gpu_norm != downstream.cpu_argmax_on_cpu_norm_of_gpu_hidden {
+        causal.insert(AttributionCategory::FinalRmsnormDrift);
+    }
+    if downstream.deterministic_argmax_on_actual_gpu_logits
+        != downstream.cpu_argmax_on_actual_gpu_norm
+    {
+        causal.insert(AttributionCategory::LmHeadGemvDrift);
+    }
+    if gpu_token != downstream.deterministic_argmax_on_actual_gpu_logits {
+        causal.insert(AttributionCategory::GreedyCutoffDrift);
+    }
+    if router
+        .layers
+        .iter()
+        .any(|layer| layer.same_input_stage == SameInputRouterStage::GpuRouterGemvDrift)
+    {
+        causal.insert(AttributionCategory::RouterGemvDrift);
+    }
+    let mut supporting = causal.iter().copied().collect::<Vec<_>>();
+    if historical_token == gpu_token && exact_token != gpu_token {
+        supporting.push(AttributionCategory::NumericalCompensation);
+    }
+    let primary = match causal.len() {
+        0 if supporting.contains(&AttributionCategory::NumericalCompensation) => {
+            AttributionCategory::NumericalCompensation
+        }
+        0 => AttributionCategory::Unresolved,
+        1 => *causal.iter().next().unwrap(),
+        _ => AttributionCategory::MultiStageDrift,
+    };
+    ConservativeAttributionEvidence {
+        primary,
+        supporting_classifications: supporting,
+        classification_uses_hidden_numerical_threshold: false,
+        mere_bit_inequality_promoted_to_causal_attribution: false,
+        no_production_correction_justified: true,
+    }
+}
+
+fn cpu_plane_full_trace(
+    plane: &'static str,
+    trace: &crate::gpu_native_diagnostics::ModelDiagnosticTrace,
+) -> Result<PlaneFullTraceEvidence, String> {
+    if trace.layer_post_attn.len() != EXPECTED_NUM_LAYERS
+        || trace.layer_router_input.len() != EXPECTED_NUM_LAYERS
+        || trace.layer_selected_ids.len() != EXPECTED_NUM_LAYERS
+        || trace.layer_selected_weights.len() != EXPECTED_NUM_LAYERS
+        || trace.layer_routed_moe_output.len() != EXPECTED_NUM_LAYERS
+        || trace.layer_post_moe.len() != EXPECTED_NUM_LAYERS
+    {
+        return Err(format!("{plane} full trace layer geometry is incomplete"));
+    }
+    let mut layers = Vec::with_capacity(EXPECTED_NUM_LAYERS);
+    for layer in 0..EXPECTED_NUM_LAYERS {
+        layers.push(FullTraceLayerEvidence {
+            layer,
+            pre_attention_residual: ExactVectorTraceEvidence::new(
+                format!("{plane}-layer-{layer}-pre-attention-residual"),
+                if layer == 0 {
+                    &trace.embedding
+                } else {
+                    &trace.layer_post_moe[layer - 1]
+                },
+                true,
+            ),
+            post_attention: ExactVectorTraceEvidence::new(
+                format!("{plane}-layer-{layer}-post-attention"),
+                &trace.layer_post_attn[layer],
+                true,
+            ),
+            router_input: ExactVectorTraceEvidence::new(
+                format!("{plane}-layer-{layer}-router-input"),
+                &trace.layer_router_input[layer],
+                true,
+            ),
+            selected_expert_ids: trace.layer_selected_ids[layer].clone(),
+            selected_weights: ExactVectorTraceEvidence::new(
+                format!("{plane}-layer-{layer}-selected-weights"),
+                &trace.layer_selected_weights[layer],
+                true,
+            ),
+            routed_moe_output: ExactVectorTraceEvidence::new(
+                format!("{plane}-layer-{layer}-routed-moe-output"),
+                &trace.layer_routed_moe_output[layer],
+                true,
+            ),
+            post_moe_residual: ExactVectorTraceEvidence::new(
+                format!("{plane}-layer-{layer}-post-moe-residual"),
+                &trace.layer_post_moe[layer],
+                true,
+            ),
+        });
+    }
+    let final_hidden = trace
+        .layer_post_moe
+        .last()
+        .ok_or_else(|| format!("{plane} final hidden is missing"))?;
+    Ok(PlaneFullTraceEvidence {
+        plane,
+        embedding: ExactVectorTraceEvidence::new(
+            format!("{plane}-embedding"),
+            &trace.embedding,
+            true,
+        ),
+        layers,
+        final_hidden: ExactVectorTraceEvidence::new(
+            format!("{plane}-final-hidden"),
+            final_hidden,
+            true,
+        ),
+        final_rmsnorm: ExactVectorTraceEvidence::new(
+            format!("{plane}-final-rmsnorm"),
+            &trace.final_norm,
+            true,
+        ),
+        full_lm_head_logits: ExactVectorTraceEvidence::new(
+            format!("{plane}-full-lm-head-logits"),
+            &trace.logits,
+            true,
+        ),
+        greedy_argmax: trace.sampled_token,
+    })
+}
+
+fn gpu_plane_full_trace(
+    trace: &crate::gpu_native_diagnostics::GpuNativeDiagnosticTrace,
+    semantic: &crate::gpu_native_semantic_parity_corpus::SemanticCorpusGpuTrace,
+) -> Result<PlaneFullTraceEvidence, String> {
+    if trace.layer_post_attn.len() != EXPECTED_NUM_LAYERS
+        || trace.layer_router_input.len() != EXPECTED_NUM_LAYERS
+        || trace.layer_selected_ids.len() != EXPECTED_NUM_LAYERS
+        || trace.layer_selected_weights.len() != EXPECTED_NUM_LAYERS
+        || trace.layer_post_moe.len() != EXPECTED_NUM_LAYERS
+        || semantic.layers.len() != EXPECTED_NUM_LAYERS
+    {
+        return Err("GPU-native full trace layer geometry is incomplete".into());
+    }
+    let mut layers = Vec::with_capacity(EXPECTED_NUM_LAYERS);
+    for layer in 0..EXPECTED_NUM_LAYERS {
+        let semantic_layer = &semantic.layers[layer];
+        if trace.layer_router_input[layer] != semantic_layer.router_input
+            || trace.layer_selected_ids[layer] != semantic_layer.selected_ids
+            || trace.layer_selected_weights[layer] != semantic_layer.selected_weights
+        {
+            return Err(format!("GPU diagnostic sinks disagree at layer {layer}"));
+        }
+        layers.push(FullTraceLayerEvidence {
+            layer,
+            pre_attention_residual: ExactVectorTraceEvidence::new(
+                format!("GPU_NATIVE-layer-{layer}-pre-attention-residual"),
+                if layer == 0 {
+                    &trace.embedding
+                } else {
+                    &trace.layer_post_moe[layer - 1]
+                },
+                true,
+            ),
+            post_attention: ExactVectorTraceEvidence::new(
+                format!("GPU_NATIVE-layer-{layer}-post-attention"),
+                &trace.layer_post_attn[layer],
+                true,
+            ),
+            router_input: ExactVectorTraceEvidence::new(
+                format!("GPU_NATIVE-layer-{layer}-router-input"),
+                &trace.layer_router_input[layer],
+                true,
+            ),
+            selected_expert_ids: trace.layer_selected_ids[layer].clone(),
+            selected_weights: ExactVectorTraceEvidence::new(
+                format!("GPU_NATIVE-layer-{layer}-selected-weights"),
+                &trace.layer_selected_weights[layer],
+                true,
+            ),
+            routed_moe_output: ExactVectorTraceEvidence::new(
+                format!("GPU_NATIVE-layer-{layer}-routed-moe-output"),
+                &semantic_layer.routed_moe_output,
+                true,
+            ),
+            post_moe_residual: ExactVectorTraceEvidence::new(
+                format!("GPU_NATIVE-layer-{layer}-post-moe-residual"),
+                &trace.layer_post_moe[layer],
+                true,
+            ),
+        });
+    }
+    let final_hidden = trace
+        .layer_post_moe
+        .last()
+        .ok_or("GPU-native final hidden is missing")?;
+    Ok(PlaneFullTraceEvidence {
+        plane: "GPU_NATIVE",
+        embedding: ExactVectorTraceEvidence::new("GPU_NATIVE-embedding", &trace.embedding, true),
+        layers,
+        final_hidden: ExactVectorTraceEvidence::new("GPU_NATIVE-final-hidden", final_hidden, true),
+        final_rmsnorm: ExactVectorTraceEvidence::new(
+            "GPU_NATIVE-final-rmsnorm",
+            &trace.final_norm,
+            true,
+        ),
+        full_lm_head_logits: ExactVectorTraceEvidence::new(
+            "GPU_NATIVE-full-lm-head-logits",
+            &trace.logits,
+            true,
+        ),
+        greedy_argmax: trace.sampled_token,
+    })
+}
+
+fn compare_final_traces(
+    exact: &crate::gpu_native_diagnostics::ModelDiagnosticTrace,
+    historical: &crate::gpu_native_diagnostics::ModelDiagnosticTrace,
+    gpu: &crate::gpu_native_diagnostics::GpuNativeDiagnosticTrace,
+    gpu_semantic: &crate::gpu_native_semantic_parity_corpus::SemanticCorpusGpuTrace,
+) -> Result<FinalPositionTraceComparison, String> {
+    let mut layers = Vec::with_capacity(EXPECTED_NUM_LAYERS);
+    for layer in 0..EXPECTED_NUM_LAYERS {
+        layers.push(ThreeWayLayerTraceComparison {
+            layer,
+            pre_attention_residual: three_way_compare(
+                "pre-attention-residual",
+                if layer == 0 {
+                    &exact.embedding
+                } else {
+                    &exact.layer_post_moe[layer - 1]
+                },
+                if layer == 0 {
+                    &historical.embedding
+                } else {
+                    &historical.layer_post_moe[layer - 1]
+                },
+                if layer == 0 {
+                    &gpu.embedding
+                } else {
+                    &gpu.layer_post_moe[layer - 1]
+                },
+            )?,
+            post_attention: three_way_compare(
+                "post-attention",
+                &exact.layer_post_attn[layer],
+                &historical.layer_post_attn[layer],
+                &gpu.layer_post_attn[layer],
+            )?,
+            router_input: three_way_compare(
+                "router-input",
+                &exact.layer_router_input[layer],
+                &historical.layer_router_input[layer],
+                &gpu.layer_router_input[layer],
+            )?,
+            selected_ids: ThreeWaySelectedIds {
+                exact_f32_cpu: exact.layer_selected_ids[layer].clone(),
+                historical_f16_cpu: historical.layer_selected_ids[layer].clone(),
+                gpu_native: gpu.layer_selected_ids[layer].clone(),
+            },
+            selected_weights: three_way_compare(
+                "selected-weights",
+                &exact.layer_selected_weights[layer],
+                &historical.layer_selected_weights[layer],
+                &gpu.layer_selected_weights[layer],
+            )?,
+            routed_moe_output: three_way_compare(
+                "routed-moe-output",
+                &exact.layer_routed_moe_output[layer],
+                &historical.layer_routed_moe_output[layer],
+                &gpu_semantic.layers[layer].routed_moe_output,
+            )?,
+            post_moe_residual: three_way_compare(
+                "post-moe-residual",
+                &exact.layer_post_moe[layer],
+                &historical.layer_post_moe[layer],
+                &gpu.layer_post_moe[layer],
+            )?,
+        });
+    }
+    Ok(FinalPositionTraceComparison {
+        embedding: three_way_compare(
+            "embedding",
+            &exact.embedding,
+            &historical.embedding,
+            &gpu.embedding,
+        )?,
+        layers,
+        final_hidden: three_way_compare(
+            "final-hidden",
+            exact
+                .layer_post_moe
+                .last()
+                .ok_or("exact final hidden missing")?,
+            historical
+                .layer_post_moe
+                .last()
+                .ok_or("historical final hidden missing")?,
+            gpu.layer_post_moe
+                .last()
+                .ok_or("GPU final hidden missing")?,
+        )?,
+        final_rmsnorm: three_way_compare(
+            "final-rmsnorm",
+            &exact.final_norm,
+            &historical.final_norm,
+            &gpu.final_norm,
+        )?,
+        full_lm_head_logits: three_way_compare(
+            "lm-head-logits",
+            &exact.logits,
+            &historical.logits,
+            &gpu.logits,
+        )?,
+        greedy_argmax_exact_f32_cpu: exact.sampled_token,
+        greedy_argmax_historical_f16_cpu: historical.sampled_token,
+        greedy_argmax_gpu_native: gpu.sampled_token,
+    })
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct PlaneRuntimeEvidence {
+    pub plane: &'static str,
+    pub runtime_mode: &'static str,
+    pub isolated_runtime: bool,
+    pub kv_or_session_state_shared_with_another_plane: bool,
+    pub caller_owned_prompt_token_ids_sha256: String,
+    pub per_plane_retokenization_performed: bool,
+    pub resolved_config_sha256: String,
+    pub execution_plan: crate::qualification::ExecutionPlanEvidence,
+    pub model_load: crate::greedy_parity::ModelLoadEvidence,
+    pub boundary_before: Option<crate::engine::CpuQ4BoundaryEmulationSnapshot>,
+    pub boundary_after: Option<crate::engine::CpuQ4BoundaryEmulationSnapshot>,
+    pub routed_execution_after: crate::engine::RoutedExpertExecutionSnapshot,
+    pub gpu_token_loop_after: Option<crate::gpu_native_token_loop::GpuNativeTokenLoopSnapshot>,
+    pub prompt_token_steps_completed: usize,
+    pub generated_token_continuation_steps: usize,
+    pub background_shutdown: crate::greedy_parity::BackgroundShutdownEvidence,
+}
+
+struct CpuPlaneCapture {
+    final_hidden_by_prompt_position: Vec<Vec<f32>>,
+    final_trace: crate::gpu_native_diagnostics::ModelDiagnosticTrace,
+    runtime: PlaneRuntimeEvidence,
+}
+
+struct HistoricalPlaneCapture {
+    plane: CpuPlaneCapture,
+    same_input_expert_outputs: Vec<Vec<Vec<f32>>>,
+}
+
+struct GpuPlaneCapture {
+    final_hidden_by_prompt_position: Vec<Vec<f32>>,
+    final_trace: crate::gpu_native_diagnostics::GpuNativeDiagnosticTrace,
+    final_semantic_trace: crate::gpu_native_semantic_parity_corpus::SemanticCorpusGpuTrace,
+    runtime: PlaneRuntimeEvidence,
+    device: crate::backend::GpuDeviceIdentity,
+}
+
+struct ExactPlaneCapture {
+    plane: CpuPlaneCapture,
+    router: RouterAttributionEvidence,
+    expert_boundary: SameInputExpertBoundaryEvidence,
+    same_input_rmsnorm: SameInputFinalRmsnormEvidence,
+    same_input_lm_head: SameInputLmHeadEvidence,
+    downstream: DownstreamCounterfactuals,
+}
+
+fn model_load_is_strict(load: &crate::greedy_parity::ModelLoadEvidence) -> bool {
+    load.strict
+        && load.required_tensors > 0
+        && load.loaded_tensors == load.required_tensors
+        && !load.seeded_fallback_remained
+        && load.loader != "seeded"
+}
+
+fn validate_cpu_geometry(runtime: &crate::BenchRealRuntime) -> Result<(), String> {
+    if runtime.model.config.num_layers != EXPECTED_NUM_LAYERS
+        || runtime.model.config.num_experts != EXPECTED_NUM_EXPERTS
+        || runtime.model.config.top_k != EXPECTED_TOP_K
+        || runtime.model.config.d_model != EXPECTED_D_MODEL
+        || runtime.model.config.d_ff != EXPECTED_D_FF
+    {
+        return Err("CPU plane model geometry differs from frozen Qwen geometry".into());
+    }
+    Ok(())
+}
+
+fn validate_gpu_plan(plan: &crate::qualification::ExecutionPlanEvidence) -> Result<(), String> {
+    if plan.requested != "gpu"
+        || plan.resolved != "gpu"
+        || plan.embeddings != "gpu"
+        || plan.lm_head != "gpu"
+        || plan.dense_projections != "gpu"
+        || plan.attention != "gpu"
+        || plan.kv != "gpu"
+        || plan.router != "gpu"
+        || plan.routed_experts != "gpu"
+        || plan.routed_expert_dtype != "q4_0"
+        || plan.fallback_occurred
+    {
+        return Err("GPU_NATIVE did not resolve to the exact all-GPU production plan".into());
+    }
+    Ok(())
+}
+
+fn require_exact_boundary_clean(
+    snapshot: crate::engine::CpuQ4BoundaryEmulationSnapshot,
+) -> Result<(), String> {
+    if snapshot.enabled || snapshot.routed_expert_dispatches != 0 {
+        return Err(format!(
+            "EXACT_F32_CPU boundary must remain disabled/zero, observed enabled={} dispatches={}",
+            snapshot.enabled, snapshot.routed_expert_dispatches
+        ));
+    }
+    Ok(())
+}
+
+fn enable_historical_boundary_clean(
+    engine: &crate::engine::Engine,
+) -> Result<crate::engine::CpuQ4BoundaryEmulationSnapshot, String> {
+    engine.enable_cpu_q4_boundary_emulation()?;
+    let snapshot = engine.cpu_q4_boundary_emulation_snapshot();
+    require_historical_boundary_clean(snapshot)?;
+    Ok(snapshot)
+}
+
+fn require_historical_boundary_clean(
+    snapshot: crate::engine::CpuQ4BoundaryEmulationSnapshot,
+) -> Result<(), String> {
+    if !snapshot.enabled || snapshot.routed_expert_dispatches != 0 {
+        return Err(format!(
+            "HISTORICAL_F16_CPU boundary must start enabled/zero, observed enabled={} dispatches={}",
+            snapshot.enabled, snapshot.routed_expert_dispatches
+        ));
+    }
+    Ok(())
+}
+
+async fn capture_cpu_prompt(
+    runtime: &crate::BenchRealRuntime,
+    token_ids: &[u32],
+    watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+    plane: &'static str,
+) -> Result<
+    (
+        Vec<Vec<f32>>,
+        crate::gpu_native_diagnostics::ModelDiagnosticTrace,
+    ),
+    Box<dyn std::error::Error>,
+> {
+    let mut kv = runtime.model.fresh_kv_caches();
+    let mut final_hidden_by_prompt_position = Vec::with_capacity(token_ids.len());
+    let mut final_trace = None;
+    for (position, &token_id) in token_ids.iter().enumerate() {
+        let trace = crate::with_progress_timeout(
+            format!("Spanish first-token {plane} prefill position {position}"),
+            watchdog,
+            async {
+                Ok::<_, Box<dyn std::error::Error>>(
+                    runtime
+                        .model
+                        .forward_token_diagnostic_trace(
+                            &runtime.engine,
+                            token_id,
+                            position,
+                            &mut kv,
+                            None,
+                        )
+                        .await?,
+                )
+            },
+        )
+        .await?;
+        final_hidden_by_prompt_position.push(
+            trace
+                .layer_post_moe
+                .last()
+                .ok_or("CPU trace omitted final hidden")?
+                .clone(),
+        );
+        final_trace = Some(trace);
+    }
+    Ok((
+        final_hidden_by_prompt_position,
+        final_trace.ok_or("CPU plane did not execute a final prompt position")?,
+    ))
+}
+
+async fn execute_gpu_plane(
+    spec: &ResolvedRealCliSpec,
+    tokenizer: Arc<crate::tokenizer::Tokenizer>,
+    token_ids: Arc<Vec<u32>>,
+    resolved_config_sha256: &str,
+    expected_adapter_name: &str,
+    watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+) -> Result<GpuPlaneCapture, Box<dyn std::error::Error>> {
+    let runtime = crate::build_isolated_greedy_runtime(
+        spec,
+        RealCliRuntimeMode::IsolatedGpuNativeDiagnostic,
+        tokenizer,
+    )
+    .await?;
+    let attempt = async {
+        let observed_config_sha256 = crate::resolved_real_runtime_identity_sha256(
+            &runtime.cfg,
+            runtime.model.config.architecture,
+            runtime.model.config.first_k_dense_replace,
+            &runtime.model.config.advanced,
+        )?;
+        if observed_config_sha256 != resolved_config_sha256 {
+            return Err("GPU_NATIVE resolved configuration identity drifted".into());
+        }
+        let execution_plan: crate::qualification::ExecutionPlanEvidence =
+            runtime.engine.execution_context().plan().into();
+        validate_gpu_plan(&execution_plan)?;
+        let device = runtime
+            .engine
+            .gpu_device_identity()
+            .ok_or("GPU_NATIVE runtime has no authoritative adapter identity")?;
+        if expected_adapter_name != REQUIRED_ADAPTER_NAME
+            || device.name != expected_adapter_name
+            || device.software_adapter
+            || device.device_type.eq_ignore_ascii_case("cpu")
+        {
+            return Err(format!(
+                "GPU_NATIVE selected adapter {:?}, required exact {:?}",
+                device.name, REQUIRED_ADAPTER_NAME
+            )
+            .into());
+        }
+        let token_loop = runtime
+            .gpu_native_token_loop
+            .as_ref()
+            .ok_or("GPU_NATIVE token loop was not constructed")?;
+        let geometry = token_loop.model_geometry();
+        if geometry.num_layers != EXPECTED_NUM_LAYERS
+            || geometry.num_experts != EXPECTED_NUM_EXPERTS
+            || geometry.top_k != EXPECTED_TOP_K
+            || geometry.d_model != EXPECTED_D_MODEL
+            || geometry.d_ff != EXPECTED_D_FF
+        {
+            return Err("GPU_NATIVE geometry differs from the frozen target".into());
+        }
+        if token_loop.snapshot() != crate::gpu_native_token_loop::GpuNativeTokenLoopSnapshot::default()
+        {
+            return Err("GPU_NATIVE token-loop counters did not start at zero".into());
+        }
+        let model_load = crate::greedy_parity_model_load(&runtime);
+        if !model_load_is_strict(&model_load) {
+            return Err("GPU_NATIVE did not load the strict real model".into());
+        }
+        let full_layout = crate::gpu_native_diagnostics::GpuNativeDiagnosticTraceLayout::try_new(
+            geometry.num_layers,
+            geometry.d_model,
+            geometry.top_k,
+            geometry.vocab_size,
+        )?;
+        let semantic_layout =
+            crate::gpu_native_semantic_parity_corpus::SemanticCorpusTraceLayout::try_new(geometry)?;
+        let full_staging = token_loop.create_diagnostic_staging_buffer(&full_layout)?;
+        let semantic_staging =
+            token_loop.create_semantic_parity_corpus_diagnostic_staging_buffer(&semantic_layout)?;
+        let mut request = token_loop.create_semantic_parity_corpus_diagnostic_request_state()?;
+        let last_position = token_ids.len() - 1;
+        let mut final_hidden_by_prompt_position = Vec::with_capacity(token_ids.len());
+        for (position, &token_id) in token_ids[..last_position].iter().enumerate() {
+            let (trace, _) = crate::with_progress_timeout(
+                format!("Spanish first-token GPU_NATIVE prefill position {position}"),
+                watchdog,
+                async {
+                    Ok::<_, Box<dyn std::error::Error>>(
+                        token_loop
+                            .step_token_diagnostic(
+                                &runtime.engine,
+                                &mut request,
+                                token_id,
+                                position,
+                                false,
+                                &full_layout,
+                                &full_staging,
+                            )
+                            .await?,
+                    )
+                },
+            )
+            .await?;
+            if trace.final_status != 0 || trace.layer_statuses.iter().any(|status| *status != 0) {
+                return Err(format!(
+                    "GPU_NATIVE prefill position {position} reported nonzero diagnostic status"
+                )
+                .into());
+            }
+            final_hidden_by_prompt_position.push(
+                trace
+                    .layer_post_moe
+                    .last()
+                    .ok_or("GPU prefix trace omitted final hidden")?
+                    .clone(),
+            );
+        }
+        let final_token_id = token_ids[last_position];
+        let (final_trace, final_semantic_trace, sampled_token, _) =
+            crate::with_progress_timeout(
+                "Spanish first-token GPU_NATIVE final prompt position".to_string(),
+                watchdog,
+                async {
+                    Ok::<_, Box<dyn std::error::Error>>(
+                        token_loop
+                            .step_token_full_and_semantic_corpus_diagnostic(
+                                &runtime.engine,
+                                &mut request,
+                                final_token_id,
+                                last_position,
+                                &full_layout,
+                                &full_staging,
+                                &semantic_layout,
+                                &semantic_staging,
+                            )
+                            .await?,
+                    )
+                },
+            )
+            .await?;
+        if final_trace.final_status != 0
+            || final_trace
+                .layer_statuses
+                .iter()
+                .any(|status| *status != 0)
+        {
+            return Err("GPU_NATIVE final prompt position reported nonzero diagnostic status".into());
+        }
+        if sampled_token != final_trace.sampled_token || sampled_token != FROZEN_GPU_TOKEN {
+            return Err(format!(
+                "GPU_NATIVE Spanish first token was {sampled_token}, frozen target is {FROZEN_GPU_TOKEN}"
+            )
+            .into());
+        }
+        final_hidden_by_prompt_position.push(
+            final_trace
+                .layer_post_moe
+                .last()
+                .ok_or("GPU final trace omitted final hidden")?
+                .clone(),
+        );
+        if request.committed_position() != token_ids.len() {
+            return Err("GPU_NATIVE executed an incomplete or extra prompt step".into());
+        }
+        let loop_after = token_loop.snapshot();
+        if loop_after.tokens_completed != token_ids.len() as u64
+            || loop_after.fatal_failures != 0
+            || loop_after.no_progress_failures != 0
+        {
+            return Err("GPU_NATIVE token loop did not complete the prompt cleanly".into());
+        }
+        let routed = runtime.engine.routed_expert_execution_snapshot();
+        if routed.cpu_routed_expert_dispatches != 0
+            || routed.gpu_cpu_fallbacks != 0
+            || routed.degraded_expert_substitutions != 0
+        {
+            return Err("GPU_NATIVE observed CPU expert fallback or degradation".into());
+        }
+        Ok::<_, Box<dyn std::error::Error>>(GpuPlaneCapture {
+            final_hidden_by_prompt_position,
+            final_trace,
+            final_semantic_trace,
+            runtime: PlaneRuntimeEvidence {
+                plane: "GPU_NATIVE",
+                runtime_mode: "RealCliRuntimeMode::IsolatedGpuNativeDiagnostic",
+                isolated_runtime: true,
+                kv_or_session_state_shared_with_another_plane: false,
+                caller_owned_prompt_token_ids_sha256:
+                    crate::greedy_parity::token_ids_sha256(&token_ids),
+                per_plane_retokenization_performed: false,
+                resolved_config_sha256: observed_config_sha256,
+                execution_plan,
+                model_load,
+                boundary_before: None,
+                boundary_after: None,
+                routed_execution_after: routed,
+                gpu_token_loop_after: Some(loop_after),
+                prompt_token_steps_completed: token_ids.len(),
+                generated_token_continuation_steps: 0,
+                background_shutdown:
+                    crate::greedy_parity::BackgroundShutdownEvidence::default(),
+            },
+            device,
+        })
+    }
+    .await;
+    let shutdown = runtime.shutdown_isolated().await;
+    match (attempt, shutdown) {
+        (Ok(mut capture), Ok(shutdown)) => {
+            capture.runtime.background_shutdown = shutdown;
+            Ok(capture)
+        }
+        (Err(error), Ok(_)) => Err(error),
+        (Ok(_), Err(shutdown_error)) => Err(shutdown_error.into()),
+        (Err(error), Err(shutdown_error)) => Err(IsolatedRuntimeShutdownError::new(format!(
+            "{error}; GPU_NATIVE shutdown also failed: {shutdown_error}"
+        ))
+        .into()),
+    }
+}
+
+async fn execute_historical_plane(
+    spec: &ResolvedRealCliSpec,
+    tokenizer: Arc<crate::tokenizer::Tokenizer>,
+    token_ids: Arc<Vec<u32>>,
+    resolved_config_sha256: &str,
+    gpu_semantic: &crate::gpu_native_semantic_parity_corpus::SemanticCorpusGpuTrace,
+    watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+) -> Result<HistoricalPlaneCapture, Box<dyn std::error::Error>> {
+    let runtime = crate::build_isolated_greedy_runtime(
+        spec,
+        RealCliRuntimeMode::IsolatedGreedyParityCpu,
+        tokenizer,
+    )
+    .await?;
+    let attempt = async {
+        validate_cpu_geometry(&runtime)?;
+        let observed_config_sha256 = crate::resolved_real_runtime_identity_sha256(
+            &runtime.cfg,
+            runtime.model.config.architecture,
+            runtime.model.config.first_k_dense_replace,
+            &runtime.model.config.advanced,
+        )?;
+        if observed_config_sha256 != resolved_config_sha256 {
+            return Err("HISTORICAL_F16_CPU resolved configuration identity drifted".into());
+        }
+        let execution_plan: crate::qualification::ExecutionPlanEvidence =
+            runtime.engine.execution_context().plan().into();
+        if !crate::greedy_parity::cpu_plan_exact(&execution_plan)
+            || runtime.gpu_native_token_loop.is_some()
+            || runtime.engine.gpu_device_identity().is_some()
+        {
+            return Err("HISTORICAL_F16_CPU did not resolve to strict CPU-only Q4".into());
+        }
+        let model_load = crate::greedy_parity_model_load(&runtime);
+        if !model_load_is_strict(&model_load) {
+            return Err("HISTORICAL_F16_CPU did not load the strict real model".into());
+        }
+        let boundary_before = enable_historical_boundary_clean(&runtime.engine)?;
+        let (final_hidden_by_prompt_position, final_trace) =
+            capture_cpu_prompt(&runtime, &token_ids, watchdog, "HISTORICAL_F16_CPU").await?;
+        if final_trace.sampled_token != HISTORICAL_F16_CPU_TOKEN {
+            return Err(format!(
+                "HISTORICAL_F16_CPU Spanish first token was {}, frozen target is {HISTORICAL_F16_CPU_TOKEN}",
+                final_trace.sampled_token
+            )
+            .into());
+        }
+        let same_input_expert_outputs =
+            replay_historical_same_input_experts(&runtime, gpu_semantic).await?;
+        let boundary_after = runtime.engine.cpu_q4_boundary_emulation_snapshot();
+        if !boundary_after.enabled || boundary_after.routed_expert_dispatches == 0 {
+            return Err("HISTORICAL_F16_CPU boundary was not exercised".into());
+        }
+        Ok::<_, Box<dyn std::error::Error>>(HistoricalPlaneCapture {
+            plane: CpuPlaneCapture {
+                final_hidden_by_prompt_position,
+                final_trace,
+                runtime: PlaneRuntimeEvidence {
+                    plane: "HISTORICAL_F16_CPU",
+                    runtime_mode: "RealCliRuntimeMode::IsolatedGreedyParityCpu",
+                    isolated_runtime: true,
+                    kv_or_session_state_shared_with_another_plane: false,
+                    caller_owned_prompt_token_ids_sha256:
+                        crate::greedy_parity::token_ids_sha256(&token_ids),
+                    per_plane_retokenization_performed: false,
+                    resolved_config_sha256: observed_config_sha256,
+                    execution_plan,
+                    model_load,
+                    boundary_before: Some(boundary_before),
+                    boundary_after: Some(boundary_after),
+                    routed_execution_after: runtime.engine.routed_expert_execution_snapshot(),
+                    gpu_token_loop_after: None,
+                    prompt_token_steps_completed: token_ids.len(),
+                    generated_token_continuation_steps: 0,
+                    background_shutdown:
+                        crate::greedy_parity::BackgroundShutdownEvidence::default(),
+                },
+            },
+            same_input_expert_outputs,
+        })
+    }
+    .await;
+    let shutdown = runtime.shutdown_isolated().await;
+    match (attempt, shutdown) {
+        (Ok(mut capture), Ok(shutdown)) => {
+            capture.plane.runtime.background_shutdown = shutdown;
+            Ok(capture)
+        }
+        (Err(error), Ok(_)) => Err(error),
+        (Ok(_), Err(shutdown_error)) => Err(shutdown_error.into()),
+        (Err(error), Err(shutdown_error)) => Err(IsolatedRuntimeShutdownError::new(format!(
+            "{error}; HISTORICAL_F16_CPU shutdown also failed: {shutdown_error}"
+        ))
+        .into()),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn execute_exact_plane(
+    spec: &ResolvedRealCliSpec,
+    tokenizer: Arc<crate::tokenizer::Tokenizer>,
+    token_ids: Arc<Vec<u32>>,
+    resolved_config_sha256: &str,
+    historical_trace: &crate::gpu_native_diagnostics::ModelDiagnosticTrace,
+    historical_same_input_expert_outputs: &[Vec<Vec<f32>>],
+    gpu: &GpuPlaneCapture,
+    watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+) -> Result<ExactPlaneCapture, Box<dyn std::error::Error>> {
+    let runtime = crate::build_isolated_greedy_runtime(
+        spec,
+        RealCliRuntimeMode::IsolatedGreedyParityCpu,
+        tokenizer,
+    )
+    .await?;
+    let attempt = async {
+        validate_cpu_geometry(&runtime)?;
+        let observed_config_sha256 = crate::resolved_real_runtime_identity_sha256(
+            &runtime.cfg,
+            runtime.model.config.architecture,
+            runtime.model.config.first_k_dense_replace,
+            &runtime.model.config.advanced,
+        )?;
+        if observed_config_sha256 != resolved_config_sha256 {
+            return Err("EXACT_F32_CPU resolved configuration identity drifted".into());
+        }
+        let execution_plan: crate::qualification::ExecutionPlanEvidence =
+            runtime.engine.execution_context().plan().into();
+        if !crate::greedy_parity::cpu_plan_exact(&execution_plan)
+            || runtime.gpu_native_token_loop.is_some()
+            || runtime.engine.gpu_device_identity().is_some()
+        {
+            return Err("EXACT_F32_CPU did not resolve to strict CPU-only Q4".into());
+        }
+        let model_load = crate::greedy_parity_model_load(&runtime);
+        if !model_load_is_strict(&model_load) {
+            return Err("EXACT_F32_CPU did not load the strict real model".into());
+        }
+        let boundary_before = runtime.engine.cpu_q4_boundary_emulation_snapshot();
+        require_exact_boundary_clean(boundary_before)?;
+        let (final_hidden_by_prompt_position, final_trace) =
+            capture_cpu_prompt(&runtime, &token_ids, watchdog, "EXACT_F32_CPU").await?;
+        if final_trace.sampled_token != EXACT_F32_CPU_TOKEN {
+            return Err(format!(
+                "EXACT_F32_CPU Spanish first token was {}, frozen target is {EXACT_F32_CPU_TOKEN}",
+                final_trace.sampled_token
+            )
+            .into());
+        }
+        let router = router_attribution(
+            &final_trace,
+            historical_trace,
+            &gpu.final_trace,
+            &gpu.final_semantic_trace,
+            &runtime.model,
+        )?;
+        let expert_boundary = same_input_expert_boundary(
+            &runtime,
+            &gpu.final_semantic_trace,
+            historical_same_input_expert_outputs,
+        )
+        .await?;
+        let (same_input_rmsnorm, same_input_lm_head, downstream) = same_input_downstream(
+            &runtime.model,
+            &final_trace,
+            historical_trace,
+            &gpu.final_trace,
+        )?;
+        let boundary_after = runtime.engine.cpu_q4_boundary_emulation_snapshot();
+        require_exact_boundary_clean(boundary_after)?;
+        Ok::<_, Box<dyn std::error::Error>>(ExactPlaneCapture {
+            plane: CpuPlaneCapture {
+                final_hidden_by_prompt_position,
+                final_trace,
+                runtime: PlaneRuntimeEvidence {
+                    plane: "EXACT_F32_CPU",
+                    runtime_mode: "RealCliRuntimeMode::IsolatedGreedyParityCpu",
+                    isolated_runtime: true,
+                    kv_or_session_state_shared_with_another_plane: false,
+                    caller_owned_prompt_token_ids_sha256: crate::greedy_parity::token_ids_sha256(
+                        &token_ids,
+                    ),
+                    per_plane_retokenization_performed: false,
+                    resolved_config_sha256: observed_config_sha256,
+                    execution_plan,
+                    model_load,
+                    boundary_before: Some(boundary_before),
+                    boundary_after: Some(boundary_after),
+                    routed_execution_after: runtime.engine.routed_expert_execution_snapshot(),
+                    gpu_token_loop_after: None,
+                    prompt_token_steps_completed: token_ids.len(),
+                    generated_token_continuation_steps: 0,
+                    background_shutdown: crate::greedy_parity::BackgroundShutdownEvidence::default(
+                    ),
+                },
+            },
+            router,
+            expert_boundary,
+            same_input_rmsnorm,
+            same_input_lm_head,
+            downstream,
+        })
+    }
+    .await;
+    let shutdown = runtime.shutdown_isolated().await;
+    match (attempt, shutdown) {
+        (Ok(mut capture), Ok(shutdown)) => {
+            capture.plane.runtime.background_shutdown = shutdown;
+            Ok(capture)
+        }
+        (Err(error), Ok(_)) => Err(error),
+        (Ok(_), Err(shutdown_error)) => Err(shutdown_error.into()),
+        (Err(error), Err(shutdown_error)) => Err(IsolatedRuntimeShutdownError::new(format!(
+            "{error}; EXACT_F32_CPU shutdown also failed: {shutdown_error}"
+        ))
+        .into()),
+    }
+}
+
+fn prefill_summaries(
+    token_ids: &[u32],
+    exact: &[Vec<f32>],
+    historical: &[Vec<f32>],
+    gpu: &[Vec<f32>],
+) -> Result<Vec<PrefillPositionSummary>, String> {
+    if exact.len() != token_ids.len()
+        || historical.len() != token_ids.len()
+        || gpu.len() != token_ids.len()
+    {
+        return Err("three-plane prefill summary position counts differ".into());
+    }
+    token_ids
+        .iter()
+        .copied()
+        .enumerate()
+        .map(|(position, token_id)| {
+            Ok(PrefillPositionSummary {
+                position,
+                token_id,
+                final_hidden: three_way_compare(
+                    "prefill-final-hidden",
+                    &exact[position],
+                    &historical[position],
+                    &gpu[position],
+                )?,
+            })
+        })
+        .collect()
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ProductionSemanticsEvidence {
+    pub diagnostic_only: bool,
+    pub production_inference_changed: bool,
+    pub production_q4_changed: bool,
+    pub production_q4_wgsl_changed: bool,
+    pub production_router_gemv_changed: bool,
+    pub production_attention_changed: bool,
+    pub production_dense_gemv_changed: bool,
+    pub production_rmsnorm_changed: bool,
+    pub production_lm_head_changed: bool,
+    pub production_greedy_argmax_changed: bool,
+    pub production_residency_replay_or_prefetch_changed: bool,
+    pub v1_changed: bool,
+    pub v2_changed: bool,
+    pub limits_corpus_or_prompts_changed: bool,
+    pub numerical_threshold_introduced: bool,
+    pub production_correction_justified: bool,
+}
+
+impl Default for ProductionSemanticsEvidence {
+    fn default() -> Self {
+        Self {
+            diagnostic_only: true,
+            production_inference_changed: false,
+            production_q4_changed: false,
+            production_q4_wgsl_changed: false,
+            production_router_gemv_changed: false,
+            production_attention_changed: false,
+            production_dense_gemv_changed: false,
+            production_rmsnorm_changed: false,
+            production_lm_head_changed: false,
+            production_greedy_argmax_changed: false,
+            production_residency_replay_or_prefetch_changed: false,
+            v1_changed: false,
+            v2_changed: false,
+            limits_corpus_or_prompts_changed: false,
+            numerical_threshold_introduced: false,
+            production_correction_justified: false,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct DiagnosticProvenance {
+    pub build: crate::qualification::BuildProvenance,
+    pub executable_sha256: String,
+    pub artifacts: crate::qualification::QualificationArtifacts,
+    pub source_config: crate::gpu_native_greedy_parity::SourceConfigEvidence,
+    pub model_identity: crate::greedy_parity::ModelIdentityEvidence,
+    pub expert_metadata: crate::qualification::ExpertMetadataEvidence,
+    pub expected_adapter_name: String,
+    pub actual_adapter: crate::backend::GpuDeviceIdentity,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct SpanishFirstTokenAttributionReport {
+    pub schema: &'static str,
+    pub mode: &'static str,
+    pub diagnostic_only: bool,
+    pub diagnostic_complete: bool,
+    qualification_pass: bool,
+    pub failure: Option<String>,
+    pub frozen_evidence_preflight: FrozenEvidencePreflight,
+    pub target: FrozenSpanishTargetIdentity,
+    pub shared_tokenization: SharedTokenizationEvidence,
+    pub provenance: DiagnosticProvenance,
+    pub runtimes: Vec<PlaneRuntimeEvidence>,
+    pub prefill_position_summaries: Vec<PrefillPositionSummary>,
+    pub final_position_full_traces: Vec<PlaneFullTraceEvidence>,
+    pub final_position_three_way_comparison: FinalPositionTraceComparison,
+    pub same_input_router_analysis: RouterAttributionEvidence,
+    pub same_input_expert_boundary: SameInputExpertBoundaryEvidence,
+    pub same_input_final_rmsnorm: SameInputFinalRmsnormEvidence,
+    pub same_input_lm_head: SameInputLmHeadEvidence,
+    pub historical_f16_compensation_analysis: HistoricalF16CompensationAnalysis,
+    pub attribution: ConservativeAttributionEvidence,
+    pub production_semantics: ProductionSemanticsEvidence,
+    pub positions_after_generated_position_zero_inspected: bool,
+    pub scientific_interpretation: Vec<String>,
+}
+
+impl SpanishFirstTokenAttributionReport {
+    pub const fn qualification_pass(&self) -> bool {
+        self.qualification_pass
+    }
+}
+
+fn emit_report(
+    report: &SpanishFirstTokenAttributionReport,
+    report_out: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if report.qualification_pass()
+        || !report.diagnostic_only
+        || !report.diagnostic_complete
+        || report.failure.is_some()
+    {
+        return Err("Spanish attribution report must remain complete, diagnostic-only, and qualification false".into());
+    }
+    if let Some(parent) = report_out.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut json = serde_json::to_vec_pretty(report)?;
+    json.push(b'\n');
+    std::fs::write(report_out, json)?;
+    eprintln!(
+        "GPU-native Spanish first-token attribution report written to {}",
+        report_out.display()
+    );
+    Ok(())
+}
+
+fn validate_first_token_scope(
+    prompt_token_count: usize,
+    runtimes: &[PlaneRuntimeEvidence],
+) -> Result<(), String> {
+    if runtimes.len() != 3
+        || runtimes.iter().any(|runtime| {
+            runtime.prompt_token_steps_completed != prompt_token_count
+                || runtime.generated_token_continuation_steps != 0
+        })
+    {
+        return Err("three-plane execution must stop immediately after first-token argmax".into());
+    }
+    Ok(())
+}
+
+fn validate_three_plane_isolation(
+    runtimes: &[PlaneRuntimeEvidence],
+    prompt_token_ids_sha256: &str,
+) -> Result<(), String> {
+    let expected = ["EXACT_F32_CPU", "HISTORICAL_F16_CPU", "GPU_NATIVE"];
+    if runtimes.len() != expected.len()
+        || runtimes
+            .iter()
+            .zip(expected)
+            .any(|(runtime, plane)| runtime.plane != plane)
+        || runtimes.iter().any(|runtime| {
+            !runtime.isolated_runtime
+                || runtime.kv_or_session_state_shared_with_another_plane
+                || runtime.per_plane_retokenization_performed
+                || runtime.caller_owned_prompt_token_ids_sha256 != prompt_token_ids_sha256
+                || runtime.execution_plan.context_id.is_empty()
+        })
+        || runtimes
+            .iter()
+            .map(|runtime| runtime.execution_plan.context_id.as_str())
+            .collect::<BTreeSet<_>>()
+            .len()
+            != expected.len()
+    {
+        return Err("the exact, historical, and GPU planes were not independently isolated".into());
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn run_diagnostic(
+    config: PathBuf,
+    cfg: crate::config::Config,
+    v2_report: PathBuf,
+    expected_v2_report_sha256: String,
+    stage_report: PathBuf,
+    expected_stage_report_sha256: String,
+    boundary_audit_report: PathBuf,
+    expected_boundary_audit_report_sha256: String,
+    expected_adapter_name: String,
+    report_out: PathBuf,
+    progress_watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use crate::qualification::BuildProvenance;
+
+    // Immutable historical evidence validation is deliberately the first
+    // operation, before tokenizer, model, engine, device, or runtime creation.
+    let frozen = FrozenInputs::read_and_validate(
+        &v2_report,
+        &expected_v2_report_sha256,
+        &stage_report,
+        &expected_stage_report_sha256,
+        &boundary_audit_report,
+        &expected_boundary_audit_report_sha256,
+    )?;
+    if output_conflicts_with_input(&report_out, &frozen.identity)? {
+        return Err("report output must not overwrite a frozen historical input".into());
+    }
+    if progress_watchdog.timeout.is_none() {
+        return Err("Spanish first-token attribution requires a positive progress timeout".into());
+    }
+    if expected_adapter_name != REQUIRED_ADAPTER_NAME {
+        return Err(format!(
+            "Spanish first-token attribution requires --expected-adapter-name {REQUIRED_ADAPTER_NAME:?}"
+        )
+        .into());
+    }
+    let build = BuildProvenance::embedded();
+    if build.dirty != Some(false) || build.git_sha.as_deref().is_none_or(|sha| !is_hex(sha, 40)) {
+        return Err(
+            "Spanish first-token attribution requires clean embedded Git provenance".into(),
+        );
+    }
+    let (artifacts, artifact_errors) = crate::qualification_artifacts(&config, &cfg);
+    if !artifact_errors.is_empty() {
+        return Err(format!(
+            "Spanish first-token attribution artifact preflight failed: {}",
+            artifact_errors.join("; ")
+        )
+        .into());
+    }
+    let capacity_bytes = cfg
+        .gpu_cache
+        .vram_capacity_mb
+        .checked_mul(1024 * 1024)
+        .and_then(|bytes| u64::try_from(bytes).ok())
+        .unwrap_or(0);
+    let source_config = crate::gpu_native_greedy_parity::SourceConfigEvidence {
+        real_transformer_enabled: cfg.real_transformer.enabled,
+        gpu_native_enabled: cfg.real_transformer.gpu_native,
+        weights_dir_configured: cfg.real_transformer.weights_dir.is_some(),
+        strict_weights: cfg.real_transformer.strict_weights,
+        allow_seeded_fallback: cfg.real_transformer.allow_seeded_fallback,
+        allow_degraded_experts: cfg.real_transformer.allow_degraded_experts,
+        allow_nonfinite_attention_fallback: cfg.real_transformer.allow_nonfinite_attention_fallback,
+        allow_truncated_expert_payloads: cfg.real_transformer.allow_truncated_expert_payloads,
+        distributed_enabled: cfg.distributed.enabled,
+        gpu_cache_enabled: cfg.gpu_cache.enabled,
+        gpu_expert_capacity_bytes: capacity_bytes,
+        routed_expert_dtype: cfg.model.dtype.as_str().to_string(),
+    };
+    if !source_config.is_strict() {
+        return Err(
+            "Spanish first-token attribution requires strict GPU-native Q4 configuration".into(),
+        );
+    }
+    let expert_metadata =
+        crate::qualification::read_expert_metadata(&cfg.model.data_dir.join("metadata.json"))
+            .map_err(|error| format!("Spanish attribution expert metadata failed: {error}"))?;
+    if expert_metadata.dtype.as_deref() != Some("q4_0")
+        || expert_metadata.q4_0_layout.as_deref() != Some(crate::inference::Q4_0_LAYOUT_STANDARD_V1)
+        || expert_metadata.explicitly_synthetic
+    {
+        return Err(
+            "Spanish first-token attribution requires canonical nonsynthetic Q4_0 metadata".into(),
+        );
+    }
+
+    let mut gpu_spec = crate::resolve_real_cli_spec_from_config(
+        cfg,
+        RealCliRuntimeMode::IsolatedGpuNativeDiagnostic,
+    )?;
+    gpu_spec.cfg.real_transformer.gpu_native = true;
+    gpu_spec.cfg.real_transformer.compute_offload = crate::backend::ComputeOffload::Gpu;
+    let model_identity = crate::greedy_parity_model_identity(&gpu_spec);
+    if !model_identity.is_qwen3_coder_30b_a3b_q4_0() {
+        return Err(
+            "Spanish first-token attribution requires exact Qwen3-Coder 30B-A3B Q4_0 geometry"
+                .into(),
+        );
+    }
+    let gpu_resolved_config_sha256 = crate::resolved_real_cli_spec_sha256(&gpu_spec)?;
+    let mut cpu_spec = gpu_spec.clone();
+    cpu_spec.cfg.real_transformer.gpu_native = false;
+    cpu_spec.cfg.real_transformer.compute_offload = crate::backend::ComputeOffload::Cpu;
+    let cpu_resolved_config_sha256 = crate::resolved_real_cli_spec_sha256(&cpu_spec)?;
+    let tokenizer_path = gpu_spec
+        .cfg
+        .tokenizer
+        .path
+        .as_ref()
+        .ok_or("Spanish first-token attribution requires tokenizer.path")?;
+    let tokenizer = Arc::new(crate::tokenizer::Tokenizer::from_file(tokenizer_path)?);
+    let (token_ids, shared_tokenization) = shared_tokenization(&tokenizer)?;
+    let [gpu_token_ids, historical_token_ids, exact_token_ids] = shared_plane_token_ids(&token_ids);
+
+    let gpu = execute_gpu_plane(
+        &gpu_spec,
+        tokenizer.clone(),
+        gpu_token_ids,
+        &gpu_resolved_config_sha256,
+        &expected_adapter_name,
+        progress_watchdog,
+    )
+    .await?;
+    let historical = execute_historical_plane(
+        &cpu_spec,
+        tokenizer.clone(),
+        historical_token_ids,
+        &cpu_resolved_config_sha256,
+        &gpu.final_semantic_trace,
+        progress_watchdog,
+    )
+    .await?;
+    let exact = execute_exact_plane(
+        &cpu_spec,
+        tokenizer,
+        exact_token_ids,
+        &cpu_resolved_config_sha256,
+        &historical.plane.final_trace,
+        &historical.same_input_expert_outputs,
+        &gpu,
+        progress_watchdog,
+    )
+    .await?;
+
+    let prefill_position_summaries = prefill_summaries(
+        &token_ids,
+        &exact.plane.final_hidden_by_prompt_position,
+        &historical.plane.final_hidden_by_prompt_position,
+        &gpu.final_hidden_by_prompt_position,
+    )?;
+    let final_position_three_way_comparison = compare_final_traces(
+        &exact.plane.final_trace,
+        &historical.plane.final_trace,
+        &gpu.final_trace,
+        &gpu.final_semantic_trace,
+    )?;
+    let historical_f16_compensation_analysis =
+        compensation_analysis(&final_position_three_way_comparison);
+    let attribution = derive_attribution(
+        exact.plane.final_trace.sampled_token,
+        historical.plane.final_trace.sampled_token,
+        gpu.final_trace.sampled_token,
+        &exact.downstream,
+        &exact.router,
+    );
+    let full_traces = vec![
+        cpu_plane_full_trace("EXACT_F32_CPU", &exact.plane.final_trace)?,
+        cpu_plane_full_trace("HISTORICAL_F16_CPU", &historical.plane.final_trace)?,
+        gpu_plane_full_trace(&gpu.final_trace, &gpu.final_semantic_trace)?,
+    ];
+    let runtimes = vec![exact.plane.runtime, historical.plane.runtime, gpu.runtime];
+    validate_first_token_scope(token_ids.len(), &runtimes)?;
+    validate_three_plane_isolation(&runtimes, &shared_tokenization.prompt_token_ids_sha256)?;
+    if runtimes.iter().any(|runtime| {
+        !runtime.background_shutdown.controlled_shutdown_requested
+            || !runtime.background_shutdown.all_runtime_resources_released
+            || runtime.caller_owned_prompt_token_ids_sha256
+                != shared_tokenization.prompt_token_ids_sha256
+    }) {
+        return Err(
+            "one or more attribution runtimes violated shutdown/tokenization/scope contracts"
+                .into(),
+        );
+    }
+    let (_, executable_sha256) = crate::current_executable_identity()?;
+    let report = SpanishFirstTokenAttributionReport {
+        schema: SCHEMA_VERSION,
+        mode: MODE,
+        diagnostic_only: true,
+        diagnostic_complete: true,
+        qualification_pass: QUALIFICATION_PASS,
+        failure: None,
+        frozen_evidence_preflight: frozen.identity,
+        target: FrozenSpanishTargetIdentity::default(),
+        shared_tokenization,
+        provenance: DiagnosticProvenance {
+            build,
+            executable_sha256,
+            artifacts,
+            source_config,
+            model_identity,
+            expert_metadata,
+            expected_adapter_name,
+            actual_adapter: gpu.device,
+        },
+        runtimes,
+        prefill_position_summaries,
+        final_position_full_traces: full_traces,
+        final_position_three_way_comparison,
+        same_input_router_analysis: exact.router,
+        same_input_expert_boundary: exact.expert_boundary,
+        same_input_final_rmsnorm: exact.same_input_rmsnorm,
+        same_input_lm_head: exact.same_input_lm_head,
+        historical_f16_compensation_analysis,
+        attribution,
+        production_semantics: ProductionSemanticsEvidence::default(),
+        positions_after_generated_position_zero_inspected: false,
+        scientific_interpretation: vec![
+            "the exact-f32 CPU, historical-f16 CPU, and production GPU-native planes were isolated and consumed one caller-owned frozen tokenization".into(),
+            "historical-f16 proximity is descriptive compensation evidence and does not make the old f16 boundary the correct reference".into(),
+            "no production correction is justified by this diagnostic branch alone".into(),
+        ],
+    };
+    emit_report(&report, &report_out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_v2() -> FrozenV2Envelope {
+        let token_cases = crate::gpu_native_semantic_parity_v2::HOLDOUT_CORPUS
+            .into_iter()
+            .map(|case| {
+                let mut reference = vec![11; 16];
+                let mut gpu = reference.clone();
+                if case.name == TARGET_CASE {
+                    reference[0] = HISTORICAL_F16_CPU_TOKEN;
+                    gpu[0] = FROZEN_GPU_TOKEN;
+                }
+                let comparison = crate::gpu_native_semantic_parity_corpus::TokenCaseEvidence::new(
+                    case.name,
+                    reference.clone(),
+                    gpu.clone(),
+                );
+                FrozenTokenCaseEnvelope {
+                    case: case.name.into(),
+                    reference_generated_token_ids: reference,
+                    gpu_generated_token_ids: gpu,
+                    exact_match_count: comparison.exact_match_count,
+                    mismatch_count: comparison.mismatch_count,
+                    first_mismatch_position: comparison.first_mismatch_position,
+                }
+            })
+            .collect();
+        FrozenV2Envelope {
+            schema: crate::gpu_native_semantic_parity_v2::SCHEMA_VERSION.into(),
+            qualification_pass: false,
+            provenance: FrozenProvenanceEnvelope {
+                build: FrozenBuildEnvelope {
+                    git_sha: Some(FROZEN_V2_BUILD_SHA.into()),
+                },
+            },
+            holdout_corpus: FrozenCorpusEnvelope {
+                id: crate::gpu_native_semantic_parity_v2::HOLDOUT_CORPUS_ID.into(),
+                version: crate::gpu_native_semantic_parity_v2::HOLDOUT_CORPUS_VERSION,
+                sha256: crate::gpu_native_semantic_parity_v2::HOLDOUT_CORPUS_SHA256.into(),
+                case_count: 4,
+                output_token_limit: 16,
+            },
+            numerical_limits: FrozenNumericalLimitsEnvelope {
+                max_absolute_error_limit:
+                    crate::gpu_native_semantic_parity_v2::MAX_ABSOLUTE_ERROR_LIMIT,
+                rms_error_limit: crate::gpu_native_semantic_parity_v2::RMS_ERROR_LIMIT,
+                mean_absolute_error_limit:
+                    crate::gpu_native_semantic_parity_v2::MEAN_ABSOLUTE_ERROR_LIMIT,
+                nonfinite_mismatch_limit:
+                    crate::gpu_native_semantic_parity_v2::NONFINITE_MISMATCH_LIMIT,
+                semantic_correctness_not_bit_parity: true,
+            },
+            token_cases,
+        }
+    }
+
+    fn valid_stage() -> FrozenStageEnvelope {
+        let targets = expected_stage_targets();
+        FrozenStageEnvelope {
+            schema: crate::gpu_native_q4_expert_stage_attribution::SCHEMA_VERSION.into(),
+            diagnostic_complete: true,
+            qualification_pass: false,
+            failure: None,
+            provenance: FrozenProvenanceEnvelope {
+                build: FrozenBuildEnvelope {
+                    git_sha: Some(FROZEN_STAGE_BUILD_SHA.into()),
+                },
+            },
+            frozen_targets: targets.clone(),
+            targets: targets
+                .into_iter()
+                .map(|target| FrozenStageTargetEnvelope {
+                    target,
+                    experts: vec![serde_json::Value::Null; 8],
+                    failure: None,
+                })
+                .collect(),
+        }
+    }
+
+    fn token_case(case: &str) -> FrozenCpuTokenCaseEnvelope {
+        let spanish = case == TARGET_CASE;
+        let corrected = if spanish {
+            vec![EXACT_F32_CPU_TOKEN; 16]
+        } else if case == "rust-ownership-holdout" {
+            let mut values = vec![11; 16];
+            values[1] = 8_822;
+            values
+        } else {
+            vec![11; 16]
+        };
+        let gpu = if spanish {
+            vec![FROZEN_GPU_TOKEN; 16]
+        } else {
+            corrected.clone()
+        };
+        let historical = if spanish {
+            vec![HISTORICAL_F16_CPU_TOKEN; 16]
+        } else if case == "rust-ownership-holdout" {
+            let mut values = gpu.clone();
+            values[1] = 785;
+            values
+        } else {
+            gpu.clone()
+        };
+        FrozenCpuTokenCaseEnvelope {
+            case: case.into(),
+            requested_tokens: 16,
+            completed_tokens: 16,
+            exact_token_matches: if spanish { 0 } else { 16 },
+            mismatch_count: if spanish { 16 } else { 0 },
+            first_mismatch_position: spanish.then_some(0),
+            corrected_ordinary_f32_cpu_token_ids: corrected,
+            frozen_gpu_token_ids: gpu,
+            historical_old_boundary_cpu_reference_token_ids: historical,
+        }
+    }
+
+    fn valid_boundary() -> FrozenBoundaryEnvelope {
+        FrozenBoundaryEnvelope {
+            schema: crate::gpu_native_f32_reference_boundary_audit::SCHEMA_VERSION.into(),
+            diagnostic_only: true,
+            diagnostic_complete: true,
+            qualification_pass: false,
+            failure: None,
+            provenance: FrozenProvenanceEnvelope {
+                build: FrozenBuildEnvelope {
+                    git_sha: Some(FROZEN_BOUNDARY_AUDIT_BUILD_SHA.into()),
+                },
+            },
+            frozen_inputs: FrozenBoundaryInputsEnvelope {
+                v2_report: FrozenArtifactEnvelope {
+                    sha256: FROZEN_V2_REPORT_SHA256.into(),
+                },
+                stage_report: FrozenArtifactEnvelope {
+                    sha256: FROZEN_STAGE_REPORT_SHA256.into(),
+                },
+                exact_expert_identity_count: 72,
+                immutable_inputs_verified_before_runtime: true,
+            },
+            expert_records: vec![
+                FrozenBoundaryExpertEnvelope {
+                    improvement: FrozenImprovementEnvelope {
+                        exact_f32_error_smaller_than_old_f16_error_maxabs: true,
+                        exact_f32_error_smaller_than_old_f16_error_rms: true,
+                        exact_f32_error_smaller_than_old_f16_error_meanabs: true,
+                    },
+                };
+                72
+            ],
+            part_a_aggregation: FrozenPartAAggregationEnvelope {
+                expert_record_count: 72,
+                exact_f32_smaller_than_old_f16_maxabs_count: 72,
+                exact_f32_smaller_than_old_f16_rms_count: 72,
+                exact_f32_smaller_than_old_f16_meanabs_count: 72,
+            },
+            corrected_cpu_token_cases: crate::gpu_native_semantic_parity_v2::HOLDOUT_CORPUS
+                .into_iter()
+                .map(|case| token_case(case.name))
+                .collect(),
+            rust_ownership_position_one: FrozenRustPositionOneEnvelope {
+                historical_old_cpu_token_id: 785,
+                frozen_gpu_token_id: 8_822,
+                new_ordinary_f32_cpu_token_id: 8_822,
+            },
+            part_b_token_summary: FrozenPartBEnvelope {
+                requested_tokens: 64,
+                completed_tokens: 64,
+                exact_token_matches: 48,
+                mismatch_count: 16,
+            },
+            production_semantics: FrozenProductionSemanticsEnvelope {
+                diagnostic_only: true,
+                production_inference_changed: false,
+                production_q4_changed: false,
+                production_q4_wgsl_changed: false,
+                production_router_changed: false,
+                production_attention_changed: false,
+                v1_changed: false,
+                v2_changed: false,
+                v2_limits_changed: false,
+                v2_corpus_or_prompts_changed: false,
+                production_correction_made_or_justified: false,
+            },
+        }
+    }
+
+    fn runtime_evidence(plane: &'static str, prompt_steps: usize) -> PlaneRuntimeEvidence {
+        PlaneRuntimeEvidence {
+            plane,
+            runtime_mode: "isolated",
+            isolated_runtime: true,
+            kv_or_session_state_shared_with_another_plane: false,
+            caller_owned_prompt_token_ids_sha256: "a".repeat(64),
+            per_plane_retokenization_performed: false,
+            resolved_config_sha256: "b".repeat(64),
+            execution_plan: crate::qualification::ExecutionPlanEvidence {
+                context_id: plane.into(),
+                requested: "cpu".into(),
+                resolved: "cpu".into(),
+                embeddings: "cpu".into(),
+                lm_head: "cpu".into(),
+                dense_projections: "cpu".into(),
+                attention: "cpu".into(),
+                kv: "cpu".into(),
+                router: "cpu".into(),
+                routed_experts: "cpu".into(),
+                routed_expert_dtype: "q4_0".into(),
+                fallback_occurred: false,
+                reason: None,
+            },
+            model_load: crate::greedy_parity::ModelLoadEvidence {
+                strict: true,
+                loader: "test".into(),
+                loaded_tensors: 1,
+                required_tensors: 1,
+                optional_probed: 0,
+                optional_loaded: 0,
+                seeded_fallback_remained: false,
+            },
+            boundary_before: None,
+            boundary_after: None,
+            routed_execution_after: crate::engine::RoutedExpertExecutionSnapshot::default(),
+            gpu_token_loop_after: None,
+            prompt_token_steps_completed: prompt_steps,
+            generated_token_continuation_steps: 0,
+            background_shutdown: crate::greedy_parity::BackgroundShutdownEvidence::default(),
+        }
+    }
+
+    #[test]
+    fn schema_mode_target_and_diagnostic_contract_are_frozen() {
+        assert_eq!(
+            SCHEMA_VERSION,
+            "mer.gpu-native-spanish-first-token-attribution.v1"
+        );
+        assert_eq!(MODE, "diagnose-gpu-native-spanish-first-token-attribution");
+        assert!(!QUALIFICATION_PASS);
+        assert_eq!(FrozenSpanishTargetIdentity::default().case, TARGET_CASE);
+        assert_eq!(
+            FrozenSpanishTargetIdentity::default().corrected_exact_f32_cpu_token,
+            140_003
+        );
+    }
+
+    #[test]
+    fn exact_three_report_preflight_envelopes_fail_closed() {
+        assert!(validate_v2(&valid_v2()).is_ok());
+        assert!(validate_stage(&valid_stage()).is_ok());
+        assert!(validate_boundary(&valid_boundary()).is_ok());
+
+        let mut v2 = valid_v2();
+        v2.token_cases
+            .iter_mut()
+            .find(|case| case.case == TARGET_CASE)
+            .unwrap()
+            .gpu_generated_token_ids[0] = 1;
+        assert!(validate_v2(&v2).is_err());
+        let mut v2 = valid_v2();
+        v2.numerical_limits.max_absolute_error_limit = 1.0;
+        assert!(validate_v2(&v2).is_err());
+        let mut stage = valid_stage();
+        stage.targets[0].experts.pop();
+        assert!(validate_stage(&stage).is_err());
+        let mut boundary = valid_boundary();
+        boundary.expert_records[0]
+            .improvement
+            .exact_f32_error_smaller_than_old_f16_error_rms = false;
+        assert!(validate_boundary(&boundary).is_err());
+    }
+
+    #[test]
+    fn frozen_sha_arguments_are_literal() {
+        assert!(validate_expected_sha(
+            FROZEN_BOUNDARY_AUDIT_REPORT_SHA256,
+            FROZEN_BOUNDARY_AUDIT_REPORT_SHA256,
+            "boundary"
+        )
+        .is_ok());
+        assert!(validate_expected_sha(
+            &"0".repeat(64),
+            FROZEN_BOUNDARY_AUDIT_REPORT_SHA256,
+            "boundary"
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn snapshot_hash_validation_uses_one_byte_identity() {
+        let bytes = b"one-immutable-snapshot";
+        let sha = crate::greedy_parity::sha256_hex(bytes);
+        let artifact = crate::qualification::ArtifactDigest {
+            configured_path: "report.json".into(),
+            canonical_path: "/report.json".into(),
+            byte_length: bytes.len() as u64,
+            sha256: sha.clone(),
+        };
+        assert!(validate_artifact_hash(&artifact, &sha, &sha, "report").is_ok());
+        assert!(validate_artifact_hash(&artifact, &"0".repeat(64), &sha, "report").is_err());
+    }
+
+    #[test]
+    fn caller_owned_token_ids_are_shared_by_all_three_planes() {
+        let ids = Arc::new(vec![1, 2, 3]);
+        let planes = shared_plane_token_ids(&ids);
+        assert!(planes.iter().all(|plane| Arc::ptr_eq(&ids, plane)));
+        assert_eq!(
+            crate::greedy_parity::token_ids_sha256(&planes[0]),
+            crate::greedy_parity::token_ids_sha256(&planes[2])
+        );
+    }
+
+    #[test]
+    fn exact_f32_boundary_must_remain_disabled_and_zero() {
+        assert!(require_exact_boundary_clean(
+            crate::engine::CpuQ4BoundaryEmulationSnapshot::default()
+        )
+        .is_ok());
+        assert!(
+            require_exact_boundary_clean(crate::engine::CpuQ4BoundaryEmulationSnapshot {
+                enabled: true,
+                routed_expert_dispatches: 0,
+            })
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn historical_f16_boundary_must_start_explicitly_enabled_and_zero() {
+        assert!(
+            require_historical_boundary_clean(crate::engine::CpuQ4BoundaryEmulationSnapshot {
+                enabled: true,
+                routed_expert_dispatches: 0,
+            })
+            .is_ok()
+        );
+        assert!(require_historical_boundary_clean(
+            crate::engine::CpuQ4BoundaryEmulationSnapshot::default()
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn three_plane_scope_stops_after_first_argmax() {
+        let mut runtimes = vec![
+            runtime_evidence("EXACT_F32_CPU", 4),
+            runtime_evidence("HISTORICAL_F16_CPU", 4),
+            runtime_evidence("GPU_NATIVE", 4),
+        ];
+        let shared_sha = "a".repeat(64);
+        assert!(validate_first_token_scope(4, &runtimes).is_ok());
+        assert!(validate_three_plane_isolation(&runtimes, &shared_sha).is_ok());
+        runtimes[1].execution_plan.context_id = runtimes[0].execution_plan.context_id.clone();
+        assert!(validate_three_plane_isolation(&runtimes, &shared_sha).is_err());
+        let mut bad = runtimes;
+        bad[2].generated_token_continuation_steps = 1;
+        assert!(validate_first_token_scope(4, &bad).is_err());
+    }
+
+    #[test]
+    fn same_input_router_stage_is_ordered_and_explicit() {
+        assert_eq!(
+            derive_same_input_router_stage(&[1, 2], &[1, 2], &[1, 2]),
+            SameInputRouterStage::ExactOrderedMatch
+        );
+        assert_eq!(
+            derive_same_input_router_stage(&[1, 2], &[2, 1], &[2, 1]),
+            SameInputRouterStage::GpuRouterGemvDrift
+        );
+        assert_eq!(
+            derive_same_input_router_stage(&[1, 2], &[1, 2], &[2, 1]),
+            SameInputRouterStage::GpuRouterSoftmaxTopkDrift
+        );
+    }
+
+    #[test]
+    fn same_input_rmsnorm_and_lm_head_interventions_drive_discrete_categories() {
+        let router = RouterAttributionEvidence {
+            layers: Vec::new(),
+            first_same_input_ordered_id_mismatch_layer: None,
+            known_postgres_defect_preserved_as_separate: true,
+            known_postgres_defect: "separate",
+        };
+        let rms = derive_attribution(
+            EXACT_F32_CPU_TOKEN,
+            FROZEN_GPU_TOKEN,
+            FROZEN_GPU_TOKEN,
+            &DownstreamCounterfactuals {
+                cpu_argmax_on_cpu_norm_of_gpu_hidden: EXACT_F32_CPU_TOKEN,
+                cpu_argmax_on_actual_gpu_norm: FROZEN_GPU_TOKEN,
+                deterministic_argmax_on_actual_gpu_logits: FROZEN_GPU_TOKEN,
+            },
+            &router,
+        );
+        assert!(rms
+            .supporting_classifications
+            .contains(&AttributionCategory::FinalRmsnormDrift));
+        let lm = derive_attribution(
+            EXACT_F32_CPU_TOKEN,
+            FROZEN_GPU_TOKEN,
+            FROZEN_GPU_TOKEN,
+            &DownstreamCounterfactuals {
+                cpu_argmax_on_cpu_norm_of_gpu_hidden: EXACT_F32_CPU_TOKEN,
+                cpu_argmax_on_actual_gpu_norm: EXACT_F32_CPU_TOKEN,
+                deterministic_argmax_on_actual_gpu_logits: FROZEN_GPU_TOKEN,
+            },
+            &router,
+        );
+        assert!(lm
+            .supporting_classifications
+            .contains(&AttributionCategory::LmHeadGemvDrift));
+    }
+
+    #[test]
+    fn explicit_spanish_candidate_view_contains_140003_and_54275() {
+        let mut logits = vec![-10.0; EXACT_F32_CPU_TOKEN as usize + 1];
+        logits[EXACT_F32_CPU_TOKEN as usize] = 2.0;
+        logits[FROZEN_GPU_TOKEN as usize] = 1.5;
+        let view = logit_view("test", &logits).unwrap();
+        assert_eq!(view.argmax, EXACT_F32_CPU_TOKEN);
+        assert_eq!(view.top_12.len(), 12);
+        assert_eq!(
+            view.candidates_140003_and_54275
+                .iter()
+                .map(|candidate| candidate.token_id)
+                .collect::<Vec<_>>(),
+            [EXACT_F32_CPU_TOKEN, FROZEN_GPU_TOKEN]
+        );
+    }
+
+    #[test]
+    fn compensation_is_direct_descriptive_and_threshold_free() {
+        assert_eq!(
+            distance_relation(Some(1.0), Some(2.0)),
+            DistanceRelation::HistoricalF16Closer
+        );
+        assert_eq!(
+            distance_relation(Some(3.0), Some(2.0)),
+            DistanceRelation::ExactF32Closer
+        );
+        assert!(!ProductionSemanticsEvidence::default().numerical_threshold_introduced);
+    }
+
+    #[test]
+    fn production_v1_v2_and_numerics_remain_unchanged() {
+        let semantics = ProductionSemanticsEvidence::default();
+        assert!(semantics.diagnostic_only);
+        assert!(!semantics.production_inference_changed);
+        assert!(!semantics.production_q4_changed);
+        assert!(!semantics.production_q4_wgsl_changed);
+        assert!(!semantics.production_router_gemv_changed);
+        assert!(!semantics.v1_changed);
+        assert!(!semantics.v2_changed);
+        assert!(!semantics.limits_corpus_or_prompts_changed);
+        assert!(!semantics.production_correction_justified);
+    }
+}

--- a/rust-engine/src/gpu_native_spanish_first_token_attribution.rs
+++ b/rust-engine/src/gpu_native_spanish_first_token_attribution.rs
@@ -1936,20 +1936,115 @@ fn validate_cpu_geometry(runtime: &crate::BenchRealRuntime) -> Result<(), String
     Ok(())
 }
 
-fn validate_gpu_plan(plan: &crate::qualification::ExecutionPlanEvidence) -> Result<(), String> {
+struct GpuNativeAuthoritativeRuntimeEvidence {
+    legacy_execution_context: crate::qualification::ExecutionPlanEvidence,
+    gpu_native_token_loop_geometry: Option<crate::gpu_native_token_loop::GpuNativeModelGeometry>,
+    authoritative_device: Option<crate::backend::GpuDeviceIdentity>,
+    model_load: crate::greedy_parity::ModelLoadEvidence,
+    real_transformer_gpu_native: bool,
+    compute_offload: crate::backend::ComputeOffload,
+}
+
+/// Validate the deliberately retained legacy `ExecutionContext` plane map.
+///
+/// The CPU markers in this evidence do not describe placement in the
+/// GPU-native token loop. They prove that the legacy routed-expert registry is
+/// disabled while the authoritative context still owns the Vulkan device used
+/// by the separate GPU-native full-token path.
+fn validate_gpu_native_legacy_execution_context_contract(
+    plan: &crate::qualification::ExecutionPlanEvidence,
+) -> Result<(), String> {
     if plan.requested != "gpu"
         || plan.resolved != "gpu"
-        || plan.embeddings != "gpu"
-        || plan.lm_head != "gpu"
-        || plan.dense_projections != "gpu"
+        || plan.embeddings != "cpu"
+        || plan.lm_head != "cpu"
+        || plan.dense_projections != "cpu"
         || plan.attention != "gpu"
         || plan.kv != "gpu"
-        || plan.router != "gpu"
-        || plan.routed_experts != "gpu"
+        || plan.router != "cpu"
+        || plan.routed_experts != "cpu"
         || plan.routed_expert_dtype != "q4_0"
         || plan.fallback_occurred
     {
-        return Err("GPU_NATIVE did not resolve to the exact all-GPU production plan".into());
+        return Err(format!(
+            "GPU-native authoritative runtime contract rejected legacy ExecutionPlanEvidence: \
+             observed={plan:?}; expected requested=\"gpu\", resolved=\"gpu\", \
+             embeddings=\"cpu\", lm_head=\"cpu\", dense_projections=\"cpu\", \
+             attention=\"gpu\", kv=\"gpu\", router=\"cpu\", \
+             routed_experts=\"cpu\", routed_expert_dtype=\"q4_0\", \
+             fallback_occurred=false. ExecutionPlanEvidence is legacy \
+             execution-context evidence, not GPU-native token-loop placement; \
+             gpu_native_token_loop is validated separately as the authoritative \
+             GPU-native full-token path"
+        ));
+    }
+    Ok(())
+}
+
+fn validate_gpu_native_authoritative_runtime_contract(
+    evidence: &GpuNativeAuthoritativeRuntimeEvidence,
+    expected_adapter_name: &str,
+) -> Result<(), String> {
+    validate_gpu_native_legacy_execution_context_contract(&evidence.legacy_execution_context)?;
+
+    if !evidence.real_transformer_gpu_native
+        || evidence.compute_offload != crate::backend::ComputeOffload::Gpu
+    {
+        return Err(format!(
+            "GPU-native authoritative runtime contract requires \
+             real_transformer.gpu_native=true and compute_offload=Gpu, observed \
+             gpu_native={} compute_offload={:?}",
+            evidence.real_transformer_gpu_native, evidence.compute_offload
+        ));
+    }
+
+    let device = evidence.authoritative_device.as_ref().ok_or(
+        "GPU-native authoritative runtime contract requires authoritative GPU device identity; \
+         gpu_native_token_loop is the separately validated authoritative full-token path",
+    )?;
+    if expected_adapter_name != REQUIRED_ADAPTER_NAME
+        || device.name != expected_adapter_name
+        || device.vendor_id != 0x10de
+        || device.device_type != "DiscreteGpu"
+        || device.wgpu_backend != "vulkan"
+        || device.compute_plane != "wgpu-vulkan"
+        || device.software_adapter
+    {
+        return Err(format!(
+            "GPU-native authoritative runtime contract rejected authoritative device: \
+             observed={device:?}; expected adapter={REQUIRED_ADAPTER_NAME:?}, \
+             vendor_id=0x10de, device_type=\"DiscreteGpu\", wgpu_backend=\"vulkan\", \
+             compute_plane=\"wgpu-vulkan\", software_adapter=false; \
+             expected_adapter_name argument was {expected_adapter_name:?}"
+        ));
+    }
+
+    let geometry = evidence.gpu_native_token_loop_geometry.ok_or(
+        "GPU-native authoritative runtime contract requires gpu_native_token_loop; \
+         ExecutionPlanEvidence is only legacy execution-context evidence and is not \
+         proof of the authoritative GPU-native full-token path",
+    )?;
+    if geometry.num_layers != EXPECTED_NUM_LAYERS
+        || geometry.num_experts != EXPECTED_NUM_EXPERTS
+        || geometry.top_k != EXPECTED_TOP_K
+        || geometry.d_model != EXPECTED_D_MODEL
+        || geometry.d_ff != EXPECTED_D_FF
+    {
+        return Err(format!(
+            "GPU-native authoritative runtime contract rejected gpu_native_token_loop geometry: \
+             observed={geometry:?}; expected num_layers={EXPECTED_NUM_LAYERS}, \
+             num_experts={EXPECTED_NUM_EXPERTS}, top_k={EXPECTED_TOP_K}, \
+             d_model={EXPECTED_D_MODEL}, d_ff={EXPECTED_D_FF}"
+        ));
+    }
+
+    if !model_load_is_strict(&evidence.model_load) {
+        return Err(format!(
+            "GPU-native authoritative runtime contract rejected strict real model load: \
+             observed={:?}; expected strict=true, loaded_tensors=required_tensors>0, \
+             seeded_fallback_remained=false, loader!=\"seeded\"",
+            evidence.model_load
+        ));
     }
     Ok(())
 }
@@ -2063,42 +2158,32 @@ async fn execute_gpu_plane(
         }
         let execution_plan: crate::qualification::ExecutionPlanEvidence =
             runtime.engine.execution_context().plan().into();
-        validate_gpu_plan(&execution_plan)?;
-        let device = runtime
-            .engine
-            .gpu_device_identity()
-            .ok_or("GPU_NATIVE runtime has no authoritative adapter identity")?;
-        if expected_adapter_name != REQUIRED_ADAPTER_NAME
-            || device.name != expected_adapter_name
-            || device.software_adapter
-            || device.device_type.eq_ignore_ascii_case("cpu")
-        {
-            return Err(format!(
-                "GPU_NATIVE selected adapter {:?}, required exact {:?}",
-                device.name, REQUIRED_ADAPTER_NAME
-            )
-            .into());
-        }
+        let device = runtime.engine.gpu_device_identity();
+        let model_load = crate::greedy_parity_model_load(&runtime);
+        let authoritative_runtime = GpuNativeAuthoritativeRuntimeEvidence {
+            legacy_execution_context: execution_plan.clone(),
+            gpu_native_token_loop_geometry: runtime
+                .gpu_native_token_loop
+                .as_ref()
+                .map(|token_loop| token_loop.model_geometry()),
+            authoritative_device: device.clone(),
+            model_load: model_load.clone(),
+            real_transformer_gpu_native: runtime.cfg.real_transformer.gpu_native,
+            compute_offload: runtime.cfg.real_transformer.compute_offload,
+        };
+        validate_gpu_native_authoritative_runtime_contract(
+            &authoritative_runtime,
+            expected_adapter_name,
+        )?;
+        let device = device.expect("authoritative runtime contract requires device identity");
         let token_loop = runtime
             .gpu_native_token_loop
             .as_ref()
-            .ok_or("GPU_NATIVE token loop was not constructed")?;
+            .expect("authoritative runtime contract requires gpu_native_token_loop");
         let geometry = token_loop.model_geometry();
-        if geometry.num_layers != EXPECTED_NUM_LAYERS
-            || geometry.num_experts != EXPECTED_NUM_EXPERTS
-            || geometry.top_k != EXPECTED_TOP_K
-            || geometry.d_model != EXPECTED_D_MODEL
-            || geometry.d_ff != EXPECTED_D_FF
-        {
-            return Err("GPU_NATIVE geometry differs from the frozen target".into());
-        }
         if token_loop.snapshot() != crate::gpu_native_token_loop::GpuNativeTokenLoopSnapshot::default()
         {
             return Err("GPU_NATIVE token-loop counters did not start at zero".into());
-        }
-        let model_load = crate::greedy_parity_model_load(&runtime);
-        if !model_load_is_strict(&model_load) {
-            return Err("GPU_NATIVE did not load the strict real model".into());
         }
         let full_layout = crate::gpu_native_diagnostics::GpuNativeDiagnosticTraceLayout::try_new(
             geometry.num_layers,
@@ -3076,6 +3161,79 @@ mod tests {
         }
     }
 
+    fn gpu_native_legacy_plan() -> crate::qualification::ExecutionPlanEvidence {
+        crate::qualification::ExecutionPlanEvidence {
+            context_id: "gpu-native-authoritative".into(),
+            requested: "gpu".into(),
+            resolved: "gpu".into(),
+            embeddings: "cpu".into(),
+            lm_head: "cpu".into(),
+            dense_projections: "cpu".into(),
+            attention: "gpu".into(),
+            kv: "gpu".into(),
+            router: "cpu".into(),
+            routed_experts: "cpu".into(),
+            routed_expert_dtype: "q4_0".into(),
+            fallback_occurred: false,
+            reason: None,
+        }
+    }
+
+    fn gpu_native_geometry() -> crate::gpu_native_token_loop::GpuNativeModelGeometry {
+        crate::gpu_native_token_loop::GpuNativeModelGeometry {
+            num_layers: EXPECTED_NUM_LAYERS,
+            d_model: EXPECTED_D_MODEL,
+            d_ff: EXPECTED_D_FF,
+            num_experts: EXPECTED_NUM_EXPERTS,
+            top_k: EXPECTED_TOP_K,
+            num_heads: 1,
+            num_kv_heads: 1,
+            head_dim: EXPECTED_D_MODEL,
+            rope_dim: EXPECTED_D_MODEL,
+            vocab_size: 151_936,
+            max_seq_len: 32,
+            rms_eps: 1e-6,
+            rope_base: 10_000.0,
+        }
+    }
+
+    fn strict_model_load() -> crate::greedy_parity::ModelLoadEvidence {
+        crate::greedy_parity::ModelLoadEvidence {
+            strict: true,
+            loader: "safetensors".into(),
+            loaded_tensors: 435,
+            required_tensors: 435,
+            optional_probed: 0,
+            optional_loaded: 0,
+            seeded_fallback_remained: false,
+        }
+    }
+
+    fn nvidia_l4_device() -> crate::backend::GpuDeviceIdentity {
+        crate::backend::GpuDeviceIdentity {
+            name: REQUIRED_ADAPTER_NAME.into(),
+            vendor_id: 0x10de,
+            device_id: 0,
+            device_type: "DiscreteGpu".into(),
+            wgpu_backend: "vulkan".into(),
+            driver: "580.173.02".into(),
+            driver_info: "test".into(),
+            compute_plane: "wgpu-vulkan".into(),
+            software_adapter: false,
+        }
+    }
+
+    fn gpu_native_authoritative_runtime() -> GpuNativeAuthoritativeRuntimeEvidence {
+        GpuNativeAuthoritativeRuntimeEvidence {
+            legacy_execution_context: gpu_native_legacy_plan(),
+            gpu_native_token_loop_geometry: Some(gpu_native_geometry()),
+            authoritative_device: Some(nvidia_l4_device()),
+            model_load: strict_model_load(),
+            real_transformer_gpu_native: true,
+            compute_offload: crate::backend::ComputeOffload::Gpu,
+        }
+    }
+
     fn runtime_evidence(plane: &'static str, prompt_steps: usize) -> PlaneRuntimeEvidence {
         PlaneRuntimeEvidence {
             plane,
@@ -3120,14 +3278,225 @@ mod tests {
     }
 
     #[test]
+    fn gpu_native_authoritative_runtime_accepts_factory_legacy_plan_and_separate_token_loop() {
+        let runtime = gpu_native_authoritative_runtime();
+        assert!(validate_gpu_native_authoritative_runtime_contract(
+            &runtime,
+            REQUIRED_ADAPTER_NAME
+        )
+        .is_ok());
+        assert_eq!(runtime.legacy_execution_context.embeddings, "cpu");
+        assert_eq!(runtime.legacy_execution_context.lm_head, "cpu");
+        assert_eq!(runtime.legacy_execution_context.dense_projections, "cpu");
+        assert_eq!(runtime.legacy_execution_context.router, "cpu");
+        assert_eq!(runtime.legacy_execution_context.routed_experts, "cpu");
+        assert!(runtime.gpu_native_token_loop_geometry.is_some());
+    }
+
+    #[test]
+    fn previous_all_gpu_execution_plan_assumption_is_rejected_with_observed_evidence() {
+        let mut runtime = gpu_native_authoritative_runtime();
+        runtime.legacy_execution_context.embeddings = "gpu".into();
+        runtime.legacy_execution_context.lm_head = "gpu".into();
+        runtime.legacy_execution_context.dense_projections = "gpu".into();
+        runtime.legacy_execution_context.router = "gpu".into();
+        runtime.legacy_execution_context.routed_experts = "gpu".into();
+        let error =
+            validate_gpu_native_authoritative_runtime_contract(&runtime, REQUIRED_ADAPTER_NAME)
+                .unwrap_err();
+        assert!(error.contains("observed=ExecutionPlanEvidence"));
+        assert!(error.contains("legacy execution-context evidence"));
+        assert!(error.contains("gpu_native_token_loop is validated separately"));
+    }
+
+    #[test]
+    fn gpu_native_legacy_plan_rejects_wrong_mode_and_fallback() {
+        for (requested, resolved) in [("cpu", "gpu"), ("gpu", "cpu")] {
+            let mut runtime = gpu_native_authoritative_runtime();
+            runtime.legacy_execution_context.requested = requested.into();
+            runtime.legacy_execution_context.resolved = resolved.into();
+            assert!(validate_gpu_native_authoritative_runtime_contract(
+                &runtime,
+                REQUIRED_ADAPTER_NAME
+            )
+            .is_err());
+        }
+        let mut runtime = gpu_native_authoritative_runtime();
+        runtime.legacy_execution_context.fallback_occurred = true;
+        assert!(validate_gpu_native_authoritative_runtime_contract(
+            &runtime,
+            REQUIRED_ADAPTER_NAME
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn gpu_native_legacy_plan_rejects_cpu_attention_or_kv() {
+        let mut attention = gpu_native_authoritative_runtime();
+        attention.legacy_execution_context.attention = "cpu".into();
+        assert!(validate_gpu_native_authoritative_runtime_contract(
+            &attention,
+            REQUIRED_ADAPTER_NAME
+        )
+        .is_err());
+
+        let mut kv = gpu_native_authoritative_runtime();
+        kv.legacy_execution_context.kv = "cpu".into();
+        assert!(
+            validate_gpu_native_authoritative_runtime_contract(&kv, REQUIRED_ADAPTER_NAME).is_err()
+        );
+    }
+
+    #[test]
+    fn gpu_native_legacy_plan_rejects_wrong_dtype_or_active_legacy_expert_registry() {
+        let mut dtype = gpu_native_authoritative_runtime();
+        dtype.legacy_execution_context.routed_expert_dtype = "f16".into();
+        assert!(
+            validate_gpu_native_authoritative_runtime_contract(&dtype, REQUIRED_ADAPTER_NAME)
+                .is_err()
+        );
+
+        let mut legacy_registry = gpu_native_authoritative_runtime();
+        legacy_registry.legacy_execution_context.routed_experts = "gpu".into();
+        assert!(validate_gpu_native_authoritative_runtime_contract(
+            &legacy_registry,
+            REQUIRED_ADAPTER_NAME
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn gpu_native_authoritative_runtime_requires_token_loop_and_exact_geometry() {
+        let mut missing = gpu_native_authoritative_runtime();
+        missing.gpu_native_token_loop_geometry = None;
+        let error =
+            validate_gpu_native_authoritative_runtime_contract(&missing, REQUIRED_ADAPTER_NAME)
+                .unwrap_err();
+        assert!(error.contains("requires gpu_native_token_loop"));
+
+        let mut wrong = gpu_native_authoritative_runtime();
+        wrong.gpu_native_token_loop_geometry.as_mut().unwrap().d_ff += 1;
+        assert!(
+            validate_gpu_native_authoritative_runtime_contract(&wrong, REQUIRED_ADAPTER_NAME)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn gpu_native_authoritative_runtime_requires_exact_hardware_vulkan_identity() {
+        let mut missing = gpu_native_authoritative_runtime();
+        missing.authoritative_device = None;
+        assert!(validate_gpu_native_authoritative_runtime_contract(
+            &missing,
+            REQUIRED_ADAPTER_NAME
+        )
+        .is_err());
+
+        let mut wrong_name = gpu_native_authoritative_runtime();
+        wrong_name.authoritative_device.as_mut().unwrap().name = "other".into();
+        assert!(validate_gpu_native_authoritative_runtime_contract(
+            &wrong_name,
+            REQUIRED_ADAPTER_NAME
+        )
+        .is_err());
+
+        let mut software = gpu_native_authoritative_runtime();
+        software
+            .authoritative_device
+            .as_mut()
+            .unwrap()
+            .software_adapter = true;
+        assert!(validate_gpu_native_authoritative_runtime_contract(
+            &software,
+            REQUIRED_ADAPTER_NAME
+        )
+        .is_err());
+
+        let mut wrong_backend = gpu_native_authoritative_runtime();
+        wrong_backend
+            .authoritative_device
+            .as_mut()
+            .unwrap()
+            .wgpu_backend = "metal".into();
+        assert!(validate_gpu_native_authoritative_runtime_contract(
+            &wrong_backend,
+            REQUIRED_ADAPTER_NAME
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn gpu_native_authoritative_runtime_requires_gpu_native_config_and_strict_model() {
+        let mut wrong_config = gpu_native_authoritative_runtime();
+        wrong_config.real_transformer_gpu_native = false;
+        assert!(validate_gpu_native_authoritative_runtime_contract(
+            &wrong_config,
+            REQUIRED_ADAPTER_NAME
+        )
+        .is_err());
+
+        let mut wrong_offload = gpu_native_authoritative_runtime();
+        wrong_offload.compute_offload = crate::backend::ComputeOffload::Cpu;
+        assert!(validate_gpu_native_authoritative_runtime_contract(
+            &wrong_offload,
+            REQUIRED_ADAPTER_NAME
+        )
+        .is_err());
+
+        let mut non_strict = gpu_native_authoritative_runtime();
+        non_strict.model_load.strict = false;
+        assert!(validate_gpu_native_authoritative_runtime_contract(
+            &non_strict,
+            REQUIRED_ADAPTER_NAME
+        )
+        .is_err());
+
+        let mut incomplete = gpu_native_authoritative_runtime();
+        incomplete.model_load.loaded_tensors -= 1;
+        assert!(validate_gpu_native_authoritative_runtime_contract(
+            &incomplete,
+            REQUIRED_ADAPTER_NAME
+        )
+        .is_err());
+
+        let mut seeded = gpu_native_authoritative_runtime();
+        seeded.model_load.seeded_fallback_remained = true;
+        assert!(
+            validate_gpu_native_authoritative_runtime_contract(&seeded, REQUIRED_ADAPTER_NAME)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn exact_and_historical_cpu_plane_contracts_remain_cpu_only() {
+        for plane in ["EXACT_F32_CPU", "HISTORICAL_F16_CPU"] {
+            let runtime = runtime_evidence(plane, 1);
+            assert!(crate::greedy_parity::cpu_plan_exact(
+                &runtime.execution_plan
+            ));
+            assert!(runtime.gpu_token_loop_after.is_none());
+        }
+    }
+
+    #[test]
     fn schema_mode_target_and_diagnostic_contract_are_frozen() {
         assert_eq!(
             SCHEMA_VERSION,
             "mer.gpu-native-spanish-first-token-attribution.v1"
         );
         assert_eq!(MODE, "diagnose-gpu-native-spanish-first-token-attribution");
+        assert!(ProductionSemanticsEvidence::default().diagnostic_only);
         assert!(!QUALIFICATION_PASS);
         assert_eq!(FrozenSpanishTargetIdentity::default().case, TARGET_CASE);
+        assert_eq!(FrozenSpanishTargetIdentity::default().generated_position, 0);
+        assert_eq!(
+            FrozenSpanishTargetIdentity::default().historical_f16_boundary_cpu_token,
+            HISTORICAL_F16_CPU_TOKEN
+        );
+        assert_eq!(
+            FrozenSpanishTargetIdentity::default().frozen_gpu_token,
+            FROZEN_GPU_TOKEN
+        );
         assert_eq!(
             FrozenSpanishTargetIdentity::default().corrected_exact_f32_cpu_token,
             140_003

--- a/rust-engine/src/gpu_native_token_loop.rs
+++ b/rust-engine/src/gpu_native_token_loop.rs
@@ -14,7 +14,8 @@ use crate::architecture::Architecture;
 use crate::backend::gpu_native::{
     GpuNativeAttentionGeometry, GpuNativeAttentionNorm, GpuNativeAttentionPlan,
     GpuNativeAttentionScratch, GpuNativeBootstrapError, GpuNativeDenseWeightHandle,
-    GpuNativeDenseWeightKey, GpuNativeExecutorContext, GpuNativeKvState, GpuNativeQ4ExpertGeometry,
+    GpuNativeDenseWeightKey, GpuNativeExecutorContext, GpuNativeKvState,
+    GpuNativePreExpertCheckpointLayout, GpuNativePreExpertCheckpoints, GpuNativeQ4ExpertGeometry,
     GpuNativeQ4ExpertScratch, GpuNativeRmsNormHandle, GpuNativeRouterGeometry, GpuNativeRouterPlan,
     GpuNativeRouterScratch, GpuNativeScratch, GpuNativeTokenState, GPU_NATIVE_STATUS_FATAL_MASK,
     GPU_NATIVE_STATUS_RETRYABLE_MASK, MAX_GPU_NATIVE_ROUTER_EXPERTS, MAX_GPU_NATIVE_ROUTER_TOP_K,
@@ -1094,6 +1095,14 @@ impl GpuNativeTokenLoop {
             .executor
             .create_scratch(self.model_geometry.vocab_size)?;
         let sampled_token_buf = self.executor.create_boundary_result_scratch(1)?;
+        let checkpoint_layout = GpuNativePreExpertCheckpointLayout::try_new(
+            self.model_geometry.num_layers,
+            self.model_geometry.d_model,
+            self.model_geometry.top_k,
+        )?;
+        let pre_expert_checkpoints = self
+            .executor
+            .create_pre_expert_checkpoints(checkpoint_layout)?;
 
         let gpu = self.executor.authoritative_gpu()?;
         let staging_buffer = gpu.device.create_buffer(&wgpu::BufferDescriptor {
@@ -1111,6 +1120,7 @@ impl GpuNativeTokenLoop {
             expert_scratch,
             logits_scratch,
             sampled_token_buf,
+            pre_expert_checkpoints,
             staging_buffer,
             committed_position: 0,
             max_seq_len: self.model_geometry.max_seq_len,
@@ -2658,6 +2668,7 @@ pub struct GpuNativeRequestState {
     pub expert_scratch: GpuNativeQ4ExpertScratch,
     pub logits_scratch: GpuNativeScratch,
     pub sampled_token_buf: GpuNativeScratch,
+    pub pre_expert_checkpoints: GpuNativePreExpertCheckpoints,
     pub staging_buffer: wgpu::Buffer,
     pub committed_position: usize,
     pub max_seq_len: usize,

--- a/rust-engine/src/gpu_native_token_loop.rs
+++ b/rust-engine/src/gpu_native_token_loop.rs
@@ -1057,7 +1057,7 @@ impl GpuNativeTokenLoop {
         let prefix_count = prompt_ids.len().saturating_sub(1);
         for &token_id in &prompt_ids[..prefix_count] {
             let pos = request.committed_position;
-            self.step_token(engine, request, token_id, pos, false)
+            self.step_token_unified_inner(engine, request, token_id, pos, false, None)
                 .await?;
         }
 
@@ -1065,8 +1065,9 @@ impl GpuNativeTokenLoop {
         let final_prompt = *prompt_ids.last().expect("checked non-empty");
         let final_prompt_pos = request.committed_position;
         let first_completion = self
-            .step_token(engine, request, final_prompt, final_prompt_pos, true)
+            .step_token_unified_inner(engine, request, final_prompt, final_prompt_pos, true, None)
             .await?
+            .sampled_token
             .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
                 detail: "final prompt step produced no sampled token".into(),
             })?;
@@ -1081,8 +1082,9 @@ impl GpuNativeTokenLoop {
                 break;
             }
             let next_token = self
-                .step_token(engine, request, last_token, pos, true)
+                .step_token_unified_inner(engine, request, last_token, pos, true, None)
                 .await?
+                .sampled_token
                 .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
                     detail: "decode step produced no sampled token".into(),
                 })?;
@@ -1102,8 +1104,9 @@ impl GpuNativeTokenLoop {
         position: usize,
         sample: bool,
     ) -> Result<Option<u32>, GpuNativeTokenLoopError> {
+        let _guard = self.execution_guard.lock().await;
         let out = self
-            .step_token_unified(engine, request, token_id, position, sample, None)
+            .step_token_unified_inner(engine, request, token_id, position, sample, None)
             .await?;
         Ok(out.sampled_token)
     }
@@ -1125,8 +1128,9 @@ impl GpuNativeTokenLoop {
         ),
         GpuNativeTokenLoopError,
     > {
+        let _guard = self.execution_guard.lock().await;
         let out = self
-            .step_token_unified(
+            .step_token_unified_inner(
                 engine,
                 request,
                 token_id,
@@ -1159,7 +1163,8 @@ impl GpuNativeTokenLoop {
     }
 
     /// Authoritative internal loop for stepping a token with bounded retries and demand residency service.
-    async fn step_token_unified(
+    /// Caller MUST hold self.execution_guard for the duration of the step or generation request.
+    async fn step_token_unified_inner(
         &self,
         engine: &Arc<Engine>,
         request: &mut GpuNativeRequestState,
@@ -1171,8 +1176,6 @@ impl GpuNativeTokenLoop {
             &wgpu::Buffer,
         )>,
     ) -> Result<GpuNativeStepOutput, GpuNativeTokenLoopError> {
-        let _guard = self.execution_guard.lock().await;
-
         let max_attempts = self.layers.len() + 1;
         let mut attempt = 0usize;
         let mut last_miss_sig: Option<(usize, Vec<u32>)> = None;
@@ -2150,9 +2153,11 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn gpu_native_token_state_hidden_and_residual_have_no_copy_src() {
+    fn gpu_native_token_state_hidden_and_residual_have_copy_src_and_no_map() {
         let usage = crate::backend::gpu_native::GpuNativeTokenStateLayout::tensor_usage();
-        assert!(!usage.contains(wgpu::BufferUsages::COPY_SRC));
+        assert!(usage.contains(wgpu::BufferUsages::STORAGE));
+        assert!(usage.contains(wgpu::BufferUsages::COPY_DST));
+        assert!(usage.contains(wgpu::BufferUsages::COPY_SRC));
         assert!(!usage.contains(wgpu::BufferUsages::MAP_READ));
         assert!(!usage.contains(wgpu::BufferUsages::MAP_WRITE));
     }
@@ -2164,11 +2169,11 @@ pub(crate) mod tests {
         };
 
         // 1. Generic scratch (hidden, residual, logits, attention/expert scratch):
-        // STORAGE | COPY_DST, strictly no COPY_SRC, no MAP_READ, no MAP_WRITE
+        // STORAGE | COPY_DST | COPY_SRC, strictly no MAP_READ, no MAP_WRITE
         let generic_scratch = GpuNativeScratchLayout::usage();
         assert!(generic_scratch.contains(wgpu::BufferUsages::STORAGE));
         assert!(generic_scratch.contains(wgpu::BufferUsages::COPY_DST));
-        assert!(!generic_scratch.contains(wgpu::BufferUsages::COPY_SRC));
+        assert!(generic_scratch.contains(wgpu::BufferUsages::COPY_SRC));
         assert!(!generic_scratch
             .intersects(wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::MAP_WRITE));
 
@@ -2429,47 +2434,6 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn successful_token_position_accounting_invariants() {
-        // Verifies the exact accounting delta invariant for successful token steps:
-        // - Starting committed_position = N advances to N + 1 (never N + 2)
-        // - tokens_completed delta is exactly 1 per completed token
-        // - warm_tokens_completed delta is exactly 1 for warm tokens, 0 for retried/cold tokens
-        let start_pos = 42usize;
-        let mut committed_position = start_pos;
-        let counters = GpuNativeTokenLoopCounters::default();
-
-        // 1. Warm successful token step (attempt 0 success, is_warm = true)
-        let is_warm_1 = true;
-        committed_position += 1;
-        counters.tokens_completed.fetch_add(1, Ordering::Relaxed);
-        if is_warm_1 {
-            counters
-                .warm_tokens_completed
-                .fetch_add(1, Ordering::Relaxed);
-        }
-
-        assert_eq!(committed_position, start_pos + 1);
-        let snap1 = counters.snapshot();
-        assert_eq!(snap1.tokens_completed, 1);
-        assert_eq!(snap1.warm_tokens_completed, 1);
-
-        // 2. Cold / retried successful token step (is_warm = false)
-        let is_warm_2 = false;
-        committed_position += 1;
-        counters.tokens_completed.fetch_add(1, Ordering::Relaxed);
-        if is_warm_2 {
-            counters
-                .warm_tokens_completed
-                .fetch_add(1, Ordering::Relaxed);
-        }
-
-        assert_eq!(committed_position, start_pos + 2);
-        let snap2 = counters.snapshot();
-        assert_eq!(snap2.tokens_completed, 2);
-        assert_eq!(snap2.warm_tokens_completed, 1);
-    }
-
-    #[test]
     fn disabled_mode_preserves_legacy_state() {
         let toml_str = r#"
             [model]
@@ -2569,23 +2533,35 @@ pub(crate) mod tests {
         }
     }
 
-    #[test]
-    #[ignore = "requires authoritative NVIDIA L4 WGPU validation hardware"]
-    fn live_l4_gpu_native_full_token_loop_retry() {
+    struct LiveL4Harness {
+        _temp_dir: TempDir,
+        engine: Arc<Engine>,
+        token_loop: Arc<GpuNativeTokenLoop>,
+        ram_cache: Arc<crate::multi_layer_cache::MultiLayerExpertCache>,
+        gpu_cache: Arc<crate::expert_cache::GpuExpertCache>,
+        residency_manager: Arc<GpuNativeTieredResidencyManager>,
+    }
+
+    const LIVE_L4_D_MODEL: usize = 32;
+    const LIVE_L4_D_FF: usize = 32;
+    const LIVE_L4_NUM_EXPERTS: usize = 4;
+    const LIVE_L4_TOP_K: usize = 2;
+    const LIVE_L4_NUM_LAYERS: usize = 2;
+    const LIVE_L4_VOCAB_SIZE: usize = 32;
+    const LIVE_L4_MAX_SEQ_LEN: usize = 8;
+
+    fn setup_live_l4_harness(tag: &str) -> LiveL4Harness {
         use crate::backend::{resolve_execution_context_for_gpu_native, GpuBackendGeometry};
         use crate::buffer_pool::BufferPool;
         use crate::expert_cache::{ExpertResident, GpuExpertCache, GpuResident};
 
-        const D_MODEL: usize = 32;
-        const D_FF: usize = 32;
-        const NUM_EXPERTS: usize = 4;
-        const TOP_K: usize = 2;
-        const NUM_LAYERS: usize = 2;
-        const VOCAB_SIZE: usize = 32;
-        const MAX_SEQ_LEN: usize = 8;
-
-        let geometry =
-            GpuNativeQ4ExpertGeometry::try_new(D_MODEL, D_FF, NUM_EXPERTS, TOP_K).unwrap();
+        let geometry = GpuNativeQ4ExpertGeometry::try_new(
+            LIVE_L4_D_MODEL,
+            LIVE_L4_D_FF,
+            LIVE_L4_NUM_EXPERTS,
+            LIVE_L4_TOP_K,
+        )
+        .unwrap();
         let payload_template =
             crate::backend::gpu_native::tests::q4_uniform_expert(geometry, 0.01, 0.02, 0.005);
         let payload_bytes = payload_template.len();
@@ -2594,8 +2570,8 @@ pub(crate) mod tests {
 
         let execution = resolve_execution_context_for_gpu_native(
             GpuBackendGeometry {
-                num_layers: NUM_LAYERS,
-                max_seq_len: MAX_SEQ_LEN,
+                num_layers: LIVE_L4_NUM_LAYERS,
+                max_seq_len: LIVE_L4_MAX_SEQ_LEN,
                 num_heads: 2,
                 num_kv_heads: 2,
                 head_dim: 16,
@@ -2608,7 +2584,7 @@ pub(crate) mod tests {
 
         let executor = Arc::new(
             execution
-                .create_gpu_native_executor_context(D_MODEL)
+                .create_gpu_native_executor_context(LIVE_L4_D_MODEL)
                 .expect("GPU-native executor must retain the authoritative backend"),
         );
         assert_eq!(executor.device_identity().vendor_id, 0x10de);
@@ -2618,47 +2594,48 @@ pub(crate) mod tests {
             executor.device_identity().name
         );
 
-        let total_budget = (payload_bytes as u64) * (TOP_K as u64) * (NUM_LAYERS as u64) * 2;
+        let total_budget =
+            (payload_bytes as u64) * (LIVE_L4_TOP_K as u64) * (LIVE_L4_NUM_LAYERS as u64) * 2;
         let residency_manager = Arc::new(
             GpuNativeTieredResidencyManager::try_new(
                 executor.clone(),
                 gpu_cache.clone(),
-                NUM_LAYERS,
+                LIVE_L4_NUM_LAYERS,
                 geometry,
                 total_budget,
             )
             .unwrap(),
         );
 
-        let temp_dir = TempDir::new("full_token_loop");
+        let temp_dir = TempDir::new(tag);
         let storage = Arc::new(
             crate::io_provider::NvmeStorage::new(crate::io_provider::StorageConfig {
                 base_path: temp_dir.path.clone(),
                 expert_size: payload_bytes,
                 block_align: 4,
                 use_direct_io: false,
-                num_experts_per_layer: Some(NUM_EXPERTS as u32),
+                num_experts_per_layer: Some(LIVE_L4_NUM_EXPERTS as u32),
             })
             .unwrap(),
         );
 
         let router = crate::gating::Router::Markov(Arc::new(crate::router::TopKRouter::new(
-            (NUM_EXPERTS * NUM_LAYERS) as u32,
-            TOP_K,
+            (LIVE_L4_NUM_EXPERTS * LIVE_L4_NUM_LAYERS) as u32,
+            LIVE_L4_TOP_K,
             0xC0FFEE,
         )));
         let predictor = Arc::new(crate::router::PredictiveLoader::new(
-            (NUM_EXPERTS * NUM_LAYERS) as u32,
-            TOP_K,
+            (LIVE_L4_NUM_EXPERTS * LIVE_L4_NUM_LAYERS) as u32,
+            LIVE_L4_TOP_K,
             0.0,
             42,
         ));
 
         let ram_cache = Arc::new(
             crate::multi_layer_cache::MultiLayerExpertCache::with_uniform_capacity(
-                NUM_LAYERS,
+                LIVE_L4_NUM_LAYERS,
                 16,
-                NUM_EXPERTS as u32,
+                LIVE_L4_NUM_EXPERTS as u32,
             ),
         );
 
@@ -2669,8 +2646,8 @@ pub(crate) mod tests {
             router,
             predictor,
             crate::engine::ModelShape {
-                d_model: D_MODEL,
-                d_ff: D_FF,
+                d_model: LIVE_L4_D_MODEL,
+                d_ff: LIVE_L4_D_FF,
                 hidden_seed: 0xC0FFEE,
             },
             crate::engine::EngineOptions {
@@ -2698,15 +2675,15 @@ pub(crate) mod tests {
         let engine = Arc::new(engine_builder);
 
         let cfg = RealModelConfig {
-            d_model: D_MODEL,
-            d_ff: D_FF,
+            d_model: LIVE_L4_D_MODEL,
+            d_ff: LIVE_L4_D_FF,
             num_heads: 2,
             num_kv_heads: 2,
             head_dim: 16,
-            vocab_size: VOCAB_SIZE,
-            num_layers: NUM_LAYERS,
-            num_experts: NUM_EXPERTS,
-            top_k: TOP_K,
+            vocab_size: LIVE_L4_VOCAB_SIZE,
+            num_layers: LIVE_L4_NUM_LAYERS,
+            num_experts: LIVE_L4_NUM_EXPERTS,
+            top_k: LIVE_L4_TOP_K,
             rope_base: 10_000.0,
             rms_eps: 1e-5,
             window_size: None,
@@ -2720,16 +2697,14 @@ pub(crate) mod tests {
             executor.clone(),
             residency_manager.clone(),
             &model,
-            MAX_SEQ_LEN,
+            LIVE_L4_MAX_SEQ_LEN,
         )
         .unwrap();
 
-        let mut request_state = token_loop.create_request_state().unwrap();
-
         let pool = BufferPool::new(16, payload_bytes, 4);
-        for layer_idx in 0..NUM_LAYERS {
-            for local_id in 0..NUM_EXPERTS as u32 {
-                let global_id = layer_idx as u32 * NUM_EXPERTS as u32 + local_id;
+        for layer_idx in 0..LIVE_L4_NUM_LAYERS {
+            for local_id in 0..LIVE_L4_NUM_EXPERTS as u32 {
+                let global_id = layer_idx as u32 * LIVE_L4_NUM_EXPERTS as u32 + local_id;
                 let payload = crate::backend::gpu_native::tests::q4_uniform_expert(
                     geometry,
                     0.01 * (global_id + 1) as f32,
@@ -2755,33 +2730,57 @@ pub(crate) mod tests {
             }
         }
 
+        LiveL4Harness {
+            _temp_dir: temp_dir,
+            engine,
+            token_loop,
+            ram_cache,
+            gpu_cache,
+            residency_manager,
+        }
+    }
+
+    #[test]
+    #[ignore = "requires authoritative NVIDIA L4 WGPU validation hardware"]
+    fn live_l4_gpu_native_full_token_loop_retry() {
+        let harness = setup_live_l4_harness("full_token_loop");
+        let mut request_state = harness.token_loop.create_request_state().unwrap();
+
         // Precondition assertions: RAM warm, logical GPU admissions present, physical VRAM cold.
-        for layer_idx in 0..NUM_LAYERS {
-            for local_id in 0..NUM_EXPERTS as u32 {
-                let global_id = layer_idx as u32 * NUM_EXPERTS as u32 + local_id;
+        for layer_idx in 0..LIVE_L4_NUM_LAYERS {
+            for local_id in 0..LIVE_L4_NUM_EXPERTS as u32 {
+                let global_id = layer_idx as u32 * LIVE_L4_NUM_EXPERTS as u32 + local_id;
                 assert!(
-                    ram_cache.contains(global_id),
+                    harness.ram_cache.contains(global_id),
                     "RAM cache must contain global_id {global_id}"
                 );
                 assert!(
-                    gpu_cache.current_admission(global_id).is_some(),
+                    harness.gpu_cache.current_admission(global_id).is_some(),
                     "gpu_cache must contain logical admission for global_id {global_id}"
                 );
                 assert_eq!(
-                    residency_manager.has_current_for_demand(global_id).unwrap(),
+                    harness
+                        .residency_manager
+                        .has_current_for_demand(global_id)
+                        .unwrap(),
                     false,
                     "physical residency manager must initially be cold for global_id {global_id}"
                 );
             }
         }
 
-        let first_token =
-            pollster::block_on(token_loop.step_token(&engine, &mut request_state, 1, 0, true))
-                .unwrap()
-                .expect("cold token 0 must succeed after retries");
+        let first_token = pollster::block_on(harness.token_loop.step_token(
+            &harness.engine,
+            &mut request_state,
+            1,
+            0,
+            true,
+        ))
+        .unwrap()
+        .expect("cold token 0 must succeed after retries");
 
         assert_eq!(request_state.committed_position, 1);
-        let snap1 = token_loop.snapshot();
+        let snap1 = harness.token_loop.snapshot();
         assert_eq!(snap1.tokens_completed, 1);
         assert_eq!(snap1.token_attempts, 3);
         assert_eq!(snap1.residency_miss_attempts, 2);
@@ -2789,8 +2788,8 @@ pub(crate) mod tests {
         assert_eq!(snap1.residency_services, 2);
         assert_eq!(snap1.fatal_failures, 0);
 
-        let _second_token = pollster::block_on(token_loop.step_token(
-            &engine,
+        let _second_token = pollster::block_on(harness.token_loop.step_token(
+            &harness.engine,
             &mut request_state,
             first_token,
             1,
@@ -2800,7 +2799,7 @@ pub(crate) mod tests {
         .expect("warm token 1 must succeed directly");
 
         assert_eq!(request_state.committed_position, 2);
-        let snap2 = token_loop.snapshot();
+        let snap2 = harness.token_loop.snapshot();
         assert_eq!(snap2.tokens_completed, 2);
         assert_eq!(snap2.warm_tokens_completed, 1);
         assert_eq!(snap2.token_attempts, 4);
@@ -2811,9 +2810,91 @@ pub(crate) mod tests {
         assert_eq!(snap2.fatal_failures, 0);
 
         assert_eq!(
-            engine.report().bytes_read,
+            harness.engine.report().bytes_read,
             0,
             "pure RAM->VRAM qualification must not fall back to storage reads"
         );
+    }
+
+    #[test]
+    #[ignore = "requires authoritative NVIDIA L4 WGPU validation hardware"]
+    fn live_l4_gpu_native_diagnostic_smoke() {
+        let harness = setup_live_l4_harness("diag_smoke");
+        let mut request_state = harness.token_loop.create_request_state().unwrap();
+
+        let trace_layout = crate::gpu_native_diagnostics::GpuNativeDiagnosticTraceLayout::try_new(
+            LIVE_L4_NUM_LAYERS,
+            LIVE_L4_D_MODEL,
+            LIVE_L4_TOP_K,
+            LIVE_L4_VOCAB_SIZE,
+        )
+        .unwrap();
+
+        let staging_buffer = harness
+            .token_loop
+            .create_diagnostic_staging_buffer(&trace_layout)
+            .unwrap();
+
+        let (trace, attempts) = pollster::block_on(harness.token_loop.step_token_diagnostic(
+            &harness.engine,
+            &mut request_state,
+            1,
+            0,
+            true,
+            &trace_layout,
+            &staging_buffer,
+        ))
+        .expect("diagnostic step on L4 must succeed");
+
+        assert_eq!(trace.embedding.len(), LIVE_L4_D_MODEL);
+        assert_eq!(trace.layer_post_attn.len(), LIVE_L4_NUM_LAYERS);
+        assert_eq!(trace.layer_router_input.len(), LIVE_L4_NUM_LAYERS);
+        assert_eq!(trace.layer_selected_ids.len(), LIVE_L4_NUM_LAYERS);
+        assert_eq!(trace.layer_selected_weights.len(), LIVE_L4_NUM_LAYERS);
+        assert_eq!(trace.layer_post_moe.len(), LIVE_L4_NUM_LAYERS);
+        assert_eq!(trace.layer_statuses.len(), LIVE_L4_NUM_LAYERS);
+        assert_eq!(trace.final_norm.len(), LIVE_L4_D_MODEL);
+        assert_eq!(trace.logits.len(), LIVE_L4_VOCAB_SIZE);
+        assert!(trace.sampled_token < LIVE_L4_VOCAB_SIZE as u32);
+        assert_eq!(trace.final_status, 0);
+        assert_eq!(request_state.committed_position, 1);
+        assert!(attempts > 0);
+
+        for l in 0..LIVE_L4_NUM_LAYERS {
+            assert_eq!(trace.layer_selected_ids[l].len(), LIVE_L4_TOP_K);
+            assert_eq!(trace.layer_selected_weights[l].len(), LIVE_L4_TOP_K);
+            assert_eq!(trace.layer_statuses[l], 0);
+            assert!(trace.layer_post_attn[l].iter().all(|v| v.is_finite()));
+            assert!(trace.layer_router_input[l].iter().all(|v| v.is_finite()));
+            assert!(trace.layer_selected_weights[l]
+                .iter()
+                .all(|v| v.is_finite()));
+            assert!(trace.layer_post_moe[l].iter().all(|v| v.is_finite()));
+        }
+
+        assert!(trace.embedding.iter().all(|v| v.is_finite()));
+        assert!(trace.final_norm.iter().all(|v| v.is_finite()));
+        assert!(trace.logits.iter().all(|v| v.is_finite()));
+    }
+
+    #[test]
+    #[ignore = "requires authoritative NVIDIA L4 WGPU validation hardware"]
+    fn live_l4_gpu_native_ingest_no_deadlock() {
+        let harness = setup_live_l4_harness("ingest_deadlock");
+        let mut request_state = harness.token_loop.create_request_state().unwrap();
+
+        let prompt_ids = [1u32, 2u32];
+        let completion = pollster::block_on(harness.token_loop.ingest_prompt_and_generate(
+            &harness.engine,
+            &mut request_state,
+            &prompt_ids,
+            1,
+            &SamplingParams::greedy(),
+        ))
+        .expect("ingest_prompt_and_generate must succeed without deadlock");
+
+        assert_eq!(completion.len(), 1);
+        assert!(completion[0] < LIVE_L4_VOCAB_SIZE as u32);
+        assert_eq!(request_state.committed_position, 2);
     }
 }

--- a/rust-engine/src/gpu_native_token_loop.rs
+++ b/rust-engine/src/gpu_native_token_loop.rs
@@ -3,6 +3,7 @@
 //! Owns the execution of the entire forward transformer pass on GPU:
 //! Embedding lookup -> Layer (Attention RMSNorm -> QKV/RoPE/KV -> Causal Attention/O -> MoE RMSNorm -> Router -> Q4 Expert Combine) -> Final RMSNorm -> LM Head -> GPU Greedy Argmax.
 
+use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -26,7 +27,7 @@ use crate::model::RealModel;
 use crate::sampling::SamplingParams;
 
 /// Structured summary of runtime counters across the GPU-native token loop.
-#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct GpuNativeTokenLoopSnapshot {
     pub token_attempts: u64,
     pub tokens_completed: u64,
@@ -542,7 +543,7 @@ pub struct GpuNativeLayerPlan {
     pub router_plan: GpuNativeRouterPlan,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GpuNativeModelGeometry {
     pub num_layers: usize,
     pub d_model: usize,
@@ -557,6 +558,23 @@ pub struct GpuNativeModelGeometry {
     pub max_seq_len: usize,
     pub rms_eps: f32,
     pub rope_base: f32,
+}
+
+/// Diagnostic trace sink for capturing intermediate layer states during an attempt.
+pub struct GpuNativeDiagnosticSink<'a> {
+    pub layout: &'a crate::gpu_native_diagnostics::GpuNativeDiagnosticTraceLayout,
+    pub staging_buffer: &'a wgpu::Buffer,
+}
+
+struct GpuNativeAttemptOutput {
+    boundary_report: GpuNativeBoundaryReport,
+    diagnostic_trace: Option<crate::gpu_native_diagnostics::GpuNativeDiagnosticTrace>,
+}
+
+struct GpuNativeStepOutput {
+    sampled_token: Option<u32>,
+    attempts: usize,
+    diagnostic_trace: Option<crate::gpu_native_diagnostics::GpuNativeDiagnosticTrace>,
 }
 
 /// Persistent, model-scoped owner of the GPU-native token loop.
@@ -1084,13 +1102,85 @@ impl GpuNativeTokenLoop {
         position: usize,
         sample: bool,
     ) -> Result<Option<u32>, GpuNativeTokenLoopError> {
-        let mut attempt = 0;
-        let mut last_miss_sig: Option<(usize, Vec<u32>)> = None;
+        let out = self
+            .step_token_unified(engine, request, token_id, position, sample, None)
+            .await?;
+        Ok(out.sampled_token)
+    }
+
+    /// Diagnostic variant of step_token that captures intermediate activation traces on the final attempt.
+    pub async fn step_token_diagnostic(
+        &self,
+        engine: &Arc<Engine>,
+        request: &mut GpuNativeRequestState,
+        token_id: u32,
+        position: usize,
+        sample: bool,
+        trace_layout: &crate::gpu_native_diagnostics::GpuNativeDiagnosticTraceLayout,
+        diagnostic_staging_buffer: &wgpu::Buffer,
+    ) -> Result<
+        (
+            crate::gpu_native_diagnostics::GpuNativeDiagnosticTrace,
+            usize,
+        ),
+        GpuNativeTokenLoopError,
+    > {
+        let out = self
+            .step_token_unified(
+                engine,
+                request,
+                token_id,
+                position,
+                sample,
+                Some((trace_layout, diagnostic_staging_buffer)),
+            )
+            .await?;
+        let trace =
+            out.diagnostic_trace
+                .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
+                    detail: "diagnostic trace was not collected".into(),
+                })?;
+        Ok((trace, out.attempts))
+    }
+
+    /// Allocate a device-resident staging buffer for diagnostic trace readbacks.
+    pub fn create_diagnostic_staging_buffer(
+        &self,
+        trace_layout: &crate::gpu_native_diagnostics::GpuNativeDiagnosticTraceLayout,
+    ) -> Result<wgpu::Buffer, GpuNativeTokenLoopError> {
+        let gpu = self.executor.authoritative_gpu()?;
+        let staging_buffer = gpu.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("gpu_native_diagnostic_staging"),
+            size: trace_layout.total_bytes,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+            mapped_at_creation: false,
+        });
+        Ok(staging_buffer)
+    }
+
+    /// Authoritative internal loop for stepping a token with bounded retries and demand residency service.
+    async fn step_token_unified(
+        &self,
+        engine: &Arc<Engine>,
+        request: &mut GpuNativeRequestState,
+        token_id: u32,
+        position: usize,
+        sample: bool,
+        diagnostic_sink: Option<(
+            &crate::gpu_native_diagnostics::GpuNativeDiagnosticTraceLayout,
+            &wgpu::Buffer,
+        )>,
+    ) -> Result<GpuNativeStepOutput, GpuNativeTokenLoopError> {
+        let _guard = self.execution_guard.lock().await;
+
         let max_attempts = self.layers.len() + 1;
+        let mut attempt = 0usize;
+        let mut last_miss_sig: Option<(usize, Vec<u32>)> = None;
         let mut is_warm = true;
 
         loop {
             if attempt >= max_attempts {
+                self.counters.fatal_failures.fetch_add(1, Ordering::Relaxed);
                 return Err(GpuNativeTokenLoopError::AttemptBoundExceeded {
                     attempts: attempt,
                     max_attempts,
@@ -1098,7 +1188,19 @@ impl GpuNativeTokenLoop {
             }
 
             let replay = attempt > 0;
-            let report = self.execute_token_attempt(request, token_id, position, sample, replay)?;
+            let sink = diagnostic_sink.map(|(layout, buf)| GpuNativeDiagnosticSink {
+                layout,
+                staging_buffer: buf,
+            });
+            let output = self.execute_token_attempt_unified(
+                request,
+                token_id,
+                position,
+                sample,
+                replay,
+                sink.as_ref(),
+            )?;
+            let report = output.boundary_report;
 
             if let Some(fail_layer) = report.first_failure_layer() {
                 let layer_status = report.layer_statuses[fail_layer];
@@ -1204,13 +1306,27 @@ impl GpuNativeTokenLoop {
                     .fetch_add(1, Ordering::Relaxed);
             }
 
+            request.committed_position += 1;
+            self.counters
+                .tokens_completed
+                .fetch_add(1, Ordering::Relaxed);
+            if is_warm {
+                self.counters
+                    .warm_tokens_completed
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+
             engine.record_gpu_native_actual_routes(&report.selected_ids);
 
-            if sample {
-                return Ok(Some(report.sampled_token));
-            } else {
-                return Ok(None);
-            }
+            return Ok(GpuNativeStepOutput {
+                sampled_token: if sample {
+                    Some(report.sampled_token)
+                } else {
+                    None
+                },
+                attempts: attempt + 1,
+                diagnostic_trace: output.diagnostic_trace,
+            });
         }
     }
 
@@ -1223,6 +1339,52 @@ impl GpuNativeTokenLoop {
         sample: bool,
         replay: bool,
     ) -> Result<GpuNativeBoundaryReport, GpuNativeTokenLoopError> {
+        let output =
+            self.execute_token_attempt_unified(request, token_id, position, sample, replay, None)?;
+        Ok(output.boundary_report)
+    }
+
+    /// Diagnostic variant of execute_token_attempt that additionally records full activation traces.
+    pub fn execute_token_attempt_diagnostic(
+        &self,
+        request: &mut GpuNativeRequestState,
+        token_id: u32,
+        position: usize,
+        sample: bool,
+        replay: bool,
+        trace_layout: &crate::gpu_native_diagnostics::GpuNativeDiagnosticTraceLayout,
+        diagnostic_staging_buffer: &wgpu::Buffer,
+    ) -> Result<crate::gpu_native_diagnostics::GpuNativeDiagnosticTrace, GpuNativeTokenLoopError>
+    {
+        let sink = GpuNativeDiagnosticSink {
+            layout: trace_layout,
+            staging_buffer: diagnostic_staging_buffer,
+        };
+        let output = self.execute_token_attempt_unified(
+            request,
+            token_id,
+            position,
+            sample,
+            replay,
+            Some(&sink),
+        )?;
+        output
+            .diagnostic_trace
+            .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "diagnostic trace was not collected".into(),
+            })
+    }
+
+    /// Single authoritative internal forward attempt encoder and executor.
+    fn execute_token_attempt_unified(
+        &self,
+        request: &mut GpuNativeRequestState,
+        token_id: u32,
+        position: usize,
+        sample: bool,
+        replay: bool,
+        diagnostic_sink: Option<&GpuNativeDiagnosticSink<'_>>,
+    ) -> Result<GpuNativeAttemptOutput, GpuNativeTokenLoopError> {
         if position != request.committed_position {
             return Err(GpuNativeTokenLoopError::PositionMismatch {
                 requested_position: position,
@@ -1247,7 +1409,11 @@ impl GpuNativeTokenLoop {
         let mut encoder = gpu
             .device
             .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                label: Some("gpu_native_token_attempt"),
+                label: Some(if diagnostic_sink.is_some() {
+                    "gpu_native_token_attempt_diagnostic"
+                } else {
+                    "gpu_native_token_attempt"
+                }),
             });
 
         if replay {
@@ -1261,6 +1427,16 @@ impl GpuNativeTokenLoop {
             token_id,
             &request.token_state,
         )?;
+
+        if let Some(sink) = diagnostic_sink {
+            encoder.copy_buffer_to_buffer(
+                request.token_state.hidden_buffer(),
+                0,
+                sink.staging_buffer,
+                sink.layout.embedding_offset as u64,
+                sink.layout.embedding_bytes as u64,
+            );
+        }
 
         let num_layers = self.layers.len();
         let top_k = self.model_geometry.top_k;
@@ -1295,6 +1471,16 @@ impl GpuNativeTokenLoop {
                 position + 1,
             )?;
 
+            if let Some(sink) = diagnostic_sink {
+                encoder.copy_buffer_to_buffer(
+                    request.token_state.hidden_buffer(),
+                    0,
+                    sink.staging_buffer,
+                    sink.layout.layer_post_attn_offset(layer_idx),
+                    (self.model_geometry.d_model * 4) as u64,
+                );
+            }
+
             // 4. MoE Pre-Norm
             self.executor.encode_rms_norm_state_in_place(
                 &mut encoder,
@@ -1303,6 +1489,16 @@ impl GpuNativeTokenLoop {
                 &request.token_state,
             )?;
 
+            if let Some(sink) = diagnostic_sink {
+                encoder.copy_buffer_to_buffer(
+                    request.token_state.hidden_buffer(),
+                    0,
+                    sink.staging_buffer,
+                    sink.layout.layer_router_input_offset(layer_idx),
+                    (self.model_geometry.d_model * 4) as u64,
+                );
+            }
+
             // 5. Router
             self.executor.encode_router(
                 &mut encoder,
@@ -1310,6 +1506,23 @@ impl GpuNativeTokenLoop {
                 &request.token_state,
                 &request.router_scratch,
             )?;
+
+            if let Some(sink) = diagnostic_sink {
+                encoder.copy_buffer_to_buffer(
+                    request.router_scratch.selected_ids_buffer(),
+                    0,
+                    sink.staging_buffer,
+                    sink.layout.layer_selected_ids_offset(layer_idx),
+                    (top_k * 4) as u64,
+                );
+                encoder.copy_buffer_to_buffer(
+                    request.router_scratch.selected_weights_buffer(),
+                    0,
+                    sink.staging_buffer,
+                    sink.layout.layer_selected_weights_offset(layer_idx),
+                    (top_k * 4) as u64,
+                );
+            }
 
             // 6. Expert Combine
             let arena = self.residency_manager.arena(layer_idx).ok_or_else(|| {
@@ -1325,6 +1538,23 @@ impl GpuNativeTokenLoop {
                 &request.token_state,
                 &request.expert_scratch,
             )?;
+
+            if let Some(sink) = diagnostic_sink {
+                encoder.copy_buffer_to_buffer(
+                    request.token_state.hidden_buffer(),
+                    0,
+                    sink.staging_buffer,
+                    sink.layout.layer_post_moe_offset(layer_idx),
+                    (self.model_geometry.d_model * 4) as u64,
+                );
+                encoder.copy_buffer_to_buffer(
+                    request.token_state.status_buffer(),
+                    0,
+                    sink.staging_buffer,
+                    sink.layout.layer_status_offset(layer_idx),
+                    4,
+                );
+            }
 
             // Copy layer status to staging
             let status_offset = (layer_idx * 4) as u64;
@@ -1356,6 +1586,16 @@ impl GpuNativeTokenLoop {
                 &request.token_state,
             )?;
 
+            if let Some(sink) = diagnostic_sink {
+                encoder.copy_buffer_to_buffer(
+                    request.token_state.hidden_buffer(),
+                    0,
+                    sink.staging_buffer,
+                    sink.layout.final_norm_offset as u64,
+                    sink.layout.final_norm_bytes as u64,
+                );
+            }
+
             // LM Head GEMV
             self.executor.encode_dense_gemv_hidden_to_scratch(
                 &mut encoder,
@@ -1363,6 +1603,16 @@ impl GpuNativeTokenLoop {
                 &request.token_state,
                 &request.logits_scratch,
             )?;
+
+            if let Some(sink) = diagnostic_sink {
+                encoder.copy_buffer_to_buffer(
+                    request.logits_scratch.buffer(),
+                    0,
+                    sink.staging_buffer,
+                    sink.layout.logits_offset as u64,
+                    sink.layout.logits_bytes as u64,
+                );
+            }
 
             // GPU Greedy Argmax
             self.executor.encode_greedy_argmax(
@@ -1373,7 +1623,24 @@ impl GpuNativeTokenLoop {
                 self.model_geometry.vocab_size,
             )?;
 
-            // Copy final status and sampled token
+            if let Some(sink) = diagnostic_sink {
+                encoder.copy_buffer_to_buffer(
+                    request.sampled_token_buf.buffer(),
+                    0,
+                    sink.staging_buffer,
+                    sink.layout.sampled_token_offset as u64,
+                    4,
+                );
+                encoder.copy_buffer_to_buffer(
+                    request.token_state.status_buffer(),
+                    0,
+                    sink.staging_buffer,
+                    sink.layout.final_status_offset as u64,
+                    4,
+                );
+            }
+
+            // Copy final status and sampled token to production staging
             let final_status_offset = (num_layers * 4 + num_layers * top_k * 4) as u64;
             encoder.copy_buffer_to_buffer(
                 request.token_state.status_buffer(),
@@ -1391,7 +1658,7 @@ impl GpuNativeTokenLoop {
                 4,
             );
         } else {
-            // Ingest-only: copy final status to staging
+            // Ingest-only: copy final status to production staging
             let final_status_offset = (num_layers * 4 + num_layers * top_k * 4) as u64;
             encoder.copy_buffer_to_buffer(
                 request.token_state.status_buffer(),
@@ -1400,6 +1667,15 @@ impl GpuNativeTokenLoop {
                 final_status_offset,
                 4,
             );
+            if let Some(sink) = diagnostic_sink {
+                encoder.copy_buffer_to_buffer(
+                    request.token_state.status_buffer(),
+                    0,
+                    sink.staging_buffer,
+                    sink.layout.final_status_offset as u64,
+                    4,
+                );
+            }
         }
 
         // ONE submission
@@ -1408,7 +1684,7 @@ impl GpuNativeTokenLoop {
             .queue_submissions
             .fetch_add(1, Ordering::Relaxed);
 
-        // ONE map/readback
+        // ONE map/readback for production boundary report
         let slice = request
             .staging_buffer
             .slice(..self.report_layout.total_bytes);
@@ -1432,7 +1708,29 @@ impl GpuNativeTokenLoop {
             .boundary_readbacks
             .fetch_add(1, Ordering::Relaxed);
 
-        Ok(report)
+        let diagnostic_trace = if let Some(sink) = diagnostic_sink {
+            let diag_slice = sink.staging_buffer.slice(..sink.layout.total_bytes);
+            let (tx_d, rx_d) = std::sync::mpsc::sync_channel(1);
+            diag_slice.map_async(wgpu::MapMode::Read, move |res| {
+                let _ = tx_d.send(res);
+            });
+            gpu.device.poll(wgpu::Maintain::Wait);
+            rx_d.recv()
+                .map_err(|e| GpuNativeTokenLoopError::MapFailed(e.to_string()))?
+                .map_err(|e| GpuNativeTokenLoopError::MapFailed(format!("{e:?}")))?;
+            let diag_mapped = diag_slice.get_mapped_range();
+            let trace = sink.layout.parse(&diag_mapped)?;
+            drop(diag_mapped);
+            sink.staging_buffer.unmap();
+            Some(trace)
+        } else {
+            None
+        };
+
+        Ok(GpuNativeAttemptOutput {
+            boundary_report: report,
+            diagnostic_trace,
+        })
     }
 }
 

--- a/rust-engine/src/gpu_native_token_loop.rs
+++ b/rust-engine/src/gpu_native_token_loop.rs
@@ -3751,6 +3751,69 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn tiny_cold_recovery_fixture_matches_warm_generated_token_sequence() {
+        const NUM_LAYERS: usize = 6;
+        const MISS_LAYER: usize = 2;
+
+        fn layer_step(hidden: u32, layer: usize) -> u32 {
+            hidden.wrapping_mul(33).wrapping_add(layer as u32 + 1) % 1_009
+        }
+
+        fn generate(cold_first_token: bool) -> (Vec<u32>, GpuNativeRecoverySnapshot) {
+            let mut input = 7u32;
+            let mut output = Vec::new();
+            let counters = GpuNativeRecoveryCounters::default();
+            for position in 0..3 {
+                let mut hidden = input.wrapping_add(position);
+                if cold_first_token && position == 0 {
+                    for layer in 0..MISS_LAYER {
+                        hidden = layer_step(hidden, layer);
+                    }
+                    let checkpoint = hidden;
+                    let mut cursor = GpuNativeRecoveryCursor::after_serviced_miss(
+                        NUM_LAYERS,
+                        recovery_miss(MISS_LAYER),
+                    )
+                    .unwrap();
+                    loop {
+                        let segment = cursor.plan(NUM_LAYERS).unwrap();
+                        if matches!(
+                            segment.attempt_start,
+                            GpuNativeAttemptStart::ResumeExpert { .. }
+                        ) {
+                            hidden = checkpoint;
+                            hidden = layer_step(hidden, MISS_LAYER);
+                            counters.resume_attempts.fetch_add(1, Ordering::Relaxed);
+                            counters.checkpoint_restores.fetch_add(1, Ordering::Relaxed);
+                        }
+                        counters.recovery_segments.fetch_add(1, Ordering::Relaxed);
+                        for layer in segment.ordinary_layers.clone() {
+                            hidden = layer_step(hidden, layer);
+                        }
+                        if cursor.record_clean_segment(&segment, NUM_LAYERS).unwrap() {
+                            break;
+                        }
+                    }
+                } else {
+                    for layer in 0..NUM_LAYERS {
+                        hidden = layer_step(hidden, layer);
+                    }
+                }
+                input = hidden;
+                output.push(hidden);
+            }
+            (output, counters.snapshot())
+        }
+
+        let (warm_tokens, warm_recovery) = generate(false);
+        let (cold_tokens, cold_recovery) = generate(true);
+        assert_eq!(cold_tokens, warm_tokens);
+        assert_eq!(warm_recovery.resume_attempts, 0);
+        assert!(cold_recovery.resume_attempts > 0);
+        assert_eq!(cold_recovery.full_token_replay_attempts, 0);
+    }
+
+    #[test]
     fn recovery_route_assembly_overwrites_only_attempted_layers() {
         let warm_routes = vec![vec![3, 1], vec![2, 0], vec![1, 3], vec![0, 2]];
         let mut assembled = warm_routes.clone();

--- a/rust-engine/src/gpu_native_token_loop.rs
+++ b/rust-engine/src/gpu_native_token_loop.rs
@@ -566,15 +566,23 @@ pub struct GpuNativeDiagnosticSink<'a> {
     pub staging_buffer: &'a wgpu::Buffer,
 }
 
+/// Target-layer-only sink used exclusively by the router-rank diagnostic.
+pub struct GpuNativeRouterRankDiagnosticSink<'a> {
+    pub layout: &'a crate::gpu_native_router_rank_diagnostics::RouterRankTraceLayout,
+    pub staging_buffer: &'a wgpu::Buffer,
+}
+
 struct GpuNativeAttemptOutput {
     boundary_report: GpuNativeBoundaryReport,
     diagnostic_trace: Option<crate::gpu_native_diagnostics::GpuNativeDiagnosticTrace>,
+    router_rank_trace: Option<crate::gpu_native_router_rank_diagnostics::RouterRankGpuTrace>,
 }
 
 struct GpuNativeStepOutput {
     sampled_token: Option<u32>,
     attempts: usize,
     diagnostic_trace: Option<crate::gpu_native_diagnostics::GpuNativeDiagnosticTrace>,
+    router_rank_trace: Option<crate::gpu_native_router_rank_diagnostics::RouterRankGpuTrace>,
 }
 
 /// Persistent, model-scoped owner of the GPU-native token loop.
@@ -931,6 +939,21 @@ impl GpuNativeTokenLoop {
 
     /// Allocate request-local device resources for one GPU-native sequence.
     pub fn create_request_state(&self) -> Result<GpuNativeRequestState, GpuNativeTokenLoopError> {
+        self.create_request_state_inner(false)
+    }
+
+    /// Allocate request-local resources with copyable raw router logits for
+    /// the explicit router-rank diagnostic only.
+    pub fn create_router_rank_diagnostic_request_state(
+        &self,
+    ) -> Result<GpuNativeRequestState, GpuNativeTokenLoopError> {
+        self.create_request_state_inner(true)
+    }
+
+    fn create_request_state_inner(
+        &self,
+        router_rank_diagnostic: bool,
+    ) -> Result<GpuNativeRequestState, GpuNativeTokenLoopError> {
         let token_state = self.executor.create_token_state()?;
         let kv_width = self.model_geometry.num_kv_heads * self.model_geometry.head_dim;
         let kv_state = self.executor.create_kv_state(
@@ -953,7 +976,12 @@ impl GpuNativeTokenLoop {
             self.model_geometry.num_experts,
             self.model_geometry.top_k,
         )?;
-        let router_scratch = self.executor.create_router_scratch(router_geom)?;
+        let router_scratch = if router_rank_diagnostic {
+            self.executor
+                .create_router_diagnostic_scratch(router_geom)?
+        } else {
+            self.executor.create_router_scratch(router_geom)?
+        };
 
         let expert_geom = GpuNativeQ4ExpertGeometry::try_new(
             self.model_geometry.d_model,
@@ -1057,7 +1085,7 @@ impl GpuNativeTokenLoop {
         let prefix_count = prompt_ids.len().saturating_sub(1);
         for &token_id in &prompt_ids[..prefix_count] {
             let pos = request.committed_position;
-            self.step_token_unified_inner(engine, request, token_id, pos, false, None)
+            self.step_token_unified_inner(engine, request, token_id, pos, false, None, None)
                 .await?;
         }
 
@@ -1065,7 +1093,15 @@ impl GpuNativeTokenLoop {
         let final_prompt = *prompt_ids.last().expect("checked non-empty");
         let final_prompt_pos = request.committed_position;
         let first_completion = self
-            .step_token_unified_inner(engine, request, final_prompt, final_prompt_pos, true, None)
+            .step_token_unified_inner(
+                engine,
+                request,
+                final_prompt,
+                final_prompt_pos,
+                true,
+                None,
+                None,
+            )
             .await?
             .sampled_token
             .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
@@ -1082,7 +1118,7 @@ impl GpuNativeTokenLoop {
                 break;
             }
             let next_token = self
-                .step_token_unified_inner(engine, request, last_token, pos, true, None)
+                .step_token_unified_inner(engine, request, last_token, pos, true, None, None)
                 .await?
                 .sampled_token
                 .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
@@ -1106,7 +1142,7 @@ impl GpuNativeTokenLoop {
     ) -> Result<Option<u32>, GpuNativeTokenLoopError> {
         let _guard = self.execution_guard.lock().await;
         let out = self
-            .step_token_unified_inner(engine, request, token_id, position, sample, None)
+            .step_token_unified_inner(engine, request, token_id, position, sample, None, None)
             .await?;
         Ok(out.sampled_token)
     }
@@ -1137,6 +1173,7 @@ impl GpuNativeTokenLoop {
                 position,
                 sample,
                 Some((trace_layout, diagnostic_staging_buffer)),
+                None,
             )
             .await?;
         let trace =
@@ -1145,6 +1182,49 @@ impl GpuNativeTokenLoop {
                     detail: "diagnostic trace was not collected".into(),
                 })?;
         Ok((trace, out.attempts))
+    }
+
+    /// Diagnostic-only token step that captures the exact production router
+    /// input, dense-GEMV logits, and selected outputs at one target layer.
+    pub async fn step_token_router_rank_diagnostic(
+        &self,
+        engine: &Arc<Engine>,
+        request: &mut GpuNativeRequestState,
+        token_id: u32,
+        position: usize,
+        trace_layout: &crate::gpu_native_router_rank_diagnostics::RouterRankTraceLayout,
+        diagnostic_staging_buffer: &wgpu::Buffer,
+    ) -> Result<
+        (
+            crate::gpu_native_router_rank_diagnostics::RouterRankGpuTrace,
+            u32,
+            usize,
+        ),
+        GpuNativeTokenLoopError,
+    > {
+        let _guard = self.execution_guard.lock().await;
+        let out = self
+            .step_token_unified_inner(
+                engine,
+                request,
+                token_id,
+                position,
+                true,
+                None,
+                Some((trace_layout, diagnostic_staging_buffer)),
+            )
+            .await?;
+        let trace = out.router_rank_trace.ok_or_else(|| {
+            GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "router-rank diagnostic trace was not collected".into(),
+            }
+        })?;
+        let sampled_token =
+            out.sampled_token
+                .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
+                    detail: "router-rank diagnostic step produced no sampled token".into(),
+                })?;
+        Ok((trace, sampled_token, out.attempts))
     }
 
     /// Allocate a device-resident staging buffer for diagnostic trace readbacks.
@@ -1160,6 +1240,20 @@ impl GpuNativeTokenLoop {
             mapped_at_creation: false,
         });
         Ok(staging_buffer)
+    }
+
+    /// Allocate the target-layer-only router-rank readback buffer.
+    pub fn create_router_rank_diagnostic_staging_buffer(
+        &self,
+        trace_layout: &crate::gpu_native_router_rank_diagnostics::RouterRankTraceLayout,
+    ) -> Result<wgpu::Buffer, GpuNativeTokenLoopError> {
+        let gpu = self.executor.authoritative_gpu()?;
+        Ok(gpu.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("gpu_native_router_rank_diagnostic_staging"),
+            size: trace_layout.total_bytes,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+            mapped_at_creation: false,
+        }))
     }
     /// Diagnostic variant for layer-0 attention only. Bypasses router, MoE, and later layers.
     /// Executes one prompt position and captures all layer-0 attention intermediates.
@@ -1337,6 +1431,10 @@ impl GpuNativeTokenLoop {
             &crate::gpu_native_diagnostics::GpuNativeDiagnosticTraceLayout,
             &wgpu::Buffer,
         )>,
+        router_rank_sink: Option<(
+            &crate::gpu_native_router_rank_diagnostics::RouterRankTraceLayout,
+            &wgpu::Buffer,
+        )>,
     ) -> Result<GpuNativeStepOutput, GpuNativeTokenLoopError> {
         let max_attempts = self.layers.len() + 1;
         let mut attempt = 0usize;
@@ -1357,6 +1455,11 @@ impl GpuNativeTokenLoop {
                 layout,
                 staging_buffer: buf,
             });
+            let router_rank_sink =
+                router_rank_sink.map(|(layout, buf)| GpuNativeRouterRankDiagnosticSink {
+                    layout,
+                    staging_buffer: buf,
+                });
             let output = self.execute_token_attempt_unified(
                 request,
                 token_id,
@@ -1364,6 +1467,7 @@ impl GpuNativeTokenLoop {
                 sample,
                 replay,
                 sink.as_ref(),
+                router_rank_sink.as_ref(),
             )?;
             let report = output.boundary_report;
 
@@ -1481,6 +1585,7 @@ impl GpuNativeTokenLoop {
                 },
                 attempts: attempt + 1,
                 diagnostic_trace: output.diagnostic_trace,
+                router_rank_trace: output.router_rank_trace,
             });
         }
     }
@@ -1494,8 +1599,9 @@ impl GpuNativeTokenLoop {
         sample: bool,
         replay: bool,
     ) -> Result<GpuNativeBoundaryReport, GpuNativeTokenLoopError> {
-        let output =
-            self.execute_token_attempt_unified(request, token_id, position, sample, replay, None)?;
+        let output = self.execute_token_attempt_unified(
+            request, token_id, position, sample, replay, None, None,
+        )?;
         Ok(output.boundary_report)
     }
 
@@ -1522,6 +1628,7 @@ impl GpuNativeTokenLoop {
             sample,
             replay,
             Some(&sink),
+            None,
         )?;
         output
             .diagnostic_trace
@@ -1539,6 +1646,7 @@ impl GpuNativeTokenLoop {
         sample: bool,
         replay: bool,
         diagnostic_sink: Option<&GpuNativeDiagnosticSink<'_>>,
+        router_rank_sink: Option<&GpuNativeRouterRankDiagnosticSink<'_>>,
     ) -> Result<GpuNativeAttemptOutput, GpuNativeTokenLoopError> {
         if position != request.committed_position {
             return Err(GpuNativeTokenLoopError::PositionMismatch {
@@ -1566,6 +1674,8 @@ impl GpuNativeTokenLoop {
             .create_command_encoder(&wgpu::CommandEncoderDescriptor {
                 label: Some(if diagnostic_sink.is_some() {
                     "gpu_native_token_attempt_diagnostic"
+                } else if router_rank_sink.is_some() {
+                    "gpu_native_router_rank_diagnostic"
                 } else {
                     "gpu_native_token_attempt"
                 }),
@@ -1654,6 +1764,17 @@ impl GpuNativeTokenLoop {
                     (self.model_geometry.d_model * 4) as u64,
                 );
             }
+            if let Some(sink) =
+                router_rank_sink.filter(|sink| sink.layout.target_layer == layer_idx)
+            {
+                encoder.copy_buffer_to_buffer(
+                    request.token_state.hidden_buffer(),
+                    0,
+                    sink.staging_buffer,
+                    sink.layout.router_input_offset,
+                    sink.layout.router_input_bytes,
+                );
+            }
 
             // 5. Router
             self.executor.encode_router(
@@ -1677,6 +1798,31 @@ impl GpuNativeTokenLoop {
                     sink.staging_buffer,
                     sink.layout.layer_selected_weights_offset(layer_idx),
                     (top_k * 4) as u64,
+                );
+            }
+            if let Some(sink) =
+                router_rank_sink.filter(|sink| sink.layout.target_layer == layer_idx)
+            {
+                encoder.copy_buffer_to_buffer(
+                    request.router_scratch.logits_buffer(),
+                    0,
+                    sink.staging_buffer,
+                    sink.layout.raw_logits_offset,
+                    sink.layout.raw_logits_bytes,
+                );
+                encoder.copy_buffer_to_buffer(
+                    request.router_scratch.selected_ids_buffer(),
+                    0,
+                    sink.staging_buffer,
+                    sink.layout.selected_ids_offset,
+                    sink.layout.selected_ids_bytes,
+                );
+                encoder.copy_buffer_to_buffer(
+                    request.router_scratch.selected_weights_buffer(),
+                    0,
+                    sink.staging_buffer,
+                    sink.layout.selected_weights_offset,
+                    sink.layout.selected_weights_bytes,
                 );
             }
 
@@ -1883,9 +2029,33 @@ impl GpuNativeTokenLoop {
             None
         };
 
+        let router_rank_trace = if let Some(sink) = router_rank_sink {
+            let rank_slice = sink.staging_buffer.slice(..sink.layout.total_bytes);
+            let (tx_rank, rx_rank) = std::sync::mpsc::sync_channel(1);
+            rank_slice.map_async(wgpu::MapMode::Read, move |res| {
+                let _ = tx_rank.send(res);
+            });
+            gpu.device.poll(wgpu::Maintain::Wait);
+            rx_rank
+                .recv()
+                .map_err(|e| GpuNativeTokenLoopError::MapFailed(e.to_string()))?
+                .map_err(|e| GpuNativeTokenLoopError::MapFailed(format!("{e:?}")))?;
+            let rank_mapped = rank_slice.get_mapped_range();
+            let trace = sink
+                .layout
+                .parse(&rank_mapped)
+                .map_err(|detail| GpuNativeTokenLoopError::InvalidBoundaryReport { detail })?;
+            drop(rank_mapped);
+            sink.staging_buffer.unmap();
+            Some(trace)
+        } else {
+            None
+        };
+
         Ok(GpuNativeAttemptOutput {
             boundary_report: report,
             diagnostic_trace,
+            router_rank_trace,
         })
     }
 }

--- a/rust-engine/src/gpu_native_token_loop.rs
+++ b/rust-engine/src/gpu_native_token_loop.rs
@@ -572,10 +572,17 @@ pub struct GpuNativeRouterRankDiagnosticSink<'a> {
     pub staging_buffer: &'a wgpu::Buffer,
 }
 
+/// Target-layer-only sink used exclusively by the expert-permutation semantic diagnostic.
+pub struct GpuNativeExpertPermutationSemanticSink<'a> {
+    pub layout: &'a crate::gpu_native_expert_permutation_semantic_parity::SemanticTraceLayout,
+    pub staging_buffer: &'a wgpu::Buffer,
+}
+
 struct GpuNativeAttemptOutput {
     boundary_report: GpuNativeBoundaryReport,
     diagnostic_trace: Option<crate::gpu_native_diagnostics::GpuNativeDiagnosticTrace>,
     router_rank_trace: Option<crate::gpu_native_router_rank_diagnostics::RouterRankGpuTrace>,
+    semantic_trace: Option<crate::gpu_native_expert_permutation_semantic_parity::SemanticGpuTrace>,
 }
 
 struct GpuNativeStepOutput {
@@ -583,6 +590,7 @@ struct GpuNativeStepOutput {
     attempts: usize,
     diagnostic_trace: Option<crate::gpu_native_diagnostics::GpuNativeDiagnosticTrace>,
     router_rank_trace: Option<crate::gpu_native_router_rank_diagnostics::RouterRankGpuTrace>,
+    semantic_trace: Option<crate::gpu_native_expert_permutation_semantic_parity::SemanticGpuTrace>,
 }
 
 /// Persistent, model-scoped owner of the GPU-native token loop.
@@ -939,7 +947,7 @@ impl GpuNativeTokenLoop {
 
     /// Allocate request-local device resources for one GPU-native sequence.
     pub fn create_request_state(&self) -> Result<GpuNativeRequestState, GpuNativeTokenLoopError> {
-        self.create_request_state_inner(false)
+        self.create_request_state_inner(false, false)
     }
 
     /// Allocate request-local resources with copyable raw router logits for
@@ -947,12 +955,21 @@ impl GpuNativeTokenLoop {
     pub fn create_router_rank_diagnostic_request_state(
         &self,
     ) -> Result<GpuNativeRequestState, GpuNativeTokenLoopError> {
-        self.create_request_state_inner(true)
+        self.create_request_state_inner(true, false)
+    }
+
+    /// Allocate request-local copy-capable router/expert scratch only for the
+    /// explicit expert-permutation semantic witness.
+    pub fn create_expert_permutation_semantic_diagnostic_request_state(
+        &self,
+    ) -> Result<GpuNativeRequestState, GpuNativeTokenLoopError> {
+        self.create_request_state_inner(true, true)
     }
 
     fn create_request_state_inner(
         &self,
         router_rank_diagnostic: bool,
+        semantic_diagnostic: bool,
     ) -> Result<GpuNativeRequestState, GpuNativeTokenLoopError> {
         let token_state = self.executor.create_token_state()?;
         let kv_width = self.model_geometry.num_kv_heads * self.model_geometry.head_dim;
@@ -989,7 +1006,12 @@ impl GpuNativeTokenLoop {
             self.model_geometry.num_experts,
             self.model_geometry.top_k,
         )?;
-        let expert_scratch = self.executor.create_q4_expert_scratch(expert_geom)?;
+        let expert_scratch = if semantic_diagnostic {
+            self.executor
+                .create_q4_expert_semantic_diagnostic_scratch(expert_geom)?
+        } else {
+            self.executor.create_q4_expert_scratch(expert_geom)?
+        };
 
         let logits_scratch = self
             .executor
@@ -1085,7 +1107,7 @@ impl GpuNativeTokenLoop {
         let prefix_count = prompt_ids.len().saturating_sub(1);
         for &token_id in &prompt_ids[..prefix_count] {
             let pos = request.committed_position;
-            self.step_token_unified_inner(engine, request, token_id, pos, false, None, None)
+            self.step_token_unified_inner(engine, request, token_id, pos, false, None, None, None)
                 .await?;
         }
 
@@ -1099,6 +1121,7 @@ impl GpuNativeTokenLoop {
                 final_prompt,
                 final_prompt_pos,
                 true,
+                None,
                 None,
                 None,
             )
@@ -1118,7 +1141,7 @@ impl GpuNativeTokenLoop {
                 break;
             }
             let next_token = self
-                .step_token_unified_inner(engine, request, last_token, pos, true, None, None)
+                .step_token_unified_inner(engine, request, last_token, pos, true, None, None, None)
                 .await?
                 .sampled_token
                 .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
@@ -1142,7 +1165,9 @@ impl GpuNativeTokenLoop {
     ) -> Result<Option<u32>, GpuNativeTokenLoopError> {
         let _guard = self.execution_guard.lock().await;
         let out = self
-            .step_token_unified_inner(engine, request, token_id, position, sample, None, None)
+            .step_token_unified_inner(
+                engine, request, token_id, position, sample, None, None, None,
+            )
             .await?;
         Ok(out.sampled_token)
     }
@@ -1173,6 +1198,7 @@ impl GpuNativeTokenLoop {
                 position,
                 sample,
                 Some((trace_layout, diagnostic_staging_buffer)),
+                None,
                 None,
             )
             .await?;
@@ -1212,6 +1238,7 @@ impl GpuNativeTokenLoop {
                 true,
                 None,
                 Some((trace_layout, diagnostic_staging_buffer)),
+                None,
             )
             .await?;
         let trace = out.router_rank_trace.ok_or_else(|| {
@@ -1223,6 +1250,51 @@ impl GpuNativeTokenLoop {
             out.sampled_token
                 .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
                     detail: "router-rank diagnostic step produced no sampled token".into(),
+                })?;
+        Ok((trace, sampled_token, out.attempts))
+    }
+
+    /// Diagnostic-only token step that captures the exact target-layer router
+    /// evidence, every per-route GPU expert output, and the production GPU
+    /// routed-MoE combined vector without changing the encoded math.
+    pub async fn step_token_expert_permutation_semantic_diagnostic(
+        &self,
+        engine: &Arc<Engine>,
+        request: &mut GpuNativeRequestState,
+        token_id: u32,
+        position: usize,
+        trace_layout: &crate::gpu_native_expert_permutation_semantic_parity::SemanticTraceLayout,
+        diagnostic_staging_buffer: &wgpu::Buffer,
+    ) -> Result<
+        (
+            crate::gpu_native_expert_permutation_semantic_parity::SemanticGpuTrace,
+            u32,
+            usize,
+        ),
+        GpuNativeTokenLoopError,
+    > {
+        let _guard = self.execution_guard.lock().await;
+        let out = self
+            .step_token_unified_inner(
+                engine,
+                request,
+                token_id,
+                position,
+                true,
+                None,
+                None,
+                Some((trace_layout, diagnostic_staging_buffer)),
+            )
+            .await?;
+        let trace =
+            out.semantic_trace
+                .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
+                    detail: "expert-permutation semantic trace was not collected".into(),
+                })?;
+        let sampled_token =
+            out.sampled_token
+                .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
+                    detail: "expert-permutation semantic step produced no sampled token".into(),
                 })?;
         Ok((trace, sampled_token, out.attempts))
     }
@@ -1250,6 +1322,20 @@ impl GpuNativeTokenLoop {
         let gpu = self.executor.authoritative_gpu()?;
         Ok(gpu.device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("gpu_native_router_rank_diagnostic_staging"),
+            size: trace_layout.total_bytes,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+            mapped_at_creation: false,
+        }))
+    }
+
+    /// Allocate the target-layer-only expert-permutation semantic readback buffer.
+    pub fn create_expert_permutation_semantic_diagnostic_staging_buffer(
+        &self,
+        trace_layout: &crate::gpu_native_expert_permutation_semantic_parity::SemanticTraceLayout,
+    ) -> Result<wgpu::Buffer, GpuNativeTokenLoopError> {
+        let gpu = self.executor.authoritative_gpu()?;
+        Ok(gpu.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("gpu_native_expert_permutation_semantic_diagnostic_staging"),
             size: trace_layout.total_bytes,
             usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
             mapped_at_creation: false,
@@ -1435,6 +1521,10 @@ impl GpuNativeTokenLoop {
             &crate::gpu_native_router_rank_diagnostics::RouterRankTraceLayout,
             &wgpu::Buffer,
         )>,
+        semantic_sink: Option<(
+            &crate::gpu_native_expert_permutation_semantic_parity::SemanticTraceLayout,
+            &wgpu::Buffer,
+        )>,
     ) -> Result<GpuNativeStepOutput, GpuNativeTokenLoopError> {
         let max_attempts = self.layers.len() + 1;
         let mut attempt = 0usize;
@@ -1460,6 +1550,11 @@ impl GpuNativeTokenLoop {
                     layout,
                     staging_buffer: buf,
                 });
+            let semantic_sink =
+                semantic_sink.map(|(layout, buf)| GpuNativeExpertPermutationSemanticSink {
+                    layout,
+                    staging_buffer: buf,
+                });
             let output = self.execute_token_attempt_unified(
                 request,
                 token_id,
@@ -1468,6 +1563,7 @@ impl GpuNativeTokenLoop {
                 replay,
                 sink.as_ref(),
                 router_rank_sink.as_ref(),
+                semantic_sink.as_ref(),
             )?;
             let report = output.boundary_report;
 
@@ -1586,6 +1682,7 @@ impl GpuNativeTokenLoop {
                 attempts: attempt + 1,
                 diagnostic_trace: output.diagnostic_trace,
                 router_rank_trace: output.router_rank_trace,
+                semantic_trace: output.semantic_trace,
             });
         }
     }
@@ -1600,7 +1697,7 @@ impl GpuNativeTokenLoop {
         replay: bool,
     ) -> Result<GpuNativeBoundaryReport, GpuNativeTokenLoopError> {
         let output = self.execute_token_attempt_unified(
-            request, token_id, position, sample, replay, None, None,
+            request, token_id, position, sample, replay, None, None, None,
         )?;
         Ok(output.boundary_report)
     }
@@ -1629,6 +1726,7 @@ impl GpuNativeTokenLoop {
             replay,
             Some(&sink),
             None,
+            None,
         )?;
         output
             .diagnostic_trace
@@ -1647,6 +1745,7 @@ impl GpuNativeTokenLoop {
         replay: bool,
         diagnostic_sink: Option<&GpuNativeDiagnosticSink<'_>>,
         router_rank_sink: Option<&GpuNativeRouterRankDiagnosticSink<'_>>,
+        semantic_sink: Option<&GpuNativeExpertPermutationSemanticSink<'_>>,
     ) -> Result<GpuNativeAttemptOutput, GpuNativeTokenLoopError> {
         if position != request.committed_position {
             return Err(GpuNativeTokenLoopError::PositionMismatch {
@@ -1676,6 +1775,8 @@ impl GpuNativeTokenLoop {
                     "gpu_native_token_attempt_diagnostic"
                 } else if router_rank_sink.is_some() {
                     "gpu_native_router_rank_diagnostic"
+                } else if semantic_sink.is_some() {
+                    "gpu_native_expert_permutation_semantic_diagnostic"
                 } else {
                     "gpu_native_token_attempt"
                 }),
@@ -1825,6 +1926,36 @@ impl GpuNativeTokenLoop {
                     sink.layout.selected_weights_bytes,
                 );
             }
+            if let Some(sink) = semantic_sink.filter(|sink| sink.layout.target_layer == layer_idx) {
+                encoder.copy_buffer_to_buffer(
+                    request.token_state.hidden_buffer(),
+                    0,
+                    sink.staging_buffer,
+                    sink.layout.router_input_offset,
+                    sink.layout.router_input_bytes,
+                );
+                encoder.copy_buffer_to_buffer(
+                    request.router_scratch.logits_buffer(),
+                    0,
+                    sink.staging_buffer,
+                    sink.layout.raw_logits_offset,
+                    sink.layout.raw_logits_bytes,
+                );
+                encoder.copy_buffer_to_buffer(
+                    request.router_scratch.selected_ids_buffer(),
+                    0,
+                    sink.staging_buffer,
+                    sink.layout.selected_ids_offset,
+                    sink.layout.selected_ids_bytes,
+                );
+                encoder.copy_buffer_to_buffer(
+                    request.router_scratch.selected_weights_buffer(),
+                    0,
+                    sink.staging_buffer,
+                    sink.layout.selected_weights_offset,
+                    sink.layout.selected_weights_bytes,
+                );
+            }
 
             // 6. Expert Combine
             let arena = self.residency_manager.arena(layer_idx).ok_or_else(|| {
@@ -1840,6 +1971,23 @@ impl GpuNativeTokenLoop {
                 &request.token_state,
                 &request.expert_scratch,
             )?;
+
+            if let Some(sink) = semantic_sink.filter(|sink| sink.layout.target_layer == layer_idx) {
+                encoder.copy_buffer_to_buffer(
+                    request.expert_scratch.route_outputs_buffer(),
+                    0,
+                    sink.staging_buffer,
+                    sink.layout.route_outputs_offset,
+                    sink.layout.route_outputs_bytes,
+                );
+                encoder.copy_buffer_to_buffer(
+                    request.expert_scratch.combined_buffer(),
+                    0,
+                    sink.staging_buffer,
+                    sink.layout.routed_moe_output_offset,
+                    sink.layout.routed_moe_output_bytes,
+                );
+            }
 
             if let Some(sink) = diagnostic_sink {
                 encoder.copy_buffer_to_buffer(
@@ -2052,10 +2200,34 @@ impl GpuNativeTokenLoop {
             None
         };
 
+        let semantic_trace = if let Some(sink) = semantic_sink {
+            let semantic_slice = sink.staging_buffer.slice(..sink.layout.total_bytes);
+            let (tx_semantic, rx_semantic) = std::sync::mpsc::sync_channel(1);
+            semantic_slice.map_async(wgpu::MapMode::Read, move |result| {
+                let _ = tx_semantic.send(result);
+            });
+            gpu.device.poll(wgpu::Maintain::Wait);
+            rx_semantic
+                .recv()
+                .map_err(|error| GpuNativeTokenLoopError::MapFailed(error.to_string()))?
+                .map_err(|error| GpuNativeTokenLoopError::MapFailed(format!("{error:?}")))?;
+            let mapped = semantic_slice.get_mapped_range();
+            let trace = sink
+                .layout
+                .parse(&mapped)
+                .map_err(|detail| GpuNativeTokenLoopError::InvalidBoundaryReport { detail })?;
+            drop(mapped);
+            sink.staging_buffer.unmap();
+            Some(trace)
+        } else {
+            None
+        };
+
         Ok(GpuNativeAttemptOutput {
             boundary_report: report,
             diagnostic_trace,
             router_rank_trace,
+            semantic_trace,
         })
     }
 }

--- a/rust-engine/src/gpu_native_token_loop.rs
+++ b/rust-engine/src/gpu_native_token_loop.rs
@@ -1429,6 +1429,65 @@ impl GpuNativeTokenLoop {
         Ok((trace, sampled_token, out.attempts))
     }
 
+    /// Diagnostic-only final-prompt step that captures both the established
+    /// full activation trace and the established semantic-corpus router/expert
+    /// trace from one unchanged production traversal. Ordinary token steps
+    /// never allocate either sink.
+    pub async fn step_token_full_and_semantic_corpus_diagnostic(
+        &self,
+        engine: &Arc<Engine>,
+        request: &mut GpuNativeRequestState,
+        token_id: u32,
+        position: usize,
+        full_trace_layout: &crate::gpu_native_diagnostics::GpuNativeDiagnosticTraceLayout,
+        full_trace_staging_buffer: &wgpu::Buffer,
+        semantic_trace_layout: &crate::gpu_native_semantic_parity_corpus::SemanticCorpusTraceLayout,
+        semantic_trace_staging_buffer: &wgpu::Buffer,
+    ) -> Result<
+        (
+            crate::gpu_native_diagnostics::GpuNativeDiagnosticTrace,
+            crate::gpu_native_semantic_parity_corpus::SemanticCorpusGpuTrace,
+            u32,
+            usize,
+        ),
+        GpuNativeTokenLoopError,
+    > {
+        let _guard = self.execution_guard.lock().await;
+        let out = self
+            .step_token_unified_inner(
+                engine,
+                request,
+                token_id,
+                position,
+                true,
+                Some((full_trace_layout, full_trace_staging_buffer)),
+                None,
+                Some((
+                    GpuNativeSemanticDiagnosticLayout::Corpus(semantic_trace_layout),
+                    semantic_trace_staging_buffer,
+                    None,
+                )),
+            )
+            .await?;
+        let full_trace =
+            out.diagnostic_trace
+                .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
+                    detail: "combined diagnostic full trace was not collected".into(),
+                })?;
+        let semantic_trace = out.semantic_corpus_trace.ok_or_else(|| {
+            GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "combined diagnostic semantic trace was not collected".into(),
+            }
+        })?;
+        let sampled_token =
+            out.sampled_token
+                .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
+                    detail: "combined diagnostic final-prompt step produced no sampled token"
+                        .into(),
+                })?;
+        Ok((full_trace, semantic_trace, sampled_token, out.attempts))
+    }
+
     /// Diagnostic-only token step that observes raw gate, raw up,
     /// post-SwiGLU gated activation, diagnostic down, and the unchanged
     /// production down output at one or more frozen layers.

--- a/rust-engine/src/gpu_native_token_loop.rs
+++ b/rust-engine/src/gpu_native_token_loop.rs
@@ -572,10 +572,47 @@ pub struct GpuNativeRouterRankDiagnosticSink<'a> {
     pub staging_buffer: &'a wgpu::Buffer,
 }
 
-/// Target-layer-only sink used exclusively by the expert-permutation semantic diagnostic.
+#[derive(Clone, Copy)]
+enum GpuNativeSemanticDiagnosticLayout<'a> {
+    Target(&'a crate::gpu_native_expert_permutation_semantic_parity::SemanticTraceLayout),
+    Corpus(&'a crate::gpu_native_semantic_parity_corpus::SemanticCorpusTraceLayout),
+}
+
+/// Copy-only observation sink used exclusively by semantic diagnostics.
 pub struct GpuNativeExpertPermutationSemanticSink<'a> {
-    pub layout: &'a crate::gpu_native_expert_permutation_semantic_parity::SemanticTraceLayout,
+    layout: GpuNativeSemanticDiagnosticLayout<'a>,
     pub staging_buffer: &'a wgpu::Buffer,
+}
+
+impl GpuNativeExpertPermutationSemanticSink<'_> {
+    fn target_layout_for_layer(
+        &self,
+        layer: usize,
+    ) -> Option<&crate::gpu_native_expert_permutation_semantic_parity::SemanticTraceLayout> {
+        match self.layout {
+            GpuNativeSemanticDiagnosticLayout::Target(layout) if layout.target_layer == layer => {
+                Some(layout)
+            }
+            GpuNativeSemanticDiagnosticLayout::Target(_)
+            | GpuNativeSemanticDiagnosticLayout::Corpus(_) => None,
+        }
+    }
+
+    fn corpus_layout(
+        &self,
+    ) -> Option<&crate::gpu_native_semantic_parity_corpus::SemanticCorpusTraceLayout> {
+        match self.layout {
+            GpuNativeSemanticDiagnosticLayout::Corpus(layout) => Some(layout),
+            GpuNativeSemanticDiagnosticLayout::Target(_) => None,
+        }
+    }
+
+    fn total_bytes(&self) -> u64 {
+        match self.layout {
+            GpuNativeSemanticDiagnosticLayout::Target(layout) => layout.total_bytes,
+            GpuNativeSemanticDiagnosticLayout::Corpus(layout) => layout.total_bytes,
+        }
+    }
 }
 
 struct GpuNativeAttemptOutput {
@@ -583,6 +620,7 @@ struct GpuNativeAttemptOutput {
     diagnostic_trace: Option<crate::gpu_native_diagnostics::GpuNativeDiagnosticTrace>,
     router_rank_trace: Option<crate::gpu_native_router_rank_diagnostics::RouterRankGpuTrace>,
     semantic_trace: Option<crate::gpu_native_expert_permutation_semantic_parity::SemanticGpuTrace>,
+    semantic_corpus_trace: Option<crate::gpu_native_semantic_parity_corpus::SemanticCorpusGpuTrace>,
 }
 
 struct GpuNativeStepOutput {
@@ -591,6 +629,7 @@ struct GpuNativeStepOutput {
     diagnostic_trace: Option<crate::gpu_native_diagnostics::GpuNativeDiagnosticTrace>,
     router_rank_trace: Option<crate::gpu_native_router_rank_diagnostics::RouterRankGpuTrace>,
     semantic_trace: Option<crate::gpu_native_expert_permutation_semantic_parity::SemanticGpuTrace>,
+    semantic_corpus_trace: Option<crate::gpu_native_semantic_parity_corpus::SemanticCorpusGpuTrace>,
 }
 
 /// Persistent, model-scoped owner of the GPU-native token loop.
@@ -966,6 +1005,14 @@ impl GpuNativeTokenLoop {
         self.create_request_state_inner(true, true)
     }
 
+    /// Allocate request-local copy-capable router/expert scratch for the
+    /// diagnostic-only full-corpus semantic survey.
+    pub fn create_semantic_parity_corpus_diagnostic_request_state(
+        &self,
+    ) -> Result<GpuNativeRequestState, GpuNativeTokenLoopError> {
+        self.create_request_state_inner(true, true)
+    }
+
     fn create_request_state_inner(
         &self,
         router_rank_diagnostic: bool,
@@ -1283,7 +1330,10 @@ impl GpuNativeTokenLoop {
                 true,
                 None,
                 None,
-                Some((trace_layout, diagnostic_staging_buffer)),
+                Some((
+                    GpuNativeSemanticDiagnosticLayout::Target(trace_layout),
+                    diagnostic_staging_buffer,
+                )),
             )
             .await?;
         let trace =
@@ -1296,6 +1346,54 @@ impl GpuNativeTokenLoop {
                 .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
                     detail: "expert-permutation semantic step produced no sampled token".into(),
                 })?;
+        Ok((trace, sampled_token, out.attempts))
+    }
+
+    /// Diagnostic-only token step that copies the exact production router
+    /// evidence, per-route expert outputs, and routed-MoE result for every
+    /// layer in one frozen traversal step.
+    pub async fn step_token_semantic_parity_corpus_diagnostic(
+        &self,
+        engine: &Arc<Engine>,
+        request: &mut GpuNativeRequestState,
+        token_id: u32,
+        position: usize,
+        trace_layout: &crate::gpu_native_semantic_parity_corpus::SemanticCorpusTraceLayout,
+        diagnostic_staging_buffer: &wgpu::Buffer,
+    ) -> Result<
+        (
+            crate::gpu_native_semantic_parity_corpus::SemanticCorpusGpuTrace,
+            u32,
+            usize,
+        ),
+        GpuNativeTokenLoopError,
+    > {
+        let _guard = self.execution_guard.lock().await;
+        let out = self
+            .step_token_unified_inner(
+                engine,
+                request,
+                token_id,
+                position,
+                true,
+                None,
+                None,
+                Some((
+                    GpuNativeSemanticDiagnosticLayout::Corpus(trace_layout),
+                    diagnostic_staging_buffer,
+                )),
+            )
+            .await?;
+        let trace = out.semantic_corpus_trace.ok_or_else(|| {
+            GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "semantic corpus trace was not collected".into(),
+            }
+        })?;
+        let sampled_token = out.sampled_token.ok_or_else(|| {
+            GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "semantic corpus diagnostic step produced no sampled token".into(),
+            }
+        })?;
         Ok((trace, sampled_token, out.attempts))
     }
 
@@ -1336,6 +1434,20 @@ impl GpuNativeTokenLoop {
         let gpu = self.executor.authoritative_gpu()?;
         Ok(gpu.device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("gpu_native_expert_permutation_semantic_diagnostic_staging"),
+            size: trace_layout.total_bytes,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+            mapped_at_creation: false,
+        }))
+    }
+
+    /// Allocate the full-layer semantic-corpus readback buffer.
+    pub fn create_semantic_parity_corpus_diagnostic_staging_buffer(
+        &self,
+        trace_layout: &crate::gpu_native_semantic_parity_corpus::SemanticCorpusTraceLayout,
+    ) -> Result<wgpu::Buffer, GpuNativeTokenLoopError> {
+        let gpu = self.executor.authoritative_gpu()?;
+        Ok(gpu.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("gpu_native_semantic_parity_corpus_diagnostic_staging"),
             size: trace_layout.total_bytes,
             usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
             mapped_at_creation: false,
@@ -1522,7 +1634,7 @@ impl GpuNativeTokenLoop {
             &wgpu::Buffer,
         )>,
         semantic_sink: Option<(
-            &crate::gpu_native_expert_permutation_semantic_parity::SemanticTraceLayout,
+            GpuNativeSemanticDiagnosticLayout<'_>,
             &wgpu::Buffer,
         )>,
     ) -> Result<GpuNativeStepOutput, GpuNativeTokenLoopError> {
@@ -1550,11 +1662,12 @@ impl GpuNativeTokenLoop {
                     layout,
                     staging_buffer: buf,
                 });
-            let semantic_sink =
-                semantic_sink.map(|(layout, buf)| GpuNativeExpertPermutationSemanticSink {
+            let semantic_sink = semantic_sink.map(|(layout, buf)| {
+                GpuNativeExpertPermutationSemanticSink {
                     layout,
                     staging_buffer: buf,
-                });
+                }
+            });
             let output = self.execute_token_attempt_unified(
                 request,
                 token_id,
@@ -1683,6 +1796,7 @@ impl GpuNativeTokenLoop {
                 diagnostic_trace: output.diagnostic_trace,
                 router_rank_trace: output.router_rank_trace,
                 semantic_trace: output.semantic_trace,
+                semantic_corpus_trace: output.semantic_corpus_trace,
             });
         }
     }
@@ -1926,35 +2040,67 @@ impl GpuNativeTokenLoop {
                     sink.layout.selected_weights_bytes,
                 );
             }
-            if let Some(sink) = semantic_sink.filter(|sink| sink.layout.target_layer == layer_idx) {
-                encoder.copy_buffer_to_buffer(
-                    request.token_state.hidden_buffer(),
-                    0,
-                    sink.staging_buffer,
-                    sink.layout.router_input_offset,
-                    sink.layout.router_input_bytes,
-                );
-                encoder.copy_buffer_to_buffer(
-                    request.router_scratch.logits_buffer(),
-                    0,
-                    sink.staging_buffer,
-                    sink.layout.raw_logits_offset,
-                    sink.layout.raw_logits_bytes,
-                );
-                encoder.copy_buffer_to_buffer(
-                    request.router_scratch.selected_ids_buffer(),
-                    0,
-                    sink.staging_buffer,
-                    sink.layout.selected_ids_offset,
-                    sink.layout.selected_ids_bytes,
-                );
-                encoder.copy_buffer_to_buffer(
-                    request.router_scratch.selected_weights_buffer(),
-                    0,
-                    sink.staging_buffer,
-                    sink.layout.selected_weights_offset,
-                    sink.layout.selected_weights_bytes,
-                );
+            if let Some(sink) = semantic_sink {
+                if let Some(layout) = sink.target_layout_for_layer(layer_idx) {
+                    encoder.copy_buffer_to_buffer(
+                        request.token_state.hidden_buffer(),
+                        0,
+                        sink.staging_buffer,
+                        layout.router_input_offset,
+                        layout.router_input_bytes,
+                    );
+                    encoder.copy_buffer_to_buffer(
+                        request.router_scratch.logits_buffer(),
+                        0,
+                        sink.staging_buffer,
+                        layout.raw_logits_offset,
+                        layout.raw_logits_bytes,
+                    );
+                    encoder.copy_buffer_to_buffer(
+                        request.router_scratch.selected_ids_buffer(),
+                        0,
+                        sink.staging_buffer,
+                        layout.selected_ids_offset,
+                        layout.selected_ids_bytes,
+                    );
+                    encoder.copy_buffer_to_buffer(
+                        request.router_scratch.selected_weights_buffer(),
+                        0,
+                        sink.staging_buffer,
+                        layout.selected_weights_offset,
+                        layout.selected_weights_bytes,
+                    );
+                }
+                if let Some(layout) = sink.corpus_layout() {
+                    encoder.copy_buffer_to_buffer(
+                        request.token_state.hidden_buffer(),
+                        0,
+                        sink.staging_buffer,
+                        layout.router_input_offset(layer_idx),
+                        layout.router_input_layer_bytes,
+                    );
+                    encoder.copy_buffer_to_buffer(
+                        request.router_scratch.logits_buffer(),
+                        0,
+                        sink.staging_buffer,
+                        layout.raw_logits_offset(layer_idx),
+                        layout.raw_logits_layer_bytes,
+                    );
+                    encoder.copy_buffer_to_buffer(
+                        request.router_scratch.selected_ids_buffer(),
+                        0,
+                        sink.staging_buffer,
+                        layout.selected_ids_offset(layer_idx),
+                        layout.selected_ids_layer_bytes,
+                    );
+                    encoder.copy_buffer_to_buffer(
+                        request.router_scratch.selected_weights_buffer(),
+                        0,
+                        sink.staging_buffer,
+                        layout.selected_weights_offset(layer_idx),
+                        layout.selected_weights_layer_bytes,
+                    );
+                }
             }
 
             // 6. Expert Combine
@@ -1972,21 +2118,39 @@ impl GpuNativeTokenLoop {
                 &request.expert_scratch,
             )?;
 
-            if let Some(sink) = semantic_sink.filter(|sink| sink.layout.target_layer == layer_idx) {
-                encoder.copy_buffer_to_buffer(
-                    request.expert_scratch.route_outputs_buffer(),
-                    0,
-                    sink.staging_buffer,
-                    sink.layout.route_outputs_offset,
-                    sink.layout.route_outputs_bytes,
-                );
-                encoder.copy_buffer_to_buffer(
-                    request.expert_scratch.combined_buffer(),
-                    0,
-                    sink.staging_buffer,
-                    sink.layout.routed_moe_output_offset,
-                    sink.layout.routed_moe_output_bytes,
-                );
+            if let Some(sink) = semantic_sink {
+                if let Some(layout) = sink.target_layout_for_layer(layer_idx) {
+                    encoder.copy_buffer_to_buffer(
+                        request.expert_scratch.route_outputs_buffer(),
+                        0,
+                        sink.staging_buffer,
+                        layout.route_outputs_offset,
+                        layout.route_outputs_bytes,
+                    );
+                    encoder.copy_buffer_to_buffer(
+                        request.expert_scratch.combined_buffer(),
+                        0,
+                        sink.staging_buffer,
+                        layout.routed_moe_output_offset,
+                        layout.routed_moe_output_bytes,
+                    );
+                }
+                if let Some(layout) = sink.corpus_layout() {
+                    encoder.copy_buffer_to_buffer(
+                        request.expert_scratch.route_outputs_buffer(),
+                        0,
+                        sink.staging_buffer,
+                        layout.route_outputs_offset(layer_idx),
+                        layout.route_outputs_layer_bytes,
+                    );
+                    encoder.copy_buffer_to_buffer(
+                        request.expert_scratch.combined_buffer(),
+                        0,
+                        sink.staging_buffer,
+                        layout.routed_moe_output_offset(layer_idx),
+                        layout.routed_moe_output_layer_bytes,
+                    );
+                }
             }
 
             if let Some(sink) = diagnostic_sink {
@@ -2200,8 +2364,8 @@ impl GpuNativeTokenLoop {
             None
         };
 
-        let semantic_trace = if let Some(sink) = semantic_sink {
-            let semantic_slice = sink.staging_buffer.slice(..sink.layout.total_bytes);
+        let (semantic_trace, semantic_corpus_trace) = if let Some(sink) = semantic_sink {
+            let semantic_slice = sink.staging_buffer.slice(..sink.total_bytes());
             let (tx_semantic, rx_semantic) = std::sync::mpsc::sync_channel(1);
             semantic_slice.map_async(wgpu::MapMode::Read, move |result| {
                 let _ = tx_semantic.send(result);
@@ -2212,15 +2376,25 @@ impl GpuNativeTokenLoop {
                 .map_err(|error| GpuNativeTokenLoopError::MapFailed(error.to_string()))?
                 .map_err(|error| GpuNativeTokenLoopError::MapFailed(format!("{error:?}")))?;
             let mapped = semantic_slice.get_mapped_range();
-            let trace = sink
-                .layout
-                .parse(&mapped)
-                .map_err(|detail| GpuNativeTokenLoopError::InvalidBoundaryReport { detail })?;
+            let parsed = match sink.layout {
+                GpuNativeSemanticDiagnosticLayout::Target(layout) => (
+                    Some(layout.parse(&mapped).map_err(|detail| {
+                        GpuNativeTokenLoopError::InvalidBoundaryReport { detail }
+                    })?),
+                    None,
+                ),
+                GpuNativeSemanticDiagnosticLayout::Corpus(layout) => (
+                    None,
+                    Some(layout.parse(&mapped).map_err(|detail| {
+                        GpuNativeTokenLoopError::InvalidBoundaryReport { detail }
+                    })?),
+                ),
+            };
             drop(mapped);
             sink.staging_buffer.unmap();
-            Some(trace)
+            parsed
         } else {
-            None
+            (None, None)
         };
 
         Ok(GpuNativeAttemptOutput {
@@ -2228,6 +2402,7 @@ impl GpuNativeTokenLoop {
             diagnostic_trace,
             router_rank_trace,
             semantic_trace,
+            semantic_corpus_trace,
         })
     }
 }

--- a/rust-engine/src/gpu_native_token_loop.rs
+++ b/rust-engine/src/gpu_native_token_loop.rs
@@ -1306,16 +1306,6 @@ impl GpuNativeTokenLoop {
                     .fetch_add(1, Ordering::Relaxed);
             }
 
-            request.committed_position += 1;
-            self.counters
-                .tokens_completed
-                .fetch_add(1, Ordering::Relaxed);
-            if is_warm {
-                self.counters
-                    .warm_tokens_completed
-                    .fetch_add(1, Ordering::Relaxed);
-            }
-
             engine.record_gpu_native_actual_routes(&report.selected_ids);
 
             return Ok(GpuNativeStepOutput {
@@ -2395,6 +2385,8 @@ pub(crate) mod tests {
         let counters = GpuNativeTokenLoopCounters::default();
         let snap0 = counters.snapshot();
         assert_eq!(snap0.token_attempts, 0);
+        assert_eq!(snap0.tokens_completed, 0);
+        assert_eq!(snap0.warm_tokens_completed, 0);
         assert_eq!(snap0.queue_submissions, 0);
         assert_eq!(snap0.boundary_maps, 0);
         assert_eq!(snap0.boundary_readbacks, 0);
@@ -2434,6 +2426,47 @@ pub(crate) mod tests {
         assert_eq!(snap5.token_attempts, 2);
         assert_eq!(snap5.replay_attempts, 1);
         assert_eq!(snap5.queue_submissions, 1);
+    }
+
+    #[test]
+    fn successful_token_position_accounting_invariants() {
+        // Verifies the exact accounting delta invariant for successful token steps:
+        // - Starting committed_position = N advances to N + 1 (never N + 2)
+        // - tokens_completed delta is exactly 1 per completed token
+        // - warm_tokens_completed delta is exactly 1 for warm tokens, 0 for retried/cold tokens
+        let start_pos = 42usize;
+        let mut committed_position = start_pos;
+        let counters = GpuNativeTokenLoopCounters::default();
+
+        // 1. Warm successful token step (attempt 0 success, is_warm = true)
+        let is_warm_1 = true;
+        committed_position += 1;
+        counters.tokens_completed.fetch_add(1, Ordering::Relaxed);
+        if is_warm_1 {
+            counters
+                .warm_tokens_completed
+                .fetch_add(1, Ordering::Relaxed);
+        }
+
+        assert_eq!(committed_position, start_pos + 1);
+        let snap1 = counters.snapshot();
+        assert_eq!(snap1.tokens_completed, 1);
+        assert_eq!(snap1.warm_tokens_completed, 1);
+
+        // 2. Cold / retried successful token step (is_warm = false)
+        let is_warm_2 = false;
+        committed_position += 1;
+        counters.tokens_completed.fetch_add(1, Ordering::Relaxed);
+        if is_warm_2 {
+            counters
+                .warm_tokens_completed
+                .fetch_add(1, Ordering::Relaxed);
+        }
+
+        assert_eq!(committed_position, start_pos + 2);
+        let snap2 = counters.snapshot();
+        assert_eq!(snap2.tokens_completed, 2);
+        assert_eq!(snap2.warm_tokens_completed, 1);
     }
 
     #[test]

--- a/rust-engine/src/gpu_native_token_loop.rs
+++ b/rust-engine/src/gpu_native_token_loop.rs
@@ -1161,6 +1161,167 @@ impl GpuNativeTokenLoop {
         });
         Ok(staging_buffer)
     }
+    /// Diagnostic variant for layer-0 attention only. Bypasses router, MoE, and later layers.
+    /// Executes one prompt position and captures all layer-0 attention intermediates.
+    pub async fn step_layer0_attention_diagnostic(
+        &self,
+        _engine: &Arc<Engine>,
+        request: &mut GpuNativeRequestState,
+        token_id: u32,
+        position: usize,
+        trace_layout: &crate::gpu_native_layer0_diagnostics::Layer0AttentionDiagnosticTraceLayout,
+        diagnostic_staging_buffer: &wgpu::Buffer,
+    ) -> Result<
+        crate::gpu_native_layer0_diagnostics::Layer0AttentionDiagnosticTrace,
+        GpuNativeTokenLoopError,
+    > {
+        let _guard = self.execution_guard.lock().await;
+
+        if position != request.committed_position {
+            return Err(GpuNativeTokenLoopError::PositionMismatch {
+                requested_position: position,
+                committed_position: request.committed_position,
+            });
+        }
+        if position >= request.max_seq_len {
+            return Err(GpuNativeTokenLoopError::ContextLimitExceeded {
+                requested_position: position,
+                max_seq_len: request.max_seq_len,
+            });
+        }
+
+        if self.layers.is_empty() {
+            return Err(GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "no layers available in token loop".into(),
+            });
+        }
+
+        let gpu = self.executor.authoritative_gpu()?;
+        let mut encoder = gpu
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("gpu_native_layer0_attention_diagnostic"),
+            });
+
+        let layer_0 = &self.layers[0];
+        let sink = crate::backend::gpu_native::Layer0AttentionGpuDiagnosticSink {
+            layout: trace_layout,
+            staging_buffer: diagnostic_staging_buffer,
+        };
+
+        // 1. Embedding lookup
+        self.executor.encode_embedding_lookup(
+            &mut encoder,
+            &self.embedding_handle,
+            token_id,
+            &request.token_state,
+        )?;
+        encoder.copy_buffer_to_buffer(
+            request.token_state.hidden_buffer(),
+            0,
+            diagnostic_staging_buffer,
+            trace_layout.embedding_offset as u64,
+            trace_layout.embedding_bytes as u64,
+        );
+
+        // 2. Attention Pre-Norm
+        self.executor.encode_rms_norm_state_in_place(
+            &mut encoder,
+            &layer_0.rms_attn_handle,
+            self.model_geometry.rms_eps,
+            &request.token_state,
+        )?;
+        encoder.copy_buffer_to_buffer(
+            request.token_state.hidden_buffer(),
+            0,
+            diagnostic_staging_buffer,
+            trace_layout.attention_pre_norm_offset as u64,
+            trace_layout.attention_pre_norm_bytes as u64,
+        );
+
+        // 3. Attention Prepare (Q, K, V, QK-Norm, RoPE, KV Append)
+        self.executor.encode_attention_prepare_layer0_diagnostic(
+            &mut encoder,
+            &layer_0.attn_plan,
+            &request.token_state,
+            &request.attn_scratch,
+            &request.kv_state,
+            position,
+            &sink,
+        )?;
+
+        // 4. Attention Complete (Causal Attention, O Projection, Residual Add)
+        self.executor.encode_attention_complete_layer0_diagnostic(
+            &mut encoder,
+            &layer_0.attn_plan,
+            &request.token_state,
+            &request.attn_scratch,
+            &request.kv_state,
+            position + 1,
+            &sink,
+        )?;
+
+        // 5. Post-Attention Residual & Status copy
+        encoder.copy_buffer_to_buffer(
+            request.token_state.hidden_buffer(),
+            0,
+            diagnostic_staging_buffer,
+            trace_layout.post_attention_residual_offset as u64,
+            trace_layout.post_attention_residual_bytes as u64,
+        );
+        encoder.copy_buffer_to_buffer(
+            request.token_state.status_buffer(),
+            0,
+            diagnostic_staging_buffer,
+            trace_layout.status_offset as u64,
+            4,
+        );
+
+        gpu.queue.submit(Some(encoder.finish()));
+
+        // Map and parse diagnostic trace
+        let slice = diagnostic_staging_buffer.slice(..trace_layout.total_bytes);
+        let (tx, rx) = std::sync::mpsc::sync_channel(1);
+        slice.map_async(wgpu::MapMode::Read, move |res| {
+            let _ = tx.send(res);
+        });
+        gpu.device.poll(wgpu::Maintain::Wait);
+        rx.recv()
+            .map_err(|e| GpuNativeTokenLoopError::MapFailed(e.to_string()))?
+            .map_err(|e| GpuNativeTokenLoopError::MapFailed(format!("{e:?}")))?;
+
+        let mapped = slice.get_mapped_range();
+        let trace = trace_layout
+            .parse(&mapped)
+            .map_err(|e| GpuNativeTokenLoopError::InvalidBoundaryReport { detail: e })?;
+        drop(mapped);
+        diagnostic_staging_buffer.unmap();
+
+        if (trace.status & GPU_NATIVE_STATUS_FATAL_MASK) != 0 {
+            return Err(GpuNativeTokenLoopError::FatalNumericalFailure {
+                layer_index: Some(0),
+                status_bits: trace.status,
+            });
+        }
+
+        request.committed_position += 1;
+        Ok(trace)
+    }
+
+    /// Allocate a device-resident staging buffer for Layer-0 diagnostic trace readbacks.
+    pub fn create_layer0_diagnostic_staging_buffer(
+        &self,
+        trace_layout: &crate::gpu_native_layer0_diagnostics::Layer0AttentionDiagnosticTraceLayout,
+    ) -> Result<wgpu::Buffer, GpuNativeTokenLoopError> {
+        let gpu = self.executor.authoritative_gpu()?;
+        let staging_buffer = gpu.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("gpu_native_layer0_diagnostic_staging"),
+            size: trace_layout.total_bytes,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+            mapped_at_creation: false,
+        });
+        Ok(staging_buffer)
+    }
 
     /// Authoritative internal loop for stepping a token with bounded retries and demand residency service.
     /// Caller MUST hold self.execution_guard for the duration of the step or generation request.
@@ -2896,5 +3057,82 @@ pub(crate) mod tests {
         assert_eq!(completion.len(), 1);
         assert!(completion[0] < LIVE_L4_VOCAB_SIZE as u32);
         assert_eq!(request_state.committed_position, 2);
+
+        #[test]
+        #[ignore = "requires authoritative NVIDIA L4 WGPU validation hardware"]
+        fn live_l4_gpu_native_layer0_attention_diagnostic_smoke() {
+            let harness = setup_live_l4_harness("layer0_smoke");
+            let mut request_state = harness.token_loop.create_request_state().unwrap();
+
+            let geom = harness.token_loop.model_geometry();
+            let q_width = geom.num_heads * geom.head_dim;
+            let kv_width = geom.num_kv_heads * geom.head_dim;
+
+            let trace_layout = crate::gpu_native_layer0_diagnostics::Layer0AttentionDiagnosticTraceLayout::try_new(
+            geom.d_model,
+            q_width,
+            kv_width,
+        )
+        .unwrap();
+
+            let staging_buffer = harness
+                .token_loop
+                .create_layer0_diagnostic_staging_buffer(&trace_layout)
+                .unwrap();
+
+            // 1. Position 0
+            let trace0 = pollster::block_on(harness.token_loop.step_layer0_attention_diagnostic(
+                &harness.engine,
+                &mut request_state,
+                1,
+                0,
+                &trace_layout,
+                &staging_buffer,
+            ))
+            .expect("layer-0 diagnostic step 0 must succeed");
+
+            assert_eq!(trace0.embedding.len(), geom.d_model);
+            assert_eq!(trace0.attention_pre_norm.len(), geom.d_model);
+            assert_eq!(trace0.q_raw.len(), q_width);
+            assert_eq!(trace0.k_raw.len(), kv_width);
+            assert_eq!(trace0.v_raw.len(), kv_width);
+            assert_eq!(trace0.q_after_norm.len(), q_width);
+            assert_eq!(trace0.k_after_norm.len(), kv_width);
+            assert_eq!(trace0.q_after_rope.len(), q_width);
+            assert_eq!(trace0.k_after_rope.len(), kv_width);
+            assert_eq!(trace0.attention_context.len(), q_width);
+            assert_eq!(trace0.o_projection.len(), geom.d_model);
+            assert_eq!(trace0.post_attention_residual.len(), geom.d_model);
+            assert_eq!(trace0.status, 0);
+            assert_eq!(request_state.committed_position, 1);
+
+            assert!(trace0.embedding.iter().all(|v| v.is_finite()));
+            assert!(trace0.attention_pre_norm.iter().all(|v| v.is_finite()));
+            assert!(trace0.q_raw.iter().all(|v| v.is_finite()));
+            assert!(trace0.k_raw.iter().all(|v| v.is_finite()));
+            assert!(trace0.v_raw.iter().all(|v| v.is_finite()));
+            assert!(trace0.q_after_norm.iter().all(|v| v.is_finite()));
+            assert!(trace0.k_after_norm.iter().all(|v| v.is_finite()));
+            assert!(trace0.q_after_rope.iter().all(|v| v.is_finite()));
+            assert!(trace0.k_after_rope.iter().all(|v| v.is_finite()));
+            assert!(trace0.attention_context.iter().all(|v| v.is_finite()));
+            assert!(trace0.o_projection.iter().all(|v| v.is_finite()));
+            assert!(trace0.post_attention_residual.iter().all(|v| v.is_finite()));
+
+            // 2. Position 1 (persisting KV across positions)
+            let trace1 = pollster::block_on(harness.token_loop.step_layer0_attention_diagnostic(
+                &harness.engine,
+                &mut request_state,
+                2,
+                1,
+                &trace_layout,
+                &staging_buffer,
+            ))
+            .expect("layer-0 diagnostic step 1 must succeed");
+
+            assert_eq!(trace1.status, 0);
+            assert_eq!(request_state.committed_position, 2);
+            assert!(trace1.post_attention_residual.iter().all(|v| v.is_finite()));
+        }
     }
 }

--- a/rust-engine/src/gpu_native_token_loop.rs
+++ b/rust-engine/src/gpu_native_token_loop.rs
@@ -6,8 +6,10 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::fmt;
+use std::ops::Range;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::Instant;
 use tokio::sync::Mutex as TokioMutex;
 
 use crate::architecture::Architecture;
@@ -43,6 +45,23 @@ pub struct GpuNativeTokenLoopSnapshot {
     pub boundary_readbacks: u64,
 }
 
+/// Separate PR1 recovery accounting so frozen token-loop schemas retain their
+/// literal historical meaning.
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct GpuNativeRecoverySnapshot {
+    pub resume_attempts: u64,
+    pub recovery_segments: u64,
+    pub checkpoint_captures: u64,
+    pub checkpoint_restores: u64,
+    pub full_token_replay_attempts: u64,
+    pub layers_encoded: u64,
+    pub attention_layers_reexecuted: u64,
+    pub expert_layers_reexecuted: u64,
+    pub invalid_tail_layers_encoded: u64,
+    pub residency_service_us: u64,
+    pub boundary_wait_us: u64,
+}
+
 #[derive(Default)]
 struct GpuNativeTokenLoopCounters {
     token_attempts: AtomicU64,
@@ -56,6 +75,43 @@ struct GpuNativeTokenLoopCounters {
     queue_submissions: AtomicU64,
     boundary_maps: AtomicU64,
     boundary_readbacks: AtomicU64,
+}
+
+#[derive(Default)]
+struct GpuNativeRecoveryCounters {
+    resume_attempts: AtomicU64,
+    recovery_segments: AtomicU64,
+    checkpoint_captures: AtomicU64,
+    checkpoint_restores: AtomicU64,
+    full_token_replay_attempts: AtomicU64,
+    layers_encoded: AtomicU64,
+    attention_layers_reexecuted: AtomicU64,
+    expert_layers_reexecuted: AtomicU64,
+    invalid_tail_layers_encoded: AtomicU64,
+    residency_service_us: AtomicU64,
+    boundary_wait_us: AtomicU64,
+}
+
+impl GpuNativeRecoveryCounters {
+    fn snapshot(&self) -> GpuNativeRecoverySnapshot {
+        GpuNativeRecoverySnapshot {
+            resume_attempts: self.resume_attempts.load(Ordering::Relaxed),
+            recovery_segments: self.recovery_segments.load(Ordering::Relaxed),
+            checkpoint_captures: self.checkpoint_captures.load(Ordering::Relaxed),
+            checkpoint_restores: self.checkpoint_restores.load(Ordering::Relaxed),
+            full_token_replay_attempts: self.full_token_replay_attempts.load(Ordering::Relaxed),
+            layers_encoded: self.layers_encoded.load(Ordering::Relaxed),
+            attention_layers_reexecuted: self.attention_layers_reexecuted.load(Ordering::Relaxed),
+            expert_layers_reexecuted: self.expert_layers_reexecuted.load(Ordering::Relaxed),
+            invalid_tail_layers_encoded: self.invalid_tail_layers_encoded.load(Ordering::Relaxed),
+            residency_service_us: self.residency_service_us.load(Ordering::Relaxed),
+            boundary_wait_us: self.boundary_wait_us.load(Ordering::Relaxed),
+        }
+    }
+}
+
+fn saturating_micros(start: Instant) -> u64 {
+    u64::try_from(start.elapsed().as_micros()).unwrap_or(u64::MAX)
 }
 
 impl GpuNativeTokenLoopCounters {
@@ -99,6 +155,11 @@ pub enum GpuNativeTokenLoopError {
     FatalNumericalFailure {
         layer_index: Option<usize>,
         status_bits: u32,
+    },
+    UnknownStatusBits {
+        layer_index: Option<usize>,
+        status_bits: u32,
+        unknown_bits: u32,
     },
     ResidencyServiceFailed(GpuNativeDemandResidencyError),
     UnsupportedSampling {
@@ -162,6 +223,14 @@ impl fmt::Display for GpuNativeTokenLoopError {
                 f,
                 "fatal numerical failure on {:?} with status bits 0x{status_bits:08x}",
                 layer_index
+            ),
+            Self::UnknownStatusBits {
+                layer_index,
+                status_bits,
+                unknown_bits,
+            } => write!(
+                f,
+                "unknown GPU-native status bits 0x{unknown_bits:08x} on {layer_index:?} in status 0x{status_bits:08x}"
             ),
             Self::ResidencyServiceFailed(err) => write!(f, "residency service failed: {err}"),
             Self::UnsupportedSampling { reason } => write!(f, "unsupported sampling: {reason}"),
@@ -533,6 +602,247 @@ impl GpuNativeBoundaryReport {
     pub fn first_failure_layer(&self) -> Option<usize> {
         self.layer_statuses.iter().position(|&status| status != 0)
     }
+
+    /// Inspect only the layer interval encoded by the current boundary.
+    pub fn first_failure_layer_in(
+        &self,
+        attempted_layers: Range<usize>,
+    ) -> Result<Option<usize>, GpuNativeTokenLoopError> {
+        if attempted_layers.start >= attempted_layers.end
+            || attempted_layers.end > self.layer_statuses.len()
+        {
+            return Err(GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: format!(
+                    "attempted layer range {:?} is invalid for {} layer statuses",
+                    attempted_layers,
+                    self.layer_statuses.len()
+                ),
+            });
+        }
+        Ok(self.layer_statuses[attempted_layers.clone()]
+            .iter()
+            .position(|&status| status != 0)
+            .map(|relative| attempted_layers.start + relative))
+    }
+}
+
+const GPU_NATIVE_RECOVERY_INITIAL_WINDOW: usize = 1;
+const GPU_NATIVE_RECOVERY_MAX_WINDOW: usize = 8;
+
+fn gpu_native_attempt_bound(num_layers: usize) -> Result<usize, GpuNativeTokenLoopError> {
+    num_layers
+        .checked_mul(2)
+        .and_then(|bound| bound.checked_add(2))
+        .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
+            detail: "GPU-native recovery attempt bound overflow".into(),
+        })
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum GpuNativeAttemptStart {
+    Fresh,
+    ResumeExpert { layer_index: usize },
+    Continue { layer_index: usize },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct GpuNativeMissSignature {
+    layer_index: usize,
+    selected_ids: Vec<u32>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct GpuNativeExecutionSegment {
+    attempt_start: GpuNativeAttemptStart,
+    ordinary_layers: Range<usize>,
+    attempted_layers: Range<usize>,
+    completes_token: bool,
+}
+
+impl GpuNativeExecutionSegment {
+    fn fresh(num_layers: usize) -> Result<Self, GpuNativeTokenLoopError> {
+        if num_layers == 0 {
+            return Err(GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "cannot encode a token with zero layers".into(),
+            });
+        }
+        Ok(Self {
+            attempt_start: GpuNativeAttemptStart::Fresh,
+            ordinary_layers: 0..num_layers,
+            attempted_layers: 0..num_layers,
+            completes_token: true,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct GpuNativeRecoveryCursor {
+    next_layer: usize,
+    window_layers: usize,
+    last_miss: Option<GpuNativeMissSignature>,
+    residency_services: usize,
+    clean_segments: usize,
+    pending_resume_layer: Option<usize>,
+}
+
+impl GpuNativeRecoveryCursor {
+    fn after_serviced_miss(
+        num_layers: usize,
+        miss: GpuNativeMissSignature,
+    ) -> Result<Self, GpuNativeTokenLoopError> {
+        if miss.layer_index >= num_layers {
+            return Err(GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: format!(
+                    "recovery miss layer {} is outside 0..{num_layers}",
+                    miss.layer_index
+                ),
+            });
+        }
+        Ok(Self {
+            next_layer: miss.layer_index + 1,
+            window_layers: GPU_NATIVE_RECOVERY_INITIAL_WINDOW,
+            last_miss: Some(miss.clone()),
+            residency_services: 1,
+            clean_segments: 0,
+            pending_resume_layer: Some(miss.layer_index),
+        })
+    }
+
+    fn plan(
+        &self,
+        num_layers: usize,
+    ) -> Result<GpuNativeExecutionSegment, GpuNativeTokenLoopError> {
+        if num_layers == 0
+            || self.window_layers == 0
+            || self.window_layers > GPU_NATIVE_RECOVERY_MAX_WINDOW
+            || self.next_layer > num_layers
+        {
+            return Err(GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: format!("invalid GPU-native recovery cursor: {self:?}"),
+            });
+        }
+
+        let (attempt_start, attempted_start, ordinary_start) =
+            if let Some(layer_index) = self.pending_resume_layer {
+                if layer_index >= num_layers || self.next_layer != layer_index + 1 {
+                    return Err(GpuNativeTokenLoopError::InvalidBoundaryReport {
+                        detail: format!("invalid pending resume cursor: {self:?}"),
+                    });
+                }
+                (
+                    GpuNativeAttemptStart::ResumeExpert { layer_index },
+                    layer_index,
+                    self.next_layer,
+                )
+            } else {
+                if self.next_layer >= num_layers {
+                    return Err(GpuNativeTokenLoopError::InvalidBoundaryReport {
+                        detail: "completed recovery cursor cannot plan another segment".into(),
+                    });
+                }
+                (
+                    GpuNativeAttemptStart::Continue {
+                        layer_index: self.next_layer,
+                    },
+                    self.next_layer,
+                    self.next_layer,
+                )
+            };
+        let ordinary_end = ordinary_start
+            .saturating_add(self.window_layers)
+            .min(num_layers);
+        Ok(GpuNativeExecutionSegment {
+            attempt_start,
+            ordinary_layers: ordinary_start..ordinary_end,
+            attempted_layers: attempted_start..ordinary_end,
+            completes_token: ordinary_end == num_layers,
+        })
+    }
+
+    fn record_clean_segment(
+        &mut self,
+        segment: &GpuNativeExecutionSegment,
+        num_layers: usize,
+    ) -> Result<bool, GpuNativeTokenLoopError> {
+        if self.plan(num_layers)? != *segment {
+            return Err(GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "recovery segment does not match current cursor".into(),
+            });
+        }
+        let previous_next = self.next_layer;
+        self.next_layer = segment.ordinary_layers.end;
+        self.pending_resume_layer = None;
+        self.clean_segments = self.clean_segments.saturating_add(1);
+        self.window_layers = self
+            .window_layers
+            .saturating_mul(2)
+            .min(GPU_NATIVE_RECOVERY_MAX_WINDOW);
+        if self.next_layer <= previous_next && !segment.completes_token {
+            return Err(GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "clean recovery segment made no forward progress".into(),
+            });
+        }
+        Ok(segment.completes_token)
+    }
+
+    fn record_serviced_miss(
+        &mut self,
+        segment: &GpuNativeExecutionSegment,
+        miss: GpuNativeMissSignature,
+    ) -> Result<(), GpuNativeTokenLoopError> {
+        if !segment.attempted_layers.contains(&miss.layer_index) {
+            return Err(GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: format!(
+                    "miss layer {} is outside attempted interval {:?}",
+                    miss.layer_index, segment.attempted_layers
+                ),
+            });
+        }
+        if self.last_miss.as_ref() == Some(&miss) {
+            return Err(GpuNativeTokenLoopError::NoProgress {
+                layer_index: miss.layer_index,
+                selected_ids: miss.selected_ids,
+            });
+        }
+        self.next_layer = miss.layer_index + 1;
+        self.window_layers = GPU_NATIVE_RECOVERY_INITIAL_WINDOW;
+        self.pending_resume_layer = Some(miss.layer_index);
+        self.last_miss = Some(miss);
+        self.residency_services = self.residency_services.saturating_add(1);
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum GpuNativeStatusDisposition {
+    Clean,
+    RetryableResidencyMiss,
+}
+
+fn classify_gpu_native_status(
+    status_bits: u32,
+    layer_index: Option<usize>,
+) -> Result<GpuNativeStatusDisposition, GpuNativeTokenLoopError> {
+    if (status_bits & GPU_NATIVE_STATUS_FATAL_MASK) != 0 {
+        return Err(GpuNativeTokenLoopError::FatalNumericalFailure {
+            layer_index,
+            status_bits,
+        });
+    }
+    let known_status_mask = GPU_NATIVE_STATUS_FATAL_MASK | GPU_NATIVE_STATUS_RETRYABLE_MASK;
+    let unknown_bits = status_bits & !known_status_mask;
+    if unknown_bits != 0 {
+        return Err(GpuNativeTokenLoopError::UnknownStatusBits {
+            layer_index,
+            status_bits,
+            unknown_bits,
+        });
+    }
+    if status_bits == GPU_NATIVE_STATUS_RETRYABLE_MASK {
+        Ok(GpuNativeStatusDisposition::RetryableResidencyMiss)
+    } else {
+        Ok(GpuNativeStatusDisposition::Clean)
+    }
 }
 
 /// Persistent per-layer plans and handles for one Qwen3-MoE transformer layer.
@@ -666,6 +976,7 @@ pub struct GpuNativeTokenLoop {
     layers: Vec<GpuNativeLayerPlan>,
     report_layout: GpuNativeBoundaryReportLayout,
     counters: GpuNativeTokenLoopCounters,
+    recovery_counters: GpuNativeRecoveryCounters,
     execution_guard: TokioMutex<()>,
 }
 
@@ -987,6 +1298,7 @@ impl GpuNativeTokenLoop {
             layers,
             report_layout,
             counters: GpuNativeTokenLoopCounters::default(),
+            recovery_counters: GpuNativeRecoveryCounters::default(),
             execution_guard: TokioMutex::new(()),
         }))
     }
@@ -1005,6 +1317,10 @@ impl GpuNativeTokenLoop {
 
     pub fn snapshot(&self) -> GpuNativeTokenLoopSnapshot {
         self.counters.snapshot()
+    }
+
+    pub fn recovery_snapshot(&self) -> GpuNativeRecoverySnapshot {
+        self.recovery_counters.snapshot()
     }
 
     /// Allocate request-local device resources for one GPU-native sequence.
@@ -1820,21 +2136,24 @@ impl GpuNativeTokenLoop {
             Option<&GpuNativeScratch>,
         )>,
     ) -> Result<GpuNativeStepOutput, GpuNativeTokenLoopError> {
-        let max_attempts = self.layers.len() + 1;
-        let mut attempt = 0usize;
-        let mut last_miss_sig: Option<(usize, Vec<u32>)> = None;
+        let max_attempts = gpu_native_attempt_bound(self.layers.len())?;
+        let mut attempts = 0usize;
+        let mut recovery: Option<GpuNativeRecoveryCursor> = None;
         let mut is_warm = true;
 
         loop {
-            if attempt >= max_attempts {
+            if attempts >= max_attempts {
                 self.counters.fatal_failures.fetch_add(1, Ordering::Relaxed);
                 return Err(GpuNativeTokenLoopError::AttemptBoundExceeded {
-                    attempts: attempt,
+                    attempts,
                     max_attempts,
                 });
             }
 
-            let replay = attempt > 0;
+            let segment = match recovery.as_ref() {
+                Some(cursor) => cursor.plan(self.layers.len())?,
+                None => GpuNativeExecutionSegment::fresh(self.layers.len())?,
+            };
             let sink = diagnostic_sink.map(|(layout, buf)| GpuNativeDiagnosticSink {
                 layout,
                 staging_buffer: buf,
@@ -1851,110 +2170,177 @@ impl GpuNativeTokenLoop {
                     stage_scratch,
                 }
             });
-            let output = self.execute_token_attempt_unified(
-                request,
-                token_id,
-                position,
-                sample,
-                replay,
-                sink.as_ref(),
-                router_rank_sink.as_ref(),
-                semantic_sink.as_ref(),
-            )?;
-            let report = output.boundary_report;
+            let output = if matches!(segment.attempt_start, GpuNativeAttemptStart::Fresh) {
+                self.execute_token_attempt_unified(
+                    request,
+                    token_id,
+                    position,
+                    sample,
+                    false,
+                    sink.as_ref(),
+                    router_rank_sink.as_ref(),
+                    semantic_sink.as_ref(),
+                )?
+            } else {
+                self.execute_token_segment_unified(
+                    request,
+                    token_id,
+                    position,
+                    sample,
+                    false,
+                    &segment,
+                    sink.as_ref(),
+                    router_rank_sink.as_ref(),
+                    semantic_sink.as_ref(),
+                )?
+            };
+            attempts += 1;
+            let report = &output.boundary_report;
 
-            if let Some(fail_layer) = report.first_failure_layer() {
+            if let Some(fail_layer) =
+                report.first_failure_layer_in(segment.attempted_layers.clone())?
+            {
                 let layer_status = report.layer_statuses[fail_layer];
-                if (layer_status & GPU_NATIVE_STATUS_FATAL_MASK) != 0 {
-                    self.counters.fatal_failures.fetch_add(1, Ordering::Relaxed);
-                    return Err(GpuNativeTokenLoopError::FatalNumericalFailure {
-                        layer_index: Some(fail_layer),
-                        status_bits: layer_status,
-                    });
-                }
-                if (layer_status & GPU_NATIVE_STATUS_RETRYABLE_MASK)
-                    == GPU_NATIVE_STATUS_RETRYABLE_MASK
-                {
-                    is_warm = false;
-                    self.counters
-                        .residency_miss_attempts
-                        .fetch_add(1, Ordering::Relaxed);
-                    let local_ids = &report.selected_ids[fail_layer];
-
-                    for &id in local_ids {
-                        if id as usize >= self.model_geometry.num_experts {
-                            return Err(GpuNativeTokenLoopError::InvalidSelectedExpertId {
-                                layer_index: fail_layer,
-                                expert_id: id,
-                            });
-                        }
-                    }
-                    let mut seen = HashSet::with_capacity(local_ids.len());
-                    for &id in local_ids {
-                        if !seen.insert(id) {
-                            return Err(GpuNativeTokenLoopError::DuplicateSelectedExpertId {
-                                layer_index: fail_layer,
-                                expert_id: id,
-                            });
-                        }
-                    }
-                    if local_ids.len() != self.model_geometry.top_k {
-                        return Err(GpuNativeTokenLoopError::InvalidTopKCount {
-                            expected: self.model_geometry.top_k,
-                            actual: local_ids.len(),
+                match classify_gpu_native_status(layer_status, Some(fail_layer)) {
+                    Ok(GpuNativeStatusDisposition::RetryableResidencyMiss) => {}
+                    Ok(GpuNativeStatusDisposition::Clean) => {
+                        self.counters.fatal_failures.fetch_add(1, Ordering::Relaxed);
+                        return Err(GpuNativeTokenLoopError::InvalidBoundaryReport {
+                            detail: format!(
+                                "failure layer {fail_layer} classified as clean status"
+                            ),
                         });
                     }
-
-                    if let Some((prev_layer, ref prev_ids)) = last_miss_sig {
-                        if prev_layer == fail_layer && prev_ids == local_ids {
-                            self.counters
-                                .no_progress_failures
-                                .fetch_add(1, Ordering::Relaxed);
-                            return Err(GpuNativeTokenLoopError::NoProgress {
-                                layer_index: fail_layer,
-                                selected_ids: local_ids.clone(),
-                            });
-                        }
+                    Err(error) => {
+                        self.counters.fatal_failures.fetch_add(1, Ordering::Relaxed);
+                        return Err(error);
                     }
-
-                    let global_ids: Vec<u32> = local_ids
-                        .iter()
-                        .map(|&loc| {
-                            fail_layer as u32 * self.model_geometry.num_experts as u32 + loc
-                        })
-                        .collect();
-
-                    engine
-                        .ensure_gpu_native_demand_residency(fail_layer, &global_ids)
-                        .await
-                        .map_err(GpuNativeTokenLoopError::ResidencyServiceFailed)?;
-
-                    self.counters
-                        .residency_services
-                        .fetch_add(1, Ordering::Relaxed);
-                    last_miss_sig = Some((fail_layer, local_ids.clone()));
-                    attempt += 1;
-                    continue;
                 }
 
-                return Err(GpuNativeTokenLoopError::FatalNumericalFailure {
-                    layer_index: Some(fail_layer),
-                    status_bits: layer_status,
-                });
+                is_warm = false;
+                self.counters
+                    .residency_miss_attempts
+                    .fetch_add(1, Ordering::Relaxed);
+                self.recovery_counters
+                    .invalid_tail_layers_encoded
+                    .fetch_add(
+                        segment
+                            .attempted_layers
+                            .end
+                            .saturating_sub(fail_layer.saturating_add(1))
+                            as u64,
+                        Ordering::Relaxed,
+                    );
+                let local_ids = &report.selected_ids[fail_layer];
+                if local_ids.len() != self.model_geometry.top_k {
+                    return Err(GpuNativeTokenLoopError::InvalidTopKCount {
+                        expected: self.model_geometry.top_k,
+                        actual: local_ids.len(),
+                    });
+                }
+                for &id in local_ids {
+                    if id as usize >= self.model_geometry.num_experts {
+                        return Err(GpuNativeTokenLoopError::InvalidSelectedExpertId {
+                            layer_index: fail_layer,
+                            expert_id: id,
+                        });
+                    }
+                }
+                let mut seen = HashSet::with_capacity(local_ids.len());
+                for &id in local_ids {
+                    if !seen.insert(id) {
+                        return Err(GpuNativeTokenLoopError::DuplicateSelectedExpertId {
+                            layer_index: fail_layer,
+                            expert_id: id,
+                        });
+                    }
+                }
+
+                let miss = GpuNativeMissSignature {
+                    layer_index: fail_layer,
+                    selected_ids: local_ids.clone(),
+                };
+                if recovery
+                    .as_ref()
+                    .and_then(|cursor| cursor.last_miss.as_ref())
+                    == Some(&miss)
+                {
+                    self.counters
+                        .no_progress_failures
+                        .fetch_add(1, Ordering::Relaxed);
+                    return Err(GpuNativeTokenLoopError::NoProgress {
+                        layer_index: fail_layer,
+                        selected_ids: local_ids.clone(),
+                    });
+                }
+
+                let layer_base = fail_layer
+                    .checked_mul(self.model_geometry.num_experts)
+                    .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
+                        detail: "global expert layer offset overflow".into(),
+                    })?;
+                let global_ids = local_ids
+                    .iter()
+                    .map(|&local_id| {
+                        layer_base
+                            .checked_add(local_id as usize)
+                            .and_then(|global_id| u32::try_from(global_id).ok())
+                            .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
+                                detail: "global selected expert id overflow".into(),
+                            })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+
+                let residency_started = Instant::now();
+                engine
+                    .ensure_gpu_native_demand_residency(fail_layer, &global_ids)
+                    .await
+                    .map_err(GpuNativeTokenLoopError::ResidencyServiceFailed)?;
+                self.recovery_counters
+                    .residency_service_us
+                    .fetch_add(saturating_micros(residency_started), Ordering::Relaxed);
+                self.counters
+                    .residency_services
+                    .fetch_add(1, Ordering::Relaxed);
+
+                match recovery.as_mut() {
+                    Some(cursor) => cursor.record_serviced_miss(&segment, miss)?,
+                    None => {
+                        recovery = Some(GpuNativeRecoveryCursor::after_serviced_miss(
+                            self.layers.len(),
+                            miss,
+                        )?);
+                    }
+                }
+                continue;
             }
 
-            if (report.final_status & GPU_NATIVE_STATUS_FATAL_MASK) != 0 {
-                self.counters.fatal_failures.fetch_add(1, Ordering::Relaxed);
-                return Err(GpuNativeTokenLoopError::FatalNumericalFailure {
-                    layer_index: None,
-                    status_bits: report.final_status,
-                });
+            if let Some(cursor) = recovery.as_mut() {
+                let completed = cursor.record_clean_segment(&segment, self.layers.len())?;
+                if completed != segment.completes_token {
+                    return Err(GpuNativeTokenLoopError::InvalidBoundaryReport {
+                        detail: "recovery completion disagrees with encoded segment".into(),
+                    });
+                }
             }
-            if report.final_status != 0 {
-                return Err(GpuNativeTokenLoopError::FatalNumericalFailure {
-                    layer_index: None,
-                    status_bits: report.final_status,
-                });
+
+            if !segment.completes_token {
+                continue;
+            }
+
+            match classify_gpu_native_status(report.final_status, None) {
+                Ok(GpuNativeStatusDisposition::Clean) => {}
+                Ok(GpuNativeStatusDisposition::RetryableResidencyMiss) => {
+                    self.counters.fatal_failures.fetch_add(1, Ordering::Relaxed);
+                    return Err(GpuNativeTokenLoopError::FatalNumericalFailure {
+                        layer_index: None,
+                        status_bits: report.final_status,
+                    });
+                }
+                Err(error) => {
+                    self.counters.fatal_failures.fetch_add(1, Ordering::Relaxed);
+                    return Err(error);
+                }
             }
 
             request.committed_position += 1;
@@ -1975,7 +2361,7 @@ impl GpuNativeTokenLoop {
                 } else {
                     None
                 },
-                attempts: attempt + 1,
+                attempts,
                 diagnostic_trace: output.diagnostic_trace,
                 router_rank_trace: output.router_rank_trace,
                 semantic_trace: output.semantic_trace,
@@ -2033,6 +2419,143 @@ impl GpuNativeTokenLoop {
             })
     }
 
+    /// Encode the routed expert stage for one layer from the exact current
+    /// hidden/residual/router state. This is shared by ordinary layers and
+    /// checkpoint-restored recovery.
+    fn encode_expert_layer_unified(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        request: &GpuNativeRequestState,
+        layer_idx: usize,
+        diagnostic_sink: Option<&GpuNativeDiagnosticSink<'_>>,
+        semantic_sink: Option<&GpuNativeExpertPermutationSemanticSink<'_>>,
+    ) -> Result<(), GpuNativeTokenLoopError> {
+        let layer_plan = self.layers.get(layer_idx).ok_or_else(|| {
+            GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: format!("missing GPU-native layer plan {layer_idx}"),
+            }
+        })?;
+        let arena = self.residency_manager.arena(layer_idx).ok_or_else(|| {
+            GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: format!("missing expert arena for layer {layer_idx}"),
+            }
+        })?;
+        if let Some(sink) = semantic_sink {
+            if let Some(layout) = sink.q4_expert_stage_layout_for_layer(layer_idx) {
+                let stage_scratch = sink.stage_scratch.ok_or_else(|| {
+                    GpuNativeTokenLoopError::InvalidBoundaryReport {
+                        detail: "Q4 expert stage sink is missing diagnostic scratch".into(),
+                    }
+                })?;
+                self.executor.encode_q4_expert_stage_diagnostic(
+                    encoder,
+                    &layer_plan.router_plan,
+                    &request.router_scratch,
+                    arena,
+                    &request.token_state,
+                    &request.expert_scratch,
+                    stage_scratch,
+                )?;
+                encoder.copy_buffer_to_buffer(
+                    stage_scratch.buffer(),
+                    0,
+                    sink.staging_buffer,
+                    layout.stages_offset,
+                    layout.stages_bytes,
+                );
+            }
+        }
+        self.executor.encode_q4_expert_arena_combine(
+            encoder,
+            &layer_plan.router_plan,
+            &request.router_scratch,
+            arena,
+            &request.token_state,
+            &request.expert_scratch,
+        )?;
+
+        if let Some(sink) = semantic_sink {
+            if let Some(layout) = sink.target_layout_for_layer(layer_idx) {
+                encoder.copy_buffer_to_buffer(
+                    request.expert_scratch.route_outputs_buffer(),
+                    0,
+                    sink.staging_buffer,
+                    layout.route_outputs_offset,
+                    layout.route_outputs_bytes,
+                );
+                encoder.copy_buffer_to_buffer(
+                    request.expert_scratch.combined_buffer(),
+                    0,
+                    sink.staging_buffer,
+                    layout.routed_moe_output_offset,
+                    layout.routed_moe_output_bytes,
+                );
+            }
+            if let Some(layout) = sink.corpus_layout() {
+                encoder.copy_buffer_to_buffer(
+                    request.expert_scratch.route_outputs_buffer(),
+                    0,
+                    sink.staging_buffer,
+                    layout.route_outputs_offset(layer_idx),
+                    layout.route_outputs_layer_bytes,
+                );
+                encoder.copy_buffer_to_buffer(
+                    request.expert_scratch.combined_buffer(),
+                    0,
+                    sink.staging_buffer,
+                    layout.routed_moe_output_offset(layer_idx),
+                    layout.routed_moe_output_layer_bytes,
+                );
+            }
+            if let Some(layout) = sink.q4_expert_stage_layout_for_layer(layer_idx) {
+                encoder.copy_buffer_to_buffer(
+                    request.expert_scratch.route_outputs_buffer(),
+                    0,
+                    sink.staging_buffer,
+                    layout.production_down_offset,
+                    layout.production_down_bytes,
+                );
+            }
+        }
+
+        if let Some(sink) = diagnostic_sink {
+            encoder.copy_buffer_to_buffer(
+                request.token_state.hidden_buffer(),
+                0,
+                sink.staging_buffer,
+                sink.layout.layer_post_moe_offset(layer_idx),
+                (self.model_geometry.d_model * 4) as u64,
+            );
+            encoder.copy_buffer_to_buffer(
+                request.token_state.status_buffer(),
+                0,
+                sink.staging_buffer,
+                sink.layout.layer_status_offset(layer_idx),
+                4,
+            );
+        }
+
+        let status_offset = (layer_idx * 4) as u64;
+        encoder.copy_buffer_to_buffer(
+            request.token_state.status_buffer(),
+            0,
+            &request.staging_buffer,
+            status_offset,
+            4,
+        );
+        let ids_offset = (self.layers.len() * 4
+            + layer_idx * self.model_geometry.top_k * std::mem::size_of::<u32>())
+            as u64;
+        encoder.copy_buffer_to_buffer(
+            request.router_scratch.selected_ids_buffer(),
+            0,
+            &request.staging_buffer,
+            ids_offset,
+            (self.model_geometry.top_k * std::mem::size_of::<u32>()) as u64,
+        );
+        Ok(())
+    }
+
     /// Single authoritative internal forward attempt encoder and executor.
     fn execute_token_attempt_unified(
         &self,
@@ -2041,6 +2564,34 @@ impl GpuNativeTokenLoop {
         position: usize,
         sample: bool,
         replay: bool,
+        diagnostic_sink: Option<&GpuNativeDiagnosticSink<'_>>,
+        router_rank_sink: Option<&GpuNativeRouterRankDiagnosticSink<'_>>,
+        semantic_sink: Option<&GpuNativeExpertPermutationSemanticSink<'_>>,
+    ) -> Result<GpuNativeAttemptOutput, GpuNativeTokenLoopError> {
+        let segment = GpuNativeExecutionSegment::fresh(self.layers.len())?;
+        self.execute_token_segment_unified(
+            request,
+            token_id,
+            position,
+            sample,
+            replay,
+            &segment,
+            diagnostic_sink,
+            router_rank_sink,
+            semantic_sink,
+        )
+    }
+
+    /// Shared monolithic/recovery segment encoder and boundary executor.
+    #[allow(clippy::too_many_arguments)]
+    fn execute_token_segment_unified(
+        &self,
+        request: &mut GpuNativeRequestState,
+        token_id: u32,
+        position: usize,
+        sample: bool,
+        full_token_replay: bool,
+        segment: &GpuNativeExecutionSegment,
         diagnostic_sink: Option<&GpuNativeDiagnosticSink<'_>>,
         router_rank_sink: Option<&GpuNativeRouterRankDiagnosticSink<'_>>,
         semantic_sink: Option<&GpuNativeExpertPermutationSemanticSink<'_>>,
@@ -2059,9 +2610,17 @@ impl GpuNativeTokenLoop {
         }
 
         self.counters.token_attempts.fetch_add(1, Ordering::Relaxed);
-        if replay {
+        if full_token_replay {
+            if segment.attempt_start != GpuNativeAttemptStart::Fresh {
+                return Err(GpuNativeTokenLoopError::InvalidBoundaryReport {
+                    detail: "full-token replay requires a fresh segment".into(),
+                });
+            }
             self.counters
                 .replay_attempts
+                .fetch_add(1, Ordering::Relaxed);
+            self.recovery_counters
+                .full_token_replay_attempts
                 .fetch_add(1, Ordering::Relaxed);
         }
 
@@ -2080,33 +2639,73 @@ impl GpuNativeTokenLoop {
                 }),
             });
 
-        if replay {
-            self.executor
-                .encode_clear_retryable_status(&mut encoder, &request.token_state)?;
-        }
-
-        self.executor.encode_embedding_lookup(
-            &mut encoder,
-            &self.embedding_handle,
-            token_id,
-            &request.token_state,
-        )?;
-
-        if let Some(sink) = diagnostic_sink {
-            encoder.copy_buffer_to_buffer(
-                request.token_state.hidden_buffer(),
-                0,
-                sink.staging_buffer,
-                sink.layout.embedding_offset as u64,
-                sink.layout.embedding_bytes as u64,
-            );
-        }
-
         let num_layers = self.layers.len();
         let top_k = self.model_geometry.top_k;
         let rms_eps = self.model_geometry.rms_eps;
+        if segment.attempted_layers.start >= segment.attempted_layers.end
+            || segment.attempted_layers.end > num_layers
+            || segment.ordinary_layers.start > segment.ordinary_layers.end
+            || segment.ordinary_layers.end > num_layers
+        {
+            return Err(GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: format!("invalid GPU-native execution segment: {segment:?}"),
+            });
+        }
 
-        for (layer_idx, layer_plan) in self.layers.iter().enumerate() {
+        match segment.attempt_start {
+            GpuNativeAttemptStart::Fresh => {
+                if full_token_replay {
+                    self.executor
+                        .encode_clear_retryable_status(&mut encoder, &request.token_state)?;
+                }
+                self.executor.encode_embedding_lookup(
+                    &mut encoder,
+                    &self.embedding_handle,
+                    token_id,
+                    &request.token_state,
+                )?;
+                if let Some(sink) = diagnostic_sink {
+                    encoder.copy_buffer_to_buffer(
+                        request.token_state.hidden_buffer(),
+                        0,
+                        sink.staging_buffer,
+                        sink.layout.embedding_offset as u64,
+                        sink.layout.embedding_bytes as u64,
+                    );
+                }
+            }
+            GpuNativeAttemptStart::ResumeExpert { layer_index } => {
+                self.executor
+                    .encode_clear_retryable_status(&mut encoder, &request.token_state)?;
+                self.executor.encode_restore_pre_expert_checkpoint(
+                    &mut encoder,
+                    &request.pre_expert_checkpoints,
+                    layer_index,
+                    &request.token_state,
+                    &request.router_scratch,
+                )?;
+                self.recovery_counters
+                    .checkpoint_restores
+                    .fetch_add(1, Ordering::Relaxed);
+                self.encode_expert_layer_unified(
+                    &mut encoder,
+                    request,
+                    layer_index,
+                    diagnostic_sink,
+                    semantic_sink,
+                )?;
+            }
+            GpuNativeAttemptStart::Continue { layer_index } => {
+                if segment.ordinary_layers.start != layer_index {
+                    return Err(GpuNativeTokenLoopError::InvalidBoundaryReport {
+                        detail: format!("continuation does not start at layer {layer_index}"),
+                    });
+                }
+            }
+        }
+
+        for layer_idx in segment.ordinary_layers.clone() {
+            let layer_plan = &self.layers[layer_idx];
             // 1. Attention Pre-Norm
             self.executor.encode_rms_norm_state_in_place(
                 &mut encoder,
@@ -2310,129 +2909,27 @@ impl GpuNativeTokenLoop {
                 }
             }
 
-            // 6. Expert Combine
-            let arena = self.residency_manager.arena(layer_idx).ok_or_else(|| {
-                GpuNativeTokenLoopError::InvalidBoundaryReport {
-                    detail: format!("missing expert arena for layer {layer_idx}"),
-                }
-            })?;
-            if let Some(sink) = semantic_sink {
-                if let Some(layout) = sink.q4_expert_stage_layout_for_layer(layer_idx) {
-                    let stage_scratch = sink.stage_scratch.ok_or_else(|| {
-                        GpuNativeTokenLoopError::InvalidBoundaryReport {
-                            detail: "Q4 expert stage sink is missing diagnostic scratch".into(),
-                        }
-                    })?;
-                    self.executor.encode_q4_expert_stage_diagnostic(
-                        &mut encoder,
-                        &layer_plan.router_plan,
-                        &request.router_scratch,
-                        arena,
-                        &request.token_state,
-                        &request.expert_scratch,
-                        stage_scratch,
-                    )?;
-                    encoder.copy_buffer_to_buffer(
-                        stage_scratch.buffer(),
-                        0,
-                        sink.staging_buffer,
-                        layout.stages_offset,
-                        layout.stages_bytes,
-                    );
-                }
-            }
-            self.executor.encode_q4_expert_arena_combine(
+            self.executor.encode_capture_pre_expert_checkpoint(
                 &mut encoder,
-                &layer_plan.router_plan,
-                &request.router_scratch,
-                arena,
+                &request.pre_expert_checkpoints,
+                layer_idx,
                 &request.token_state,
-                &request.expert_scratch,
+                &request.router_scratch,
             )?;
+            self.recovery_counters
+                .checkpoint_captures
+                .fetch_add(1, Ordering::Relaxed);
 
-            if let Some(sink) = semantic_sink {
-                if let Some(layout) = sink.target_layout_for_layer(layer_idx) {
-                    encoder.copy_buffer_to_buffer(
-                        request.expert_scratch.route_outputs_buffer(),
-                        0,
-                        sink.staging_buffer,
-                        layout.route_outputs_offset,
-                        layout.route_outputs_bytes,
-                    );
-                    encoder.copy_buffer_to_buffer(
-                        request.expert_scratch.combined_buffer(),
-                        0,
-                        sink.staging_buffer,
-                        layout.routed_moe_output_offset,
-                        layout.routed_moe_output_bytes,
-                    );
-                }
-                if let Some(layout) = sink.corpus_layout() {
-                    encoder.copy_buffer_to_buffer(
-                        request.expert_scratch.route_outputs_buffer(),
-                        0,
-                        sink.staging_buffer,
-                        layout.route_outputs_offset(layer_idx),
-                        layout.route_outputs_layer_bytes,
-                    );
-                    encoder.copy_buffer_to_buffer(
-                        request.expert_scratch.combined_buffer(),
-                        0,
-                        sink.staging_buffer,
-                        layout.routed_moe_output_offset(layer_idx),
-                        layout.routed_moe_output_layer_bytes,
-                    );
-                }
-                if let Some(layout) = sink.q4_expert_stage_layout_for_layer(layer_idx) {
-                    encoder.copy_buffer_to_buffer(
-                        request.expert_scratch.route_outputs_buffer(),
-                        0,
-                        sink.staging_buffer,
-                        layout.production_down_offset,
-                        layout.production_down_bytes,
-                    );
-                }
-            }
-
-            if let Some(sink) = diagnostic_sink {
-                encoder.copy_buffer_to_buffer(
-                    request.token_state.hidden_buffer(),
-                    0,
-                    sink.staging_buffer,
-                    sink.layout.layer_post_moe_offset(layer_idx),
-                    (self.model_geometry.d_model * 4) as u64,
-                );
-                encoder.copy_buffer_to_buffer(
-                    request.token_state.status_buffer(),
-                    0,
-                    sink.staging_buffer,
-                    sink.layout.layer_status_offset(layer_idx),
-                    4,
-                );
-            }
-
-            // Copy layer status to staging
-            let status_offset = (layer_idx * 4) as u64;
-            encoder.copy_buffer_to_buffer(
-                request.token_state.status_buffer(),
-                0,
-                &request.staging_buffer,
-                status_offset,
-                4,
-            );
-
-            // Copy selected ids to staging before scratch reuse
-            let ids_offset = (num_layers * 4 + layer_idx * top_k * 4) as u64;
-            encoder.copy_buffer_to_buffer(
-                request.router_scratch.selected_ids_buffer(),
-                0,
-                &request.staging_buffer,
-                ids_offset,
-                (top_k * 4) as u64,
-            );
+            self.encode_expert_layer_unified(
+                &mut encoder,
+                request,
+                layer_idx,
+                diagnostic_sink,
+                semantic_sink,
+            )?;
         }
 
-        if sample {
+        if segment.completes_token && sample {
             // Final RMSNorm
             self.executor.encode_rms_norm_hidden_in_place(
                 &mut encoder,
@@ -2512,7 +3009,7 @@ impl GpuNativeTokenLoop {
                 token_offset,
                 4,
             );
-        } else {
+        } else if segment.completes_token {
             // Ingest-only: copy final status to production staging
             let final_status_offset = (num_layers * 4 + num_layers * top_k * 4) as u64;
             encoder.copy_buffer_to_buffer(
@@ -2533,6 +3030,32 @@ impl GpuNativeTokenLoop {
             }
         }
 
+        let resume_layers = usize::from(matches!(
+            segment.attempt_start,
+            GpuNativeAttemptStart::ResumeExpert { .. }
+        ));
+        self.recovery_counters.layers_encoded.fetch_add(
+            (segment.ordinary_layers.len() + resume_layers) as u64,
+            Ordering::Relaxed,
+        );
+        if !matches!(segment.attempt_start, GpuNativeAttemptStart::Fresh) {
+            self.recovery_counters
+                .recovery_segments
+                .fetch_add(1, Ordering::Relaxed);
+            self.recovery_counters
+                .attention_layers_reexecuted
+                .fetch_add(segment.ordinary_layers.len() as u64, Ordering::Relaxed);
+            self.recovery_counters.expert_layers_reexecuted.fetch_add(
+                (segment.ordinary_layers.len() + resume_layers) as u64,
+                Ordering::Relaxed,
+            );
+        }
+        if resume_layers == 1 {
+            self.recovery_counters
+                .resume_attempts
+                .fetch_add(1, Ordering::Relaxed);
+        }
+
         // ONE submission
         gpu.queue.submit(Some(encoder.finish()));
         self.counters
@@ -2543,6 +3066,7 @@ impl GpuNativeTokenLoop {
         let slice = request
             .staging_buffer
             .slice(..self.report_layout.total_bytes);
+        let boundary_wait_started = Instant::now();
         let (tx, rx) = std::sync::mpsc::sync_channel(1);
         slice.map_async(wgpu::MapMode::Read, move |res| {
             let _ = tx.send(res);
@@ -2562,6 +3086,9 @@ impl GpuNativeTokenLoop {
         self.counters
             .boundary_readbacks
             .fetch_add(1, Ordering::Relaxed);
+        self.recovery_counters
+            .boundary_wait_us
+            .fetch_add(saturating_micros(boundary_wait_started), Ordering::Relaxed);
 
         let diagnostic_trace = if let Some(sink) = diagnostic_sink {
             let diag_slice = sink.staging_buffer.slice(..sink.layout.total_bytes);
@@ -3030,6 +3557,240 @@ pub(crate) mod tests {
         assert_eq!(report.first_failure_layer(), Some(2));
     }
 
+    fn recovery_miss(layer_index: usize) -> GpuNativeMissSignature {
+        GpuNativeMissSignature {
+            layer_index,
+            selected_ids: vec![7, 2, 5, 1],
+        }
+    }
+
+    #[test]
+    fn zero_miss_warm_plan_is_one_monolithic_boundary() {
+        let segment = GpuNativeExecutionSegment::fresh(48).unwrap();
+        assert_eq!(segment.attempt_start, GpuNativeAttemptStart::Fresh);
+        assert_eq!(segment.ordinary_layers, 0..48);
+        assert_eq!(segment.attempted_layers, 0..48);
+        assert!(segment.completes_token);
+        assert_eq!(gpu_native_attempt_bound(48).unwrap(), 98);
+    }
+
+    #[test]
+    fn recovery_resumes_layer_zero_middle_and_last_without_prior_layers() {
+        for layer_index in [0, 24, 47] {
+            let cursor =
+                GpuNativeRecoveryCursor::after_serviced_miss(48, recovery_miss(layer_index))
+                    .unwrap();
+            let segment = cursor.plan(48).unwrap();
+            assert_eq!(
+                segment.attempt_start,
+                GpuNativeAttemptStart::ResumeExpert { layer_index }
+            );
+            assert_eq!(segment.attempted_layers.start, layer_index);
+            assert_eq!(segment.ordinary_layers.start, layer_index + 1);
+            assert_eq!(segment.ordinary_layers.end, (layer_index + 2).min(48));
+            assert_eq!(segment.completes_token, layer_index == 47);
+            assert!(segment.ordinary_layers.start > layer_index);
+        }
+    }
+
+    #[test]
+    fn recovery_window_doubles_one_two_four_eight_and_caps() {
+        let mut cursor =
+            GpuNativeRecoveryCursor::after_serviced_miss(48, recovery_miss(10)).unwrap();
+        let expected = [
+            (1, 11..12),
+            (2, 12..14),
+            (4, 14..18),
+            (8, 18..26),
+            (8, 26..34),
+        ];
+        for (window, ordinary_layers) in expected {
+            assert_eq!(cursor.window_layers, window);
+            let segment = cursor.plan(48).unwrap();
+            assert_eq!(segment.ordinary_layers, ordinary_layers);
+            assert!(!cursor.record_clean_segment(&segment, 48).unwrap());
+        }
+        assert_eq!(cursor.window_layers, 8);
+        assert_eq!(cursor.clean_segments, 5);
+    }
+
+    #[test]
+    fn new_miss_resets_window_and_strictly_increasing_misses_resume() {
+        let mut cursor =
+            GpuNativeRecoveryCursor::after_serviced_miss(48, recovery_miss(0)).unwrap();
+        let first = cursor.plan(48).unwrap();
+        cursor
+            .record_serviced_miss(&first, recovery_miss(1))
+            .unwrap();
+        assert_eq!(cursor.window_layers, 1);
+        assert_eq!(cursor.pending_resume_layer, Some(1));
+        let second = cursor.plan(48).unwrap();
+        assert_eq!(second.attempted_layers, 1..3);
+        cursor
+            .record_serviced_miss(&second, recovery_miss(2))
+            .unwrap();
+        assert_eq!(cursor.window_layers, 1);
+        assert_eq!(cursor.residency_services, 3);
+
+        let third = cursor.plan(48).unwrap();
+        assert!(cursor.record_clean_segment(&third, 48).is_ok());
+        let fourth = cursor.plan(48).unwrap();
+        assert_eq!(cursor.window_layers, 2);
+        cursor
+            .record_serviced_miss(&fourth, recovery_miss(fourth.ordinary_layers.start))
+            .unwrap();
+        assert_eq!(cursor.window_layers, 1);
+    }
+
+    #[test]
+    fn repeated_same_ordered_miss_is_no_progress() {
+        let mut cursor =
+            GpuNativeRecoveryCursor::after_serviced_miss(48, recovery_miss(10)).unwrap();
+        let segment = cursor.plan(48).unwrap();
+        assert_eq!(
+            cursor.record_serviced_miss(&segment, recovery_miss(10)),
+            Err(GpuNativeTokenLoopError::NoProgress {
+                layer_index: 10,
+                selected_ids: vec![7, 2, 5, 1],
+            })
+        );
+        let reordered = GpuNativeMissSignature {
+            layer_index: 10,
+            selected_ids: vec![2, 7, 5, 1],
+        };
+        assert!(cursor.record_serviced_miss(&segment, reordered).is_ok());
+    }
+
+    #[test]
+    fn recovery_cursor_fails_closed_without_forward_progress() {
+        let mut cursor =
+            GpuNativeRecoveryCursor::after_serviced_miss(48, recovery_miss(10)).unwrap();
+        cursor.window_layers = 0;
+        assert!(matches!(
+            cursor.plan(48),
+            Err(GpuNativeTokenLoopError::InvalidBoundaryReport { .. })
+        ));
+
+        let mut last = GpuNativeRecoveryCursor::after_serviced_miss(48, recovery_miss(47)).unwrap();
+        let final_segment = last.plan(48).unwrap();
+        assert!(last.record_clean_segment(&final_segment, 48).unwrap());
+        assert!(matches!(
+            last.plan(48),
+            Err(GpuNativeTokenLoopError::InvalidBoundaryReport { .. })
+        ));
+
+        assert!(matches!(
+            gpu_native_attempt_bound(usize::MAX),
+            Err(GpuNativeTokenLoopError::InvalidBoundaryReport { .. })
+        ));
+    }
+
+    #[test]
+    fn attempted_range_ignores_stale_statuses_outside_segment() {
+        let report = GpuNativeBoundaryReport {
+            layer_statuses: vec![GPU_NATIVE_STATUS_RETRYABLE_MASK, 0, 0, 1 << 31],
+            selected_ids: vec![vec![0, 1]; 4],
+            final_status: GPU_NATIVE_STATUS_RETRYABLE_MASK,
+            sampled_token: 9,
+        };
+        assert_eq!(report.first_failure_layer(), Some(0));
+        assert_eq!(report.first_failure_layer_in(1..3).unwrap(), None);
+        assert_eq!(report.first_failure_layer_in(2..4).unwrap(), Some(3));
+        assert!(report.first_failure_layer_in(4..4).is_err());
+    }
+
+    #[test]
+    fn recovery_kv_rows_equal_warm_reference_and_commit_once() {
+        const NUM_LAYERS: usize = 8;
+        const POSITION: u64 = 7;
+        let warm = (0..NUM_LAYERS)
+            .map(|layer| POSITION * 100 + layer as u64)
+            .collect::<Vec<_>>();
+        let invalid = u64::MAX;
+        let first_miss = 2usize;
+
+        // The monolithic miss attempt has authoritative KV through the failed
+        // layer; later invalid tail rows will be overwritten at the same
+        // absolute position by recovery.
+        let mut recovered = warm.clone();
+        recovered[first_miss + 1..].fill(invalid);
+        let prior_rows = recovered[..=first_miss].to_vec();
+        let mut committed_position = POSITION as usize;
+        let mut cursor =
+            GpuNativeRecoveryCursor::after_serviced_miss(NUM_LAYERS, recovery_miss(first_miss))
+                .unwrap();
+        let mut injected_second_miss = false;
+
+        loop {
+            let segment = cursor.plan(NUM_LAYERS).unwrap();
+            for layer in segment.ordinary_layers.clone() {
+                recovered[layer] = warm[layer];
+            }
+            if !injected_second_miss && segment.ordinary_layers.contains(&4) {
+                let second_miss = 4;
+                for value in &mut recovered[second_miss + 1..segment.ordinary_layers.end] {
+                    *value = invalid;
+                }
+                cursor
+                    .record_serviced_miss(&segment, recovery_miss(second_miss))
+                    .unwrap();
+                injected_second_miss = true;
+                assert_eq!(committed_position, POSITION as usize);
+                continue;
+            }
+            if cursor.record_clean_segment(&segment, NUM_LAYERS).unwrap() {
+                committed_position += 1;
+                break;
+            }
+            assert_eq!(committed_position, POSITION as usize);
+        }
+
+        assert_eq!(&recovered[..=first_miss], prior_rows.as_slice());
+        assert_eq!(recovered, warm);
+        assert_eq!(committed_position, POSITION as usize + 1);
+    }
+
+    #[test]
+    fn recovery_route_assembly_overwrites_only_attempted_layers() {
+        let warm_routes = vec![vec![3, 1], vec![2, 0], vec![1, 3], vec![0, 2]];
+        let mut assembled = warm_routes.clone();
+        assembled[2] = vec![99, 99];
+        assembled[3] = vec![88, 88];
+        let attempted = 1..3;
+        for layer in attempted.clone() {
+            assembled[layer] = warm_routes[layer].clone();
+        }
+        assert_eq!(assembled[0], warm_routes[0]);
+        assert_eq!(assembled[1], warm_routes[1]);
+        assert_eq!(assembled[2], warm_routes[2]);
+        assert_ne!(assembled[3], warm_routes[3]);
+        assembled[3] = warm_routes[3].clone();
+        assert_eq!(assembled, warm_routes);
+    }
+
+    #[test]
+    fn recovery_counter_snapshot_keeps_full_replay_zero() {
+        let counters = GpuNativeRecoveryCounters::default();
+        counters.resume_attempts.fetch_add(2, Ordering::Relaxed);
+        counters.recovery_segments.fetch_add(2, Ordering::Relaxed);
+        counters.checkpoint_captures.fetch_add(3, Ordering::Relaxed);
+        counters.checkpoint_restores.fetch_add(2, Ordering::Relaxed);
+        counters.layers_encoded.fetch_add(4, Ordering::Relaxed);
+        counters
+            .attention_layers_reexecuted
+            .fetch_add(1, Ordering::Relaxed);
+        counters
+            .expert_layers_reexecuted
+            .fetch_add(3, Ordering::Relaxed);
+        let snapshot = counters.snapshot();
+        assert_eq!(snapshot.resume_attempts, 2);
+        assert_eq!(snapshot.recovery_segments, 2);
+        assert_eq!(snapshot.checkpoint_restores, 2);
+        assert_eq!(snapshot.full_token_replay_attempts, 0);
+        assert_eq!(snapshot.attention_layers_reexecuted, 1);
+        assert_eq!(snapshot.expert_layers_reexecuted, 3);
+    }
+
     #[test]
     fn greedy_argmax_reference_semantics() {
         let reference_argmax = |logits: &[f32]| -> Result<u32, &'static str> {
@@ -3083,6 +3844,36 @@ pub(crate) mod tests {
             ),
             GPU_NATIVE_STATUS_FATAL_MASK
         );
+
+        let unknown = 1u32 << 31;
+        assert_eq!(
+            crate::backend::gpu_native::status_after_retryable_clear(
+                GPU_NATIVE_STATUS_FATAL_MASK | GPU_NATIVE_STATUS_RETRYABLE_MASK | unknown
+            ),
+            GPU_NATIVE_STATUS_FATAL_MASK | unknown
+        );
+        assert!(matches!(
+            classify_gpu_native_status(
+                GPU_NATIVE_STATUS_FATAL_MASK | GPU_NATIVE_STATUS_RETRYABLE_MASK,
+                Some(4)
+            ),
+            Err(GpuNativeTokenLoopError::FatalNumericalFailure {
+                layer_index: Some(4),
+                ..
+            })
+        ));
+        assert!(matches!(
+            classify_gpu_native_status(unknown, Some(5)),
+            Err(GpuNativeTokenLoopError::UnknownStatusBits {
+                layer_index: Some(5),
+                unknown_bits,
+                ..
+            }) if unknown_bits == unknown
+        ));
+        assert_eq!(
+            classify_gpu_native_status(GPU_NATIVE_STATUS_RETRYABLE_MASK, Some(6)),
+            Ok(GpuNativeStatusDisposition::RetryableResidencyMiss)
+        );
     }
 
     #[test]
@@ -3127,11 +3918,12 @@ pub(crate) mod tests {
         assert!(status.contains(wgpu::BufferUsages::COPY_SRC));
         assert!(!status.intersects(wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::MAP_WRITE));
 
-        // 4. Router selected-ids result:
-        // STORAGE | COPY_SRC, strictly no MAP_READ, no MAP_WRITE
+        // 4. Router selected ids/weights are checkpoint-restorable:
+        // STORAGE | COPY_SRC | COPY_DST, strictly no MAP_READ, no MAP_WRITE
         let router_result = GpuNativeRouterScratchLayout::result_usage();
         assert!(router_result.contains(wgpu::BufferUsages::STORAGE));
         assert!(router_result.contains(wgpu::BufferUsages::COPY_SRC));
+        assert!(router_result.contains(wgpu::BufferUsages::COPY_DST));
         assert!(
             !router_result.intersects(wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::MAP_WRITE)
         );
@@ -3717,9 +4509,14 @@ pub(crate) mod tests {
         assert_eq!(snap1.tokens_completed, 1);
         assert_eq!(snap1.token_attempts, 3);
         assert_eq!(snap1.residency_miss_attempts, 2);
-        assert_eq!(snap1.replay_attempts, 2);
+        assert_eq!(snap1.replay_attempts, 0);
         assert_eq!(snap1.residency_services, 2);
         assert_eq!(snap1.fatal_failures, 0);
+        let recovery1 = harness.token_loop.recovery_snapshot();
+        assert_eq!(recovery1.resume_attempts, 2);
+        assert_eq!(recovery1.recovery_segments, 2);
+        assert_eq!(recovery1.checkpoint_restores, 2);
+        assert_eq!(recovery1.full_token_replay_attempts, 0);
 
         let _second_token = pollster::block_on(harness.token_loop.step_token(
             &harness.engine,
@@ -3741,6 +4538,8 @@ pub(crate) mod tests {
         assert_eq!(snap2.boundary_readbacks, 4);
         assert_eq!(snap2.residency_services, 2);
         assert_eq!(snap2.fatal_failures, 0);
+        let recovery2 = harness.token_loop.recovery_snapshot();
+        assert_eq!(recovery2.full_token_replay_attempts, 0);
 
         assert_eq!(
             harness.engine.report().bytes_read,

--- a/rust-engine/src/gpu_native_token_loop.rs
+++ b/rust-engine/src/gpu_native_token_loop.rs
@@ -3057,82 +3057,83 @@ pub(crate) mod tests {
         assert_eq!(completion.len(), 1);
         assert!(completion[0] < LIVE_L4_VOCAB_SIZE as u32);
         assert_eq!(request_state.committed_position, 2);
+    }
 
-        #[test]
-        #[ignore = "requires authoritative NVIDIA L4 WGPU validation hardware"]
-        fn live_l4_gpu_native_layer0_attention_diagnostic_smoke() {
-            let harness = setup_live_l4_harness("layer0_smoke");
-            let mut request_state = harness.token_loop.create_request_state().unwrap();
+    #[test]
+    #[ignore = "requires authoritative NVIDIA L4 WGPU validation hardware"]
+    fn live_l4_gpu_native_layer0_attention_diagnostic_smoke() {
+        let harness = setup_live_l4_harness("layer0_smoke");
+        let mut request_state = harness.token_loop.create_request_state().unwrap();
 
-            let geom = harness.token_loop.model_geometry();
-            let q_width = geom.num_heads * geom.head_dim;
-            let kv_width = geom.num_kv_heads * geom.head_dim;
+        let geom = harness.token_loop.model_geometry();
+        let q_width = geom.num_heads * geom.head_dim;
+        let kv_width = geom.num_kv_heads * geom.head_dim;
 
-            let trace_layout = crate::gpu_native_layer0_diagnostics::Layer0AttentionDiagnosticTraceLayout::try_new(
-            geom.d_model,
-            q_width,
-            kv_width,
-        )
-        .unwrap();
+        let trace_layout =
+            crate::gpu_native_layer0_diagnostics::Layer0AttentionDiagnosticTraceLayout::try_new(
+                geom.d_model,
+                q_width,
+                kv_width,
+            )
+            .unwrap();
 
-            let staging_buffer = harness
-                .token_loop
-                .create_layer0_diagnostic_staging_buffer(&trace_layout)
-                .unwrap();
+        let staging_buffer = harness
+            .token_loop
+            .create_layer0_diagnostic_staging_buffer(&trace_layout)
+            .unwrap();
 
-            // 1. Position 0
-            let trace0 = pollster::block_on(harness.token_loop.step_layer0_attention_diagnostic(
-                &harness.engine,
-                &mut request_state,
-                1,
-                0,
-                &trace_layout,
-                &staging_buffer,
-            ))
-            .expect("layer-0 diagnostic step 0 must succeed");
+        // 1. Position 0
+        let trace0 = pollster::block_on(harness.token_loop.step_layer0_attention_diagnostic(
+            &harness.engine,
+            &mut request_state,
+            1,
+            0,
+            &trace_layout,
+            &staging_buffer,
+        ))
+        .expect("layer-0 diagnostic step 0 must succeed");
 
-            assert_eq!(trace0.embedding.len(), geom.d_model);
-            assert_eq!(trace0.attention_pre_norm.len(), geom.d_model);
-            assert_eq!(trace0.q_raw.len(), q_width);
-            assert_eq!(trace0.k_raw.len(), kv_width);
-            assert_eq!(trace0.v_raw.len(), kv_width);
-            assert_eq!(trace0.q_after_norm.len(), q_width);
-            assert_eq!(trace0.k_after_norm.len(), kv_width);
-            assert_eq!(trace0.q_after_rope.len(), q_width);
-            assert_eq!(trace0.k_after_rope.len(), kv_width);
-            assert_eq!(trace0.attention_context.len(), q_width);
-            assert_eq!(trace0.o_projection.len(), geom.d_model);
-            assert_eq!(trace0.post_attention_residual.len(), geom.d_model);
-            assert_eq!(trace0.status, 0);
-            assert_eq!(request_state.committed_position, 1);
+        assert_eq!(trace0.embedding.len(), geom.d_model);
+        assert_eq!(trace0.attention_pre_norm.len(), geom.d_model);
+        assert_eq!(trace0.q_raw.len(), q_width);
+        assert_eq!(trace0.k_raw.len(), kv_width);
+        assert_eq!(trace0.v_raw.len(), kv_width);
+        assert_eq!(trace0.q_after_norm.len(), q_width);
+        assert_eq!(trace0.k_after_norm.len(), kv_width);
+        assert_eq!(trace0.q_after_rope.len(), q_width);
+        assert_eq!(trace0.k_after_rope.len(), kv_width);
+        assert_eq!(trace0.attention_context.len(), q_width);
+        assert_eq!(trace0.o_projection.len(), geom.d_model);
+        assert_eq!(trace0.post_attention_residual.len(), geom.d_model);
+        assert_eq!(trace0.status, 0);
+        assert_eq!(request_state.committed_position, 1);
 
-            assert!(trace0.embedding.iter().all(|v| v.is_finite()));
-            assert!(trace0.attention_pre_norm.iter().all(|v| v.is_finite()));
-            assert!(trace0.q_raw.iter().all(|v| v.is_finite()));
-            assert!(trace0.k_raw.iter().all(|v| v.is_finite()));
-            assert!(trace0.v_raw.iter().all(|v| v.is_finite()));
-            assert!(trace0.q_after_norm.iter().all(|v| v.is_finite()));
-            assert!(trace0.k_after_norm.iter().all(|v| v.is_finite()));
-            assert!(trace0.q_after_rope.iter().all(|v| v.is_finite()));
-            assert!(trace0.k_after_rope.iter().all(|v| v.is_finite()));
-            assert!(trace0.attention_context.iter().all(|v| v.is_finite()));
-            assert!(trace0.o_projection.iter().all(|v| v.is_finite()));
-            assert!(trace0.post_attention_residual.iter().all(|v| v.is_finite()));
+        assert!(trace0.embedding.iter().all(|v| v.is_finite()));
+        assert!(trace0.attention_pre_norm.iter().all(|v| v.is_finite()));
+        assert!(trace0.q_raw.iter().all(|v| v.is_finite()));
+        assert!(trace0.k_raw.iter().all(|v| v.is_finite()));
+        assert!(trace0.v_raw.iter().all(|v| v.is_finite()));
+        assert!(trace0.q_after_norm.iter().all(|v| v.is_finite()));
+        assert!(trace0.k_after_norm.iter().all(|v| v.is_finite()));
+        assert!(trace0.q_after_rope.iter().all(|v| v.is_finite()));
+        assert!(trace0.k_after_rope.iter().all(|v| v.is_finite()));
+        assert!(trace0.attention_context.iter().all(|v| v.is_finite()));
+        assert!(trace0.o_projection.iter().all(|v| v.is_finite()));
+        assert!(trace0.post_attention_residual.iter().all(|v| v.is_finite()));
 
-            // 2. Position 1 (persisting KV across positions)
-            let trace1 = pollster::block_on(harness.token_loop.step_layer0_attention_diagnostic(
-                &harness.engine,
-                &mut request_state,
-                2,
-                1,
-                &trace_layout,
-                &staging_buffer,
-            ))
-            .expect("layer-0 diagnostic step 1 must succeed");
+        // 2. Position 1 (persisting KV across positions)
+        let trace1 = pollster::block_on(harness.token_loop.step_layer0_attention_diagnostic(
+            &harness.engine,
+            &mut request_state,
+            2,
+            1,
+            &trace_layout,
+            &staging_buffer,
+        ))
+        .expect("layer-0 diagnostic step 1 must succeed");
 
-            assert_eq!(trace1.status, 0);
-            assert_eq!(request_state.committed_position, 2);
-            assert!(trace1.post_attention_residual.iter().all(|v| v.is_finite()));
-        }
+        assert_eq!(trace1.status, 0);
+        assert_eq!(request_state.committed_position, 2);
+        assert!(trace1.post_attention_residual.iter().all(|v| v.is_finite()));
     }
 }

--- a/rust-engine/src/gpu_native_token_loop.rs
+++ b/rust-engine/src/gpu_native_token_loop.rs
@@ -576,12 +576,14 @@ pub struct GpuNativeRouterRankDiagnosticSink<'a> {
 enum GpuNativeSemanticDiagnosticLayout<'a> {
     Target(&'a crate::gpu_native_expert_permutation_semantic_parity::SemanticTraceLayout),
     Corpus(&'a crate::gpu_native_semantic_parity_corpus::SemanticCorpusTraceLayout),
+    Q4ExpertStages(&'a crate::gpu_native_q4_expert_stage_attribution::Q4ExpertStageTraceLayout),
 }
 
 /// Copy-only observation sink used exclusively by semantic diagnostics.
 pub struct GpuNativeExpertPermutationSemanticSink<'a> {
     layout: GpuNativeSemanticDiagnosticLayout<'a>,
     pub staging_buffer: &'a wgpu::Buffer,
+    stage_scratch: Option<&'a GpuNativeScratch>,
 }
 
 impl GpuNativeExpertPermutationSemanticSink<'_> {
@@ -594,7 +596,8 @@ impl GpuNativeExpertPermutationSemanticSink<'_> {
                 Some(layout)
             }
             GpuNativeSemanticDiagnosticLayout::Target(_)
-            | GpuNativeSemanticDiagnosticLayout::Corpus(_) => None,
+            | GpuNativeSemanticDiagnosticLayout::Corpus(_)
+            | GpuNativeSemanticDiagnosticLayout::Q4ExpertStages(_) => None,
         }
     }
 
@@ -603,7 +606,21 @@ impl GpuNativeExpertPermutationSemanticSink<'_> {
     ) -> Option<&crate::gpu_native_semantic_parity_corpus::SemanticCorpusTraceLayout> {
         match self.layout {
             GpuNativeSemanticDiagnosticLayout::Corpus(layout) => Some(layout),
-            GpuNativeSemanticDiagnosticLayout::Target(_) => None,
+            GpuNativeSemanticDiagnosticLayout::Target(_)
+            | GpuNativeSemanticDiagnosticLayout::Q4ExpertStages(_) => None,
+        }
+    }
+
+    fn q4_expert_stage_layout_for_layer(
+        &self,
+        layer: usize,
+    ) -> Option<&crate::gpu_native_q4_expert_stage_attribution::Q4ExpertStageTargetLayout> {
+        match self.layout {
+            GpuNativeSemanticDiagnosticLayout::Q4ExpertStages(layout) => {
+                layout.target_for_layer(layer)
+            }
+            GpuNativeSemanticDiagnosticLayout::Target(_)
+            | GpuNativeSemanticDiagnosticLayout::Corpus(_) => None,
         }
     }
 
@@ -611,6 +628,7 @@ impl GpuNativeExpertPermutationSemanticSink<'_> {
         match self.layout {
             GpuNativeSemanticDiagnosticLayout::Target(layout) => layout.total_bytes,
             GpuNativeSemanticDiagnosticLayout::Corpus(layout) => layout.total_bytes,
+            GpuNativeSemanticDiagnosticLayout::Q4ExpertStages(layout) => layout.total_bytes,
         }
     }
 }
@@ -621,6 +639,8 @@ struct GpuNativeAttemptOutput {
     router_rank_trace: Option<crate::gpu_native_router_rank_diagnostics::RouterRankGpuTrace>,
     semantic_trace: Option<crate::gpu_native_expert_permutation_semantic_parity::SemanticGpuTrace>,
     semantic_corpus_trace: Option<crate::gpu_native_semantic_parity_corpus::SemanticCorpusGpuTrace>,
+    q4_expert_stage_trace:
+        Option<crate::gpu_native_q4_expert_stage_attribution::Q4ExpertStageGpuTrace>,
 }
 
 struct GpuNativeStepOutput {
@@ -630,6 +650,8 @@ struct GpuNativeStepOutput {
     router_rank_trace: Option<crate::gpu_native_router_rank_diagnostics::RouterRankGpuTrace>,
     semantic_trace: Option<crate::gpu_native_expert_permutation_semantic_parity::SemanticGpuTrace>,
     semantic_corpus_trace: Option<crate::gpu_native_semantic_parity_corpus::SemanticCorpusGpuTrace>,
+    q4_expert_stage_trace:
+        Option<crate::gpu_native_q4_expert_stage_attribution::Q4ExpertStageGpuTrace>,
 }
 
 /// Persistent, model-scoped owner of the GPU-native token loop.
@@ -1013,6 +1035,14 @@ impl GpuNativeTokenLoop {
         self.create_request_state_inner(true, true)
     }
 
+    /// Allocate request-local copy-capable router/expert scratch for the
+    /// diagnostic-only Q4 expert internal-stage observer.
+    pub fn create_q4_expert_stage_diagnostic_request_state(
+        &self,
+    ) -> Result<GpuNativeRequestState, GpuNativeTokenLoopError> {
+        self.create_request_state_inner(true, true)
+    }
+
     fn create_request_state_inner(
         &self,
         router_rank_diagnostic: bool,
@@ -1333,6 +1363,7 @@ impl GpuNativeTokenLoop {
                 Some((
                     GpuNativeSemanticDiagnosticLayout::Target(trace_layout),
                     diagnostic_staging_buffer,
+                    None,
                 )),
             )
             .await?;
@@ -1381,6 +1412,7 @@ impl GpuNativeTokenLoop {
                 Some((
                     GpuNativeSemanticDiagnosticLayout::Corpus(trace_layout),
                     diagnostic_staging_buffer,
+                    None,
                 )),
             )
             .await?;
@@ -1394,6 +1426,72 @@ impl GpuNativeTokenLoop {
                 detail: "semantic corpus diagnostic step produced no sampled token".into(),
             }
         })?;
+        Ok((trace, sampled_token, out.attempts))
+    }
+
+    /// Diagnostic-only token step that observes raw gate, raw up,
+    /// post-SwiGLU gated activation, diagnostic down, and the unchanged
+    /// production down output at one or more frozen layers.
+    pub async fn step_token_q4_expert_stage_diagnostic(
+        &self,
+        engine: &Arc<Engine>,
+        request: &mut GpuNativeRequestState,
+        token_id: u32,
+        position: usize,
+        trace_layout: &crate::gpu_native_q4_expert_stage_attribution::Q4ExpertStageTraceLayout,
+        diagnostic_staging_buffer: &wgpu::Buffer,
+    ) -> Result<
+        (
+            crate::gpu_native_q4_expert_stage_attribution::Q4ExpertStageGpuTrace,
+            u32,
+            usize,
+        ),
+        GpuNativeTokenLoopError,
+    > {
+        let expert_geometry = GpuNativeQ4ExpertGeometry::try_new(
+            self.model_geometry.d_model,
+            self.model_geometry.d_ff,
+            self.model_geometry.num_experts,
+            self.model_geometry.top_k,
+        )?;
+        if trace_layout.d_model != self.model_geometry.d_model
+            || trace_layout.d_ff != self.model_geometry.d_ff
+            || trace_layout.top_k != self.model_geometry.top_k
+        {
+            return Err(GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "Q4 expert stage layout does not match token-loop geometry".into(),
+            });
+        }
+        let stage_scratch = self
+            .executor
+            .create_q4_expert_stage_diagnostic_scratch(expert_geometry)?;
+        let _guard = self.execution_guard.lock().await;
+        let out = self
+            .step_token_unified_inner(
+                engine,
+                request,
+                token_id,
+                position,
+                true,
+                None,
+                None,
+                Some((
+                    GpuNativeSemanticDiagnosticLayout::Q4ExpertStages(trace_layout),
+                    diagnostic_staging_buffer,
+                    Some(&stage_scratch),
+                )),
+            )
+            .await?;
+        let trace = out.q4_expert_stage_trace.ok_or_else(|| {
+            GpuNativeTokenLoopError::InvalidBoundaryReport {
+                detail: "Q4 expert stage trace was not collected".into(),
+            }
+        })?;
+        let sampled_token =
+            out.sampled_token
+                .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
+                    detail: "Q4 expert stage diagnostic produced no sampled token".into(),
+                })?;
         Ok((trace, sampled_token, out.attempts))
     }
 
@@ -1448,6 +1546,20 @@ impl GpuNativeTokenLoop {
         let gpu = self.executor.authoritative_gpu()?;
         Ok(gpu.device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("gpu_native_semantic_parity_corpus_diagnostic_staging"),
+            size: trace_layout.total_bytes,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+            mapped_at_creation: false,
+        }))
+    }
+
+    /// Allocate the frozen-layer Q4 expert stage readback buffer.
+    pub fn create_q4_expert_stage_diagnostic_staging_buffer(
+        &self,
+        trace_layout: &crate::gpu_native_q4_expert_stage_attribution::Q4ExpertStageTraceLayout,
+    ) -> Result<wgpu::Buffer, GpuNativeTokenLoopError> {
+        let gpu = self.executor.authoritative_gpu()?;
+        Ok(gpu.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("gpu_native_q4_expert_stage_diagnostic_staging"),
             size: trace_layout.total_bytes,
             usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
             mapped_at_creation: false,
@@ -1636,6 +1748,7 @@ impl GpuNativeTokenLoop {
         semantic_sink: Option<(
             GpuNativeSemanticDiagnosticLayout<'_>,
             &wgpu::Buffer,
+            Option<&GpuNativeScratch>,
         )>,
     ) -> Result<GpuNativeStepOutput, GpuNativeTokenLoopError> {
         let max_attempts = self.layers.len() + 1;
@@ -1662,10 +1775,11 @@ impl GpuNativeTokenLoop {
                     layout,
                     staging_buffer: buf,
                 });
-            let semantic_sink = semantic_sink.map(|(layout, buf)| {
+            let semantic_sink = semantic_sink.map(|(layout, buf, stage_scratch)| {
                 GpuNativeExpertPermutationSemanticSink {
                     layout,
                     staging_buffer: buf,
+                    stage_scratch,
                 }
             });
             let output = self.execute_token_attempt_unified(
@@ -1797,6 +1911,7 @@ impl GpuNativeTokenLoop {
                 router_rank_trace: output.router_rank_trace,
                 semantic_trace: output.semantic_trace,
                 semantic_corpus_trace: output.semantic_corpus_trace,
+                q4_expert_stage_trace: output.q4_expert_stage_trace,
             });
         }
     }
@@ -2101,6 +2216,29 @@ impl GpuNativeTokenLoop {
                         layout.selected_weights_layer_bytes,
                     );
                 }
+                if let Some(layout) = sink.q4_expert_stage_layout_for_layer(layer_idx) {
+                    encoder.copy_buffer_to_buffer(
+                        request.token_state.hidden_buffer(),
+                        0,
+                        sink.staging_buffer,
+                        layout.router_input_offset,
+                        layout.router_input_bytes,
+                    );
+                    encoder.copy_buffer_to_buffer(
+                        request.router_scratch.selected_ids_buffer(),
+                        0,
+                        sink.staging_buffer,
+                        layout.selected_ids_offset,
+                        layout.selected_ids_bytes,
+                    );
+                    encoder.copy_buffer_to_buffer(
+                        request.router_scratch.selected_weights_buffer(),
+                        0,
+                        sink.staging_buffer,
+                        layout.selected_weights_offset,
+                        layout.selected_weights_bytes,
+                    );
+                }
             }
 
             // 6. Expert Combine
@@ -2109,6 +2247,31 @@ impl GpuNativeTokenLoop {
                     detail: format!("missing expert arena for layer {layer_idx}"),
                 }
             })?;
+            if let Some(sink) = semantic_sink {
+                if let Some(layout) = sink.q4_expert_stage_layout_for_layer(layer_idx) {
+                    let stage_scratch = sink.stage_scratch.ok_or_else(|| {
+                        GpuNativeTokenLoopError::InvalidBoundaryReport {
+                            detail: "Q4 expert stage sink is missing diagnostic scratch".into(),
+                        }
+                    })?;
+                    self.executor.encode_q4_expert_stage_diagnostic(
+                        &mut encoder,
+                        &layer_plan.router_plan,
+                        &request.router_scratch,
+                        arena,
+                        &request.token_state,
+                        &request.expert_scratch,
+                        stage_scratch,
+                    )?;
+                    encoder.copy_buffer_to_buffer(
+                        stage_scratch.buffer(),
+                        0,
+                        sink.staging_buffer,
+                        layout.stages_offset,
+                        layout.stages_bytes,
+                    );
+                }
+            }
             self.executor.encode_q4_expert_arena_combine(
                 &mut encoder,
                 &layer_plan.router_plan,
@@ -2149,6 +2312,15 @@ impl GpuNativeTokenLoop {
                         sink.staging_buffer,
                         layout.routed_moe_output_offset(layer_idx),
                         layout.routed_moe_output_layer_bytes,
+                    );
+                }
+                if let Some(layout) = sink.q4_expert_stage_layout_for_layer(layer_idx) {
+                    encoder.copy_buffer_to_buffer(
+                        request.expert_scratch.route_outputs_buffer(),
+                        0,
+                        sink.staging_buffer,
+                        layout.production_down_offset,
+                        layout.production_down_bytes,
                     );
                 }
             }
@@ -2364,38 +2536,48 @@ impl GpuNativeTokenLoop {
             None
         };
 
-        let (semantic_trace, semantic_corpus_trace) = if let Some(sink) = semantic_sink {
-            let semantic_slice = sink.staging_buffer.slice(..sink.total_bytes());
-            let (tx_semantic, rx_semantic) = std::sync::mpsc::sync_channel(1);
-            semantic_slice.map_async(wgpu::MapMode::Read, move |result| {
-                let _ = tx_semantic.send(result);
-            });
-            gpu.device.poll(wgpu::Maintain::Wait);
-            rx_semantic
-                .recv()
-                .map_err(|error| GpuNativeTokenLoopError::MapFailed(error.to_string()))?
-                .map_err(|error| GpuNativeTokenLoopError::MapFailed(format!("{error:?}")))?;
-            let mapped = semantic_slice.get_mapped_range();
-            let parsed = match sink.layout {
-                GpuNativeSemanticDiagnosticLayout::Target(layout) => (
-                    Some(layout.parse(&mapped).map_err(|detail| {
-                        GpuNativeTokenLoopError::InvalidBoundaryReport { detail }
-                    })?),
-                    None,
-                ),
-                GpuNativeSemanticDiagnosticLayout::Corpus(layout) => (
-                    None,
-                    Some(layout.parse(&mapped).map_err(|detail| {
-                        GpuNativeTokenLoopError::InvalidBoundaryReport { detail }
-                    })?),
-                ),
+        let (semantic_trace, semantic_corpus_trace, q4_expert_stage_trace) =
+            if let Some(sink) = semantic_sink {
+                let semantic_slice = sink.staging_buffer.slice(..sink.total_bytes());
+                let (tx_semantic, rx_semantic) = std::sync::mpsc::sync_channel(1);
+                semantic_slice.map_async(wgpu::MapMode::Read, move |result| {
+                    let _ = tx_semantic.send(result);
+                });
+                gpu.device.poll(wgpu::Maintain::Wait);
+                rx_semantic
+                    .recv()
+                    .map_err(|error| GpuNativeTokenLoopError::MapFailed(error.to_string()))?
+                    .map_err(|error| GpuNativeTokenLoopError::MapFailed(format!("{error:?}")))?;
+                let mapped = semantic_slice.get_mapped_range();
+                let parsed = match sink.layout {
+                    GpuNativeSemanticDiagnosticLayout::Target(layout) => (
+                        Some(layout.parse(&mapped).map_err(|detail| {
+                            GpuNativeTokenLoopError::InvalidBoundaryReport { detail }
+                        })?),
+                        None,
+                        None,
+                    ),
+                    GpuNativeSemanticDiagnosticLayout::Corpus(layout) => (
+                        None,
+                        Some(layout.parse(&mapped).map_err(|detail| {
+                            GpuNativeTokenLoopError::InvalidBoundaryReport { detail }
+                        })?),
+                        None,
+                    ),
+                    GpuNativeSemanticDiagnosticLayout::Q4ExpertStages(layout) => (
+                        None,
+                        None,
+                        Some(layout.parse(&mapped).map_err(|detail| {
+                            GpuNativeTokenLoopError::InvalidBoundaryReport { detail }
+                        })?),
+                    ),
+                };
+                drop(mapped);
+                sink.staging_buffer.unmap();
+                parsed
+            } else {
+                (None, None, None)
             };
-            drop(mapped);
-            sink.staging_buffer.unmap();
-            parsed
-        } else {
-            (None, None)
-        };
 
         Ok(GpuNativeAttemptOutput {
             boundary_report: report,
@@ -2403,6 +2585,7 @@ impl GpuNativeTokenLoop {
             router_rank_trace,
             semantic_trace,
             semantic_corpus_trace,
+            q4_expert_stage_trace,
         })
     }
 }

--- a/rust-engine/src/gpu_native_token_loop.rs
+++ b/rust-engine/src/gpu_native_token_loop.rs
@@ -1251,13 +1251,14 @@ impl GpuNativeTokenLoop {
         )?;
 
         // 4. Attention Complete (Causal Attention, O Projection, Residual Add)
+        // The backend expects the absolute current position and derives seq_len internally.
         self.executor.encode_attention_complete_layer0_diagnostic(
             &mut encoder,
             &layer_0.attn_plan,
             &request.token_state,
             &request.attn_scratch,
             &request.kv_state,
-            position + 1,
+            position,
             &sink,
         )?;
 
@@ -1616,13 +1617,14 @@ impl GpuNativeTokenLoop {
             )?;
 
             // 3. Attention Complete
+            // The backend expects the absolute current position and derives seq_len internally.
             self.executor.encode_attention_complete(
                 &mut encoder,
                 &layer_plan.attn_plan,
                 &request.token_state,
                 &request.attn_scratch,
                 &request.kv_state,
-                position + 1,
+                position,
             )?;
 
             if let Some(sink) = diagnostic_sink {
@@ -3120,6 +3122,24 @@ pub(crate) mod tests {
         assert!(trace0.attention_context.iter().all(|v| v.is_finite()));
         assert!(trace0.o_projection.iter().all(|v| v.is_finite()));
         assert!(trace0.post_attention_residual.iter().all(|v| v.is_finite()));
+
+        let queries_per_kv_head = geom.num_heads / geom.num_kv_heads;
+        for query_head in 0..geom.num_heads {
+            let kv_head = query_head / queries_per_kv_head;
+            for channel in 0..geom.head_dim {
+                let context_index = query_head * geom.head_dim + channel;
+                let v_index = kv_head * geom.head_dim + channel;
+                let context = trace0.attention_context[context_index];
+                let expected_v = trace0.v_raw[v_index];
+                assert_eq!(
+                    context.to_bits(),
+                    expected_v.to_bits(),
+                    "position-0 context/V identity failed: query_head={query_head}, kv_head={kv_head}, channel={channel}, expected_v={expected_v}, expected_v_bits=0x{:08x}, context={context}, context_bits=0x{:08x}",
+                    expected_v.to_bits(),
+                    context.to_bits(),
+                );
+            }
+        }
 
         // 2. Position 1 (persisting KV across positions)
         let trace1 = pollster::block_on(harness.token_loop.step_layer0_attention_diagnostic(

--- a/rust-engine/src/gpu_native_v2_holdout_failure_attribution.rs
+++ b/rust-engine/src/gpu_native_v2_holdout_failure_attribution.rs
@@ -1730,6 +1730,34 @@ async fn analyze_moe_outlier(
     })
 }
 
+fn enable_clean_cpu_q4_boundary_emulation_with<Enable, Snapshot>(
+    enable: Enable,
+    snapshot: Snapshot,
+) -> Result<crate::engine::CpuQ4BoundaryEmulationSnapshot, String>
+where
+    Enable: FnOnce() -> Result<(), String>,
+    Snapshot: FnOnce() -> crate::engine::CpuQ4BoundaryEmulationSnapshot,
+{
+    enable()?;
+    let boundary = snapshot();
+    if !boundary.enabled || boundary.routed_expert_dispatches != 0 {
+        return Err(format!(
+            "diagnostic CPU boundary emulation did not start clean: enabled={} routed_expert_dispatches={}",
+            boundary.enabled, boundary.routed_expert_dispatches
+        ));
+    }
+    Ok(boundary)
+}
+
+fn enable_clean_cpu_q4_boundary_emulation(
+    engine: &crate::engine::Engine,
+) -> Result<crate::engine::CpuQ4BoundaryEmulationSnapshot, String> {
+    enable_clean_cpu_q4_boundary_emulation_with(
+        || engine.enable_cpu_q4_boundary_emulation(),
+        || engine.cpu_q4_boundary_emulation_snapshot(),
+    )
+}
+
 async fn execute_reference_and_analyze(
     spec: &ResolvedRealCliSpec,
     tokenizer: Arc<crate::tokenizer::Tokenizer>,
@@ -1744,6 +1772,7 @@ async fn execute_reference_and_analyze(
     )
     .await?;
     let attempt = async {
+        let _boundary_before = enable_clean_cpu_q4_boundary_emulation(&runtime.engine)?;
         let observed_config_sha256 = crate::resolved_real_runtime_identity_sha256(
             &runtime.cfg,
             runtime.model.config.architecture,
@@ -1762,10 +1791,6 @@ async fn execute_reference_and_analyze(
             if gpu.gate_identities.get(&layer) != Some(&reference_identity) {
                 return Err(format!("diagnostic gate tensor identity differs at layer {layer}").into());
             }
-        }
-        let boundary_before = runtime.engine.cpu_q4_boundary_emulation_snapshot();
-        if !boundary_before.enabled || boundary_before.routed_expert_dispatches != 0 {
-            return Err("diagnostic CPU boundary emulation did not start clean".into());
         }
         let model_load = crate::greedy_parity_model_load(&runtime);
         let fixed = holdout_case(RUST_TARGET_CASE)?;
@@ -2110,6 +2135,7 @@ pub async fn run_diagnostic(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::engine::CpuQ4BoundaryEmulationSnapshot;
 
     fn strict_model_load() -> crate::greedy_parity::ModelLoadEvidence {
         crate::greedy_parity::ModelLoadEvidence {
@@ -2196,6 +2222,88 @@ mod tests {
             offline_failure_analysis_sha256: FROZEN_OFFLINE_ANALYSIS_SHA256,
             immutable_input_verified: true,
         }
+    }
+
+    #[test]
+    fn diagnostic_cpu_q4_boundary_setup_enables_before_clean_snapshot() {
+        use std::cell::{Cell, RefCell};
+
+        let enabled = Cell::new(false);
+        let dispatches = Cell::new(0u64);
+        let calls = RefCell::new(Vec::new());
+        let boundary = enable_clean_cpu_q4_boundary_emulation_with(
+            || {
+                calls.borrow_mut().push("enable");
+                enabled.set(true);
+                Ok(())
+            },
+            || {
+                calls.borrow_mut().push("snapshot");
+                CpuQ4BoundaryEmulationSnapshot {
+                    enabled: enabled.get(),
+                    routed_expert_dispatches: dispatches.get(),
+                }
+            },
+        )
+        .unwrap();
+
+        assert_eq!(*calls.borrow(), ["enable", "snapshot"]);
+        assert!(boundary.enabled);
+        assert_eq!(boundary.routed_expert_dispatches, 0);
+    }
+
+    #[test]
+    fn diagnostic_cpu_q4_boundary_setup_reports_and_preserves_nonzero_dispatches() {
+        use std::cell::Cell;
+
+        let enabled = Cell::new(false);
+        let dispatches = Cell::new(7u64);
+        let error = enable_clean_cpu_q4_boundary_emulation_with(
+            || {
+                enabled.set(true);
+                Ok(())
+            },
+            || CpuQ4BoundaryEmulationSnapshot {
+                enabled: enabled.get(),
+                routed_expert_dispatches: dispatches.get(),
+            },
+        )
+        .unwrap_err();
+
+        assert_eq!(dispatches.get(), 7);
+        assert_eq!(
+            error,
+            "diagnostic CPU boundary emulation did not start clean: enabled=true routed_expert_dispatches=7"
+        );
+    }
+
+    #[test]
+    fn diagnostic_cpu_q4_boundary_setup_propagates_strict_plan_enable_failure() {
+        use std::cell::Cell;
+
+        let snapshot_called = Cell::new(false);
+        let error = enable_clean_cpu_q4_boundary_emulation_with(
+            || {
+                Err(
+                    "Q4 boundary emulation requires a strict CPU Q4_0 routed-expert plan"
+                        .to_string(),
+                )
+            },
+            || {
+                snapshot_called.set(true);
+                CpuQ4BoundaryEmulationSnapshot {
+                    enabled: false,
+                    routed_expert_dispatches: 0,
+                }
+            },
+        )
+        .unwrap_err();
+
+        assert!(!snapshot_called.get());
+        assert_eq!(
+            error,
+            "Q4 boundary emulation requires a strict CPU Q4_0 routed-expert plan"
+        );
     }
 
     #[test]

--- a/rust-engine/src/gpu_native_v2_holdout_failure_attribution.rs
+++ b/rust-engine/src/gpu_native_v2_holdout_failure_attribution.rs
@@ -1,0 +1,2462 @@
+//! Diagnostic-only attribution for the frozen first GPU-native semantic
+//! parity v2 holdout failure.
+//!
+//! This module consumes the immutable v2 report as input evidence and reuses
+//! existing production observation seams. It is never consulted by ordinary
+//! inference or by any qualification PASS derivation.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+use crate::gpu_native_expert_permutation_semantic_parity::{
+    PermutationOnlyWitness, VectorNumericalEvidence, WeightDeltaEvidence,
+};
+use crate::gpu_native_router_rank_diagnostics::{
+    ActualGpuRouterEvidence, DiagnosticProvenance, GateIdentityEvidence, GateTensorIdentity,
+    RankedExpertEvidence, RouterEvaluationEvidence,
+};
+use crate::gpu_native_semantic_parity_corpus::{
+    RoutingClassification, SemanticCorpusGpuLayerTrace, SemanticCorpusGpuTrace,
+    SemanticCorpusTraceLayout,
+};
+use crate::gpu_native_token_loop::{GpuNativeModelGeometry, GpuNativeTokenLoopSnapshot};
+use crate::numerical_diagnostics::FloatEvidence;
+use crate::{IsolatedRuntimeShutdownError, RealCliRuntimeMode, ResolvedRealCliSpec};
+
+pub const SCHEMA_VERSION: &str = "mer.gpu-native-v2-holdout-failure-attribution.v1";
+pub const MODE: &str = "diagnose-gpu-native-v2-holdout-failures";
+pub const FROZEN_V2_BUILD_SHA: &str = "300448ac3da48ac74ef86fcd2c62ffca27ffa634";
+pub const FROZEN_V2_REPORT_SHA256: &str =
+    "9629de35a18f4457bbe38aeeaeb208fd979bb08e9d2eccb283437d6c16a5c4ad";
+pub const FROZEN_V2_EXECUTION_LOG_SHA256: &str =
+    "3122208935d1554e0eb119d8f293da42c1a94b253599af1b454b09b80d317dda";
+pub const FROZEN_OFFLINE_ANALYSIS_SHA256: &str =
+    "06c0e01fc1eb99b682ff83dc209f39e65e3472d0c70d594a99364b20f85430e8";
+
+pub const RUST_TARGET_CASE: &str = "rust-ownership-holdout";
+pub const RUST_TARGET_POSITION: usize = 1;
+pub const RUST_PRECEDING_TOKEN: u32 = 4710;
+pub const RUST_REFERENCE_TARGET_TOKEN: u32 = 785;
+pub const RUST_GPU_TARGET_TOKEN: u32 = 8822;
+
+pub const ROUTER_TARGET_CASE: &str = "postgres-window-holdout";
+pub const ROUTER_TARGET_POSITION: usize = 11;
+pub const ROUTER_TARGET_LAYER: usize = 38;
+pub const ROUTER_CPU_EXPECTED_IDS: [u32; 8] = [102, 73, 30, 87, 71, 36, 115, 107];
+pub const ROUTER_GPU_EXPECTED_IDS: [u32; 8] = [102, 73, 30, 87, 71, 36, 115, 95];
+pub const ROUTER_EXPLICIT_EXPERTS: [u32; 2] = [95, 107];
+
+#[derive(Clone, Copy, Debug, PartialEq, Serialize)]
+pub struct FrozenMoeOutlierTarget {
+    pub case: &'static str,
+    pub generated_position: usize,
+    pub layer: usize,
+    pub classification: &'static str,
+    pub frozen_max_absolute_error: f64,
+    pub frozen_rms_error: f64,
+    pub frozen_mean_absolute_error: f64,
+}
+
+pub const MOE_OUTLIER_TARGETS: [FrozenMoeOutlierTarget; 4] = [
+    FrozenMoeOutlierTarget {
+        case: "postgres-window-holdout",
+        generated_position: 13,
+        layer: 47,
+        classification: "internal-rank-permutation",
+        frozen_max_absolute_error: 0.030458450317382812,
+        frozen_rms_error: 0.0009415900264223419,
+        frozen_mean_absolute_error: 0.0002828433401447228,
+    },
+    FrozenMoeOutlierTarget {
+        case: "spanish-refactor-holdout",
+        generated_position: 11,
+        layer: 47,
+        classification: "membership-mismatch",
+        frozen_max_absolute_error: 0.025327682495117188,
+        frozen_rms_error: 0.0007412235007170731,
+        frozen_mean_absolute_error: 0.00021333931897515868,
+    },
+    FrozenMoeOutlierTarget {
+        case: "spanish-refactor-holdout",
+        generated_position: 13,
+        layer: 47,
+        classification: "internal-rank-permutation",
+        frozen_max_absolute_error: 0.02174687385559082,
+        frozen_rms_error: 0.0006797136324364518,
+        frozen_mean_absolute_error: 0.00021244322049795983,
+    },
+    FrozenMoeOutlierTarget {
+        case: "spanish-refactor-holdout",
+        generated_position: 15,
+        layer: 47,
+        classification: "internal-rank-permutation",
+        frozen_max_absolute_error: 0.021457672119140625,
+        frozen_rms_error: 0.000589083423933804,
+        frozen_mean_absolute_error: 0.00016039697858616364,
+    },
+];
+
+#[derive(Clone, Copy, Debug, PartialEq, Serialize)]
+pub struct FrozenRouterCoupledTarget {
+    pub case: &'static str,
+    pub generated_position: usize,
+    pub layer: usize,
+    pub classification: &'static str,
+    pub frozen_max_absolute_error: f64,
+    pub frozen_rms_error: f64,
+    pub frozen_mean_absolute_error: f64,
+    pub primary_attribution_target: &'static str,
+    pub excluded_from_exact_router_moe_decomposition: bool,
+}
+
+pub const ROUTER_COUPLED_TARGET: FrozenRouterCoupledTarget = FrozenRouterCoupledTarget {
+    case: ROUTER_TARGET_CASE,
+    generated_position: ROUTER_TARGET_POSITION,
+    layer: ROUTER_TARGET_LAYER,
+    classification: "router-coupled-numerical-failure",
+    frozen_max_absolute_error: 0.04648581147193909,
+    frozen_rms_error: 0.011342482386714535,
+    frozen_mean_absolute_error: 0.009020052351949914,
+    primary_attribution_target: "target-b-same-input-router-defect",
+    excluded_from_exact_router_moe_decomposition: true,
+};
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct FrozenTargetListEvidence {
+    pub rust_token_target_case: &'static str,
+    pub rust_token_target_position: usize,
+    pub rust_preceding_token: u32,
+    pub rust_reference_target_token: u32,
+    pub rust_gpu_target_token: u32,
+    pub router_target_case: &'static str,
+    pub router_target_position: usize,
+    pub router_target_layer: usize,
+    pub router_cpu_expected_ids: [u32; 8],
+    pub router_gpu_expected_ids: [u32; 8],
+    pub exact_router_moe_outliers: Vec<FrozenMoeOutlierTarget>,
+    pub router_coupled_numerical_failure: FrozenRouterCoupledTarget,
+    pub target_selection_rule: &'static str,
+}
+
+impl FrozenTargetListEvidence {
+    pub fn fixed() -> Self {
+        Self {
+            rust_token_target_case: RUST_TARGET_CASE,
+            rust_token_target_position: RUST_TARGET_POSITION,
+            rust_preceding_token: RUST_PRECEDING_TOKEN,
+            rust_reference_target_token: RUST_REFERENCE_TARGET_TOKEN,
+            rust_gpu_target_token: RUST_GPU_TARGET_TOKEN,
+            router_target_case: ROUTER_TARGET_CASE,
+            router_target_position: ROUTER_TARGET_POSITION,
+            router_target_layer: ROUTER_TARGET_LAYER,
+            router_cpu_expected_ids: ROUTER_CPU_EXPECTED_IDS,
+            router_gpu_expected_ids: ROUTER_GPU_EXPECTED_IDS,
+            exact_router_moe_outliers: MOE_OUTLIER_TARGETS.to_vec(),
+            router_coupled_numerical_failure: ROUTER_COUPLED_TARGET,
+            target_selection_rule: "exactly-one-rust-token-one-router-four-exact-router-moe-targets-frozen-before-diagnostic-hardware",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+struct FrozenNumericalLimits {
+    max_absolute_error_limit: f64,
+    rms_error_limit: f64,
+    mean_absolute_error_limit: f64,
+    nonfinite_mismatch_limit: usize,
+    semantic_correctness_not_bit_parity: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct FrozenBuildEnvelope {
+    git_sha: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FrozenProvenanceEnvelope {
+    build: FrozenBuildEnvelope,
+}
+
+#[derive(Debug, Deserialize)]
+struct FrozenCorpusEnvelope {
+    id: String,
+    sha256: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct FrozenV2ReportEnvelope {
+    schema: String,
+    qualification_pass: bool,
+    provenance: FrozenProvenanceEnvelope,
+    holdout_corpus: FrozenCorpusEnvelope,
+    numerical_limits: FrozenNumericalLimits,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct FrozenV2ResultIdentity {
+    pub report_artifact: crate::qualification::ArtifactDigest,
+    pub expected_report_sha256_argument: String,
+    pub expected_schema: &'static str,
+    pub frozen_build_sha: &'static str,
+    pub qualification_pass: bool,
+    pub holdout_corpus_id: &'static str,
+    pub holdout_corpus_sha256: &'static str,
+    pub numerical_limits: crate::gpu_native_semantic_parity_v2::NumericalLimits,
+    pub execution_log_sha256: &'static str,
+    pub offline_failure_analysis_sha256: &'static str,
+    pub immutable_input_verified: bool,
+}
+
+fn is_hex(value: &str, length: usize) -> bool {
+    value.len() == length && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn exact_f64(left: f64, right: f64) -> bool {
+    left.to_bits() == right.to_bits()
+}
+
+fn validate_expected_v2_report_sha_argument(value: &str) -> Result<(), String> {
+    if !is_hex(value, 64) || !value.eq_ignore_ascii_case(FROZEN_V2_REPORT_SHA256) {
+        return Err(format!(
+            "expected V2 report SHA must equal frozen {}",
+            FROZEN_V2_REPORT_SHA256
+        ));
+    }
+    Ok(())
+}
+
+fn validate_v2_envelope(envelope: &FrozenV2ReportEnvelope) -> Result<(), String> {
+    let expected = crate::gpu_native_semantic_parity_v2::NumericalLimits::frozen();
+    if envelope.schema != crate::gpu_native_semantic_parity_v2::SCHEMA_VERSION {
+        return Err("frozen V2 report schema differs".to_string());
+    }
+    if envelope.provenance.build.git_sha.as_deref() != Some(FROZEN_V2_BUILD_SHA) {
+        return Err("frozen V2 report build SHA differs".to_string());
+    }
+    if envelope.qualification_pass {
+        return Err("frozen V2 report unexpectedly claims qualification PASS".to_string());
+    }
+    if envelope.holdout_corpus.id != crate::gpu_native_semantic_parity_v2::HOLDOUT_CORPUS_ID
+        || envelope.holdout_corpus.sha256
+            != crate::gpu_native_semantic_parity_v2::HOLDOUT_CORPUS_SHA256
+    {
+        return Err("frozen V2 holdout identity differs".to_string());
+    }
+    let limits = &envelope.numerical_limits;
+    if !exact_f64(
+        limits.max_absolute_error_limit,
+        expected.max_absolute_error_limit,
+    ) || !exact_f64(limits.rms_error_limit, expected.rms_error_limit)
+        || !exact_f64(
+            limits.mean_absolute_error_limit,
+            expected.mean_absolute_error_limit,
+        )
+        || limits.nonfinite_mismatch_limit != expected.nonfinite_mismatch_limit
+        || limits.semantic_correctness_not_bit_parity
+            != expected.semantic_correctness_not_bit_parity
+    {
+        return Err("frozen V2 numerical limits differ".to_string());
+    }
+    Ok(())
+}
+
+fn validate_frozen_v2_report(
+    path: &Path,
+    expected_sha256: &str,
+) -> Result<FrozenV2ResultIdentity, Box<dyn std::error::Error>> {
+    validate_expected_v2_report_sha_argument(expected_sha256)?;
+    // Hash and deserialize the same immutable byte snapshot so a changed file
+    // cannot pass the digest check and then supply different JSON.
+    let bytes = std::fs::read(path)?;
+    let artifact = crate::qualification::ArtifactDigest {
+        configured_path: path.display().to_string(),
+        canonical_path: std::fs::canonicalize(path)?.display().to_string(),
+        byte_length: u64::try_from(bytes.len())
+            .map_err(|_| "frozen V2 report length does not fit u64")?,
+        sha256: crate::greedy_parity::sha256_hex(&bytes),
+    };
+    if !artifact.sha256.eq_ignore_ascii_case(expected_sha256)
+        || !artifact
+            .sha256
+            .eq_ignore_ascii_case(FROZEN_V2_REPORT_SHA256)
+    {
+        return Err(format!(
+            "frozen V2 report SHA differs: observed {} expected {}",
+            artifact.sha256, FROZEN_V2_REPORT_SHA256
+        )
+        .into());
+    }
+    let envelope: FrozenV2ReportEnvelope = serde_json::from_slice(&bytes)
+        .map_err(|error| format!("malformed frozen V2 report: {error}"))?;
+    validate_v2_envelope(&envelope)?;
+    Ok(FrozenV2ResultIdentity {
+        report_artifact: artifact,
+        expected_report_sha256_argument: expected_sha256.to_ascii_lowercase(),
+        expected_schema: crate::gpu_native_semantic_parity_v2::SCHEMA_VERSION,
+        frozen_build_sha: FROZEN_V2_BUILD_SHA,
+        qualification_pass: false,
+        holdout_corpus_id: crate::gpu_native_semantic_parity_v2::HOLDOUT_CORPUS_ID,
+        holdout_corpus_sha256: crate::gpu_native_semantic_parity_v2::HOLDOUT_CORPUS_SHA256,
+        numerical_limits: crate::gpu_native_semantic_parity_v2::NumericalLimits::frozen(),
+        execution_log_sha256: FROZEN_V2_EXECUTION_LOG_SHA256,
+        offline_failure_analysis_sha256: FROZEN_OFFLINE_ANALYSIS_SHA256,
+        immutable_input_verified: true,
+    })
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ExactVectorEvidence {
+    pub source: &'static str,
+    pub vector_length: usize,
+    pub f32_bits_sha256: String,
+    pub f32_bits: Vec<u32>,
+    pub nonfinite_count: usize,
+}
+
+impl ExactVectorEvidence {
+    fn new(source: &'static str, values: &[f32], retain_bits: bool) -> Self {
+        let bits = values
+            .iter()
+            .map(|value| value.to_bits())
+            .collect::<Vec<_>>();
+        Self {
+            source,
+            vector_length: values.len(),
+            f32_bits_sha256: crate::numerical_diagnostics::f32_bits_sha256(&bits),
+            f32_bits: retain_bits.then_some(bits).unwrap_or_default(),
+            nonfinite_count: values.iter().filter(|value| !value.is_finite()).count(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ProductionSemanticsEvidence {
+    pub diagnostic_only: bool,
+    pub production_inference_math_changed: bool,
+    pub production_router_math_changed: bool,
+    pub production_dense_gemv_changed: bool,
+    pub shader_or_wgsl_changed: bool,
+    pub production_selected_expert_order_changed: bool,
+    pub production_accumulation_order_changed: bool,
+    pub v1_changed: bool,
+    pub v2_changed: bool,
+    pub frozen_limits_changed: bool,
+    pub frozen_holdout_changed: bool,
+    pub cpu_lm_head_contract: &'static str,
+    pub gpu_observation_contract: &'static str,
+}
+
+impl Default for ProductionSemanticsEvidence {
+    fn default() -> Self {
+        Self {
+            diagnostic_only: true,
+            production_inference_math_changed: false,
+            production_router_math_changed: false,
+            production_dense_gemv_changed: false,
+            shader_or_wgsl_changed: false,
+            production_selected_expert_order_changed: false,
+            production_accumulation_order_changed: false,
+            v1_changed: false,
+            v2_changed: false,
+            frozen_limits_changed: false,
+            frozen_holdout_changed: false,
+            cpu_lm_head_contract:
+                "RealModel::diagnostic_greedy_logits -> DenseWeight::diagnostic_greedy_logits -> exact greedy_argmax per-row row_dot",
+            gpu_observation_contract:
+                "existing full-token and semantic-corpus diagnostic copy/readback seams only",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct DiscreteStageEvidence {
+    pub reference: Vec<u32>,
+    pub gpu_native: Vec<u32>,
+    pub exact_equal: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct LayerTargetTraceEvidence {
+    pub layer: usize,
+    pub post_attention: VectorNumericalEvidence,
+    pub router_input: VectorNumericalEvidence,
+    pub selected_ids: DiscreteStageEvidence,
+    pub selected_weights: VectorNumericalEvidence,
+    pub post_moe: VectorNumericalEvidence,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct FullTargetTokenTraceEvidence {
+    pub embedding: VectorNumericalEvidence,
+    pub layers: Vec<LayerTargetTraceEvidence>,
+    pub final_rms_norm: VectorNumericalEvidence,
+    pub full_vocabulary_logits: VectorNumericalEvidence,
+    pub reference_sampled_token: u32,
+    pub gpu_native_sampled_token: u32,
+    pub sampled_token_equal: bool,
+}
+
+fn compare_target_token_traces(
+    reference: &crate::gpu_native_diagnostics::ModelDiagnosticTrace,
+    gpu: &crate::gpu_native_diagnostics::GpuNativeDiagnosticTrace,
+) -> Result<FullTargetTokenTraceEvidence, String> {
+    let num_layers = reference.layer_post_attn.len();
+    if num_layers == 0
+        || gpu.layer_post_attn.len() != num_layers
+        || reference.layer_router_input.len() != num_layers
+        || gpu.layer_router_input.len() != num_layers
+        || reference.layer_selected_ids.len() != num_layers
+        || gpu.layer_selected_ids.len() != num_layers
+        || reference.layer_selected_weights.len() != num_layers
+        || gpu.layer_selected_weights.len() != num_layers
+        || reference.layer_post_moe.len() != num_layers
+        || gpu.layer_post_moe.len() != num_layers
+    {
+        return Err("target-token trace layer geometry is incomplete".to_string());
+    }
+    let mut layers = Vec::with_capacity(num_layers);
+    for layer in 0..num_layers {
+        layers.push(LayerTargetTraceEvidence {
+            layer,
+            post_attention: VectorNumericalEvidence::compare(
+                "cpu-reference-layer-post-attention",
+                "gpu-native-layer-post-attention",
+                &reference.layer_post_attn[layer],
+                &gpu.layer_post_attn[layer],
+            )?,
+            router_input: VectorNumericalEvidence::compare(
+                "cpu-reference-layer-router-input",
+                "gpu-native-layer-router-input",
+                &reference.layer_router_input[layer],
+                &gpu.layer_router_input[layer],
+            )?,
+            selected_ids: DiscreteStageEvidence {
+                reference: reference.layer_selected_ids[layer].clone(),
+                gpu_native: gpu.layer_selected_ids[layer].clone(),
+                exact_equal: reference.layer_selected_ids[layer] == gpu.layer_selected_ids[layer],
+            },
+            selected_weights: VectorNumericalEvidence::compare(
+                "cpu-reference-layer-selected-weights",
+                "gpu-native-layer-selected-weights",
+                &reference.layer_selected_weights[layer],
+                &gpu.layer_selected_weights[layer],
+            )?,
+            post_moe: VectorNumericalEvidence::compare(
+                "cpu-reference-layer-post-moe",
+                "gpu-native-layer-post-moe",
+                &reference.layer_post_moe[layer],
+                &gpu.layer_post_moe[layer],
+            )?,
+        });
+    }
+    Ok(FullTargetTokenTraceEvidence {
+        embedding: VectorNumericalEvidence::compare(
+            "cpu-reference-embedding",
+            "gpu-native-embedding",
+            &reference.embedding,
+            &gpu.embedding,
+        )?,
+        layers,
+        final_rms_norm: VectorNumericalEvidence::compare(
+            "cpu-reference-final-rmsnorm",
+            "gpu-native-final-rmsnorm",
+            &reference.final_norm,
+            &gpu.final_norm,
+        )?,
+        full_vocabulary_logits: VectorNumericalEvidence::compare(
+            "cpu-reference-full-vocabulary-logits",
+            "gpu-native-full-vocabulary-logits",
+            &reference.logits,
+            &gpu.logits,
+        )?,
+        reference_sampled_token: reference.sampled_token,
+        gpu_native_sampled_token: gpu.sampled_token,
+        sampled_token_equal: reference.sampled_token == gpu.sampled_token,
+    })
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct TokenLogitEvidence {
+    pub token_id: u32,
+    pub rank: usize,
+    pub raw_logit: FloatEvidence,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct GreedyLogitViewEvidence {
+    pub source: &'static str,
+    pub selected_token_id: u32,
+    pub top_10: Vec<TokenLogitEvidence>,
+    pub explicit_tokens_785_and_8822: Vec<TokenLogitEvidence>,
+    pub top_1_minus_top_2_margin: FloatEvidence,
+    pub full_logits: ExactVectorEvidence,
+}
+
+fn ranked_logit_indices(logits: &[f32]) -> Result<Vec<usize>, String> {
+    if logits.is_empty() || logits.iter().any(|value| !value.is_finite()) {
+        return Err("logit view is empty or nonfinite".to_string());
+    }
+    let mut ranked = (0..logits.len()).collect::<Vec<_>>();
+    ranked.sort_by(|left, right| {
+        logits[*right]
+            .total_cmp(&logits[*left])
+            .then_with(|| left.cmp(right))
+    });
+    Ok(ranked)
+}
+
+fn deterministic_argmax(logits: &[f32]) -> Result<u32, String> {
+    let ranked = ranked_logit_indices(logits)?;
+    u32::try_from(ranked[0]).map_err(|_| "argmax token ID does not fit u32".to_string())
+}
+
+fn greedy_view(
+    source: &'static str,
+    logits: &[f32],
+    selected_token_id: u32,
+) -> Result<GreedyLogitViewEvidence, String> {
+    let ranked = ranked_logit_indices(logits)?;
+    let entry = |token_id: usize, rank: usize| TokenLogitEvidence {
+        token_id: token_id as u32,
+        rank,
+        raw_logit: FloatEvidence::new(logits[token_id]),
+    };
+    let explicit_tokens_785_and_8822 = [RUST_REFERENCE_TARGET_TOKEN, RUST_GPU_TARGET_TOKEN]
+        .into_iter()
+        .map(|token_id| {
+            let index = usize::try_from(token_id).map_err(|_| "token ID overflow")?;
+            if index >= logits.len() {
+                return Err(format!("explicit token {token_id} is outside vocabulary"));
+            }
+            let rank = ranked
+                .iter()
+                .position(|candidate| *candidate == index)
+                .ok_or("explicit token is missing from ranking")?
+                + 1;
+            Ok(entry(index, rank))
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    Ok(GreedyLogitViewEvidence {
+        source,
+        selected_token_id,
+        top_10: ranked
+            .iter()
+            .take(10)
+            .enumerate()
+            .map(|(rank, token)| entry(*token, rank + 1))
+            .collect(),
+        explicit_tokens_785_and_8822,
+        top_1_minus_top_2_margin: FloatEvidence::new(logits[ranked[0]] - logits[ranked[1]]),
+        full_logits: ExactVectorEvidence::new(source, logits, false),
+    })
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TokenAttributionCategory {
+    UpstreamHiddenDrift,
+    FinalRmsnormDrift,
+    GpuLmHeadGemvDrift,
+    GpuGreedyArgmaxDrift,
+    MixedNumericalDrift,
+    Unresolved,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct TokenAttributionInputs {
+    reference_argmax: u32,
+    cpu_argmax_on_cpu_norm_of_gpu_pre_norm: u32,
+    cpu_argmax_on_actual_gpu_final_norm: u32,
+    cpu_argmax_from_actual_gpu_logits: u32,
+    actual_gpu_sampled_token: u32,
+}
+
+fn derive_token_attribution(inputs: TokenAttributionInputs) -> TokenAttributionCategory {
+    if inputs.reference_argmax != RUST_REFERENCE_TARGET_TOKEN
+        || inputs.actual_gpu_sampled_token != RUST_GPU_TARGET_TOKEN
+    {
+        TokenAttributionCategory::Unresolved
+    } else if inputs.cpu_argmax_from_actual_gpu_logits != inputs.actual_gpu_sampled_token {
+        TokenAttributionCategory::GpuGreedyArgmaxDrift
+    } else if inputs.cpu_argmax_on_actual_gpu_final_norm != inputs.actual_gpu_sampled_token {
+        TokenAttributionCategory::GpuLmHeadGemvDrift
+    } else if inputs.cpu_argmax_on_cpu_norm_of_gpu_pre_norm == inputs.reference_argmax {
+        TokenAttributionCategory::FinalRmsnormDrift
+    } else if inputs.cpu_argmax_on_cpu_norm_of_gpu_pre_norm == inputs.actual_gpu_sampled_token {
+        TokenAttributionCategory::UpstreamHiddenDrift
+    } else {
+        TokenAttributionCategory::MixedNumericalDrift
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct RustTokenReproducibilityEvidence {
+    pub case: &'static str,
+    pub target_generated_position: usize,
+    pub preceding_reference_token: u32,
+    pub preceding_gpu_token: u32,
+    pub required_preceding_token: u32,
+    pub reference_target_token: u32,
+    pub gpu_target_token: u32,
+    pub exact_frozen_result_reproduced: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct TokenDivergenceAttributionEvidence {
+    pub reproducibility: RustTokenReproducibilityEvidence,
+    pub full_target_token_trace: FullTargetTokenTraceEvidence,
+    pub same_input_final_rmsnorm: VectorNumericalEvidence,
+    pub same_input_lm_head_logits: VectorNumericalEvidence,
+    pub cpu_finalnorm_replay_lm_head_vs_gpu_logits: VectorNumericalEvidence,
+    pub greedy_views: Vec<GreedyLogitViewEvidence>,
+    pub attribution: TokenAttributionCategory,
+    pub positions_after_target_inspected_for_cpu_gpu_semantic_attribution: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct ExplicitExpertRawLogitEvidence {
+    pub expert_id: u32,
+    pub rank: usize,
+    pub raw_logit: FloatEvidence,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct RawLogitViewEvidence {
+    pub source: &'static str,
+    pub exact_vector: ExactVectorEvidence,
+    pub raw_logits: Vec<FloatEvidence>,
+    pub top_12: Vec<RankedExpertEvidence>,
+    pub experts_95_and_107: Vec<ExplicitExpertRawLogitEvidence>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct RawLogitComparisonEvidence {
+    pub comparison: VectorNumericalEvidence,
+    pub worst_expert_ulp_distance: Option<u32>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct RouterTopKViewEvidence {
+    pub source: &'static str,
+    pub top_8_ids: Vec<u32>,
+    pub top_8_weights: Vec<FloatEvidence>,
+    pub top_12: Vec<RankedExpertEvidence>,
+}
+
+fn raw_logit_view(source: &'static str, logits: &[f32]) -> Result<RawLogitViewEvidence, String> {
+    let ranked = ranked_logit_indices(logits)?;
+    let mut scores = logits.to_vec();
+    crate::transformer::softmax_inplace(&mut scores);
+    let top_12 = ranked
+        .iter()
+        .take(12)
+        .enumerate()
+        .map(|(rank, expert)| RankedExpertEvidence {
+            expert_id: *expert as u32,
+            rank: rank + 1,
+            raw_logit: FloatEvidence::new(logits[*expert]),
+            score: FloatEvidence::new(scores[*expert]),
+        })
+        .collect::<Vec<_>>();
+    let experts_95_and_107 = ROUTER_EXPLICIT_EXPERTS
+        .into_iter()
+        .map(|expert_id| {
+            let index = expert_id as usize;
+            let rank = ranked
+                .iter()
+                .position(|candidate| *candidate == index)
+                .ok_or("explicit router expert missing from rank view")?
+                + 1;
+            Ok(ExplicitExpertRawLogitEvidence {
+                expert_id,
+                rank,
+                raw_logit: FloatEvidence::new(logits[index]),
+            })
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    Ok(RawLogitViewEvidence {
+        source,
+        exact_vector: ExactVectorEvidence::new(source, logits, true),
+        raw_logits: logits.iter().copied().map(FloatEvidence::new).collect(),
+        top_12,
+        experts_95_and_107,
+    })
+}
+
+fn compare_raw_logits(
+    left_source: &'static str,
+    right_source: &'static str,
+    left: &[f32],
+    right: &[f32],
+) -> Result<RawLogitComparisonEvidence, String> {
+    let comparison = VectorNumericalEvidence::compare(left_source, right_source, left, right)?;
+    let worst_expert_ulp_distance = comparison.worst_element_index.and_then(|index| {
+        crate::gpu_native_router_rank_diagnostics::ulp_distance(left[index], right[index])
+    });
+    Ok(RawLogitComparisonEvidence {
+        comparison,
+        worst_expert_ulp_distance,
+    })
+}
+
+fn top_k_from_raw_logits(
+    source: &'static str,
+    raw_logits: &[f32],
+    top_k: usize,
+) -> Result<RouterTopKViewEvidence, String> {
+    if top_k == 0 || top_k > raw_logits.len() {
+        return Err("invalid router top-k geometry".to_string());
+    }
+    let mut scores = raw_logits.to_vec();
+    crate::transformer::softmax_inplace(&mut scores);
+    let mut ranked = (0..scores.len()).collect::<Vec<_>>();
+    ranked.sort_by(|left, right| {
+        scores[*right]
+            .total_cmp(&scores[*left])
+            .then_with(|| left.cmp(right))
+    });
+    let selected = &ranked[..top_k];
+    let selected_sum = selected.iter().map(|expert| scores[*expert]).sum::<f32>();
+    if !selected_sum.is_finite() || selected_sum <= 0.0 {
+        return Err("router selected score sum is invalid".to_string());
+    }
+    Ok(RouterTopKViewEvidence {
+        source,
+        top_8_ids: selected.iter().map(|expert| *expert as u32).collect(),
+        top_8_weights: selected
+            .iter()
+            .map(|expert| FloatEvidence::new(scores[*expert] / selected_sum))
+            .collect(),
+        top_12: ranked
+            .iter()
+            .take(12)
+            .enumerate()
+            .map(|(rank, expert)| RankedExpertEvidence {
+                expert_id: *expert as u32,
+                rank: rank + 1,
+                raw_logit: FloatEvidence::new(raw_logits[*expert]),
+                score: FloatEvidence::new(scores[*expert]),
+            })
+            .collect(),
+    })
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RouterAttributionCategory {
+    GpuRouterGemvDrift,
+    GpuRouterSoftmaxTopkDrift,
+    ExactTieOrderingDefect,
+    MixedNumericalDrift,
+    Unresolved,
+}
+
+fn derive_router_attribution(
+    cpu_production_ids: &[u32],
+    cpu_from_gpu_raw_ids: &[u32],
+    actual_gpu_ids: &[u32],
+    exact_tie_ordering_violation: bool,
+) -> RouterAttributionCategory {
+    if cpu_production_ids.is_empty()
+        || cpu_production_ids.len() != cpu_from_gpu_raw_ids.len()
+        || cpu_production_ids.len() != actual_gpu_ids.len()
+    {
+        RouterAttributionCategory::MixedNumericalDrift
+    } else if exact_tie_ordering_violation {
+        RouterAttributionCategory::ExactTieOrderingDefect
+    } else if cpu_production_ids != actual_gpu_ids && cpu_from_gpu_raw_ids == actual_gpu_ids {
+        RouterAttributionCategory::GpuRouterGemvDrift
+    } else if cpu_from_gpu_raw_ids != actual_gpu_ids {
+        RouterAttributionCategory::GpuRouterSoftmaxTopkDrift
+    } else if cpu_production_ids == actual_gpu_ids {
+        RouterAttributionCategory::Unresolved
+    } else {
+        RouterAttributionCategory::MixedNumericalDrift
+    }
+}
+
+fn exact_ordered_router_ids_equal(cpu: &[u32], gpu: &[u32]) -> bool {
+    !cpu.is_empty() && cpu == gpu
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct RouterFailureAttributionEvidence {
+    pub case: &'static str,
+    pub generated_position: usize,
+    pub layer: usize,
+    pub exact_gpu_router_input: ExactVectorEvidence,
+    pub gate_identity: GateIdentityEvidence,
+    pub cpu_production_router: RouterEvaluationEvidence,
+    pub actual_gpu_router: ActualGpuRouterEvidence,
+    pub cpu_production_raw_logits: RawLogitViewEvidence,
+    pub scalar_sequential_raw_logits: RawLogitViewEvidence,
+    pub actual_gpu_raw_logits: RawLogitViewEvidence,
+    pub cpu_production_vs_gpu: RawLogitComparisonEvidence,
+    pub scalar_sequential_vs_gpu: RawLogitComparisonEvidence,
+    pub cpu_production_vs_scalar_sequential: RawLogitComparisonEvidence,
+    pub cpu_production_top_k: RouterTopKViewEvidence,
+    pub scalar_sequential_top_k: RouterTopKViewEvidence,
+    pub cpu_top_k_from_exact_gpu_raw_logits: RouterTopKViewEvidence,
+    pub actual_gpu_production_top_k: RouterTopKViewEvidence,
+    pub frozen_cpu_ids_reproduced: bool,
+    pub frozen_gpu_ids_reproduced: bool,
+    pub exact_gpu_raw_and_scored_tie_95_107: bool,
+    pub attribution: RouterAttributionCategory,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct PerExpertMoeEvidence {
+    pub production_rank: usize,
+    pub local_expert_id: u32,
+    pub global_expert_id: u32,
+    pub weight_delta: WeightDeltaEvidence,
+    pub cpu_expert_output_f32_bits_sha256: String,
+    pub gpu_expert_output_f32_bits_sha256: String,
+    pub expert_output_comparison: VectorNumericalEvidence,
+    pub weighted_contribution_comparison: VectorNumericalEvidence,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct MixedCombinationDecompositionEvidence {
+    pub ordered_selected_expert_ids: Vec<u32>,
+    pub accumulation_contract: &'static str,
+    pub baseline_vs_actual: VectorNumericalEvidence,
+    pub baseline_vs_expert_only: VectorNumericalEvidence,
+    pub baseline_vs_weight_only: VectorNumericalEvidence,
+    pub expert_only_vs_actual: VectorNumericalEvidence,
+    pub weight_only_vs_actual: VectorNumericalEvidence,
+    pub actual_host_combination_vs_actual_gpu_production: VectorNumericalEvidence,
+    pub linear_additivity_claimed: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct MoeOutlierAttributionEvidence {
+    pub target: FrozenMoeOutlierTarget,
+    pub same_input_cpu_ordered_selected_ids: Vec<u32>,
+    pub actual_gpu_ordered_selected_ids: Vec<u32>,
+    pub valid_for_exact_router_decomposition: bool,
+    pub invalid_reason: Option<String>,
+    pub per_expert_in_production_rank_order: Vec<PerExpertMoeEvidence>,
+    pub expert_ids_ranked_by_difference_contribution: Vec<u32>,
+    pub worst_expert_id: Option<u32>,
+    pub mixed_combination_decomposition: Option<MixedCombinationDecompositionEvidence>,
+    pub permutation_only_supporting_evidence: Option<PermutationOnlyWitness>,
+}
+
+fn weight_delta(expert_id: u32, left: f32, right: f32) -> WeightDeltaEvidence {
+    let absolute = (f64::from(right) - f64::from(left)).abs();
+    WeightDeltaEvidence {
+        expert_id,
+        left: FloatEvidence::new(left),
+        right: FloatEvidence::new(right),
+        absolute_error: (left.is_finite() && right.is_finite()).then_some(absolute),
+        relative_error: (left.is_finite() && right.is_finite() && left != 0.0)
+            .then(|| absolute / f64::from(left).abs())
+            .filter(|value| value.is_finite()),
+        ulp_distance: crate::gpu_native_router_rank_diagnostics::ulp_distance(left, right),
+    }
+}
+
+fn weighted_output(output: &[f32], weight: f32) -> Vec<f32> {
+    output.iter().map(|value| weight * *value).collect()
+}
+
+fn gpu_ranks_paired_by_expert_id(cpu_ids: &[u32], gpu_ids: &[u32]) -> Result<Vec<usize>, String> {
+    let gpu_by_id = gpu_ids
+        .iter()
+        .copied()
+        .enumerate()
+        .map(|(rank, expert)| (expert, rank))
+        .collect::<BTreeMap<_, _>>();
+    if gpu_by_id.len() != gpu_ids.len() {
+        return Err("GPU selected expert IDs contain duplicates".to_string());
+    }
+    cpu_ids
+        .iter()
+        .map(|expert| {
+            gpu_by_id
+                .get(expert)
+                .copied()
+                .ok_or_else(|| format!("GPU route output is missing selected expert ID {expert}"))
+        })
+        .collect()
+}
+
+fn classify_target(value: &str) -> RoutingClassification {
+    match value {
+        "internal-rank-permutation" => RoutingClassification::InternalRankPermutation,
+        "membership-mismatch" => RoutingClassification::MembershipMismatch,
+        _ => RoutingClassification::InvalidNonfiniteIncomplete,
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
+pub struct DiagnosticRuntimeEvidence {
+    pub gpu_token_loop: GpuNativeTokenLoopSnapshot,
+    pub gpu_expected_completed_token_steps: u64,
+    pub reference_background_shutdown: crate::greedy_parity::BackgroundShutdownEvidence,
+    pub gpu_native_background_shutdown: crate::greedy_parity::BackgroundShutdownEvidence,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct GpuNativeV2HoldoutFailureAttributionReport {
+    pub schema: &'static str,
+    pub mode: &'static str,
+    pub diagnostic_only: bool,
+    pub diagnostic_complete: bool,
+    qualification_pass: bool,
+    pub failure: Option<String>,
+    pub provenance: DiagnosticProvenance,
+    pub frozen_v2_result_identity: FrozenV2ResultIdentity,
+    pub frozen_targets: FrozenTargetListEvidence,
+    pub token_divergence_attribution: Option<TokenDivergenceAttributionEvidence>,
+    pub router_failure_attribution: Option<RouterFailureAttributionEvidence>,
+    pub moe_outlier_attributions: Vec<MoeOutlierAttributionEvidence>,
+    pub router_coupled_numerical_failure: FrozenRouterCoupledTarget,
+    pub runtime: DiagnosticRuntimeEvidence,
+    pub production_semantics: ProductionSemanticsEvidence,
+    pub observation_seams_not_implemented: Vec<String>,
+}
+
+impl GpuNativeV2HoldoutFailureAttributionReport {
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        provenance: DiagnosticProvenance,
+        frozen_v2_result_identity: FrozenV2ResultIdentity,
+        failure: Option<String>,
+        token_divergence_attribution: Option<TokenDivergenceAttributionEvidence>,
+        router_failure_attribution: Option<RouterFailureAttributionEvidence>,
+        moe_outlier_attributions: Vec<MoeOutlierAttributionEvidence>,
+        runtime: DiagnosticRuntimeEvidence,
+        observation_seams_not_implemented: Vec<String>,
+    ) -> Self {
+        let all_moe_targets_complete = moe_outlier_attributions.len() == MOE_OUTLIER_TARGETS.len()
+            && moe_outlier_attributions
+                .iter()
+                .all(|target| target.valid_for_exact_router_decomposition);
+        let diagnostic_complete = failure.is_none()
+            && token_divergence_attribution.is_some()
+            && router_failure_attribution.is_some()
+            && all_moe_targets_complete
+            && observation_seams_not_implemented.is_empty();
+        Self {
+            schema: SCHEMA_VERSION,
+            mode: MODE,
+            diagnostic_only: true,
+            diagnostic_complete,
+            qualification_pass: false,
+            failure,
+            provenance,
+            frozen_v2_result_identity,
+            frozen_targets: FrozenTargetListEvidence::fixed(),
+            token_divergence_attribution,
+            router_failure_attribution,
+            moe_outlier_attributions,
+            router_coupled_numerical_failure: ROUTER_COUPLED_TARGET,
+            runtime,
+            production_semantics: ProductionSemanticsEvidence::default(),
+            observation_seams_not_implemented,
+        }
+    }
+
+    pub const fn qualification_pass(&self) -> bool {
+        self.qualification_pass
+    }
+}
+
+struct GpuSemanticCapture {
+    case: &'static str,
+    generated_position: usize,
+    trace: SemanticCorpusGpuTrace,
+}
+
+struct GpuCapture {
+    rust_preceding_token: u32,
+    rust_target_token: u32,
+    rust_target_trace: crate::gpu_native_diagnostics::GpuNativeDiagnosticTrace,
+    semantic_targets: Vec<GpuSemanticCapture>,
+    gate_identities: BTreeMap<usize, GateTensorIdentity>,
+    model_geometry: GpuNativeModelGeometry,
+    model_load: crate::greedy_parity::ModelLoadEvidence,
+    device: crate::backend::GpuDeviceIdentity,
+    background_shutdown: crate::greedy_parity::BackgroundShutdownEvidence,
+    token_loop_snapshot: GpuNativeTokenLoopSnapshot,
+    expected_completed_token_steps: u64,
+}
+
+impl GpuCapture {
+    fn semantic_layer(
+        &self,
+        case: &str,
+        generated_position: usize,
+        layer: usize,
+    ) -> Result<&SemanticCorpusGpuLayerTrace, String> {
+        self.semantic_targets
+            .iter()
+            .find(|target| target.case == case && target.generated_position == generated_position)
+            .and_then(|target| target.trace.layers.get(layer))
+            .ok_or_else(|| {
+                format!(
+                    "missing GPU semantic target {case} position {generated_position} layer {layer}"
+                )
+            })
+    }
+}
+
+struct ReferenceCapture {
+    token_attribution: Option<TokenDivergenceAttributionEvidence>,
+    router_attribution: Option<RouterFailureAttributionEvidence>,
+    moe_attributions: Vec<MoeOutlierAttributionEvidence>,
+    failure: Option<String>,
+    model_load: crate::greedy_parity::ModelLoadEvidence,
+    background_shutdown: crate::greedy_parity::BackgroundShutdownEvidence,
+}
+
+fn holdout_case(name: &str) -> Result<crate::gpu_native_semantic_parity_v2::HoldoutCase, String> {
+    crate::gpu_native_semantic_parity_v2::HOLDOUT_CORPUS
+        .into_iter()
+        .find(|case| case.name == name)
+        .ok_or_else(|| format!("unknown frozen v2 holdout case {name:?}"))
+}
+
+async fn capture_gpu_semantic_case(
+    runtime: &crate::BenchRealRuntime,
+    tokenizer: &crate::tokenizer::Tokenizer,
+    case_name: &'static str,
+    target_positions: &[usize],
+    trace_layout: &SemanticCorpusTraceLayout,
+    watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+) -> Result<(Vec<GpuSemanticCapture>, usize), Box<dyn std::error::Error>> {
+    let fixed = holdout_case(case_name)?;
+    let prompt_token_ids = tokenizer.encode(fixed.prompt)?;
+    if prompt_token_ids.is_empty() || target_positions.is_empty() {
+        return Err("semantic target prompt or target list is empty".into());
+    }
+    let maximum_target = *target_positions
+        .iter()
+        .max()
+        .ok_or("semantic target list is empty")?;
+    let token_loop = runtime
+        .gpu_native_token_loop
+        .as_ref()
+        .ok_or("diagnostic GPU-native token loop was not initialized")?;
+    let mut request = token_loop.create_semantic_parity_corpus_diagnostic_request_state()?;
+    let staging =
+        token_loop.create_semantic_parity_corpus_diagnostic_staging_buffer(trace_layout)?;
+    let captures = crate::with_progress_timeout(
+        format!("v2 holdout failure attribution GPU {case_name}"),
+        watchdog,
+        async {
+            let prefix_count = prompt_token_ids.len().saturating_sub(1);
+            for (position, &token_id) in prompt_token_ids[..prefix_count].iter().enumerate() {
+                token_loop
+                    .step_token(&runtime.engine, &mut request, token_id, position, false)
+                    .await?;
+            }
+            let mut input_token = *prompt_token_ids.last().ok_or("holdout prompt is empty")?;
+            let mut position = prefix_count;
+            let mut captures = Vec::with_capacity(target_positions.len());
+            for generated_position in 0..=maximum_target {
+                let sampled = if target_positions.contains(&generated_position) {
+                    let (trace, sampled, _) = token_loop
+                        .step_token_semantic_parity_corpus_diagnostic(
+                            &runtime.engine,
+                            &mut request,
+                            input_token,
+                            position,
+                            trace_layout,
+                            &staging,
+                        )
+                        .await?;
+                    captures.push(GpuSemanticCapture {
+                        case: case_name,
+                        generated_position,
+                        trace,
+                    });
+                    sampled
+                } else {
+                    token_loop
+                        .step_token(&runtime.engine, &mut request, input_token, position, true)
+                        .await?
+                        .ok_or("GPU semantic target step produced no token")?
+                };
+                input_token = sampled;
+                position = position
+                    .checked_add(1)
+                    .ok_or("GPU semantic target position overflow")?;
+            }
+            Ok::<_, Box<dyn std::error::Error>>(captures)
+        },
+    )
+    .await?;
+    let expected_completed = prompt_token_ids
+        .len()
+        .saturating_sub(1)
+        .checked_add(maximum_target + 1)
+        .ok_or("GPU semantic completion count overflow")?;
+    if request.committed_position() != expected_completed {
+        return Err(format!(
+            "GPU semantic case {case_name} retired at {}, expected {expected_completed}",
+            request.committed_position()
+        )
+        .into());
+    }
+    Ok((captures, expected_completed))
+}
+
+async fn execute_gpu(
+    spec: &ResolvedRealCliSpec,
+    tokenizer: Arc<crate::tokenizer::Tokenizer>,
+    resolved_config_sha256: &str,
+    expected_adapter_name: &str,
+    watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+) -> Result<GpuCapture, Box<dyn std::error::Error>> {
+    let runtime = crate::build_isolated_greedy_runtime(
+        spec,
+        RealCliRuntimeMode::IsolatedGpuNativeDiagnostic,
+        tokenizer.clone(),
+    )
+    .await?;
+    let attempt = async {
+        let observed_config_sha256 = crate::resolved_real_runtime_identity_sha256(
+            &runtime.cfg,
+            runtime.model.config.architecture,
+            runtime.model.config.first_k_dense_replace,
+            &runtime.model.config.advanced,
+        )?;
+        if observed_config_sha256 != resolved_config_sha256 {
+            return Err("diagnostic GPU resolved configuration identity drifted".into());
+        }
+        let device = runtime
+            .engine
+            .gpu_device_identity()
+            .ok_or("diagnostic GPU runtime has no authoritative adapter identity")?;
+        if device.name != expected_adapter_name
+            || device.software_adapter
+            || device.device_type.eq_ignore_ascii_case("cpu")
+        {
+            return Err(format!(
+                "diagnostic selected adapter {:?}, expected real {:?}",
+                device.name, expected_adapter_name
+            )
+            .into());
+        }
+        let token_loop = runtime
+            .gpu_native_token_loop
+            .as_ref()
+            .ok_or("diagnostic GPU-native token loop was not initialized")?;
+        let geometry = token_loop.model_geometry();
+        if geometry.num_layers != 48
+            || geometry.num_experts != 128
+            || geometry.top_k != 8
+            || geometry.d_model != 2048
+            || geometry.d_ff != 768
+        {
+            return Err("diagnostic GPU model geometry differs from frozen V2".into());
+        }
+        if token_loop.snapshot() != GpuNativeTokenLoopSnapshot::default() {
+            return Err("diagnostic GPU token-loop counters did not start at zero".into());
+        }
+        let gate_identities = [ROUTER_TARGET_LAYER, 47]
+            .into_iter()
+            .map(|layer| {
+                (
+                    layer,
+                    GateTensorIdentity::from_gate(layer, &runtime.model.layers[layer].gate),
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+        let model_load = crate::greedy_parity_model_load(&runtime);
+
+        let fixed = holdout_case(RUST_TARGET_CASE)?;
+        let prompt_token_ids = tokenizer.encode(fixed.prompt)?;
+        if prompt_token_ids.is_empty() {
+            return Err("rust holdout prompt encoded to zero tokens".into());
+        }
+        let mut request = token_loop.create_request_state()?;
+        let trace_layout = crate::gpu_native_diagnostics::GpuNativeDiagnosticTraceLayout::try_new(
+            geometry.num_layers,
+            geometry.d_model,
+            geometry.top_k,
+            geometry.vocab_size,
+        )?;
+        let staging = token_loop.create_diagnostic_staging_buffer(&trace_layout)?;
+        let (rust_preceding_token, rust_target_token, rust_target_trace) =
+            crate::with_progress_timeout(
+                "v2 holdout failure attribution GPU rust token".to_string(),
+                watchdog,
+                async {
+                    let prefix_count = prompt_token_ids.len().saturating_sub(1);
+                    for (position, &token_id) in prompt_token_ids[..prefix_count].iter().enumerate()
+                    {
+                        token_loop
+                            .step_token(&runtime.engine, &mut request, token_id, position, false)
+                            .await?;
+                    }
+                    let final_prompt = *prompt_token_ids
+                        .last()
+                        .ok_or("rust holdout prompt is empty")?;
+                    let preceding = token_loop
+                        .step_token(
+                            &runtime.engine,
+                            &mut request,
+                            final_prompt,
+                            prefix_count,
+                            true,
+                        )
+                        .await?
+                        .ok_or("GPU rust position 0 produced no token")?;
+                    let (trace, _) = token_loop
+                        .step_token_diagnostic(
+                            &runtime.engine,
+                            &mut request,
+                            preceding,
+                            prefix_count + 1,
+                            true,
+                            &trace_layout,
+                            &staging,
+                        )
+                        .await?;
+                    Ok::<_, Box<dyn std::error::Error>>((preceding, trace.sampled_token, trace))
+                },
+            )
+            .await?;
+        let rust_expected_completed = prompt_token_ids
+            .len()
+            .saturating_sub(1)
+            .checked_add(2)
+            .ok_or("GPU rust completion count overflow")?;
+        if request.committed_position() != rust_expected_completed {
+            return Err("GPU rust request retirement is incomplete".into());
+        }
+        drop(request);
+        drop(staging);
+
+        let mut semantic_targets = Vec::new();
+        let mut expected_completed = rust_expected_completed;
+        if rust_preceding_token == RUST_PRECEDING_TOKEN
+            && rust_target_token == RUST_GPU_TARGET_TOKEN
+        {
+            let semantic_layout = SemanticCorpusTraceLayout::try_new(geometry)?;
+            let (mut postgres, postgres_completed) = capture_gpu_semantic_case(
+                &runtime,
+                &tokenizer,
+                "postgres-window-holdout",
+                &[ROUTER_TARGET_POSITION, 13],
+                &semantic_layout,
+                watchdog,
+            )
+            .await?;
+            let (mut spanish, spanish_completed) = capture_gpu_semantic_case(
+                &runtime,
+                &tokenizer,
+                "spanish-refactor-holdout",
+                &[11, 13, 15],
+                &semantic_layout,
+                watchdog,
+            )
+            .await?;
+            semantic_targets.append(&mut postgres);
+            semantic_targets.append(&mut spanish);
+            expected_completed = expected_completed
+                .checked_add(postgres_completed)
+                .and_then(|value| value.checked_add(spanish_completed))
+                .ok_or("GPU diagnostic total completion count overflow")?;
+        }
+        Ok::<_, Box<dyn std::error::Error>>(GpuCapture {
+            rust_preceding_token,
+            rust_target_token,
+            rust_target_trace,
+            semantic_targets,
+            gate_identities,
+            model_geometry: geometry,
+            model_load,
+            device,
+            background_shutdown: crate::greedy_parity::BackgroundShutdownEvidence::default(),
+            token_loop_snapshot: token_loop.snapshot(),
+            expected_completed_token_steps: u64::try_from(expected_completed)
+                .map_err(|_| "GPU diagnostic completion count does not fit u64")?,
+        })
+    }
+    .await;
+    let shutdown = runtime.shutdown_isolated().await;
+    match (attempt, shutdown) {
+        (Ok(mut capture), Ok(shutdown)) => {
+            capture.background_shutdown = shutdown;
+            Ok(capture)
+        }
+        (Err(error), Ok(_)) => Err(error),
+        (Ok(_), Err(shutdown_error)) => Err(shutdown_error.into()),
+        (Err(error), Err(shutdown_error)) => Err(IsolatedRuntimeShutdownError::new(format!(
+            "{error}; diagnostic GPU shutdown also failed: {shutdown_error}"
+        ))
+        .into()),
+    }
+}
+
+fn analyze_token_divergence(
+    runtime: &crate::BenchRealRuntime,
+    reference_trace: &crate::gpu_native_diagnostics::ModelDiagnosticTrace,
+    gpu: &GpuCapture,
+    reference_preceding_token: u32,
+    reference_target_token: u32,
+    model_position: usize,
+) -> Result<TokenDivergenceAttributionEvidence, String> {
+    let reproducibility = RustTokenReproducibilityEvidence {
+        case: RUST_TARGET_CASE,
+        target_generated_position: RUST_TARGET_POSITION,
+        preceding_reference_token: reference_preceding_token,
+        preceding_gpu_token: gpu.rust_preceding_token,
+        required_preceding_token: RUST_PRECEDING_TOKEN,
+        reference_target_token,
+        gpu_target_token: gpu.rust_target_token,
+        exact_frozen_result_reproduced: reference_preceding_token == RUST_PRECEDING_TOKEN
+            && gpu.rust_preceding_token == RUST_PRECEDING_TOKEN
+            && reference_target_token == RUST_REFERENCE_TARGET_TOKEN
+            && gpu.rust_target_token == RUST_GPU_TARGET_TOKEN,
+    };
+    if !reproducibility.exact_frozen_result_reproduced {
+        return Err("rust token target did not reproduce the frozen V2 result".to_string());
+    }
+    let gpu_pre_final = gpu
+        .rust_target_trace
+        .layer_post_moe
+        .get(47)
+        .ok_or("GPU full trace omitted layer-47 post-MoE hidden")?;
+    let cpu_final_norm_on_gpu_pre = runtime.model.diagnostic_final_rms_norm(gpu_pre_final);
+    let cpu_logits_on_gpu_final = runtime
+        .model
+        .diagnostic_greedy_logits(&gpu.rust_target_trace.final_norm);
+    let cpu_logits_on_cpu_norm_of_gpu_pre = runtime
+        .model
+        .diagnostic_greedy_logits(&cpu_final_norm_on_gpu_pre);
+    let reference_argmax = runtime.model.sample_hidden(
+        &reference_trace.final_norm,
+        &crate::sampling::SamplingParams::greedy(),
+        model_position,
+    );
+    let cpu_argmax_on_actual_gpu_final_norm = runtime.model.sample_hidden(
+        &gpu.rust_target_trace.final_norm,
+        &crate::sampling::SamplingParams::greedy(),
+        model_position,
+    );
+    let cpu_argmax_on_cpu_norm_of_gpu_pre_norm = runtime.model.sample_hidden(
+        &cpu_final_norm_on_gpu_pre,
+        &crate::sampling::SamplingParams::greedy(),
+        model_position,
+    );
+    let cpu_argmax_from_actual_gpu_logits = deterministic_argmax(&gpu.rust_target_trace.logits)?;
+    let inputs = TokenAttributionInputs {
+        reference_argmax,
+        cpu_argmax_on_cpu_norm_of_gpu_pre_norm,
+        cpu_argmax_on_actual_gpu_final_norm,
+        cpu_argmax_from_actual_gpu_logits,
+        actual_gpu_sampled_token: gpu.rust_target_trace.sampled_token,
+    };
+    Ok(TokenDivergenceAttributionEvidence {
+        reproducibility,
+        full_target_token_trace: compare_target_token_traces(
+            reference_trace,
+            &gpu.rust_target_trace,
+        )?,
+        same_input_final_rmsnorm: VectorNumericalEvidence::compare(
+            "cpu-production-final-rmsnorm-on-exact-gpu-layer47-post-moe",
+            "actual-production-gpu-final-rmsnorm",
+            &cpu_final_norm_on_gpu_pre,
+            &gpu.rust_target_trace.final_norm,
+        )?,
+        same_input_lm_head_logits: VectorNumericalEvidence::compare(
+            "cpu-production-greedy-row-dot-logits-on-exact-gpu-finalnorm",
+            "actual-production-gpu-lm-head-logits",
+            &cpu_logits_on_gpu_final,
+            &gpu.rust_target_trace.logits,
+        )?,
+        cpu_finalnorm_replay_lm_head_vs_gpu_logits: VectorNumericalEvidence::compare(
+            "cpu-production-lm-head-on-cpu-finalnorm-of-exact-gpu-pre-final-hidden",
+            "actual-production-gpu-lm-head-logits",
+            &cpu_logits_on_cpu_norm_of_gpu_pre,
+            &gpu.rust_target_trace.logits,
+        )?,
+        greedy_views: vec![
+            greedy_view(
+                "cpu-production-greedy-argmax-on-reference-finalnorm",
+                &reference_trace.logits,
+                reference_argmax,
+            )?,
+            greedy_view(
+                "cpu-production-greedy-argmax-on-cpu-finalnorm-of-exact-gpu-pre-final-hidden",
+                &cpu_logits_on_cpu_norm_of_gpu_pre,
+                cpu_argmax_on_cpu_norm_of_gpu_pre_norm,
+            )?,
+            greedy_view(
+                "cpu-production-greedy-argmax-on-exact-gpu-finalnorm",
+                &cpu_logits_on_gpu_final,
+                cpu_argmax_on_actual_gpu_final_norm,
+            )?,
+            greedy_view(
+                "cpu-deterministic-argmax-derived-from-exact-gpu-raw-logits",
+                &gpu.rust_target_trace.logits,
+                cpu_argmax_from_actual_gpu_logits,
+            )?,
+            greedy_view(
+                "actual-gpu-production-sampled-token",
+                &gpu.rust_target_trace.logits,
+                gpu.rust_target_trace.sampled_token,
+            )?,
+        ],
+        attribution: derive_token_attribution(inputs),
+        positions_after_target_inspected_for_cpu_gpu_semantic_attribution: false,
+    })
+}
+
+fn router_top_k_from_cpu_evaluation(
+    source: &'static str,
+    evaluation: &RouterEvaluationEvidence,
+) -> RouterTopKViewEvidence {
+    RouterTopKViewEvidence {
+        source,
+        top_8_ids: evaluation.top_8_ids.clone(),
+        top_8_weights: evaluation.top_8_weights.clone(),
+        top_12: evaluation.top_12_ranked_experts.clone(),
+    }
+}
+
+fn analyze_router_failure(
+    gate: &crate::gating::LinearGate,
+    gpu_gate_identity: &GateTensorIdentity,
+    gpu_layer: &SemanticCorpusGpuLayerTrace,
+) -> Result<RouterFailureAttributionEvidence, String> {
+    let cpu_production = crate::gpu_native_router_rank_diagnostics::evaluate_cpu_router(
+        "cpu-production-router-on-exact-gpu-input",
+        gate,
+        &gpu_layer.router_input,
+    )?;
+    let cpu_raw = gate.weights.matvec(&gpu_layer.router_input);
+    let scalar_raw = gate
+        .weights
+        .diagnostic_greedy_logits(&gpu_layer.router_input);
+    let actual_gpu = crate::gpu_native_router_rank_diagnostics::evaluate_actual_gpu_router(
+        gpu_layer.raw_logits.clone(),
+        gpu_layer.selected_ids.clone(),
+        gpu_layer.selected_weights.clone(),
+    )?;
+    let cpu_top_k = router_top_k_from_cpu_evaluation(
+        "cpu-production-router-top-k-on-exact-gpu-input",
+        &cpu_production,
+    );
+    let scalar_top_k = top_k_from_raw_logits(
+        "scalar-sequential-row-dot-softmax-top-k",
+        &scalar_raw,
+        gate.top_k,
+    )?;
+    let gpu_raw_top_k = RouterTopKViewEvidence {
+        source: "cpu-derived-softmax-top-k-from-exact-gpu-raw-logits",
+        top_8_ids: actual_gpu
+            .cpu_top_8_ids_derived_from_exact_gpu_raw_logits
+            .clone(),
+        top_8_weights: actual_gpu
+            .cpu_top_8_weights_derived_from_exact_gpu_raw_logits
+            .clone(),
+        top_12: actual_gpu.top_12_ranked_experts.clone(),
+    };
+    let actual_gpu_top_k = RouterTopKViewEvidence {
+        source: "actual-gpu-production-top8-with-cpu-ranked-top12-from-actual-raw",
+        top_8_ids: actual_gpu.top_8_ids.clone(),
+        top_8_weights: actual_gpu.top_8_weights.clone(),
+        top_12: actual_gpu.top_12_ranked_experts.clone(),
+    };
+    let mut gpu_scores = gpu_layer.raw_logits.clone();
+    crate::transformer::softmax_inplace(&mut gpu_scores);
+    let exact_tie = gpu_layer.raw_logits[95].to_bits() == gpu_layer.raw_logits[107].to_bits()
+        && gpu_scores[95].to_bits() == gpu_scores[107].to_bits();
+    let lower_id_tie_break_violated = exact_tie
+        && match (
+            actual_gpu_top_k.top_8_ids.iter().position(|id| *id == 95),
+            actual_gpu_top_k.top_8_ids.iter().position(|id| *id == 107),
+        ) {
+            (Some(lower_rank), Some(higher_rank)) => higher_rank < lower_rank,
+            (None, Some(_)) => true,
+            _ => false,
+        };
+    let gate_identity = GateIdentityEvidence::new(
+        GateTensorIdentity::from_gate(ROUTER_TARGET_LAYER, gate),
+        gpu_gate_identity.clone(),
+    );
+    if !gate_identity.exact_identity_match {
+        return Err("router target gate tensor identity differs between runtimes".to_string());
+    }
+    let actual_gpu_ids = actual_gpu_top_k.top_8_ids.clone();
+    Ok(RouterFailureAttributionEvidence {
+        case: ROUTER_TARGET_CASE,
+        generated_position: ROUTER_TARGET_POSITION,
+        layer: ROUTER_TARGET_LAYER,
+        exact_gpu_router_input: ExactVectorEvidence::new(
+            "exact-gpu-layer38-router-input",
+            &gpu_layer.router_input,
+            true,
+        ),
+        gate_identity,
+        cpu_production_router: cpu_production,
+        actual_gpu_router: actual_gpu,
+        cpu_production_raw_logits: raw_logit_view("cpu-production-router-raw-logits", &cpu_raw)?,
+        scalar_sequential_raw_logits: raw_logit_view(
+            "diagnostic-scalar-sequential-f32-row-dot-raw-logits",
+            &scalar_raw,
+        )?,
+        actual_gpu_raw_logits: raw_logit_view(
+            "actual-gpu-production-router-raw-logits",
+            &gpu_layer.raw_logits,
+        )?,
+        cpu_production_vs_gpu: compare_raw_logits(
+            "cpu-production-router-raw-logits",
+            "actual-gpu-production-router-raw-logits",
+            &cpu_raw,
+            &gpu_layer.raw_logits,
+        )?,
+        scalar_sequential_vs_gpu: compare_raw_logits(
+            "diagnostic-scalar-sequential-f32-row-dot-raw-logits",
+            "actual-gpu-production-router-raw-logits",
+            &scalar_raw,
+            &gpu_layer.raw_logits,
+        )?,
+        cpu_production_vs_scalar_sequential: compare_raw_logits(
+            "cpu-production-router-raw-logits",
+            "diagnostic-scalar-sequential-f32-row-dot-raw-logits",
+            &cpu_raw,
+            &scalar_raw,
+        )?,
+        frozen_cpu_ids_reproduced: cpu_top_k.top_8_ids == ROUTER_CPU_EXPECTED_IDS,
+        frozen_gpu_ids_reproduced: actual_gpu_top_k.top_8_ids == ROUTER_GPU_EXPECTED_IDS,
+        attribution: derive_router_attribution(
+            &cpu_top_k.top_8_ids,
+            &gpu_raw_top_k.top_8_ids,
+            &actual_gpu_ids,
+            lower_id_tie_break_violated,
+        ),
+        cpu_production_top_k: cpu_top_k,
+        scalar_sequential_top_k: scalar_top_k,
+        cpu_top_k_from_exact_gpu_raw_logits: gpu_raw_top_k,
+        actual_gpu_production_top_k: actual_gpu_top_k,
+        exact_gpu_raw_and_scored_tie_95_107: exact_tie,
+    })
+}
+
+async fn analyze_moe_outlier(
+    runtime: &crate::BenchRealRuntime,
+    target: FrozenMoeOutlierTarget,
+    gpu_layer: &SemanticCorpusGpuLayerTrace,
+) -> Result<MoeOutlierAttributionEvidence, Box<dyn std::error::Error>> {
+    let gate = &runtime.model.layers[target.layer].gate;
+    let cpu_route = gate.route(&gpu_layer.router_input);
+    if !exact_ordered_router_ids_equal(&cpu_route.experts, &gpu_layer.selected_ids) {
+        return Ok(MoeOutlierAttributionEvidence {
+            target,
+            same_input_cpu_ordered_selected_ids: cpu_route.experts,
+            actual_gpu_ordered_selected_ids: gpu_layer.selected_ids.clone(),
+            valid_for_exact_router_decomposition: false,
+            invalid_reason: Some(
+                "same-input CPU production ordered IDs differ from actual GPU ordered IDs"
+                    .to_string(),
+            ),
+            per_expert_in_production_rank_order: Vec::new(),
+            expert_ids_ranked_by_difference_contribution: Vec::new(),
+            worst_expert_id: None,
+            mixed_combination_decomposition: None,
+            permutation_only_supporting_evidence: None,
+        });
+    }
+    if gpu_layer.route_outputs.len() != cpu_route.experts.len()
+        || gpu_layer.selected_weights.len() != cpu_route.experts.len()
+    {
+        return Err("GPU target route-output geometry is incomplete".into());
+    }
+    let global_ids = cpu_route
+        .experts
+        .iter()
+        .map(|expert| runtime.model.global_expert_id(target.layer, *expert))
+        .collect::<Vec<_>>();
+    let case_index = crate::gpu_native_semantic_parity_v2::HOLDOUT_CORPUS
+        .iter()
+        .position(|case| case.name == target.case)
+        .ok_or("MoE target case is not in frozen holdout")?;
+    let token_index = (case_index as u64)
+        .wrapping_mul(crate::gpu_native_semantic_parity_v2::OUTPUT_TOKEN_LIMIT as u64)
+        .wrapping_add(target.generated_position as u64)
+        .wrapping_mul(48)
+        .wrapping_add(target.layer as u64);
+    let cpu_outputs = runtime
+        .engine
+        .moe_step_with_timing(
+            token_index,
+            target.layer as u32,
+            &gpu_layer.router_input,
+            &global_ids,
+            None,
+        )
+        .await?;
+    if cpu_outputs.len() != cpu_route.experts.len()
+        || cpu_outputs.iter().any(|output| output.len() != 2048)
+    {
+        return Err("CPU MoE target expert-output geometry is incomplete".into());
+    }
+    let paired_gpu_ranks =
+        gpu_ranks_paired_by_expert_id(&cpu_route.experts, &gpu_layer.selected_ids)?;
+    let mut per_expert = Vec::with_capacity(cpu_route.experts.len());
+    for (rank, expert_id) in cpu_route.experts.iter().copied().enumerate() {
+        let gpu_rank = paired_gpu_ranks[rank];
+        let cpu_output = &cpu_outputs[rank];
+        let gpu_output = &gpu_layer.route_outputs[gpu_rank];
+        let cpu_weight = cpu_route.weights[rank];
+        let gpu_weight = gpu_layer.selected_weights[gpu_rank];
+        let expert_output_comparison = VectorNumericalEvidence::compare(
+            "cpu-production-expert-output-on-exact-gpu-input",
+            "actual-production-gpu-expert-output-on-exact-gpu-input",
+            cpu_output,
+            gpu_output,
+        )?;
+        let weighted_contribution_comparison = VectorNumericalEvidence::compare(
+            "cpu-expert-output-times-cpu-same-input-weight",
+            "gpu-expert-output-times-gpu-actual-weight",
+            &weighted_output(cpu_output, cpu_weight),
+            &weighted_output(gpu_output, gpu_weight),
+        )?;
+        per_expert.push(PerExpertMoeEvidence {
+            production_rank: rank + 1,
+            local_expert_id: expert_id,
+            global_expert_id: global_ids[rank],
+            weight_delta: weight_delta(expert_id, cpu_weight, gpu_weight),
+            cpu_expert_output_f32_bits_sha256: expert_output_comparison
+                .left_f32_bits_sha256
+                .clone(),
+            gpu_expert_output_f32_bits_sha256: expert_output_comparison
+                .right_f32_bits_sha256
+                .clone(),
+            expert_output_comparison,
+            weighted_contribution_comparison,
+        });
+    }
+    let mut ranked_by_contribution = per_expert.iter().collect::<Vec<_>>();
+    ranked_by_contribution.sort_by(|left, right| {
+        right
+            .weighted_contribution_comparison
+            .max_absolute_error
+            .unwrap_or(f64::NEG_INFINITY)
+            .total_cmp(
+                &left
+                    .weighted_contribution_comparison
+                    .max_absolute_error
+                    .unwrap_or(f64::NEG_INFINITY),
+            )
+            .then_with(|| left.local_expert_id.cmp(&right.local_expert_id))
+    });
+    let contribution_ranking = ranked_by_contribution
+        .iter()
+        .map(|expert| expert.local_expert_id)
+        .collect::<Vec<_>>();
+    let worst_expert_id = contribution_ranking.first().copied();
+
+    let baseline = crate::inference::combine_outputs(&cpu_outputs, &cpu_route.weights);
+    let actual =
+        crate::inference::combine_outputs(&gpu_layer.route_outputs, &gpu_layer.selected_weights);
+    let expert_only =
+        crate::inference::combine_outputs(&gpu_layer.route_outputs, &cpu_route.weights);
+    let weight_only = crate::inference::combine_outputs(&cpu_outputs, &gpu_layer.selected_weights);
+    let combinations = MixedCombinationDecompositionEvidence {
+        ordered_selected_expert_ids: cpu_route.experts.clone(),
+        accumulation_contract:
+            "production sequential f32 route order: destination += weight[rank] * expert_output[rank]",
+        baseline_vs_actual: VectorNumericalEvidence::compare(
+            "baseline-cpu-outputs-times-cpu-weights",
+            "actual-gpu-outputs-times-gpu-weights-host-replay",
+            &baseline,
+            &actual,
+        )?,
+        baseline_vs_expert_only: VectorNumericalEvidence::compare(
+            "baseline-cpu-outputs-times-cpu-weights",
+            "expert-only-gpu-outputs-times-cpu-weights",
+            &baseline,
+            &expert_only,
+        )?,
+        baseline_vs_weight_only: VectorNumericalEvidence::compare(
+            "baseline-cpu-outputs-times-cpu-weights",
+            "weight-only-cpu-outputs-times-gpu-weights",
+            &baseline,
+            &weight_only,
+        )?,
+        expert_only_vs_actual: VectorNumericalEvidence::compare(
+            "expert-only-gpu-outputs-times-cpu-weights",
+            "actual-gpu-outputs-times-gpu-weights-host-replay",
+            &expert_only,
+            &actual,
+        )?,
+        weight_only_vs_actual: VectorNumericalEvidence::compare(
+            "weight-only-cpu-outputs-times-gpu-weights",
+            "actual-gpu-outputs-times-gpu-weights-host-replay",
+            &weight_only,
+            &actual,
+        )?,
+        actual_host_combination_vs_actual_gpu_production: VectorNumericalEvidence::compare(
+            "actual-gpu-outputs-times-gpu-weights-host-replay",
+            "actual-production-gpu-routed-moe-output",
+            &actual,
+            &gpu_layer.routed_moe_output,
+        )?,
+        linear_additivity_claimed: false,
+    };
+    let permutation_only_supporting_evidence = (classify_target(target.classification)
+        == RoutingClassification::InternalRankPermutation)
+        .then(|| {
+            crate::gpu_native_expert_permutation_semantic_parity::permutation_only_witness(
+                &gpu_layer.selected_ids,
+                &gpu_layer.selected_weights,
+                &gpu_layer.route_outputs,
+            )
+        })
+        .transpose()?;
+    Ok(MoeOutlierAttributionEvidence {
+        target,
+        same_input_cpu_ordered_selected_ids: cpu_route.experts,
+        actual_gpu_ordered_selected_ids: gpu_layer.selected_ids.clone(),
+        valid_for_exact_router_decomposition: true,
+        invalid_reason: None,
+        per_expert_in_production_rank_order: per_expert,
+        expert_ids_ranked_by_difference_contribution: contribution_ranking,
+        worst_expert_id,
+        mixed_combination_decomposition: Some(combinations),
+        permutation_only_supporting_evidence,
+    })
+}
+
+async fn execute_reference_and_analyze(
+    spec: &ResolvedRealCliSpec,
+    tokenizer: Arc<crate::tokenizer::Tokenizer>,
+    resolved_config_sha256: &str,
+    gpu: &GpuCapture,
+    watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+) -> Result<ReferenceCapture, Box<dyn std::error::Error>> {
+    let runtime = crate::build_isolated_greedy_runtime(
+        spec,
+        RealCliRuntimeMode::IsolatedGreedyParityCpu,
+        tokenizer.clone(),
+    )
+    .await?;
+    let attempt = async {
+        let observed_config_sha256 = crate::resolved_real_runtime_identity_sha256(
+            &runtime.cfg,
+            runtime.model.config.architecture,
+            runtime.model.config.first_k_dense_replace,
+            &runtime.model.config.advanced,
+        )?;
+        if observed_config_sha256 != resolved_config_sha256 {
+            return Err("diagnostic reference resolved configuration identity drifted".into());
+        }
+        if runtime.model.layers.len() != gpu.model_geometry.num_layers {
+            return Err("diagnostic reference layer geometry differs from GPU".into());
+        }
+        for layer in [ROUTER_TARGET_LAYER, 47] {
+            let reference_identity =
+                GateTensorIdentity::from_gate(layer, &runtime.model.layers[layer].gate);
+            if gpu.gate_identities.get(&layer) != Some(&reference_identity) {
+                return Err(format!("diagnostic gate tensor identity differs at layer {layer}").into());
+            }
+        }
+        let boundary_before = runtime.engine.cpu_q4_boundary_emulation_snapshot();
+        if !boundary_before.enabled || boundary_before.routed_expert_dispatches != 0 {
+            return Err("diagnostic CPU boundary emulation did not start clean".into());
+        }
+        let model_load = crate::greedy_parity_model_load(&runtime);
+        let fixed = holdout_case(RUST_TARGET_CASE)?;
+        let prompt_token_ids = tokenizer.encode(fixed.prompt)?;
+        if prompt_token_ids.is_empty() {
+            return Err("reference rust holdout prompt encoded to zero tokens".into());
+        }
+        let (reference_preceding_token, reference_trace) = crate::with_progress_timeout(
+            "v2 holdout failure attribution CPU rust token".to_string(),
+            watchdog,
+            async {
+                let mut kv = runtime.model.fresh_kv_caches();
+                let prefix_count = prompt_token_ids.len().saturating_sub(1);
+                for (position, &token_id) in prompt_token_ids[..prefix_count].iter().enumerate() {
+                    runtime
+                        .model
+                        .forward_token_hidden(&runtime.engine, token_id, position, &mut kv)
+                        .await?;
+                }
+                let final_prompt = *prompt_token_ids
+                    .last()
+                    .ok_or("reference rust holdout prompt is empty")?;
+                let hidden = runtime
+                    .model
+                    .forward_token_hidden(&runtime.engine, final_prompt, prefix_count, &mut kv)
+                    .await?;
+                let preceding = runtime.model.sample_hidden(
+                    &hidden,
+                    &crate::sampling::SamplingParams::greedy(),
+                    prefix_count,
+                );
+                let trace = runtime
+                    .model
+                    .forward_token_diagnostic_trace(
+                        &runtime.engine,
+                        preceding,
+                        prefix_count + 1,
+                        &mut kv,
+                        None,
+                    )
+                    .await?;
+                Ok::<_, Box<dyn std::error::Error>>((preceding, trace))
+            },
+        )
+        .await?;
+        let reference_target_token = reference_trace.sampled_token;
+        let frozen_prefix_reproduced = reference_preceding_token == RUST_PRECEDING_TOKEN
+            && gpu.rust_preceding_token == RUST_PRECEDING_TOKEN
+            && reference_target_token == RUST_REFERENCE_TARGET_TOKEN
+            && gpu.rust_target_token == RUST_GPU_TARGET_TOKEN;
+        if !frozen_prefix_reproduced {
+            return Ok::<_, Box<dyn std::error::Error>>(ReferenceCapture {
+                token_attribution: None,
+                router_attribution: None,
+                moe_attributions: Vec::new(),
+                failure: Some(format!(
+                    "frozen rust target reproducibility failure: reference=({reference_preceding_token},{reference_target_token}) gpu=({},{}) expected=({RUST_PRECEDING_TOKEN},{RUST_REFERENCE_TARGET_TOKEN})/({RUST_PRECEDING_TOKEN},{RUST_GPU_TARGET_TOKEN})",
+                    gpu.rust_preceding_token, gpu.rust_target_token
+                )),
+                model_load,
+                background_shutdown:
+                    crate::greedy_parity::BackgroundShutdownEvidence::default(),
+            });
+        }
+        let token_attribution = analyze_token_divergence(
+            &runtime,
+            &reference_trace,
+            gpu,
+            reference_preceding_token,
+            reference_target_token,
+            prompt_token_ids.len(),
+        )?;
+        let router_layer = gpu.semantic_layer(
+            ROUTER_TARGET_CASE,
+            ROUTER_TARGET_POSITION,
+            ROUTER_TARGET_LAYER,
+        )?;
+        let router_attribution = analyze_router_failure(
+            &runtime.model.layers[ROUTER_TARGET_LAYER].gate,
+            gpu.gate_identities
+                .get(&ROUTER_TARGET_LAYER)
+                .ok_or("GPU router target gate identity is missing")?,
+            router_layer,
+        )?;
+
+        let mut moe_attributions = Vec::with_capacity(MOE_OUTLIER_TARGETS.len());
+        for target in MOE_OUTLIER_TARGETS {
+            let gpu_layer = gpu.semantic_layer(
+                target.case,
+                target.generated_position,
+                target.layer,
+            )?;
+            moe_attributions.push(analyze_moe_outlier(&runtime, target, gpu_layer).await?);
+        }
+        let mut failures = Vec::new();
+        if !router_attribution.frozen_cpu_ids_reproduced {
+            failures.push("router target CPU same-input IDs did not reproduce frozen evidence");
+        }
+        if !router_attribution.frozen_gpu_ids_reproduced {
+            failures.push("router target actual GPU IDs did not reproduce frozen evidence");
+        }
+        if moe_attributions
+            .iter()
+            .any(|target| !target.valid_for_exact_router_decomposition)
+        {
+            failures.push("one or more exact-router MoE targets failed same-input ordered-ID validation");
+        }
+        let boundary_after = runtime.engine.cpu_q4_boundary_emulation_snapshot();
+        if !boundary_after.enabled || boundary_after.routed_expert_dispatches == 0 {
+            failures.push("diagnostic CPU boundary emulation was not exercised");
+        }
+        Ok::<_, Box<dyn std::error::Error>>(ReferenceCapture {
+            token_attribution: Some(token_attribution),
+            router_attribution: Some(router_attribution),
+            moe_attributions,
+            failure: (!failures.is_empty()).then(|| failures.join("; ")),
+            model_load,
+            background_shutdown: crate::greedy_parity::BackgroundShutdownEvidence::default(),
+        })
+    }
+    .await;
+    let shutdown = runtime.shutdown_isolated().await;
+    match (attempt, shutdown) {
+        (Ok(mut capture), Ok(shutdown)) => {
+            capture.background_shutdown = shutdown;
+            Ok(capture)
+        }
+        (Err(error), Ok(_)) => Err(error),
+        (Ok(_), Err(shutdown_error)) => Err(shutdown_error.into()),
+        (Err(error), Err(shutdown_error)) => Err(IsolatedRuntimeShutdownError::new(format!(
+            "{error}; diagnostic reference shutdown also failed: {shutdown_error}"
+        ))
+        .into()),
+    }
+}
+
+fn model_load_is_strict(load: &crate::greedy_parity::ModelLoadEvidence) -> bool {
+    load.strict
+        && load.required_tensors > 0
+        && load.loaded_tensors == load.required_tensors
+        && !load.seeded_fallback_remained
+        && load.loader != "seeded"
+}
+
+fn emit_report(
+    report: &GpuNativeV2HoldoutFailureAttributionReport,
+    report_out: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if report.qualification_pass() || !report.diagnostic_only {
+        return Err("diagnostic report must remain diagnostic-only and qualification false".into());
+    }
+    if let Some(parent) = report_out.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut json = serde_json::to_vec_pretty(report)?;
+    json.push(b'\n');
+    std::fs::write(report_out, json)?;
+    eprintln!(
+        "GPU-native V2 holdout failure-attribution report written to {}",
+        report_out.display()
+    );
+    Ok(())
+}
+
+pub async fn run_diagnostic(
+    config: PathBuf,
+    cfg: crate::config::Config,
+    expected_adapter_name: String,
+    v2_report: PathBuf,
+    expected_v2_report_sha256: String,
+    report_out: PathBuf,
+    progress_watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use crate::qualification::BuildProvenance;
+
+    // This immutable identity check deliberately occurs before any runtime or
+    // hardware construction.
+    let frozen_v2_result_identity =
+        validate_frozen_v2_report(&v2_report, &expected_v2_report_sha256)?;
+    let build = BuildProvenance::embedded();
+    if progress_watchdog.timeout.is_none() {
+        return Err("V2 holdout diagnostic requires a positive progress timeout".into());
+    }
+    if build.dirty != Some(false) || build.git_sha.as_deref().is_none_or(|sha| !is_hex(sha, 40)) {
+        return Err("V2 holdout diagnostic requires clean embedded Git provenance".into());
+    }
+    let (artifacts, artifact_errors) = crate::qualification_artifacts(&config, &cfg);
+    if !artifact_errors.is_empty() {
+        return Err(format!(
+            "V2 holdout diagnostic artifact preflight failed: {}",
+            artifact_errors.join("; ")
+        )
+        .into());
+    }
+    let capacity_bytes = cfg
+        .gpu_cache
+        .vram_capacity_mb
+        .checked_mul(1024 * 1024)
+        .and_then(|bytes| u64::try_from(bytes).ok())
+        .unwrap_or(0);
+    let source_config = crate::gpu_native_greedy_parity::SourceConfigEvidence {
+        real_transformer_enabled: cfg.real_transformer.enabled,
+        gpu_native_enabled: cfg.real_transformer.gpu_native,
+        weights_dir_configured: cfg.real_transformer.weights_dir.is_some(),
+        strict_weights: cfg.real_transformer.strict_weights,
+        allow_seeded_fallback: cfg.real_transformer.allow_seeded_fallback,
+        allow_degraded_experts: cfg.real_transformer.allow_degraded_experts,
+        allow_nonfinite_attention_fallback: cfg.real_transformer.allow_nonfinite_attention_fallback,
+        allow_truncated_expert_payloads: cfg.real_transformer.allow_truncated_expert_payloads,
+        distributed_enabled: cfg.distributed.enabled,
+        gpu_cache_enabled: cfg.gpu_cache.enabled,
+        gpu_expert_capacity_bytes: capacity_bytes,
+        routed_expert_dtype: cfg.model.dtype.as_str().to_string(),
+    };
+    if !source_config.is_strict() {
+        return Err("V2 holdout diagnostic requires the strict GPU-native Q4 configuration".into());
+    }
+    let expert_metadata =
+        crate::qualification::read_expert_metadata(&cfg.model.data_dir.join("metadata.json"))
+            .map_err(|error| format!("diagnostic expert metadata preflight failed: {error}"))?;
+    if expert_metadata.dtype.as_deref() != Some("q4_0")
+        || expert_metadata.q4_0_layout.as_deref() != Some(crate::inference::Q4_0_LAYOUT_STANDARD_V1)
+        || expert_metadata.explicitly_synthetic
+    {
+        return Err("V2 holdout diagnostic requires canonical nonsynthetic Q4_0 metadata".into());
+    }
+    if expected_adapter_name.trim().is_empty() {
+        return Err("V2 holdout diagnostic requires a nonempty exact adapter name".into());
+    }
+
+    let mut gpu_spec = crate::resolve_real_cli_spec_from_config(
+        cfg,
+        RealCliRuntimeMode::IsolatedGpuNativeDiagnostic,
+    )?;
+    gpu_spec.cfg.real_transformer.gpu_native = true;
+    gpu_spec.cfg.real_transformer.compute_offload = crate::backend::ComputeOffload::Gpu;
+    let model_identity = crate::greedy_parity_model_identity(&gpu_spec);
+    if !model_identity.is_qwen3_coder_30b_a3b_q4_0() {
+        return Err(
+            "V2 holdout diagnostic requires exact Qwen3-Coder 30B-A3B Q4_0 geometry".into(),
+        );
+    }
+    let gpu_resolved_config_sha256 = crate::resolved_real_cli_spec_sha256(&gpu_spec)?;
+    let mut reference_spec = gpu_spec.clone();
+    reference_spec.cfg.real_transformer.gpu_native = false;
+    reference_spec.cfg.real_transformer.compute_offload = crate::backend::ComputeOffload::Cpu;
+    let reference_resolved_config_sha256 = crate::resolved_real_cli_spec_sha256(&reference_spec)?;
+    let tokenizer_path = gpu_spec
+        .cfg
+        .tokenizer
+        .path
+        .as_ref()
+        .ok_or("V2 holdout diagnostic requires tokenizer.path")?;
+    let tokenizer = Arc::new(crate::tokenizer::Tokenizer::from_file(tokenizer_path)?);
+
+    let gpu = execute_gpu(
+        &gpu_spec,
+        tokenizer.clone(),
+        &gpu_resolved_config_sha256,
+        &expected_adapter_name,
+        progress_watchdog,
+    )
+    .await?;
+    let reference = execute_reference_and_analyze(
+        &reference_spec,
+        tokenizer,
+        &reference_resolved_config_sha256,
+        &gpu,
+        progress_watchdog,
+    )
+    .await?;
+    let (_, executable_sha256) = crate::current_executable_identity()?;
+    let runtime = DiagnosticRuntimeEvidence {
+        gpu_token_loop: gpu.token_loop_snapshot,
+        gpu_expected_completed_token_steps: gpu.expected_completed_token_steps,
+        reference_background_shutdown: reference.background_shutdown.clone(),
+        gpu_native_background_shutdown: gpu.background_shutdown.clone(),
+    };
+    let mut failures = reference.failure.into_iter().collect::<Vec<_>>();
+    if !model_load_is_strict(&reference.model_load) || !model_load_is_strict(&gpu.model_load) {
+        failures.push("one or both diagnostic runtimes did not load the strict model".to_string());
+    }
+    if runtime.gpu_token_loop.tokens_completed != runtime.gpu_expected_completed_token_steps
+        || runtime.gpu_token_loop.fatal_failures != 0
+        || runtime.gpu_token_loop.no_progress_failures != 0
+    {
+        failures.push("diagnostic GPU execution did not complete cleanly".to_string());
+    }
+    if !runtime
+        .reference_background_shutdown
+        .controlled_shutdown_requested
+        || !runtime
+            .reference_background_shutdown
+            .all_runtime_resources_released
+        || !runtime
+            .gpu_native_background_shutdown
+            .controlled_shutdown_requested
+        || !runtime
+            .gpu_native_background_shutdown
+            .all_runtime_resources_released
+    {
+        failures.push("one or both diagnostic runtimes failed controlled shutdown".to_string());
+    }
+    let failure = (!failures.is_empty()).then(|| failures.join("; "));
+    let report = GpuNativeV2HoldoutFailureAttributionReport::new(
+        DiagnosticProvenance {
+            build,
+            executable_sha256,
+            artifacts,
+            gpu_resolved_config_sha256,
+            reference_resolved_config_sha256,
+            model_identity,
+            reference_model_load: reference.model_load,
+            gpu_native_model_load: gpu.model_load,
+            reference_background_shutdown: reference.background_shutdown,
+            gpu_native_background_shutdown: gpu.background_shutdown,
+            expert_metadata,
+            device: gpu.device,
+        },
+        frozen_v2_result_identity,
+        failure,
+        reference.token_attribution,
+        reference.router_attribution,
+        reference.moe_attributions,
+        runtime,
+        Vec::new(),
+    );
+    let diagnostic_complete = report.diagnostic_complete;
+    let failure = report.failure.clone();
+    emit_report(&report, &report_out)?;
+    if diagnostic_complete {
+        Ok(())
+    } else {
+        Err(format!(
+            "V2 holdout failure attribution incomplete: {}",
+            failure.unwrap_or_else(|| "required evidence is incomplete".to_string())
+        )
+        .into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn strict_model_load() -> crate::greedy_parity::ModelLoadEvidence {
+        crate::greedy_parity::ModelLoadEvidence {
+            strict: true,
+            loader: "safetensors".to_string(),
+            loaded_tensors: 1,
+            required_tensors: 1,
+            optional_probed: 0,
+            optional_loaded: 0,
+            seeded_fallback_remained: false,
+        }
+    }
+
+    fn released_shutdown() -> crate::greedy_parity::BackgroundShutdownEvidence {
+        crate::greedy_parity::BackgroundShutdownEvidence {
+            controlled_shutdown_requested: true,
+            all_runtime_resources_released: true,
+            poll_iterations: 1,
+        }
+    }
+
+    fn provenance() -> DiagnosticProvenance {
+        DiagnosticProvenance {
+            build: crate::qualification::BuildProvenance {
+                git_sha: Some("a".repeat(40)),
+                dirty: Some(false),
+                package_version: "0.1.0".to_string(),
+            },
+            executable_sha256: "b".repeat(64),
+            artifacts: crate::qualification::QualificationArtifacts::default(),
+            gpu_resolved_config_sha256: "c".repeat(64),
+            reference_resolved_config_sha256: "d".repeat(64),
+            model_identity: crate::greedy_parity::ModelIdentityEvidence {
+                architecture: "qwen3_moe".to_string(),
+                num_layers: 48,
+                num_experts_per_layer: 128,
+                total_experts: 6144,
+                top_k: 8,
+                d_model: 2048,
+                d_ff: 768,
+                routed_expert_dtype: "q4_0".to_string(),
+            },
+            reference_model_load: strict_model_load(),
+            gpu_native_model_load: strict_model_load(),
+            reference_background_shutdown: released_shutdown(),
+            gpu_native_background_shutdown: released_shutdown(),
+            expert_metadata: crate::qualification::ExpertMetadataEvidence {
+                dtype: Some("q4_0".to_string()),
+                q4_0_layout: Some(crate::inference::Q4_0_LAYOUT_STANDARD_V1.to_string()),
+                conversion_mode: Some("real".to_string()),
+                source: Some("test".to_string()),
+                explicitly_synthetic: false,
+            },
+            device: crate::backend::GpuDeviceIdentity {
+                name: "NVIDIA L4".to_string(),
+                vendor_id: 0x10de,
+                device_id: 0,
+                device_type: "DiscreteGpu".to_string(),
+                wgpu_backend: "vulkan".to_string(),
+                driver: "580.173.02".to_string(),
+                driver_info: "test".to_string(),
+                compute_plane: "wgpu-vulkan".to_string(),
+                software_adapter: false,
+            },
+        }
+    }
+
+    fn frozen_identity() -> FrozenV2ResultIdentity {
+        FrozenV2ResultIdentity {
+            report_artifact: crate::qualification::ArtifactDigest {
+                configured_path: "/v2.json".to_string(),
+                canonical_path: "/v2.json".to_string(),
+                byte_length: 1,
+                sha256: FROZEN_V2_REPORT_SHA256.to_string(),
+            },
+            expected_report_sha256_argument: FROZEN_V2_REPORT_SHA256.to_string(),
+            expected_schema: crate::gpu_native_semantic_parity_v2::SCHEMA_VERSION,
+            frozen_build_sha: FROZEN_V2_BUILD_SHA,
+            qualification_pass: false,
+            holdout_corpus_id: crate::gpu_native_semantic_parity_v2::HOLDOUT_CORPUS_ID,
+            holdout_corpus_sha256: crate::gpu_native_semantic_parity_v2::HOLDOUT_CORPUS_SHA256,
+            numerical_limits: crate::gpu_native_semantic_parity_v2::NumericalLimits::frozen(),
+            execution_log_sha256: FROZEN_V2_EXECUTION_LOG_SHA256,
+            offline_failure_analysis_sha256: FROZEN_OFFLINE_ANALYSIS_SHA256,
+            immutable_input_verified: true,
+        }
+    }
+
+    #[test]
+    fn schema_mode_and_diagnostic_only_contract_are_versioned() {
+        assert_eq!(
+            SCHEMA_VERSION,
+            "mer.gpu-native-v2-holdout-failure-attribution.v1"
+        );
+        assert_eq!(MODE, "diagnose-gpu-native-v2-holdout-failures");
+        let report = GpuNativeV2HoldoutFailureAttributionReport::new(
+            provenance(),
+            frozen_identity(),
+            Some("fixture incomplete".to_string()),
+            None,
+            None,
+            Vec::new(),
+            DiagnosticRuntimeEvidence::default(),
+            Vec::new(),
+        );
+        assert!(!report.qualification_pass());
+        let value = serde_json::to_value(report).unwrap();
+        assert_eq!(value["qualification_pass"], false);
+        assert_eq!(value["diagnostic_only"], true);
+    }
+
+    #[test]
+    fn frozen_v2_report_sha_argument_is_fail_closed() {
+        assert!(validate_expected_v2_report_sha_argument(FROZEN_V2_REPORT_SHA256).is_ok());
+        assert!(validate_expected_v2_report_sha_argument(&"0".repeat(64)).is_err());
+        assert!(validate_expected_v2_report_sha_argument("not-hex").is_err());
+    }
+
+    #[test]
+    fn exact_v2_schema_build_corpus_and_limits_are_required() {
+        let exact = || FrozenV2ReportEnvelope {
+            schema: crate::gpu_native_semantic_parity_v2::SCHEMA_VERSION.to_string(),
+            qualification_pass: false,
+            provenance: FrozenProvenanceEnvelope {
+                build: FrozenBuildEnvelope {
+                    git_sha: Some(FROZEN_V2_BUILD_SHA.to_string()),
+                },
+            },
+            holdout_corpus: FrozenCorpusEnvelope {
+                id: crate::gpu_native_semantic_parity_v2::HOLDOUT_CORPUS_ID.to_string(),
+                sha256: crate::gpu_native_semantic_parity_v2::HOLDOUT_CORPUS_SHA256.to_string(),
+            },
+            numerical_limits: FrozenNumericalLimits {
+                max_absolute_error_limit: 0.020,
+                rms_error_limit: 0.001,
+                mean_absolute_error_limit: 0.00075,
+                nonfinite_mismatch_limit: 0,
+                semantic_correctness_not_bit_parity: true,
+            },
+        };
+        assert!(validate_v2_envelope(&exact()).is_ok());
+        let mut wrong = exact();
+        wrong.schema.push_str("-drift");
+        assert!(validate_v2_envelope(&wrong).is_err());
+        let mut wrong = exact();
+        wrong.provenance.build.git_sha = Some("0".repeat(40));
+        assert!(validate_v2_envelope(&wrong).is_err());
+        let mut wrong = exact();
+        wrong.holdout_corpus.sha256 = "0".repeat(64);
+        assert!(validate_v2_envelope(&wrong).is_err());
+        let mut wrong = exact();
+        wrong.numerical_limits.max_absolute_error_limit = 0.0200001;
+        assert!(validate_v2_envelope(&wrong).is_err());
+    }
+
+    #[test]
+    fn target_list_is_exactly_one_token_one_router_and_four_moe_outliers() {
+        let targets = FrozenTargetListEvidence::fixed();
+        assert_eq!(targets.rust_token_target_case, RUST_TARGET_CASE);
+        assert_eq!(targets.rust_token_target_position, 1);
+        assert_eq!(targets.rust_preceding_token, 4710);
+        assert_eq!(targets.rust_reference_target_token, 785);
+        assert_eq!(targets.rust_gpu_target_token, 8822);
+        assert_eq!(targets.router_target_position, 11);
+        assert_eq!(targets.router_target_layer, 38);
+        assert_eq!(targets.router_cpu_expected_ids, ROUTER_CPU_EXPECTED_IDS);
+        assert_eq!(targets.router_gpu_expected_ids, ROUTER_GPU_EXPECTED_IDS);
+        assert_eq!(targets.exact_router_moe_outliers, MOE_OUTLIER_TARGETS);
+        assert_eq!(targets.exact_router_moe_outliers.len(), 4);
+    }
+
+    #[test]
+    fn token_attribution_categories_are_stage_specific_and_conservative() {
+        let base = TokenAttributionInputs {
+            reference_argmax: 785,
+            cpu_argmax_on_cpu_norm_of_gpu_pre_norm: 8822,
+            cpu_argmax_on_actual_gpu_final_norm: 8822,
+            cpu_argmax_from_actual_gpu_logits: 8822,
+            actual_gpu_sampled_token: 8822,
+        };
+        assert_eq!(
+            derive_token_attribution(base),
+            TokenAttributionCategory::UpstreamHiddenDrift
+        );
+        assert_eq!(
+            derive_token_attribution(TokenAttributionInputs {
+                cpu_argmax_on_cpu_norm_of_gpu_pre_norm: 785,
+                ..base
+            }),
+            TokenAttributionCategory::FinalRmsnormDrift
+        );
+        assert_eq!(
+            derive_token_attribution(TokenAttributionInputs {
+                cpu_argmax_on_actual_gpu_final_norm: 785,
+                ..base
+            }),
+            TokenAttributionCategory::GpuLmHeadGemvDrift
+        );
+        assert_eq!(
+            derive_token_attribution(TokenAttributionInputs {
+                cpu_argmax_from_actual_gpu_logits: 785,
+                ..base
+            }),
+            TokenAttributionCategory::GpuGreedyArgmaxDrift
+        );
+        assert_eq!(
+            derive_token_attribution(TokenAttributionInputs {
+                cpu_argmax_on_cpu_norm_of_gpu_pre_norm: 3333,
+                ..base
+            }),
+            TokenAttributionCategory::MixedNumericalDrift
+        );
+        assert_eq!(
+            derive_token_attribution(TokenAttributionInputs {
+                reference_argmax: 999,
+                ..base
+            }),
+            TokenAttributionCategory::Unresolved
+        );
+    }
+
+    #[test]
+    fn cpu_lm_head_contract_names_greedy_compatible_row_dot() {
+        let semantics = ProductionSemanticsEvidence::default();
+        assert!(semantics
+            .cpu_lm_head_contract
+            .contains("DenseWeight::diagnostic_greedy_logits"));
+        assert!(semantics.cpu_lm_head_contract.contains("row_dot"));
+    }
+
+    #[test]
+    fn router_attribution_distinguishes_gemv_topk_tie_and_unresolved() {
+        let cpu = [1, 2];
+        let gpu = [1, 3];
+        assert_eq!(
+            derive_router_attribution(&cpu, &gpu, &gpu, false),
+            RouterAttributionCategory::GpuRouterGemvDrift
+        );
+        assert_eq!(
+            derive_router_attribution(&cpu, &cpu, &gpu, false),
+            RouterAttributionCategory::GpuRouterSoftmaxTopkDrift
+        );
+        assert_eq!(
+            derive_router_attribution(&cpu, &cpu, &gpu, true),
+            RouterAttributionCategory::ExactTieOrderingDefect
+        );
+        assert_eq!(
+            derive_router_attribution(&[1], &cpu, &cpu, false),
+            RouterAttributionCategory::MixedNumericalDrift
+        );
+        assert_eq!(
+            derive_router_attribution(&cpu, &cpu, &cpu, false),
+            RouterAttributionCategory::Unresolved
+        );
+    }
+
+    #[test]
+    fn exact_gpu_raw_logit_topk_is_derived_without_reference_hidden() {
+        let mut logits = vec![-100.0; 128];
+        for (rank, expert) in ROUTER_GPU_EXPECTED_IDS.iter().enumerate() {
+            logits[*expert as usize] = 10.0 - rank as f32;
+        }
+        let actual = crate::gpu_native_router_rank_diagnostics::evaluate_actual_gpu_router(
+            logits,
+            ROUTER_GPU_EXPECTED_IDS.to_vec(),
+            vec![0.125; 8],
+        )
+        .unwrap();
+        assert_eq!(
+            actual.cpu_top_8_ids_derived_from_exact_gpu_raw_logits,
+            ROUTER_GPU_EXPECTED_IDS
+        );
+    }
+
+    #[test]
+    fn router_raw_views_retain_experts_95_and_107_and_full_bits() {
+        let mut logits = vec![0.0; 128];
+        logits[95] = -3.8356452;
+        logits[107] = -3.8356473;
+        let view = raw_logit_view("gpu", &logits).unwrap();
+        assert_eq!(view.exact_vector.f32_bits.len(), 128);
+        assert_eq!(
+            view.experts_95_and_107
+                .iter()
+                .map(|expert| expert.expert_id)
+                .collect::<Vec<_>>(),
+            vec![95, 107]
+        );
+    }
+
+    #[test]
+    fn exact_router_moe_decomposition_refuses_unequal_ordered_ids() {
+        assert!(exact_ordered_router_ids_equal(&[1, 2], &[1, 2]));
+        assert!(!exact_ordered_router_ids_equal(&[1, 2], &[2, 1]));
+        assert!(!exact_ordered_router_ids_equal(&[1, 2], &[1, 3]));
+    }
+
+    #[test]
+    fn per_expert_pairing_uses_expert_id_not_rank() {
+        assert_eq!(
+            gpu_ranks_paired_by_expert_id(&[7, 3, 9], &[9, 7, 3]).unwrap(),
+            vec![1, 2, 0]
+        );
+        assert!(gpu_ranks_paired_by_expert_id(&[7, 3], &[7, 9]).is_err());
+    }
+
+    #[test]
+    fn mixed_combination_uses_production_sequential_f32_order() {
+        let outputs = vec![vec![1.0, 2.0], vec![3.0, 4.0], vec![5.0, 6.0]];
+        let weights = vec![0.5, 0.25, 0.125];
+        let actual = crate::inference::combine_outputs(&outputs, &weights);
+        let mut expected = vec![0.0f32; 2];
+        for (output, weight) in outputs.iter().zip(&weights) {
+            for (destination, value) in expected.iter_mut().zip(output) {
+                *destination += *weight * *value;
+            }
+        }
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn all_four_outliers_and_router_coupled_event_remain_separate() {
+        assert_eq!(MOE_OUTLIER_TARGETS.len(), 4);
+        assert!(MOE_OUTLIER_TARGETS.iter().all(|target| target.layer == 47));
+        assert_eq!(ROUTER_COUPLED_TARGET.layer, 38);
+        assert!(ROUTER_COUPLED_TARGET.excluded_from_exact_router_moe_decomposition);
+        assert!(MOE_OUTLIER_TARGETS.iter().all(|target| {
+            (target.case, target.generated_position, target.layer)
+                != (
+                    ROUTER_COUPLED_TARGET.case,
+                    ROUTER_COUPLED_TARGET.generated_position,
+                    ROUTER_COUPLED_TARGET.layer,
+                )
+        }));
+    }
+
+    #[test]
+    fn production_and_frozen_contracts_are_declared_unchanged() {
+        let evidence = ProductionSemanticsEvidence::default();
+        assert!(evidence.diagnostic_only);
+        assert!(!evidence.production_inference_math_changed);
+        assert!(!evidence.production_router_math_changed);
+        assert!(!evidence.production_dense_gemv_changed);
+        assert!(!evidence.shader_or_wgsl_changed);
+        assert!(!evidence.v1_changed);
+        assert!(!evidence.v2_changed);
+        assert!(!evidence.frozen_limits_changed);
+        assert!(!evidence.frozen_holdout_changed);
+    }
+}

--- a/rust-engine/src/inference.rs
+++ b/rust-engine/src/inference.rs
@@ -1446,6 +1446,32 @@ pub fn forward_candle_tensors(
     d_model: usize,
     x: &[f32],
 ) -> Result<HiddenState, ExpertWeightsError> {
+    forward_candle_tensors_with_observer(gate_t, up_t, down_t, d_model, x, |_, _, _, _| Ok(()))
+        .map(|(output, ())| output)
+}
+
+/// Diagnostic-only copies of the four internal tensors produced by the
+/// ordinary Candle expert sequence. This type never participates in serving
+/// or qualification decisions.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct Q4ExpertStageTrace {
+    pub gate: Vec<f32>,
+    pub up: Vec<f32>,
+    pub gated: Vec<f32>,
+    pub down: Vec<f32>,
+}
+
+fn forward_candle_tensors_with_observer<T, Observe>(
+    gate_t: &Tensor,
+    up_t: &Tensor,
+    down_t: &Tensor,
+    d_model: usize,
+    x: &[f32],
+    observe: Observe,
+) -> Result<(HiddenState, T), ExpertWeightsError>
+where
+    Observe: FnOnce(&Tensor, &Tensor, &Tensor, &Tensor) -> Result<T, ExpertWeightsError>,
+{
     let device = Device::Cpu;
     let map_err = |e: candle_core::Error| ExpertWeightsError::Candle(e.to_string());
 
@@ -1453,12 +1479,12 @@ pub fn forward_candle_tensors(
     // line up: gate[d_ff, d_model] · x[d_model, 1] -> [d_ff, 1].
     let x_t = Tensor::from_slice(x, (d_model, 1), &device).map_err(map_err)?;
 
-    let g = gate_t.matmul(&x_t).map_err(map_err)?;
+    let raw_gate = gate_t.matmul(&x_t).map_err(map_err)?;
     let u = up_t.matmul(&x_t).map_err(map_err)?;
 
     // SwiGLU: silu(clamp(g)) ⊙ u. The clamp is the GPT-OSS `swiglu_limit`
     // (no-op for every other architecture; see `clamp_swiglu_gate`).
-    let g = clamp_swiglu_gate(g).map_err(map_err)?;
+    let g = clamp_swiglu_gate(raw_gate.clone()).map_err(map_err)?;
     let gated = candle_core::Tensor::silu(&g)
         .map_err(map_err)?
         .mul(&u)
@@ -1466,10 +1492,304 @@ pub fn forward_candle_tensors(
 
     // Down projection: down[d_model, d_ff] · gated[d_ff, 1] -> [d_model, 1].
     let y = down_t.matmul(&gated).map_err(map_err)?;
+    let observed = observe(&raw_gate, &u, &gated, &y)?;
 
     // Squeeze the trailing dim and convert back to Vec<f32>.
     let y = y.squeeze(1).map_err(map_err)?;
-    y.to_vec1::<f32>().map_err(map_err)
+    Ok((y.to_vec1::<f32>().map_err(map_err)?, observed))
+}
+
+impl OwnedExpertWeights {
+    /// Observe the existing production Candle stages without changing their
+    /// arithmetic or substituting a scalar matrix multiply.
+    pub(crate) fn diagnostic_forward_stage_trace(
+        &self,
+        x: &[f32],
+    ) -> Result<Q4ExpertStageTrace, ExpertWeightsError> {
+        let device = Device::Cpu;
+        let map_err = |error: candle_core::Error| ExpertWeightsError::Candle(error.to_string());
+        let gate_t =
+            Tensor::from_slice(&self.gate, (self.d_ff, self.d_model), &device).map_err(map_err)?;
+        let up_t =
+            Tensor::from_slice(&self.up, (self.d_ff, self.d_model), &device).map_err(map_err)?;
+        let down_t =
+            Tensor::from_slice(&self.down, (self.d_model, self.d_ff), &device).map_err(map_err)?;
+        let (output, (gate, up, gated, observed_down)) = forward_candle_tensors_with_observer(
+            &gate_t,
+            &up_t,
+            &down_t,
+            self.d_model,
+            x,
+            |gate, up, gated, down| {
+                let to_vec = |tensor: &Tensor, squeeze_dim: usize| {
+                    tensor
+                        .squeeze(squeeze_dim)
+                        .and_then(|tensor| tensor.to_vec1::<f32>())
+                        .map_err(map_err)
+                };
+                Ok((
+                    to_vec(gate, 1)?,
+                    to_vec(up, 1)?,
+                    to_vec(gated, 1)?,
+                    to_vec(down, 1)?,
+                ))
+            },
+        )?;
+        if output
+            .iter()
+            .map(|value| value.to_bits())
+            .ne(observed_down.iter().map(|value| value.to_bits()))
+        {
+            return Err(ExpertWeightsError::Candle(
+                "diagnostic observer changed the final Candle expert vector".to_string(),
+            ));
+        }
+        Ok(Q4ExpertStageTrace {
+            gate,
+            up,
+            gated,
+            down: output,
+        })
+    }
+
+    /// Replay supplied gate/up vectors through the same production Candle
+    /// clamp, SiLU, elementwise multiply, and down projection.
+    pub(crate) fn diagnostic_replay_gate_up(
+        &self,
+        gate: &[f32],
+        up: &[f32],
+    ) -> Result<Q4ExpertStageTrace, ExpertWeightsError> {
+        if gate.len() != self.d_ff || up.len() != self.d_ff {
+            return Err(ExpertWeightsError::InvalidLayout(
+                "diagnostic gate/up replay geometry differs from d_ff".to_string(),
+            ));
+        }
+        let device = Device::Cpu;
+        let map_err = |error: candle_core::Error| ExpertWeightsError::Candle(error.to_string());
+        let gate_t = Tensor::from_slice(gate, (self.d_ff, 1), &device).map_err(map_err)?;
+        let up_t = Tensor::from_slice(up, (self.d_ff, 1), &device).map_err(map_err)?;
+        let down_t =
+            Tensor::from_slice(&self.down, (self.d_model, self.d_ff), &device).map_err(map_err)?;
+        let clamped = clamp_swiglu_gate(gate_t).map_err(map_err)?;
+        let gated = Tensor::silu(&clamped)
+            .map_err(map_err)?
+            .mul(&up_t)
+            .map_err(map_err)?;
+        let down = down_t.matmul(&gated).map_err(map_err)?;
+        let gated = gated
+            .squeeze(1)
+            .and_then(|tensor| tensor.to_vec1::<f32>())
+            .map_err(map_err)?;
+        let down = down
+            .squeeze(1)
+            .and_then(|tensor| tensor.to_vec1::<f32>())
+            .map_err(map_err)?;
+        Ok(Q4ExpertStageTrace {
+            gate: gate.to_vec(),
+            up: up.to_vec(),
+            gated,
+            down,
+        })
+    }
+
+    /// Replay a supplied activation through the same production Candle down
+    /// projection used by the ordinary expert forward path.
+    pub(crate) fn diagnostic_replay_down(
+        &self,
+        gated: &[f32],
+    ) -> Result<Vec<f32>, ExpertWeightsError> {
+        if gated.len() != self.d_ff {
+            return Err(ExpertWeightsError::InvalidLayout(
+                "diagnostic gated replay geometry differs from d_ff".to_string(),
+            ));
+        }
+        let device = Device::Cpu;
+        let map_err = |error: candle_core::Error| ExpertWeightsError::Candle(error.to_string());
+        let down_t =
+            Tensor::from_slice(&self.down, (self.d_model, self.d_ff), &device).map_err(map_err)?;
+        let gated_t = Tensor::from_slice(gated, (self.d_ff, 1), &device).map_err(map_err)?;
+        down_t
+            .matmul(&gated_t)
+            .and_then(|tensor| tensor.squeeze(1))
+            .and_then(|tensor| tensor.to_vec1::<f32>())
+            .map_err(map_err)
+    }
+}
+
+/// CPU descriptions of GPU Q4 arithmetic used only by stage-attribution
+/// diagnostics. `RejectedLogicalDequant` records the failed hypothesis and is
+/// explicitly not an intended production contract.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum DiagnosticQ4DotArithmetic {
+    CurrentGpu,
+    RejectedLogicalDequant,
+}
+
+impl DiagnosticQ4DotArithmetic {
+    pub(crate) const fn status(self) -> &'static str {
+        match self {
+            Self::CurrentGpu => "descriptive-current-production-gpu-q4-arithmetic",
+            Self::RejectedLogicalDequant => {
+                "rejected-software-hypothesis-diagnostic-only-not-production"
+            }
+        }
+    }
+}
+
+fn diagnostic_q4_signed_value(block: &[u8], logical_index: usize) -> f32 {
+    let packed = block[2 + (logical_index & 15)];
+    let nibble = if logical_index < 16 {
+        packed & 0x0f
+    } else {
+        packed >> 4
+    };
+    (i32::from(nibble) - 8) as f32
+}
+
+fn diagnostic_q4_dot(blocks: &[u8], input: &[f32], arithmetic: DiagnosticQ4DotArithmetic) -> f32 {
+    debug_assert_eq!(blocks.len() % Q4_0_BLOCK_BYTES, 0);
+    debug_assert_eq!(
+        input.len(),
+        blocks.len() / Q4_0_BLOCK_BYTES * Q4_0_BLOCK_ELEMS
+    );
+    let mut sum = 0.0f32;
+    for (block_index, block) in blocks.chunks_exact(Q4_0_BLOCK_BYTES).enumerate() {
+        let scale = half::f16::from_bits(u16::from_le_bytes([block[0], block[1]])).to_f32();
+        let input_base = block_index * Q4_0_BLOCK_ELEMS;
+        match arithmetic {
+            DiagnosticQ4DotArithmetic::CurrentGpu => {
+                let mut partial = 0.0f32;
+                for nibble in 0..16 {
+                    partial = partial
+                        + diagnostic_q4_signed_value(block, nibble) * input[input_base + nibble];
+                    partial = partial
+                        + diagnostic_q4_signed_value(block, nibble + 16)
+                            * input[input_base + nibble + 16];
+                }
+                sum = sum + scale * partial;
+            }
+            DiagnosticQ4DotArithmetic::RejectedLogicalDequant => {
+                for logical_index in 0..Q4_0_BLOCK_ELEMS {
+                    let dequantized_weight =
+                        scale * diagnostic_q4_signed_value(block, logical_index);
+                    sum = sum + dequantized_weight * input[input_base + logical_index];
+                }
+            }
+        }
+    }
+    sum
+}
+
+fn diagnostic_q4_projection(
+    payload: &[u8],
+    first_block: usize,
+    rows: usize,
+    columns: usize,
+    input: &[f32],
+    arithmetic: DiagnosticQ4DotArithmetic,
+) -> Vec<f32> {
+    debug_assert_eq!(input.len(), columns);
+    let blocks_per_row = columns / Q4_0_BLOCK_ELEMS;
+    (0..rows)
+        .map(|row| {
+            let first = first_block + row * blocks_per_row;
+            let byte_start = first * Q4_0_BLOCK_BYTES;
+            let byte_end = byte_start + blocks_per_row * Q4_0_BLOCK_BYTES;
+            diagnostic_q4_dot(&payload[byte_start..byte_end], input, arithmetic)
+        })
+        .collect()
+}
+
+pub(crate) fn diagnostic_q4_0_expert_arithmetic(
+    payload: &[u8],
+    input: &[f32],
+    d_model: usize,
+    d_ff: usize,
+    arithmetic: DiagnosticQ4DotArithmetic,
+) -> Result<Q4ExpertStageTrace, ExpertWeightsError> {
+    let expected = expert_weight_bytes_for(d_model, d_ff, WeightDtype::Q4_0);
+    if payload.len() != expected
+        || input.len() != d_model
+        || !d_model.is_multiple_of(Q4_0_BLOCK_ELEMS)
+        || !d_ff.is_multiple_of(Q4_0_BLOCK_ELEMS)
+    {
+        return Err(ExpertWeightsError::InvalidLayout(
+            "diagnostic Q4 arithmetic received invalid payload or geometry".to_string(),
+        ));
+    }
+    let blocks_per_projection = d_model * d_ff / Q4_0_BLOCK_ELEMS;
+    let gate = diagnostic_q4_projection(payload, 0, d_ff, d_model, input, arithmetic);
+    let up = diagnostic_q4_projection(
+        payload,
+        blocks_per_projection,
+        d_ff,
+        d_model,
+        input,
+        arithmetic,
+    );
+    let gated = gate
+        .iter()
+        .copied()
+        .zip(up.iter().copied())
+        .map(|(gate, up)| {
+            let gate = swiglu_limit()
+                .map(|limit| gate.clamp(-limit, limit))
+                .unwrap_or(gate);
+            (gate / (1.0 + (-gate).exp())) * up
+        })
+        .collect::<Vec<_>>();
+    let down = diagnostic_q4_projection(
+        payload,
+        blocks_per_projection * 2,
+        d_model,
+        d_ff,
+        &gated,
+        arithmetic,
+    );
+    Ok(Q4ExpertStageTrace {
+        gate,
+        up,
+        gated,
+        down,
+    })
+}
+
+pub(crate) fn diagnostic_q4_0_down_arithmetic(
+    payload: &[u8],
+    gated: &[f32],
+    d_model: usize,
+    d_ff: usize,
+    arithmetic: DiagnosticQ4DotArithmetic,
+) -> Result<Vec<f32>, ExpertWeightsError> {
+    let expected = expert_weight_bytes_for(d_model, d_ff, WeightDtype::Q4_0);
+    if payload.len() != expected || gated.len() != d_ff {
+        return Err(ExpertWeightsError::InvalidLayout(
+            "diagnostic Q4 down replay received invalid payload or activation geometry".to_string(),
+        ));
+    }
+    let blocks_per_projection = d_model * d_ff / Q4_0_BLOCK_ELEMS;
+    Ok(diagnostic_q4_projection(
+        payload,
+        blocks_per_projection * 2,
+        d_model,
+        d_ff,
+        gated,
+        arithmetic,
+    ))
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct Q4ExpertStageDiagnosticBundle {
+    pub canonical_payload_sha256: String,
+    pub cpu_boundary_input: Vec<f32>,
+    pub cpu_production: Q4ExpertStageTrace,
+    pub cpu_effective_output: Vec<f32>,
+    pub current_gpu_emulation: Q4ExpertStageTrace,
+    pub rejected_logical_dequant_emulation: Q4ExpertStageTrace,
+    pub gpu_gate_up_through_cpu_swiglu_down: Q4ExpertStageTrace,
+    pub gpu_gated_through_cpu_down: Vec<f32>,
+    pub cpu_gated_through_current_gpu_down: Vec<f32>,
+    pub gpu_gated_through_current_gpu_down: Vec<f32>,
 }
 
 /// Fused gate / up SwiGLU projection: `gated[i] = silu(gate[i,:]·x) * (up[i,:]·x)`.
@@ -6591,6 +6911,75 @@ mod tests {
                 "QMatMul Q4_0 path diverged at {i}: baseline={a} qmm={b} (tol={tol})"
             );
         }
+    }
+
+    #[test]
+    fn q4_stage_observer_matches_ordinary_production_candle_output_and_geometry() {
+        let d_model = Q4_0_BLOCK_ELEMS;
+        let d_ff = 2 * Q4_0_BLOCK_ELEMS;
+        let bytes = synth_q4_0_blob(d_model, d_ff);
+        let input: Vec<f32> = (0..d_model)
+            .map(|index| (index as f32 - 15.0) / 19.0)
+            .collect();
+        let weights =
+            OwnedExpertWeights::from_bytes_q4_0(&bytes, d_model, d_ff).expect("Q4 weights");
+        let trace = weights
+            .diagnostic_forward_stage_trace(&input)
+            .expect("diagnostic Candle stages");
+        let ordinary = q4_0_cpu_reference_forward(&bytes, &input, d_model, d_ff)
+            .expect("ordinary production Candle expert");
+        assert_eq!(trace.gate.len(), d_ff);
+        assert_eq!(trace.up.len(), d_ff);
+        assert_eq!(trace.gated.len(), d_ff);
+        assert_eq!(trace.down.len(), d_model);
+        assert_eq!(
+            trace
+                .down
+                .iter()
+                .map(|value| value.to_bits())
+                .collect::<Vec<_>>(),
+            ordinary
+                .iter()
+                .map(|value| value.to_bits())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn diagnostic_q4_low_high_nibble_mapping_matches_ggml_layout() {
+        let mut block = [0u8; Q4_0_BLOCK_BYTES];
+        block[..2].copy_from_slice(&half::f16::from_f32(1.0).to_bits().to_le_bytes());
+        for nibble in 0..16 {
+            block[2 + nibble] = nibble as u8 | ((15 - nibble as u8) << 4);
+        }
+        for logical in 0..16 {
+            assert_eq!(
+                diagnostic_q4_signed_value(&block, logical),
+                logical as f32 - 8.0
+            );
+            assert_eq!(
+                diagnostic_q4_signed_value(&block, logical + 16),
+                (15 - logical) as f32 - 8.0
+            );
+        }
+    }
+
+    #[test]
+    fn diagnostic_mixed_gate_up_replay_preserves_supplied_stage_vectors() {
+        let d_model = Q4_0_BLOCK_ELEMS;
+        let d_ff = Q4_0_BLOCK_ELEMS;
+        let bytes = synth_q4_0_blob(d_model, d_ff);
+        let weights =
+            OwnedExpertWeights::from_bytes_q4_0(&bytes, d_model, d_ff).expect("Q4 weights");
+        let gate: Vec<f32> = (0..d_ff).map(|index| index as f32 / 31.0).collect();
+        let up: Vec<f32> = (0..d_ff).map(|index| 1.0 - index as f32 / 63.0).collect();
+        let replay = weights
+            .diagnostic_replay_gate_up(&gate, &up)
+            .expect("mixed replay");
+        assert_eq!(replay.gate, gate);
+        assert_eq!(replay.up, up);
+        assert_eq!(replay.gated.len(), d_ff);
+        assert_eq!(replay.down.len(), d_model);
     }
 
     #[test]

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -143,6 +143,7 @@ mod gpu_native_residency;
 pub(crate) mod gpu_native_diagnostics;
 pub(crate) mod gpu_native_greedy_parity;
 pub(crate) mod gpu_native_layer0_diagnostics;
+pub(crate) mod gpu_native_router_rank_diagnostics;
 
 pub(crate) mod gpu_native_token_loop;
 #[cfg(feature = "grpc")]
@@ -960,6 +961,27 @@ enum Cmd {
         #[arg(long)]
         report_out: Option<PathBuf>,
     },
+    /// Attribute a target GPU-native router rank permutation without changing inference or qualification semantics.
+    DiagnoseGpuNativeRouterRankDivergence {
+        /// Strict GPU-native Q4 configuration.
+        #[arg(long)]
+        config: PathBuf,
+        /// Exact required GPU adapter name (for example, "NVIDIA L4").
+        #[arg(long)]
+        expected_adapter_name: String,
+        /// Fixed-corpus case name.
+        #[arg(long)]
+        case: String,
+        /// Zero-based generated-token position to capture.
+        #[arg(long)]
+        generated_position: usize,
+        /// Zero-based transformer layer to capture.
+        #[arg(long)]
+        layer: usize,
+        /// Required versioned diagnostic JSON destination.
+        #[arg(long)]
+        report_out: PathBuf,
+    },
     /// Diagnose first internal mathematical divergence inside layer-0 attention between CPU reference and GPU-native execution.
     #[command(name = "diagnose-gpu-native-layer0-attention-first-divergence")]
     DiagnoseGpuNativeLayer0AttentionFirstDivergence {
@@ -1652,6 +1674,7 @@ fn startup_config_path(cmd: &Cmd) -> Option<&Path> {
         | Cmd::QualifyGpuNativeQ4GreedyParity { config, .. }
         | Cmd::DiagnoseHybridQ4GreedyDivergence { config, .. }
         | Cmd::DiagnoseGpuNativeQ4FirstDivergence { config, .. }
+        | Cmd::DiagnoseGpuNativeRouterRankDivergence { config, .. }
         | Cmd::DiagnoseGpuNativeLayer0AttentionFirstDivergence { config, .. }
         | Cmd::GreedyParityHybridWorkerInternal { config }
         | Cmd::GreedyParityLogitWorkerInternal { config } => Some(config.as_path()),
@@ -1798,6 +1821,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             | Cmd::QualifyHybridQ4GreedyParity { .. }
             | Cmd::QualifyGpuNativeQ4GreedyParity { .. }
             | Cmd::DiagnoseHybridQ4GreedyDivergence { .. }
+            | Cmd::DiagnoseGpuNativeRouterRankDivergence { .. }
             | Cmd::GreedyParityHybridWorkerInternal { .. }
             | Cmd::GreedyParityLogitWorkerInternal { .. }
     ) && !run_gpu_requested
@@ -2181,6 +2205,32 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 },
             ))
         }
+        Cmd::DiagnoseGpuNativeRouterRankDivergence {
+            config,
+            expected_adapter_name,
+            case,
+            generated_position,
+            layer,
+            report_out,
+        } => {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()?;
+            rt.block_on(cmd_diagnose_gpu_native_router_rank_divergence(
+                DiagnoseGpuNativeRouterRankDivergenceArgs {
+                    config,
+                    parsed_config: startup_config.take().ok_or(
+                        "diagnose-gpu-native-router-rank-divergence startup config was not parsed",
+                    )?,
+                    expected_adapter_name,
+                    case,
+                    generated_position,
+                    layer,
+                    report_out,
+                    progress_watchdog,
+                },
+            ))
+        }
         Cmd::DiagnoseGpuNativeLayer0AttentionFirstDivergence {
             config: _,
             expected_adapter_name,
@@ -2468,6 +2518,17 @@ struct DiagnoseGpuNativeQ4FirstDivergenceArgs {
     expected_adapter_name: String,
     case: String,
     report_out: Option<PathBuf>,
+    progress_watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+}
+
+struct DiagnoseGpuNativeRouterRankDivergenceArgs {
+    config: PathBuf,
+    parsed_config: crate::config::Config,
+    expected_adapter_name: String,
+    case: String,
+    generated_position: usize,
+    layer: usize,
+    report_out: PathBuf,
     progress_watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
 }
 
@@ -6162,6 +6223,25 @@ struct GpuNativeQualificationCapture {
     model_geometry: crate::gpu_native_token_loop::GpuNativeModelGeometry,
 }
 
+struct RouterRankReferenceCapture {
+    generated_token_ids: Vec<u32>,
+    target_trace: crate::gpu_native_diagnostics::ModelDiagnosticTrace,
+    gate: crate::gating::LinearGate,
+    gate_identity: crate::gpu_native_router_rank_diagnostics::GateTensorIdentity,
+    model_load: crate::greedy_parity::ModelLoadEvidence,
+    background_shutdown: crate::greedy_parity::BackgroundShutdownEvidence,
+}
+
+struct RouterRankGpuCapture {
+    generated_token_ids: Vec<u32>,
+    target_trace: crate::gpu_native_router_rank_diagnostics::RouterRankGpuTrace,
+    gate_identity: crate::gpu_native_router_rank_diagnostics::GateTensorIdentity,
+    model_load: crate::greedy_parity::ModelLoadEvidence,
+    device: crate::backend::GpuDeviceIdentity,
+    model_geometry: crate::gpu_native_token_loop::GpuNativeModelGeometry,
+    background_shutdown: crate::greedy_parity::BackgroundShutdownEvidence,
+}
+
 fn emit_gpu_native_greedy_parity_report(
     report: &crate::gpu_native_greedy_parity::GpuNativeGreedyParityReport,
     report_out: Option<&Path>,
@@ -6558,6 +6638,549 @@ async fn execute_gpu_native_qualification_case(
         ))
         .into()),
     }
+}
+
+async fn execute_router_rank_reference(
+    spec: &ResolvedRealCliSpec,
+    tokenizer: Arc<crate::tokenizer::Tokenizer>,
+    prompt_token_ids: &[u32],
+    resolved_config_sha256: &str,
+    generated_position: usize,
+    layer: usize,
+    watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+) -> Result<RouterRankReferenceCapture, Box<dyn std::error::Error>> {
+    let runtime =
+        build_isolated_greedy_runtime(spec, RealCliRuntimeMode::IsolatedGreedyParityCpu, tokenizer)
+            .await?;
+    let attempt = async {
+        runtime.engine.enable_cpu_q4_boundary_emulation()?;
+        let observed_config_sha256 = resolved_real_runtime_identity_sha256(
+            &runtime.cfg,
+            runtime.model.config.architecture,
+            runtime.model.config.first_k_dense_replace,
+            &runtime.model.config.advanced,
+        )?;
+        if observed_config_sha256 != resolved_config_sha256 {
+            return Err(format!(
+                "router-rank reference identity {observed_config_sha256} drifted from {resolved_config_sha256}"
+            )
+            .into());
+        }
+        if layer >= runtime.model.layers.len() {
+            return Err(format!("target layer {layer} is outside loaded reference model").into());
+        }
+        let boundary_before = runtime.engine.cpu_q4_boundary_emulation_snapshot();
+        if !boundary_before.enabled || boundary_before.routed_expert_dispatches != 0 {
+            return Err("router-rank reference boundary emulation did not start clean".into());
+        }
+        let routed_before = runtime.engine.routed_expert_execution_snapshot();
+        let attention_before = crate::transformer::nonfinite_softmax_fallbacks();
+        let gate = runtime.model.layers[layer].gate.clone();
+        let gate_identity =
+            crate::gpu_native_router_rank_diagnostics::GateTensorIdentity::from_gate(layer, &gate);
+        let model_load = greedy_parity_model_load(&runtime);
+        let (generated_token_ids, target_trace) = with_progress_timeout(
+            "GPU-native router-rank authoritative reference".to_string(),
+            watchdog,
+            async {
+                let mut kv = runtime.model.fresh_kv_caches();
+                let prefix_count = prompt_token_ids.len().saturating_sub(1);
+                for (position, &token_id) in prompt_token_ids[..prefix_count].iter().enumerate() {
+                    runtime
+                        .model
+                        .forward_token_hidden(&runtime.engine, token_id, position, &mut kv)
+                        .await?;
+                }
+                let mut input_token = *prompt_token_ids
+                    .last()
+                    .ok_or("router-rank reference prompt is empty")?;
+                let mut position = prefix_count;
+                let mut generated_token_ids = Vec::with_capacity(generated_position + 1);
+                let mut target_trace = None;
+                for index in 0..=generated_position {
+                    let trace = runtime
+                        .model
+                        .forward_token_diagnostic_trace(
+                            &runtime.engine,
+                            input_token,
+                            position,
+                            &mut kv,
+                            None,
+                        )
+                        .await?;
+                    input_token = trace.sampled_token;
+                    generated_token_ids.push(trace.sampled_token);
+                    if index == generated_position {
+                        target_trace = Some(trace);
+                    }
+                    position = position
+                        .checked_add(1)
+                        .ok_or("router-rank reference position overflowed")?;
+                }
+                Ok::<_, Box<dyn std::error::Error>>((
+                    generated_token_ids,
+                    target_trace.ok_or("router-rank reference target trace was not captured")?,
+                ))
+            },
+        )
+        .await?;
+        let boundary_after = runtime.engine.cpu_q4_boundary_emulation_snapshot();
+        if !boundary_after.enabled || boundary_after.routed_expert_dispatches == 0 {
+            return Err("router-rank reference did not exercise the Hybrid F16 boundary".into());
+        }
+        let routed_delta = crate::qualification::routed_execution_delta(
+            routed_before,
+            runtime.engine.routed_expert_execution_snapshot(),
+        )
+        .map_err(|failure| failure.detail)?;
+        if routed_delta.degraded_expert_substitutions != 0
+            || crate::transformer::nonfinite_softmax_fallbacks().saturating_sub(attention_before)
+                != 0
+        {
+            return Err("router-rank reference recorded degraded or nonfinite fallback".into());
+        }
+        Ok::<_, Box<dyn std::error::Error>>(RouterRankReferenceCapture {
+            generated_token_ids,
+            target_trace,
+            gate,
+            gate_identity,
+            model_load,
+            background_shutdown: crate::greedy_parity::BackgroundShutdownEvidence::default(),
+        })
+    }
+    .await;
+    let shutdown = runtime.shutdown_isolated().await;
+    match (attempt, shutdown) {
+        (Ok(mut capture), Ok(shutdown)) => {
+            capture.background_shutdown = shutdown;
+            Ok(capture)
+        }
+        (Err(error), Ok(_)) => Err(error),
+        (Ok(_), Err(shutdown_error)) => Err(shutdown_error.into()),
+        (Err(error), Err(shutdown_error)) => Err(IsolatedRuntimeShutdownError::new(format!(
+            "{error}; router-rank reference shutdown also failed: {shutdown_error}"
+        ))
+        .into()),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn execute_router_rank_gpu(
+    spec: &ResolvedRealCliSpec,
+    tokenizer: Arc<crate::tokenizer::Tokenizer>,
+    prompt_token_ids: &[u32],
+    resolved_config_sha256: &str,
+    expected_adapter_name: &str,
+    case: &str,
+    generated_position: usize,
+    layer: usize,
+    watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+) -> Result<RouterRankGpuCapture, Box<dyn std::error::Error>> {
+    let runtime = build_isolated_greedy_runtime(
+        spec,
+        RealCliRuntimeMode::IsolatedGpuNativeDiagnostic,
+        tokenizer,
+    )
+    .await?;
+    let attempt = async {
+        let observed_config_sha256 = resolved_real_runtime_identity_sha256(
+            &runtime.cfg,
+            runtime.model.config.architecture,
+            runtime.model.config.first_k_dense_replace,
+            &runtime.model.config.advanced,
+        )?;
+        if observed_config_sha256 != resolved_config_sha256 {
+            return Err(format!(
+                "router-rank GPU identity {observed_config_sha256} drifted from {resolved_config_sha256}"
+            )
+            .into());
+        }
+        let device = runtime
+            .engine
+            .gpu_device_identity()
+            .ok_or("router-rank GPU runtime has no authoritative adapter identity")?;
+        if device.name != expected_adapter_name {
+            return Err(format!(
+                "router-rank GPU runtime selected adapter {:?}, expected {:?}",
+                device.name, expected_adapter_name
+            )
+            .into());
+        }
+        if device.software_adapter || device.device_type.eq_ignore_ascii_case("cpu") {
+            return Err(format!(
+                "router-rank GPU runtime selected software adapter {:?}",
+                device.name
+            )
+            .into());
+        }
+        let token_loop = runtime
+            .gpu_native_token_loop
+            .as_ref()
+            .ok_or("GPU-native token loop was not initialized")?;
+        let model_geometry = token_loop.model_geometry();
+        crate::gpu_native_router_rank_diagnostics::validate_target(
+            case,
+            generated_position,
+            layer,
+            expected_adapter_name,
+            model_geometry,
+        )?;
+        if layer >= runtime.model.layers.len() {
+            return Err(format!("target layer {layer} is outside loaded GPU model").into());
+        }
+        let gate_identity =
+            crate::gpu_native_router_rank_diagnostics::GateTensorIdentity::from_gate(
+                layer,
+                &runtime.model.layers[layer].gate,
+            );
+        let model_load = greedy_parity_model_load(&runtime);
+        let counters_before = token_loop.snapshot();
+        if counters_before != crate::gpu_native_token_loop::GpuNativeTokenLoopSnapshot::default() {
+            return Err("router-rank GPU token-loop counters did not start at zero".into());
+        }
+        let routed_before = runtime.engine.routed_expert_execution_snapshot();
+        let attention_before = crate::transformer::nonfinite_softmax_fallbacks();
+        let mut request = token_loop.create_router_rank_diagnostic_request_state()?;
+        let trace_layout =
+            crate::gpu_native_router_rank_diagnostics::RouterRankTraceLayout::try_new(
+                model_geometry,
+                layer,
+            )?;
+        let staging = token_loop.create_router_rank_diagnostic_staging_buffer(&trace_layout)?;
+        let (generated_token_ids, target_trace) = with_progress_timeout(
+            "GPU-native router-rank candidate".to_string(),
+            watchdog,
+            async {
+                let prefix_count = prompt_token_ids.len().saturating_sub(1);
+                for (position, &token_id) in prompt_token_ids[..prefix_count].iter().enumerate() {
+                    token_loop
+                        .step_token(&runtime.engine, &mut request, token_id, position, false)
+                        .await?;
+                }
+                let mut input_token = *prompt_token_ids
+                    .last()
+                    .ok_or("router-rank GPU prompt is empty")?;
+                let mut position = prefix_count;
+                let mut generated_token_ids = Vec::with_capacity(generated_position + 1);
+                let mut target_trace = None;
+                for index in 0..=generated_position {
+                    if index == generated_position {
+                        let (trace, sampled_token, _) = token_loop
+                            .step_token_router_rank_diagnostic(
+                                &runtime.engine,
+                                &mut request,
+                                input_token,
+                                position,
+                                &trace_layout,
+                                &staging,
+                            )
+                            .await?;
+                        generated_token_ids.push(sampled_token);
+                        target_trace = Some(trace);
+                    } else {
+                        let sampled_token = token_loop
+                            .step_token(
+                                &runtime.engine,
+                                &mut request,
+                                input_token,
+                                position,
+                                true,
+                            )
+                            .await?
+                            .ok_or("router-rank GPU generation produced no token")?;
+                        input_token = sampled_token;
+                        generated_token_ids.push(sampled_token);
+                    }
+                    position = position
+                        .checked_add(1)
+                        .ok_or("router-rank GPU position overflowed")?;
+                }
+                Ok::<_, Box<dyn std::error::Error>>((
+                    generated_token_ids,
+                    target_trace.ok_or("router-rank GPU target trace was not captured")?,
+                ))
+            },
+        )
+        .await?;
+        let expected_completed = prompt_token_ids
+            .len()
+            .saturating_sub(1)
+            .checked_add(generated_position + 1)
+            .ok_or("router-rank expected completion count overflowed")?;
+        let counters_after = token_loop.snapshot();
+        if request.committed_position() != expected_completed
+            || counters_after.tokens_completed != expected_completed as u64
+            || counters_after.fatal_failures != 0
+            || counters_after.no_progress_failures != 0
+        {
+            return Err("router-rank GPU request completion/counter evidence is invalid".into());
+        }
+        let routed_delta = crate::qualification::routed_execution_delta(
+            routed_before,
+            runtime.engine.routed_expert_execution_snapshot(),
+        )
+        .map_err(|failure| failure.detail)?;
+        if routed_delta.degraded_expert_substitutions != 0
+            || routed_delta.gpu_cpu_fallbacks != 0
+            || routed_delta.gpu_dispatch_failures != 0
+            || crate::transformer::nonfinite_softmax_fallbacks().saturating_sub(attention_before)
+                != 0
+        {
+            return Err("router-rank GPU run recorded a fallback or dispatch failure".into());
+        }
+        drop(request);
+        drop(staging);
+        Ok::<_, Box<dyn std::error::Error>>(RouterRankGpuCapture {
+            generated_token_ids,
+            target_trace,
+            gate_identity,
+            model_load,
+            device,
+            model_geometry,
+            background_shutdown: crate::greedy_parity::BackgroundShutdownEvidence::default(),
+        })
+    }
+    .await;
+    let shutdown = runtime.shutdown_isolated().await;
+    match (attempt, shutdown) {
+        (Ok(mut capture), Ok(shutdown)) => {
+            capture.background_shutdown = shutdown;
+            Ok(capture)
+        }
+        (Err(error), Ok(_)) => Err(error),
+        (Ok(_), Err(shutdown_error)) => Err(shutdown_error.into()),
+        (Err(error), Err(shutdown_error)) => Err(IsolatedRuntimeShutdownError::new(format!(
+            "{error}; router-rank GPU shutdown also failed: {shutdown_error}"
+        ))
+        .into()),
+    }
+}
+
+fn emit_router_rank_divergence_report(
+    report: &crate::gpu_native_router_rank_diagnostics::RouterRankDivergenceReport,
+    report_out: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if let Some(parent) = report_out.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut json = serde_json::to_vec_pretty(report)?;
+    json.push(b'\n');
+    std::fs::write(report_out, json)?;
+    eprintln!(
+        "GPU-native router-rank diagnostic report written to {}",
+        report_out.display()
+    );
+    Ok(())
+}
+
+async fn cmd_diagnose_gpu_native_router_rank_divergence(
+    args: DiagnoseGpuNativeRouterRankDivergenceArgs,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use crate::qualification::BuildProvenance;
+
+    let cfg = args.parsed_config;
+    let provenance = BuildProvenance::embedded();
+    let (artifacts, artifact_errors) = qualification_artifacts(&args.config, &cfg);
+    if !artifact_errors.is_empty() {
+        return Err(format!(
+            "router-rank diagnostic artifact preflight failed: {}",
+            artifact_errors.join("; ")
+        )
+        .into());
+    }
+    if args.progress_watchdog.timeout.is_none() {
+        return Err("router-rank diagnostic requires a positive progress timeout".into());
+    }
+    if provenance.dirty != Some(false)
+        || provenance
+            .git_sha
+            .as_deref()
+            .is_none_or(|sha| sha.len() != 40 || !sha.bytes().all(|byte| byte.is_ascii_hexdigit()))
+    {
+        return Err("router-rank diagnostic requires clean embedded 40-hex Git provenance".into());
+    }
+    let capacity_bytes = cfg
+        .gpu_cache
+        .vram_capacity_mb
+        .checked_mul(1024 * 1024)
+        .and_then(|bytes| u64::try_from(bytes).ok())
+        .unwrap_or(0);
+    let source_config = crate::gpu_native_greedy_parity::SourceConfigEvidence {
+        real_transformer_enabled: cfg.real_transformer.enabled,
+        gpu_native_enabled: cfg.real_transformer.gpu_native,
+        weights_dir_configured: cfg.real_transformer.weights_dir.is_some(),
+        strict_weights: cfg.real_transformer.strict_weights,
+        allow_seeded_fallback: cfg.real_transformer.allow_seeded_fallback,
+        allow_degraded_experts: cfg.real_transformer.allow_degraded_experts,
+        allow_nonfinite_attention_fallback: cfg.real_transformer.allow_nonfinite_attention_fallback,
+        allow_truncated_expert_payloads: cfg.real_transformer.allow_truncated_expert_payloads,
+        distributed_enabled: cfg.distributed.enabled,
+        gpu_cache_enabled: cfg.gpu_cache.enabled,
+        gpu_expert_capacity_bytes: capacity_bytes,
+        routed_expert_dtype: cfg.model.dtype.as_str().to_string(),
+    };
+    if !source_config.is_strict() {
+        return Err(
+            "router-rank diagnostic requires the strict GPU-native Q4 qualifier configuration"
+                .into(),
+        );
+    }
+    let expert_metadata =
+        crate::qualification::read_expert_metadata(&cfg.model.data_dir.join("metadata.json"))
+            .map_err(|error| format!("router-rank expert metadata preflight failed: {error}"))?;
+    if expert_metadata.q4_0_layout.as_deref() != Some(crate::inference::Q4_0_LAYOUT_STANDARD_V1)
+        || expert_metadata.explicitly_synthetic
+    {
+        return Err("router-rank diagnostic requires canonical nonsynthetic Q4_0 metadata".into());
+    }
+    let fixed_case = crate::greedy_parity::fixed_case(&args.case)
+        .ok_or_else(|| format!("unknown fixed corpus case {:?}", args.case))?;
+    if args.generated_position >= crate::greedy_parity::OUTPUT_TOKEN_LIMIT
+        || args.layer >= cfg.model.num_layers
+        || cfg.model.num_experts <= crate::gpu_native_router_rank_diagnostics::HIGHER_EXPERT_ID
+        || cfg.model.top_k != crate::gpu_native_router_rank_diagnostics::REQUIRED_TOP_K
+        || args.expected_adapter_name.trim().is_empty()
+    {
+        return Err("router-rank target, expert geometry, or adapter is invalid".into());
+    }
+
+    let mut gpu_spec =
+        resolve_real_cli_spec_from_config(cfg, RealCliRuntimeMode::IsolatedGpuNativeDiagnostic)?;
+    gpu_spec.cfg.real_transformer.gpu_native = true;
+    gpu_spec.cfg.real_transformer.compute_offload = crate::backend::ComputeOffload::Gpu;
+    let model_identity = greedy_parity_model_identity(&gpu_spec);
+    if !model_identity.is_qwen3_coder_30b_a3b_q4_0() {
+        return Err(
+            "router-rank diagnostic requires exact Qwen3-Coder 30B-A3B Q4_0 geometry".into(),
+        );
+    }
+    let gpu_resolved_config_sha256 = resolved_real_cli_spec_sha256(&gpu_spec)?;
+    let mut reference_spec = gpu_spec.clone();
+    reference_spec.cfg.real_transformer.gpu_native = false;
+    reference_spec.cfg.real_transformer.compute_offload = crate::backend::ComputeOffload::Cpu;
+    let reference_resolved_config_sha256 = resolved_real_cli_spec_sha256(&reference_spec)?;
+    let tokenizer = load_real_cli_tokenizer(
+        &gpu_spec.cfg,
+        RealCliRuntimeMode::IsolatedGpuNativeDiagnostic,
+    )?;
+    let prompt_token_ids = tokenizer.encode(fixed_case.prompt)?;
+    if prompt_token_ids.is_empty() {
+        return Err("router-rank fixed prompt encoded to zero tokens".into());
+    }
+
+    let reference = execute_router_rank_reference(
+        &reference_spec,
+        tokenizer.clone(),
+        &prompt_token_ids,
+        &reference_resolved_config_sha256,
+        args.generated_position,
+        args.layer,
+        args.progress_watchdog,
+    )
+    .await?;
+    let gpu = execute_router_rank_gpu(
+        &gpu_spec,
+        tokenizer,
+        &prompt_token_ids,
+        &gpu_resolved_config_sha256,
+        &args.expected_adapter_name,
+        fixed_case.name,
+        args.generated_position,
+        args.layer,
+        args.progress_watchdog,
+    )
+    .await?;
+    crate::gpu_native_router_rank_diagnostics::validate_target(
+        fixed_case.name,
+        args.generated_position,
+        args.layer,
+        &args.expected_adapter_name,
+        gpu.model_geometry,
+    )?;
+
+    let reference_hidden = reference
+        .target_trace
+        .layer_router_input
+        .get(args.layer)
+        .ok_or("reference target router input is missing")?;
+    let reference_router = crate::gpu_native_router_rank_diagnostics::evaluate_cpu_router(
+        "reference-hidden-to-cpu-production-router",
+        &reference.gate,
+        reference_hidden,
+    )?;
+    let captured_reference_ids = reference
+        .target_trace
+        .layer_selected_ids
+        .get(args.layer)
+        .ok_or("reference target selected IDs are missing")?;
+    let captured_reference_weights = reference
+        .target_trace
+        .layer_selected_weights
+        .get(args.layer)
+        .ok_or("reference target selected weights are missing")?;
+    if captured_reference_ids != &reference_router.top_8_ids
+        || captured_reference_weights
+            .iter()
+            .map(|value| value.to_bits())
+            .ne(reference_router
+                .top_8_weights
+                .iter()
+                .map(|value| value.bits))
+    {
+        return Err(
+            "recomputed reference router evidence differs from the captured production decision"
+                .into(),
+        );
+    }
+    let cpu_on_gpu_input = crate::gpu_native_router_rank_diagnostics::evaluate_cpu_router(
+        "gpu-hidden-to-cpu-production-router",
+        &reference.gate,
+        &gpu.target_trace.router_input,
+    )?;
+    let actual_gpu_router = crate::gpu_native_router_rank_diagnostics::evaluate_actual_gpu_router(
+        gpu.target_trace.raw_logits,
+        gpu.target_trace.selected_ids,
+        gpu.target_trace.selected_weights,
+    )?;
+    let gate_identity = crate::gpu_native_router_rank_diagnostics::GateIdentityEvidence::new(
+        reference.gate_identity,
+        gpu.gate_identity,
+    );
+    let (_, executable_sha256) = current_executable_identity()?;
+    let report = crate::gpu_native_router_rank_diagnostics::RouterRankDivergenceReport::build(
+        crate::gpu_native_router_rank_diagnostics::DiagnosticProvenance {
+            build: provenance,
+            executable_sha256,
+            artifacts,
+            gpu_resolved_config_sha256,
+            reference_resolved_config_sha256,
+            model_identity,
+            reference_model_load: reference.model_load,
+            gpu_native_model_load: gpu.model_load,
+            reference_background_shutdown: reference.background_shutdown,
+            gpu_native_background_shutdown: gpu.background_shutdown,
+            expert_metadata,
+            device: gpu.device,
+        },
+        fixed_case.name,
+        args.generated_position,
+        args.layer,
+        prompt_token_ids,
+        reference.generated_token_ids,
+        gpu.generated_token_ids,
+        reference_hidden,
+        &gpu.target_trace.router_input,
+        gate_identity,
+        reference_router,
+        cpu_on_gpu_input,
+        actual_gpu_router,
+    )?;
+    let failure = report.failure.clone();
+    emit_router_rank_divergence_report(&report, &args.report_out)?;
+    if let Some(failure) = failure {
+        return Err(failure.into());
+    }
+    Ok(())
 }
 
 async fn cmd_qualify_gpu_native_q4_greedy_parity(
@@ -13316,6 +13939,44 @@ mod tests {
         assert_eq!(config, PathBuf::from("strict-gpu-native.toml"));
         assert_eq!(expected_adapter_name, "NVIDIA L4");
         assert_eq!(report_out, Some(PathBuf::from("gpu-native-report.json")));
+    }
+
+    #[test]
+    fn gpu_native_router_rank_diagnostic_cli_has_explicit_target_surface() {
+        let cli = <Cli as clap::Parser>::try_parse_from([
+            "micro-expert-router",
+            "diagnose-gpu-native-router-rank-divergence",
+            "--config",
+            "strict-gpu-native.toml",
+            "--expected-adapter-name",
+            "NVIDIA L4",
+            "--case",
+            "rust-generation",
+            "--generated-position",
+            "5",
+            "--layer",
+            "44",
+            "--report-out",
+            "router-rank.json",
+        ])
+        .unwrap();
+        let Cmd::DiagnoseGpuNativeRouterRankDivergence {
+            config,
+            expected_adapter_name,
+            case,
+            generated_position,
+            layer,
+            report_out,
+        } = cli.cmd
+        else {
+            panic!("expected diagnose-gpu-native-router-rank-divergence command");
+        };
+        assert_eq!(config, PathBuf::from("strict-gpu-native.toml"));
+        assert_eq!(expected_adapter_name, "NVIDIA L4");
+        assert_eq!(case, "rust-generation");
+        assert_eq!(generated_position, 5);
+        assert_eq!(layer, 44);
+        assert_eq!(report_out, PathBuf::from("router-rank.json"));
     }
 
     #[test]

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -5505,25 +5505,62 @@ async fn cmd_diagnose_gpu_native_q4_first_divergence(
     }
     report.actual_adapter = Some(device);
 
-    let mut req_state = gpu_native_token_loop.create_request_state()?;
+    let mut req_state = match gpu_native_token_loop.create_request_state() {
+        Ok(state) => state,
+        Err(e) => {
+            return fail_gpu_native_first_divergence(
+                report,
+                format!("failed to create request state: {e}"),
+                args.report_out.as_deref(),
+            );
+        }
+    };
+
     for (pos, &tid) in prompt_token_ids[..prompt_token_ids.len() - 1]
         .iter()
         .enumerate()
     {
-        gpu_native_token_loop
+        if let Err(e) = gpu_native_token_loop
             .step_token(&gpu_runtime.engine, &mut req_state, tid, pos, false)
-            .await?;
+            .await
+        {
+            return fail_gpu_native_first_divergence(
+                report,
+                format!("prefix prompt step failed at position {pos} (token {tid}): {e}"),
+                args.report_out.as_deref(),
+            );
+        }
     }
 
-    let trace_layout = crate::gpu_native_diagnostics::GpuNativeDiagnosticTraceLayout::try_new(
-        cfg.model.num_layers,
-        cfg.model.d_model,
-        cfg.model.top_k,
-        cfg.real_transformer.vocab_size,
-    )?;
-    let staging_buffer = gpu_native_token_loop.create_diagnostic_staging_buffer(&trace_layout)?;
+    let trace_layout = match crate::gpu_native_diagnostics::GpuNativeDiagnosticTraceLayout::try_new(
+        model_geometry.num_layers,
+        model_geometry.d_model,
+        model_geometry.top_k,
+        model_geometry.vocab_size,
+    ) {
+        Ok(layout) => layout,
+        Err(e) => {
+            return fail_gpu_native_first_divergence(
+                report,
+                format!("failed to construct trace layout: {e}"),
+                args.report_out.as_deref(),
+            );
+        }
+    };
 
-    let (gpu_trace, attempts) = gpu_native_token_loop
+    let staging_buffer =
+        match gpu_native_token_loop.create_diagnostic_staging_buffer(&trace_layout) {
+            Ok(buf) => buf,
+            Err(e) => {
+                return fail_gpu_native_first_divergence(
+                    report,
+                    format!("failed to create diagnostic staging buffer: {e}"),
+                    args.report_out.as_deref(),
+                );
+            }
+        };
+
+    let (gpu_trace, attempts) = match gpu_native_token_loop
         .step_token_diagnostic(
             &gpu_runtime.engine,
             &mut req_state,
@@ -5533,7 +5570,19 @@ async fn cmd_diagnose_gpu_native_q4_first_divergence(
             &trace_layout,
             &staging_buffer,
         )
-        .await?;
+        .await
+    {
+        Ok(res) => res,
+        Err(e) => {
+            return fail_gpu_native_first_divergence(
+                report,
+                format!(
+                    "diagnostic step failed at final position {final_pos} (token {final_tid}): {e}"
+                ),
+                args.report_out.as_deref(),
+            );
+        }
+    };
 
     let counters_delta = gpu_native_token_loop.snapshot();
     drop(req_state);
@@ -5542,7 +5591,16 @@ async fn cmd_diagnose_gpu_native_q4_first_divergence(
 
     // 3. Comparison
     let (first_exact_divergence, first_divergence, stages) =
-        crate::gpu_native_diagnostics::compare_diagnostic_traces(&ref_trace, &gpu_trace)?;
+        match crate::gpu_native_diagnostics::compare_diagnostic_traces(&ref_trace, &gpu_trace) {
+            Ok(res) => res,
+            Err(e) => {
+                return fail_gpu_native_first_divergence(
+                    report,
+                    format!("failed to compare diagnostic traces: {e}"),
+                    args.report_out.as_deref(),
+                );
+            }
+        };
 
     report.reference_sampled_token_id = Some(ref_trace.sampled_token);
     report.gpu_native_sampled_token_id = Some(gpu_trace.sampled_token);

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -141,6 +141,7 @@ mod gguf;
 mod gguf_loader;
 mod gpu_native_residency;
 pub(crate) mod gpu_native_diagnostics;
+pub(crate) mod gpu_native_layer0_diagnostics;
 
 pub(crate) mod gpu_native_token_loop;
 #[cfg(feature = "grpc")]
@@ -943,6 +944,25 @@ enum Cmd {
         #[arg(long)]
         report_out: Option<PathBuf>,
     },
+    /// Diagnose first internal mathematical divergence inside layer-0 attention between CPU reference and GPU-native execution.
+    #[command(name = "diagnose-gpu-native-layer0-attention-first-divergence")]
+    DiagnoseGpuNativeLayer0AttentionFirstDivergence {
+        /// Strict GPU-native Q4 configuration.
+        #[arg(long)]
+        config: PathBuf,
+        /// Expected GPU adapter name (e.g. "NVIDIA L4").
+        #[arg(long)]
+        expected_adapter_name: String,
+        /// Target case (e.g. "json-transformation").
+        #[arg(long, default_value = "json-transformation")]
+        case: String,
+        /// Optional typed diagnostic report output path.
+        #[arg(long)]
+        report_out: Option<PathBuf>,
+        /// Optional Slice 11B report path to cross-check final-position layer-0 post-attention evidence.
+        #[arg(long)]
+        slice11b_report: Option<PathBuf>,
+    },
 
 
 
@@ -1615,6 +1635,7 @@ fn startup_config_path(cmd: &Cmd) -> Option<&Path> {
         | Cmd::QualifyHybridQ4GreedyParity { config, .. }
         | Cmd::DiagnoseHybridQ4GreedyDivergence { config, .. }
         | Cmd::DiagnoseGpuNativeQ4FirstDivergence { config, .. }
+        | Cmd::DiagnoseGpuNativeLayer0AttentionFirstDivergence { config, .. }
         | Cmd::GreedyParityHybridWorkerInternal { config }
         | Cmd::GreedyParityLogitWorkerInternal { config } => Some(config.as_path()),
         _ => None,
@@ -2122,6 +2143,29 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 },
             ))
         }
+        Cmd::DiagnoseGpuNativeLayer0AttentionFirstDivergence {
+            config: _,
+            expected_adapter_name,
+            case,
+            report_out,
+            slice11b_report,
+        } => {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()?;
+            rt.block_on(cmd_diagnose_gpu_native_layer0_attention_first_divergence(
+                DiagnoseGpuNativeLayer0AttentionFirstDivergenceArgs {
+                    parsed_config: startup_config
+                        .take()
+                        .ok_or("diagnose-gpu-native-layer0-attention-first-divergence startup config was not parsed")?,
+                    expected_adapter_name,
+                    case,
+                    report_out,
+                    slice11b_report,
+                    progress_watchdog,
+                },
+            ))
+        }
 
         Cmd::MatvecMicrobench {
             backend,
@@ -2378,6 +2422,15 @@ struct DiagnoseGpuNativeQ4FirstDivergenceArgs {
     expected_adapter_name: String,
     case: String,
     report_out: Option<PathBuf>,
+    progress_watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+}
+
+struct DiagnoseGpuNativeLayer0AttentionFirstDivergenceArgs {
+    parsed_config: crate::config::Config,
+    expected_adapter_name: String,
+    case: String,
+    report_out: Option<PathBuf>,
+    slice11b_report: Option<PathBuf>,
     progress_watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
 }
 
@@ -5615,6 +5668,359 @@ async fn cmd_diagnose_gpu_native_q4_first_divergence(
 
     emit_gpu_native_first_divergence_report(&report, args.report_out.as_deref())
 }
+
+fn emit_layer0_attention_first_divergence_report(
+    report: &crate::gpu_native_layer0_diagnostics::Layer0AttentionFirstDivergenceReport,
+    out_path: Option<&std::path::Path>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let json = serde_json::to_string_pretty(report)?;
+    if let Some(path) = out_path {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(path, json)?;
+        info!(
+            report = %path.display(),
+            "GPU-native layer-0 attention first-divergence diagnostic report written"
+        );
+    } else {
+        println!("{json}");
+    }
+    if let Some(ref failure) = report.failure {
+        Err(failure.clone().into())
+    } else {
+        Ok(())
+    }
+}
+
+fn fail_layer0_attention_first_divergence(
+    mut report: crate::gpu_native_layer0_diagnostics::Layer0AttentionFirstDivergenceReport,
+    reason: String,
+    out_path: Option<&std::path::Path>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    report.fail(reason);
+    emit_layer0_attention_first_divergence_report(&report, out_path)
+}
+
+async fn cmd_diagnose_gpu_native_layer0_attention_first_divergence(
+    args: DiagnoseGpuNativeLayer0AttentionFirstDivergenceArgs,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use crate::qualification::BuildProvenance;
+
+    let provenance = BuildProvenance::embedded();
+    let build_git_sha = provenance
+        .git_sha
+        .clone()
+        .unwrap_or_else(|| "unknown".to_string());
+    let (_, executable_sha256) = current_executable_identity()?;
+
+    let cfg = args.parsed_config.clone();
+    let metadata_path = cfg.model.data_dir.join("metadata.json");
+    let expert_metadata = crate::qualification::read_expert_metadata(&metadata_path)
+        .map_err(|e| format!("failed to read expert metadata: {e}"))?;
+
+    let fixed_case = crate::greedy_parity::fixed_case(&args.case).ok_or_else(|| {
+        format!(
+            "unknown corpus case: {}; expected one of: rust-generation, rust-debugging, json-transformation, multilingual-spanish",
+            args.case
+        )
+    })?;
+
+    let prompt_sha256 = crate::greedy_parity::sha256_hex(fixed_case.prompt.as_bytes());
+
+    let mut gpu_spec = resolve_real_cli_spec_from_config(
+        cfg.clone(),
+        RealCliRuntimeMode::IsolatedGpuNativeDiagnostic,
+    )?;
+    gpu_spec.cfg.real_transformer.gpu_native = true;
+    gpu_spec.cfg.real_transformer.compute_offload = crate::backend::ComputeOffload::Gpu;
+    gpu_spec.cfg.real_transformer.strict_weights = true;
+    gpu_spec.cfg.real_transformer.allow_degraded_experts = false;
+    gpu_spec.cfg.real_transformer.allow_seeded_fallback = false;
+
+    let resolved_config_sha256 = resolved_real_cli_spec_sha256(&gpu_spec)?;
+
+    // 1. Reference Phase (CPU with strict weights)
+    let mut ref_spec = resolve_real_cli_spec_from_config(
+        cfg.clone(),
+        RealCliRuntimeMode::IsolatedGreedyParityCpu,
+    )?;
+    ref_spec.cfg.real_transformer.gpu_native = false;
+    ref_spec.cfg.real_transformer.compute_offload = crate::backend::ComputeOffload::Cpu;
+    ref_spec.cfg.real_transformer.strict_weights = true;
+    ref_spec.cfg.real_transformer.allow_degraded_experts = false;
+    ref_spec.cfg.real_transformer.allow_seeded_fallback = false;
+
+    let ref_context =
+        resolve_isolated_real_cli_context(&ref_spec, crate::backend::ComputeOffload::Cpu)?;
+
+    let ref_runtime = build_real_cli_runtime_from_spec(
+        &ref_spec,
+        RealCliRuntimeMode::IsolatedGreedyParityCpu,
+        ref_context,
+        None,
+    )
+    .await?;
+
+    let prompt_token_ids = ref_runtime.tokenizer.encode(fixed_case.prompt)?;
+    if prompt_token_ids.is_empty() {
+        return Err("prompt tokenized to zero tokens".into());
+    }
+
+    // 2. GPU-Native Phase
+    let gpu_context =
+        resolve_isolated_real_cli_context(&gpu_spec, crate::backend::ComputeOffload::Gpu)?;
+
+    let gpu_runtime = build_real_cli_runtime_from_spec(
+        &gpu_spec,
+        RealCliRuntimeMode::IsolatedGpuNativeDiagnostic,
+        gpu_context,
+        None,
+    )
+    .await?;
+
+    let device = gpu_runtime
+        .engine
+        .execution_context()
+        .gpu_device_identity()
+        .ok_or("GPU execution context has no active device identity")?;
+
+    let gpu_native_token_loop = gpu_runtime
+        .gpu_native_token_loop
+        .clone()
+        .ok_or("GPU-native token loop was not initialized on GPU runtime")?;
+
+    let model_geometry = gpu_native_token_loop.model_geometry();
+
+    let case_evidence = crate::gpu_native_diagnostics::CaseEvidence {
+        case_name: fixed_case.name.to_string(),
+        prompt_sha256,
+        prompt_token_count: prompt_token_ids.len(),
+    };
+
+    let mut report = crate::gpu_native_layer0_diagnostics::Layer0AttentionFirstDivergenceReport::new(
+        provenance,
+        build_git_sha,
+        executable_sha256,
+        resolved_config_sha256.clone(),
+        model_geometry,
+        expert_metadata,
+        case_evidence,
+        crate::greedy_parity::token_ids_sha256(&prompt_token_ids),
+        prompt_token_ids.clone(),
+        args.expected_adapter_name.clone(),
+    );
+
+    if device.name != args.expected_adapter_name {
+        return fail_layer0_attention_first_divergence(
+            report,
+            format!(
+                "adapter mismatch: runtime has {:?}, expected {:?}",
+                device.name, args.expected_adapter_name
+            ),
+            args.report_out.as_deref(),
+        );
+    }
+    report.actual_adapter = Some(device);
+
+    let q_width = model_geometry.num_heads * model_geometry.head_dim;
+    let kv_width = model_geometry.num_kv_heads * model_geometry.head_dim;
+
+    let trace_layout = match crate::gpu_native_layer0_diagnostics::Layer0AttentionDiagnosticTraceLayout::try_new(
+        model_geometry.d_model,
+        q_width,
+        kv_width,
+    ) {
+        Ok(layout) => layout,
+        Err(e) => {
+            return fail_layer0_attention_first_divergence(
+                report,
+                format!("failed to construct Layer0 trace layout: {e}"),
+                args.report_out.as_deref(),
+            );
+        }
+    };
+
+    let staging_buffer = match gpu_native_token_loop
+        .create_layer0_diagnostic_staging_buffer(&trace_layout)
+    {
+        Ok(buf) => buf,
+        Err(e) => {
+            return fail_layer0_attention_first_divergence(
+                report,
+                format!("failed to create Layer0 diagnostic staging buffer: {e}"),
+                args.report_out.as_deref(),
+            );
+        }
+    };
+
+    let mut req_state = match gpu_native_token_loop.create_request_state() {
+        Ok(state) => state,
+        Err(e) => {
+            return fail_layer0_attention_first_divergence(
+                report,
+                format!("failed to create request state: {e}"),
+                args.report_out.as_deref(),
+            );
+        }
+    };
+
+    if ref_runtime.model.layers.is_empty() {
+        return fail_layer0_attention_first_divergence(
+            report,
+            "reference model has zero layers".to_string(),
+            args.report_out.as_deref(),
+        );
+    }
+
+    let ref_layer0 = &ref_runtime.model.layers[0];
+    let mut ref_kv = crate::transformer::KvCache::new(ref_layer0.attn.kv_dim());
+    let ref_backend = ref_runtime.engine.execution_context().attention_backend();
+
+    let mut position_comparisons = Vec::with_capacity(prompt_token_ids.len());
+    let mut earliest_divergent_position: Option<usize> = None;
+    let mut first_internal_divergence: Option<crate::gpu_native_layer0_diagnostics::Layer0AttentionFirstDivergenceEvidence> = None;
+    let mut final_position_post_attention: Option<crate::gpu_native_layer0_diagnostics::Layer0AttentionStageComparison> = None;
+
+    let mut ref_scratch = crate::transformer::TransformerLayerScratch::new();
+    let mut ref_out = Vec::with_capacity(model_geometry.d_model);
+
+    for (pos, &tid) in prompt_token_ids.iter().enumerate() {
+        // 1. CPU Reference Execution for Layer 0
+        let emb = match ref_runtime.model.try_embed(tid) {
+            Ok(v) => v,
+            Err(e) => {
+                return fail_layer0_attention_first_divergence(
+                    report,
+                    format!("CPU reference embedding failed at pos {pos} (token {tid}): {e}"),
+                    args.report_out.as_deref(),
+                );
+            }
+        };
+
+        let mut cpu_sink = crate::transformer::Layer0AttentionCpuDiagnosticSink {
+            embedding: Some(emb.clone()),
+            ..Default::default()
+        };
+
+        ref_out.clear();
+        if let Err(e) = ref_layer0.try_attn_block_into_layer0_diagnostic(
+            &emb,
+            pos,
+            0,
+            &mut ref_kv,
+            &**ref_backend,
+            &mut ref_scratch,
+            &mut ref_out,
+            None,
+            &mut cpu_sink,
+        ) {
+            return fail_layer0_attention_first_divergence(
+                report,
+                format!("CPU reference layer-0 attention failed at pos {pos} (token {tid}): {e:?}"),
+                args.report_out.as_deref(),
+            );
+        }
+
+        // 2. GPU-Native Execution for Layer 0
+        let gpu_trace = match gpu_native_token_loop
+            .step_layer0_attention_diagnostic(
+                &gpu_runtime.engine,
+                &mut req_state,
+                tid,
+                pos,
+                &trace_layout,
+                &staging_buffer,
+            )
+            .await
+        {
+            Ok(t) => t,
+            Err(e) => {
+                return fail_layer0_attention_first_divergence(
+                    report,
+                    format!("GPU layer-0 diagnostic step failed at pos {pos} (token {tid}): {e}"),
+                    args.report_out.as_deref(),
+                );
+            }
+        };
+
+        // 3. Comparison
+        let pos_comp = match crate::gpu_native_layer0_diagnostics::compare_layer0_attention_traces(
+            pos,
+            tid,
+            &cpu_sink,
+            &gpu_trace,
+        ) {
+            Ok(c) => c,
+            Err(e) => {
+                return fail_layer0_attention_first_divergence(
+                    report,
+                    format!("comparison failed at pos {pos} (token {tid}): {e}"),
+                    args.report_out.as_deref(),
+                );
+            }
+        };
+
+        if !pos_comp.exact_match && earliest_divergent_position.is_none() {
+            earliest_divergent_position = Some(pos);
+            first_internal_divergence = pos_comp.first_divergence.clone();
+        }
+
+        if pos == prompt_token_ids.len() - 1 {
+            final_position_post_attention = pos_comp
+                .stages
+                .iter()
+                .find(|s| s.stage == crate::gpu_native_layer0_diagnostics::Layer0AttentionStage::PostAttentionResidual)
+                .cloned();
+        }
+
+        position_comparisons.push(pos_comp);
+    }
+
+    drop(req_state);
+    drop(staging_buffer);
+    let _ = ref_runtime.shutdown_isolated().await;
+    let _ = gpu_runtime.shutdown_isolated().await;
+
+    // 4. Optional Slice 11B Cross-Check
+    let slice11b_cross_check = if let Some(ref path) = args.slice11b_report {
+        let final_stage = final_position_post_attention.as_ref().ok_or("no final position post-attention evidence recorded")?;
+        let check = match crate::gpu_native_layer0_diagnostics::cross_check_slice11b_report(path, final_stage) {
+            Ok(c) => c,
+            Err(e) => {
+                return fail_layer0_attention_first_divergence(
+                    report,
+                    format!("Slice 11B report cross-check failed: {e}"),
+                    args.report_out.as_deref(),
+                );
+            }
+        };
+        if check.cross_check_status != "verified_match" {
+            let disc = check.discrepancy.clone().unwrap_or_default();
+            report.slice11b_cross_check = Some(check);
+            return fail_layer0_attention_first_divergence(
+                report,
+                format!("Slice 11B layer-0 replay cross-check mismatch: {disc}"),
+                args.report_out.as_deref(),
+            );
+        }
+        Some(check)
+    } else {
+        None
+    };
+
+    report.earliest_divergent_position = earliest_divergent_position;
+    report.first_internal_divergence = first_internal_divergence;
+    report.position_comparisons = position_comparisons;
+    report.final_position_post_attention = final_position_post_attention;
+    report.slice11b_cross_check = slice11b_cross_check;
+    report.diagnostic_complete = true;
+    report.qualification_pass = false;
+
+    emit_layer0_attention_first_divergence_report(&report, args.report_out.as_deref())
+}
+
+
 
 
 
@@ -12733,6 +13139,67 @@ mod tests {
             Some(Path::new("config.toml"))
         );
     }
+
+    #[test]
+    fn gpu_native_layer0_attention_first_divergence_cli_parses_expected_flags() {
+        let cli = <Cli as clap::Parser>::try_parse_from([
+            "micro-expert-router",
+            "diagnose-gpu-native-layer0-attention-first-divergence",
+            "--config",
+            "config.toml",
+            "--expected-adapter-name",
+            "NVIDIA L4",
+            "--case",
+            "json-transformation",
+            "--report-out",
+            "layer0_report.json",
+            "--slice11b-report",
+            "slice11b.json",
+        ])
+        .unwrap();
+
+        match &cli.cmd {
+            Cmd::DiagnoseGpuNativeLayer0AttentionFirstDivergence {
+                config,
+                expected_adapter_name,
+                case,
+                report_out,
+                slice11b_report,
+            } => {
+                assert_eq!(config, &PathBuf::from("config.toml"));
+                assert_eq!(expected_adapter_name, "NVIDIA L4");
+                assert_eq!(case, "json-transformation");
+                assert_eq!(report_out, &Some(PathBuf::from("layer0_report.json")));
+                assert_eq!(slice11b_report, &Some(PathBuf::from("slice11b.json")));
+            }
+            _ => panic!("unexpected command variant"),
+        }
+        assert_eq!(
+            super::startup_config_path(&cli.cmd),
+            Some(Path::new("config.toml"))
+        );
+    }
+
+    #[test]
+    fn startup_config_path_resolves_gpu_native_layer0_attention_first_divergence() {
+        let cli = <Cli as clap::Parser>::try_parse_from([
+            "micro-expert-router",
+            "diagnose-gpu-native-layer0-attention-first-divergence",
+            "--config",
+            "config.toml",
+            "--expected-adapter-name",
+            "NVIDIA L4",
+            "--case",
+            "json-transformation",
+        ])
+        .unwrap();
+
+        assert_eq!(
+            super::startup_config_path(&cli.cmd),
+            Some(Path::new("config.toml"))
+        );
+    }
+
 
     #[test]
     fn isolated_execution_context_contract_selects_expected_planes() {

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -144,6 +144,7 @@ pub(crate) mod gpu_native_diagnostics;
 pub(crate) mod gpu_native_expert_permutation_semantic_parity;
 pub(crate) mod gpu_native_greedy_parity;
 pub(crate) mod gpu_native_layer0_diagnostics;
+pub(crate) mod gpu_native_q4_expert_stage_attribution;
 pub(crate) mod gpu_native_router_rank_diagnostics;
 pub(crate) mod gpu_native_semantic_parity_corpus;
 pub(crate) mod gpu_native_semantic_parity_v2;
@@ -971,6 +972,26 @@ enum Cmd {
         report_out: PathBuf,
     },
 
+    /// Attribute internal stages of the frozen GPU-native Q4 expert failures.
+    #[command(name = "diagnose-gpu-native-q4-expert-stages")]
+    DiagnoseGpuNativeQ4ExpertStages {
+        /// Path to the strict GPU-native Q4 TOML config.
+        #[arg(long)]
+        config: PathBuf,
+        /// Exact wgpu adapter name required for the isolated GPU runtime.
+        #[arg(long)]
+        expected_adapter_name: String,
+        /// Exact frozen bea attribution report consumed as immutable evidence.
+        #[arg(long)]
+        bea_report: PathBuf,
+        /// Required frozen SHA256 of the supplied bea report.
+        #[arg(long)]
+        expected_bea_report_sha256: String,
+        /// Required typed diagnostic JSON destination.
+        #[arg(long)]
+        report_out: PathBuf,
+    },
+
     /// Collect reproducibility and complete first-token CPU/Hybrid logit
     /// evidence for the fixed json-transformation case.
     DiagnoseHybridQ4GreedyDivergence {
@@ -1745,6 +1766,7 @@ fn startup_config_path(cmd: &Cmd) -> Option<&Path> {
         | Cmd::QualifyGpuNativeQ4GreedyParity { config, .. }
         | Cmd::QualifyGpuNativeSemanticParityV2 { config, .. }
         | Cmd::DiagnoseGpuNativeV2HoldoutFailures { config, .. }
+        | Cmd::DiagnoseGpuNativeQ4ExpertStages { config, .. }
         | Cmd::DiagnoseHybridQ4GreedyDivergence { config, .. }
         | Cmd::DiagnoseGpuNativeQ4FirstDivergence { config, .. }
         | Cmd::DiagnoseGpuNativeRouterRankDivergence { config, .. }
@@ -2250,6 +2272,30 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     expected_adapter_name,
                     v2_report,
                     expected_v2_report_sha256,
+                    report_out,
+                    progress_watchdog,
+                ),
+            )
+        }
+        Cmd::DiagnoseGpuNativeQ4ExpertStages {
+            config,
+            expected_adapter_name,
+            bea_report,
+            expected_bea_report_sha256,
+            report_out,
+        } => {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()?;
+            rt.block_on(
+                crate::gpu_native_q4_expert_stage_attribution::run_diagnostic(
+                    config,
+                    startup_config.take().ok_or(
+                        "diagnose-gpu-native-q4-expert-stages startup config was not parsed",
+                    )?,
+                    expected_adapter_name,
+                    bea_report,
+                    expected_bea_report_sha256,
                     report_out,
                     progress_watchdog,
                 ),
@@ -14834,6 +14880,54 @@ mod tests {
             crate::gpu_native_v2_holdout_failure_attribution::FROZEN_V2_REPORT_SHA256
         );
         assert_eq!(report_out, &PathBuf::from("v2-holdout-attribution.json"));
+        assert_eq!(
+            super::startup_config_path(&cli.cmd),
+            Some(Path::new("strict-gpu-native.toml"))
+        );
+    }
+
+    #[test]
+    fn q4_expert_stage_attribution_cli_has_versioned_frozen_surface() {
+        let cli = <Cli as clap::Parser>::try_parse_from([
+            "micro-expert-router",
+            "diagnose-gpu-native-q4-expert-stages",
+            "--config",
+            "strict-gpu-native.toml",
+            "--expected-adapter-name",
+            "NVIDIA L4",
+            "--bea-report",
+            "bea-attribution.json",
+            "--expected-bea-report-sha256",
+            crate::gpu_native_q4_expert_stage_attribution::FROZEN_BEA_REPORT_SHA256,
+            "--report-out",
+            "q4-expert-stages.json",
+            "--progress-timeout-secs",
+            "300",
+        ])
+        .unwrap();
+        assert_eq!(cli.progress_timeout_secs, Some(300));
+        let Cmd::DiagnoseGpuNativeQ4ExpertStages {
+            config,
+            expected_adapter_name,
+            bea_report,
+            expected_bea_report_sha256,
+            report_out,
+        } = &cli.cmd
+        else {
+            panic!("expected diagnose-gpu-native-q4-expert-stages command");
+        };
+        assert_eq!(config, &PathBuf::from("strict-gpu-native.toml"));
+        assert_eq!(expected_adapter_name, "NVIDIA L4");
+        assert_eq!(bea_report, &PathBuf::from("bea-attribution.json"));
+        assert_eq!(
+            expected_bea_report_sha256,
+            crate::gpu_native_q4_expert_stage_attribution::FROZEN_BEA_REPORT_SHA256
+        );
+        assert_eq!(report_out, &PathBuf::from("q4-expert-stages.json"));
+        assert_eq!(
+            crate::gpu_native_q4_expert_stage_attribution::SCHEMA_VERSION,
+            "mer.gpu-native-q4-expert-stage-attribution.v1"
+        );
         assert_eq!(
             super::startup_config_path(&cli.cmd),
             Some(Path::new("strict-gpu-native.toml"))

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -141,6 +141,7 @@ mod gguf;
 mod gguf_loader;
 mod gpu_native_residency;
 pub(crate) mod gpu_native_diagnostics;
+pub(crate) mod gpu_native_greedy_parity;
 pub(crate) mod gpu_native_layer0_diagnostics;
 
 pub(crate) mod gpu_native_token_loop;
@@ -916,6 +917,21 @@ enum Cmd {
         report_out: Option<PathBuf>,
     },
 
+    /// Strictly compare 16 greedy tokens across the fixed four-case corpus
+    /// between the authoritative Hybrid-boundary CPU reference and the full
+    /// production GPU-native Q4 token loop.
+    QualifyGpuNativeQ4GreedyParity {
+        /// Path to the strict GPU-native Q4 TOML config.
+        #[arg(long)]
+        config: PathBuf,
+        /// Exact wgpu adapter name required for every GPU-native corpus case.
+        #[arg(long)]
+        expected_adapter_name: String,
+        /// Write the versioned typed JSON report here instead of stdout.
+        #[arg(long)]
+        report_out: Option<PathBuf>,
+    },
+
     /// Collect reproducibility and complete first-token CPU/Hybrid logit
     /// evidence for the fixed json-transformation case.
     DiagnoseHybridQ4GreedyDivergence {
@@ -1633,6 +1649,7 @@ fn startup_config_path(cmd: &Cmd) -> Option<&Path> {
         | Cmd::QualifyHybridQ4 { config, .. }
         | Cmd::QualifyHybridQ4Parity { config, .. }
         | Cmd::QualifyHybridQ4GreedyParity { config, .. }
+        | Cmd::QualifyGpuNativeQ4GreedyParity { config, .. }
         | Cmd::DiagnoseHybridQ4GreedyDivergence { config, .. }
         | Cmd::DiagnoseGpuNativeQ4FirstDivergence { config, .. }
         | Cmd::DiagnoseGpuNativeLayer0AttentionFirstDivergence { config, .. }
@@ -1779,6 +1796,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             | Cmd::QualifyHybridQ4 { .. }
             | Cmd::QualifyHybridQ4Parity { .. }
             | Cmd::QualifyHybridQ4GreedyParity { .. }
+            | Cmd::QualifyGpuNativeQ4GreedyParity { .. }
             | Cmd::DiagnoseHybridQ4GreedyDivergence { .. }
             | Cmd::GreedyParityHybridWorkerInternal { .. }
             | Cmd::GreedyParityLogitWorkerInternal { .. }
@@ -2070,6 +2088,26 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     parsed_config: startup_config
                         .take()
                         .ok_or("greedy parity startup config was not parsed")?,
+                    expected_adapter_name,
+                    report_out,
+                    progress_watchdog,
+                },
+            ))
+        }
+        Cmd::QualifyGpuNativeQ4GreedyParity {
+            config,
+            expected_adapter_name,
+            report_out,
+        } => {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()?;
+            rt.block_on(cmd_qualify_gpu_native_q4_greedy_parity(
+                QualifyGpuNativeQ4GreedyParityArgs {
+                    config,
+                    parsed_config: startup_config
+                        .take()
+                        .ok_or("GPU-native greedy parity startup config was not parsed")?,
                     expected_adapter_name,
                     report_out,
                     progress_watchdog,
@@ -2397,6 +2435,14 @@ struct QualifyHybridQ4ParityArgs {
 }
 
 struct QualifyHybridQ4GreedyParityArgs {
+    config: PathBuf,
+    parsed_config: crate::config::Config,
+    expected_adapter_name: String,
+    report_out: Option<PathBuf>,
+    progress_watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+}
+
+struct QualifyGpuNativeQ4GreedyParityArgs {
     config: PathBuf,
     parsed_config: crate::config::Config,
     expected_adapter_name: String,
@@ -6025,9 +6071,803 @@ async fn cmd_diagnose_gpu_native_layer0_attention_first_divergence(
     emit_layer0_attention_first_divergence_report(&report, args.report_out.as_deref())
 }
 
+struct ReferenceRoutingCapture {
+    generation: crate::greedy_parity::GenerationEvidence,
+    routes: Vec<Vec<Vec<u32>>>,
+    background_shutdown: crate::greedy_parity::BackgroundShutdownEvidence,
+}
 
+struct GpuNativeQualificationCapture {
+    evidence: crate::gpu_native_greedy_parity::GpuCandidateCaseEvidence,
+    device: crate::backend::GpuDeviceIdentity,
+    model_geometry: crate::gpu_native_token_loop::GpuNativeModelGeometry,
+}
 
+fn emit_gpu_native_greedy_parity_report(
+    report: &crate::gpu_native_greedy_parity::GpuNativeGreedyParityReport,
+    report_out: Option<&Path>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut json = serde_json::to_vec_pretty(report)?;
+    json.push(b'\n');
+    if let Some(path) = report_out {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(path, json)?;
+        eprintln!(
+            "GPU-native greedy-token parity report written to {}",
+            path.display()
+        );
+    } else {
+        use std::io::Write as _;
+        std::io::stdout().write_all(&json)?;
+    }
+    Ok(())
+}
 
+fn fail_gpu_native_greedy_parity(
+    mut report: crate::gpu_native_greedy_parity::GpuNativeGreedyParityReport,
+    failure: crate::qualification::QualificationFailure,
+    report_out: Option<&Path>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let summary = format!("{}: {}", failure.code, failure.detail);
+    report.fail(failure);
+    match emit_gpu_native_greedy_parity_report(&report, report_out) {
+        Ok(()) => Err(summary.into()),
+        Err(emit_error) => Err(format!(
+            "{summary}; additionally failed to emit GPU-native greedy-parity report: {emit_error}"
+        )
+        .into()),
+    }
+}
+
+fn gpu_native_generation_evidence(
+    tokenizer: &crate::tokenizer::Tokenizer,
+    prompt_token_ids_sha256: &str,
+    generated_token_ids: Vec<u32>,
+) -> Result<crate::greedy_parity::GenerationEvidence, Box<dyn std::error::Error>> {
+    let generated_text = tokenizer.decode(&generated_token_ids)?;
+    Ok(crate::greedy_parity::GenerationEvidence {
+        prompt_token_ids_sha256: prompt_token_ids_sha256.to_string(),
+        generated_token_ids_sha256: crate::greedy_parity::token_ids_sha256(&generated_token_ids),
+        generated_text_sha256: crate::greedy_parity::sha256_hex(generated_text.as_bytes()),
+        generated_token_count: generated_token_ids.len(),
+        generated_token_ids,
+        termination_reason: crate::greedy_parity::TerminationReason::LengthLimit,
+    })
+}
+
+async fn execute_gpu_native_reference_routing_replay(
+    spec: &ResolvedRealCliSpec,
+    tokenizer: Arc<crate::tokenizer::Tokenizer>,
+    prompt_token_ids: &[u32],
+    prompt_token_ids_sha256: &str,
+    resolved_config_sha256: &str,
+    watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+    case_name: &str,
+) -> Result<ReferenceRoutingCapture, Box<dyn std::error::Error>> {
+    let runtime = build_isolated_greedy_runtime(
+        spec,
+        RealCliRuntimeMode::IsolatedGreedyParityCpu,
+        tokenizer.clone(),
+    )
+    .await?;
+    let attempt = async {
+        runtime.engine.enable_cpu_q4_boundary_emulation()?;
+        let observed_config_sha256 = resolved_real_runtime_identity_sha256(
+            &runtime.cfg,
+            runtime.model.config.architecture,
+            runtime.model.config.first_k_dense_replace,
+            &runtime.model.config.advanced,
+        )?;
+        if observed_config_sha256 != resolved_config_sha256 {
+            return Err(format!(
+                "reference routing replay identity {observed_config_sha256} drifted from {resolved_config_sha256}"
+            )
+            .into());
+        }
+        let boundary_before = runtime.engine.cpu_q4_boundary_emulation_snapshot();
+        if !boundary_before.enabled || boundary_before.routed_expert_dispatches != 0 {
+            return Err("reference routing replay boundary emulation did not start clean".into());
+        }
+        let routed_before = runtime.engine.routed_expert_execution_snapshot();
+        let attention_fallbacks_before = crate::transformer::nonfinite_softmax_fallbacks();
+        let (generated_token_ids, routes) = with_progress_timeout(
+            format!("GPU-native greedy parity {case_name} reference routing replay"),
+            watchdog,
+            async {
+                let mut kv = runtime.model.fresh_kv_caches();
+                let prefix_count = prompt_token_ids.len().saturating_sub(1);
+                for (position, &token_id) in prompt_token_ids[..prefix_count].iter().enumerate() {
+                    runtime
+                        .model
+                        .forward_token_hidden(&runtime.engine, token_id, position, &mut kv)
+                        .await?;
+                }
+                let mut input_token = *prompt_token_ids
+                    .last()
+                    .ok_or("reference routing replay prompt is empty")?;
+                let mut position = prefix_count;
+                let mut generated_token_ids =
+                    Vec::with_capacity(crate::greedy_parity::OUTPUT_TOKEN_LIMIT);
+                let mut routes = Vec::with_capacity(crate::greedy_parity::OUTPUT_TOKEN_LIMIT);
+                while generated_token_ids.len() < crate::greedy_parity::OUTPUT_TOKEN_LIMIT {
+                    let trace = runtime
+                        .model
+                        .forward_token_diagnostic_trace(
+                            &runtime.engine,
+                            input_token,
+                            position,
+                            &mut kv,
+                            None,
+                        )
+                        .await?;
+                    input_token = trace.sampled_token;
+                    generated_token_ids.push(trace.sampled_token);
+                    routes.push(trace.layer_selected_ids);
+                    position = position
+                        .checked_add(1)
+                        .ok_or("reference routing replay position overflowed")?;
+                }
+                Ok::<_, Box<dyn std::error::Error>>((generated_token_ids, routes))
+            },
+        )
+        .await?;
+        let boundary_after = runtime.engine.cpu_q4_boundary_emulation_snapshot();
+        if !boundary_after.enabled || boundary_after.routed_expert_dispatches == 0 {
+            return Err("reference routing replay did not exercise the Hybrid F16 boundary".into());
+        }
+        let routed_delta = crate::qualification::routed_execution_delta(
+            routed_before,
+            runtime.engine.routed_expert_execution_snapshot(),
+        )
+        .map_err(|failure| failure.detail)?;
+        if routed_delta.degraded_expert_substitutions != 0 {
+            return Err("reference routing replay recorded degraded expert execution".into());
+        }
+        let attention_fallbacks = crate::transformer::nonfinite_softmax_fallbacks()
+            .saturating_sub(attention_fallbacks_before);
+        if attention_fallbacks != 0 {
+            return Err(format!(
+                "reference routing replay recorded {attention_fallbacks} nonfinite attention fallbacks"
+            )
+            .into());
+        }
+        let generation = gpu_native_generation_evidence(
+            &tokenizer,
+            prompt_token_ids_sha256,
+            generated_token_ids,
+        )?;
+        Ok::<_, Box<dyn std::error::Error>>(ReferenceRoutingCapture {
+            generation,
+            routes,
+            background_shutdown: crate::greedy_parity::BackgroundShutdownEvidence::default(),
+        })
+    }
+    .await;
+    let shutdown = runtime.shutdown_isolated().await;
+    match (attempt, shutdown) {
+        (Ok(mut capture), Ok(shutdown)) => {
+            capture.background_shutdown = shutdown;
+            Ok(capture)
+        }
+        (Err(error), Ok(_)) => Err(error),
+        (Ok(_), Err(shutdown_error)) => Err(shutdown_error.into()),
+        (Err(error), Err(shutdown_error)) => Err(format!(
+            "{error}; reference routing replay shutdown also failed: {shutdown_error}"
+        )
+        .into()),
+    }
+}
+
+async fn execute_gpu_native_qualification_case(
+    spec: &ResolvedRealCliSpec,
+    tokenizer: Arc<crate::tokenizer::Tokenizer>,
+    prompt_token_ids: &[u32],
+    prompt_token_ids_sha256: &str,
+    resolved_config_sha256: &str,
+    expected_adapter_name: &str,
+    watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+    case_name: &str,
+) -> Result<GpuNativeQualificationCapture, Box<dyn std::error::Error>> {
+    let runtime = build_isolated_greedy_runtime(
+        spec,
+        RealCliRuntimeMode::IsolatedGpuNativeDiagnostic,
+        tokenizer.clone(),
+    )
+    .await?;
+    let attempt = async {
+        let observed_config_sha256 = resolved_real_runtime_identity_sha256(
+            &runtime.cfg,
+            runtime.model.config.architecture,
+            runtime.model.config.first_k_dense_replace,
+            &runtime.model.config.advanced,
+        )?;
+        if observed_config_sha256 != resolved_config_sha256 {
+            return Err(format!(
+                "GPU-native runtime identity {observed_config_sha256} drifted from {resolved_config_sha256}"
+            )
+            .into());
+        }
+        let device = runtime
+            .engine
+            .gpu_device_identity()
+            .ok_or("GPU-native runtime has no authoritative adapter identity")?;
+        if device.name != expected_adapter_name {
+            return Err(format!(
+                "GPU-native runtime selected adapter {:?}, expected exact name {:?}",
+                device.name, expected_adapter_name
+            )
+            .into());
+        }
+        if device.software_adapter || device.device_type.eq_ignore_ascii_case("cpu") {
+            return Err(format!(
+                "GPU-native runtime selected software adapter {:?}",
+                device.name
+            )
+            .into());
+        }
+        let token_loop = runtime
+            .gpu_native_token_loop
+            .as_ref()
+            .ok_or("GPU-native token loop was not initialized")?;
+        let model_geometry = token_loop.model_geometry();
+        let counters_before = token_loop.snapshot();
+        if counters_before != crate::gpu_native_token_loop::GpuNativeTokenLoopSnapshot::default() {
+            return Err("GPU-native token-loop counters did not start at zero".into());
+        }
+        let routed_before = runtime.engine.routed_expert_execution_snapshot();
+        let attention_fallbacks_before = crate::transformer::nonfinite_softmax_fallbacks();
+        let mut request = token_loop.create_request_state()?;
+        let trace_layout =
+            crate::gpu_native_diagnostics::GpuNativeDiagnosticTraceLayout::try_new(
+                model_geometry.num_layers,
+                model_geometry.d_model,
+                model_geometry.top_k,
+                model_geometry.vocab_size,
+            )?;
+        let staging = token_loop.create_diagnostic_staging_buffer(&trace_layout)?;
+        let (generated_token_ids, routes) = with_progress_timeout(
+            format!("GPU-native greedy parity {case_name} candidate"),
+            watchdog,
+            async {
+                let prefix_count = prompt_token_ids.len().saturating_sub(1);
+                for (position, &token_id) in prompt_token_ids[..prefix_count].iter().enumerate() {
+                    token_loop
+                        .step_token(&runtime.engine, &mut request, token_id, position, false)
+                        .await?;
+                }
+                let mut input_token = *prompt_token_ids
+                    .last()
+                    .ok_or("GPU-native qualification prompt is empty")?;
+                let mut position = prefix_count;
+                let mut generated_token_ids =
+                    Vec::with_capacity(crate::greedy_parity::OUTPUT_TOKEN_LIMIT);
+                let mut routes = Vec::with_capacity(crate::greedy_parity::OUTPUT_TOKEN_LIMIT);
+                while generated_token_ids.len() < crate::greedy_parity::OUTPUT_TOKEN_LIMIT {
+                    let (trace, _) = token_loop
+                        .step_token_diagnostic(
+                            &runtime.engine,
+                            &mut request,
+                            input_token,
+                            position,
+                            true,
+                            &trace_layout,
+                            &staging,
+                        )
+                        .await?;
+                    if trace.final_status != 0
+                        || trace.layer_statuses.iter().any(|&status| status != 0)
+                    {
+                        return Err(format!(
+                            "GPU-native diagnostic returned nonzero numerical status at generated position {}",
+                            generated_token_ids.len()
+                        )
+                        .into());
+                    }
+                    input_token = trace.sampled_token;
+                    generated_token_ids.push(trace.sampled_token);
+                    routes.push(trace.layer_selected_ids);
+                    position = position
+                        .checked_add(1)
+                        .ok_or("GPU-native qualification position overflowed")?;
+                }
+                Ok::<_, Box<dyn std::error::Error>>((generated_token_ids, routes))
+            },
+        )
+        .await?;
+        let expected_completed = prompt_token_ids
+            .len()
+            .saturating_sub(1)
+            .checked_add(crate::greedy_parity::OUTPUT_TOKEN_LIMIT)
+            .ok_or("GPU-native expected completion count overflowed")?;
+        let request_completed_expected_tokens = request.committed_position() == expected_completed;
+        if !request_completed_expected_tokens {
+            return Err(format!(
+                "GPU-native request retired early at committed position {}, expected {expected_completed}",
+                request.committed_position()
+            )
+            .into());
+        }
+        let token_loop_counters_delta = token_loop.snapshot();
+        if token_loop_counters_delta.tokens_completed != expected_completed as u64 {
+            return Err(format!(
+                "GPU-native token counter recorded {} completions, expected {expected_completed}",
+                token_loop_counters_delta.tokens_completed
+            )
+            .into());
+        }
+        if token_loop_counters_delta.fatal_failures != 0
+            || token_loop_counters_delta.no_progress_failures != 0
+        {
+            return Err("GPU-native token loop recorded fatal or NoProgress failures".into());
+        }
+        let routed_execution_delta = crate::qualification::routed_execution_delta(
+            routed_before,
+            runtime.engine.routed_expert_execution_snapshot(),
+        )
+        .map_err(|failure| failure.detail)?;
+        if routed_execution_delta.degraded_expert_substitutions != 0
+            || routed_execution_delta.gpu_cpu_fallbacks != 0
+        {
+            return Err("GPU-native runtime recorded degraded or CPU-fallback expert execution".into());
+        }
+        let attention_softmax_nonfinite_fallbacks =
+            crate::transformer::nonfinite_softmax_fallbacks()
+                .saturating_sub(attention_fallbacks_before);
+        if attention_softmax_nonfinite_fallbacks != 0 {
+            return Err(format!(
+                "GPU-native runtime recorded {attention_softmax_nonfinite_fallbacks} nonfinite attention fallbacks"
+            )
+            .into());
+        }
+        let generation = gpu_native_generation_evidence(
+            &tokenizer,
+            prompt_token_ids_sha256,
+            generated_token_ids,
+        )?;
+        drop(request);
+        drop(staging);
+        Ok::<_, Box<dyn std::error::Error>>(GpuNativeQualificationCapture {
+            evidence: crate::gpu_native_greedy_parity::GpuCandidateCaseEvidence {
+                generation,
+                model_load: greedy_parity_model_load(&runtime),
+                selected_expert_ids_by_generated_position_layer: routes,
+                token_loop_counters_delta,
+                routed_execution_delta,
+                attention_softmax_nonfinite_fallbacks,
+                request_completed_expected_tokens,
+                background_shutdown:
+                    crate::greedy_parity::BackgroundShutdownEvidence::default(),
+            },
+            device,
+            model_geometry,
+        })
+    }
+    .await;
+    let shutdown = runtime.shutdown_isolated().await;
+    match (attempt, shutdown) {
+        (Ok(mut capture), Ok(shutdown)) => {
+            capture.evidence.background_shutdown = shutdown;
+            Ok(capture)
+        }
+        (Err(error), Ok(_)) => Err(error),
+        (Ok(_), Err(shutdown_error)) => Err(shutdown_error.into()),
+        (Err(error), Err(shutdown_error)) => Err(format!(
+            "{error}; GPU-native qualification shutdown also failed: {shutdown_error}"
+        )
+        .into()),
+    }
+}
+
+async fn cmd_qualify_gpu_native_q4_greedy_parity(
+    args: QualifyGpuNativeQ4GreedyParityArgs,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use crate::qualification::{BuildProvenance, FailureStage, QualificationFailure};
+
+    let cfg = args.parsed_config;
+    let provenance = BuildProvenance::embedded();
+    let (artifacts, artifact_errors) = qualification_artifacts(&args.config, &cfg);
+    let metadata_path = cfg.model.data_dir.join("metadata.json");
+    let metadata_result = crate::qualification::read_expert_metadata(&metadata_path);
+    let metadata = metadata_result.clone().ok();
+    let capacity_bytes = cfg
+        .gpu_cache
+        .vram_capacity_mb
+        .checked_mul(1024 * 1024)
+        .and_then(|bytes| u64::try_from(bytes).ok())
+        .unwrap_or(0);
+    let source_config = crate::gpu_native_greedy_parity::SourceConfigEvidence {
+        real_transformer_enabled: cfg.real_transformer.enabled,
+        gpu_native_enabled: cfg.real_transformer.gpu_native,
+        weights_dir_configured: cfg.real_transformer.weights_dir.is_some(),
+        strict_weights: cfg.real_transformer.strict_weights,
+        allow_seeded_fallback: cfg.real_transformer.allow_seeded_fallback,
+        allow_degraded_experts: cfg.real_transformer.allow_degraded_experts,
+        allow_nonfinite_attention_fallback: cfg.real_transformer.allow_nonfinite_attention_fallback,
+        allow_truncated_expert_payloads: cfg.real_transformer.allow_truncated_expert_payloads,
+        distributed_enabled: cfg.distributed.enabled,
+        gpu_cache_enabled: cfg.gpu_cache.enabled,
+        gpu_expert_capacity_bytes: capacity_bytes,
+        routed_expert_dtype: cfg.model.dtype.as_str().to_string(),
+    };
+    let mut report = crate::gpu_native_greedy_parity::GpuNativeGreedyParityReport::new(
+        provenance.clone(),
+        artifacts,
+        metadata.clone(),
+        args.expected_adapter_name.clone(),
+        source_config,
+    );
+
+    let preflight_failure = if args.expected_adapter_name.is_empty() {
+        Some(QualificationFailure::new(
+            FailureStage::Preflight,
+            "expected-adapter-name-empty",
+            "--expected-adapter-name must be a non-empty exact adapter name",
+        ))
+    } else if args.progress_watchdog.timeout.is_none() {
+        Some(QualificationFailure::new(
+            FailureStage::Preflight,
+            "progress-watchdog-required",
+            "GPU-native greedy parity requires a positive progress timeout",
+        ))
+    } else if !artifact_errors.is_empty() {
+        Some(qualification_artifact_failure(&artifact_errors))
+    } else if metadata_result.is_err() {
+        Some(qualification_metadata_failure(
+            metadata_result.err().unwrap(),
+        ))
+    } else if !report.source_config.is_strict() {
+        Some(QualificationFailure::new(
+            FailureStage::Preflight,
+            "non-strict-gpu-native-config",
+            "qualification requires GPU-native Q4, strict real weights, no seeded/degraded/nonfinite/truncated fallback, no distributed mode, and a positive GPU cache budget",
+        ))
+    } else if provenance.dirty != Some(false)
+        || provenance
+            .git_sha
+            .as_deref()
+            .is_none_or(|sha| sha.len() != 40 || !sha.bytes().all(|byte| byte.is_ascii_hexdigit()))
+    {
+        Some(QualificationFailure::new(
+            FailureStage::Preflight,
+            "clean-build-provenance-required",
+            "qualification requires an embedded clean 40-hex Git build identity",
+        ))
+    } else if metadata.as_ref().is_none_or(|metadata| {
+        metadata.q4_0_layout.as_deref() != Some(crate::inference::Q4_0_LAYOUT_STANDARD_V1)
+            || metadata.explicitly_synthetic
+    }) {
+        Some(QualificationFailure::new(
+            FailureStage::Preflight,
+            "noncanonical-expert-metadata",
+            "qualification requires canonical, nonsynthetic Q4_0 expert metadata",
+        ))
+    } else {
+        None
+    };
+    if let Some(failure) = preflight_failure {
+        return fail_gpu_native_greedy_parity(report, failure, args.report_out.as_deref());
+    }
+
+    let mut gpu_spec = match resolve_real_cli_spec_from_config(
+        cfg,
+        RealCliRuntimeMode::IsolatedGpuNativeDiagnostic,
+    ) {
+        Ok(spec) => spec,
+        Err(error) => {
+            return fail_gpu_native_greedy_parity(
+                report,
+                QualificationFailure::new(
+                    FailureStage::Preflight,
+                    "configuration-reconciliation-failed",
+                    error.to_string(),
+                ),
+                args.report_out.as_deref(),
+            );
+        }
+    };
+    gpu_spec.cfg.real_transformer.gpu_native = true;
+    gpu_spec.cfg.real_transformer.compute_offload = crate::backend::ComputeOffload::Gpu;
+    let identity = greedy_parity_model_identity(&gpu_spec);
+    if !identity.is_qwen3_coder_30b_a3b_q4_0() {
+        return fail_gpu_native_greedy_parity(
+            report,
+            QualificationFailure::new(
+                FailureStage::Preflight,
+                "unexpected-model-identity",
+                "fixed corpus is qualified only for Qwen3-Coder 30B-A3B Q4_0 geometry",
+            ),
+            args.report_out.as_deref(),
+        );
+    }
+    let resolved_config_sha256 = match resolved_real_cli_spec_sha256(&gpu_spec) {
+        Ok(hash) => hash,
+        Err(error) => {
+            return fail_gpu_native_greedy_parity(
+                report,
+                QualificationFailure::new(
+                    FailureStage::Preflight,
+                    "resolved-config-hash-failed",
+                    error.to_string(),
+                ),
+                args.report_out.as_deref(),
+            );
+        }
+    };
+    report.resolved_config_sha256 = Some(resolved_config_sha256.clone());
+    let mut reference_spec = gpu_spec.clone();
+    reference_spec.cfg.real_transformer.gpu_native = false;
+    reference_spec.cfg.real_transformer.compute_offload = crate::backend::ComputeOffload::Cpu;
+    let reference_resolved_config_sha256 = match resolved_real_cli_spec_sha256(&reference_spec) {
+        Ok(hash) => hash,
+        Err(error) => {
+            return fail_gpu_native_greedy_parity(
+                report,
+                QualificationFailure::new(
+                    FailureStage::Preflight,
+                    "reference-config-hash-failed",
+                    error.to_string(),
+                ),
+                args.report_out.as_deref(),
+            );
+        }
+    };
+    report.reference_resolved_config_sha256 = Some(reference_resolved_config_sha256.clone());
+    let tokenizer = match load_real_cli_tokenizer(
+        &gpu_spec.cfg,
+        RealCliRuntimeMode::IsolatedGpuNativeDiagnostic,
+    ) {
+        Ok(tokenizer) => tokenizer,
+        Err(error) => {
+            return fail_gpu_native_greedy_parity(
+                report,
+                QualificationFailure::new(
+                    FailureStage::Startup,
+                    "tokenizer-load-failed",
+                    error.to_string(),
+                ),
+                args.report_out.as_deref(),
+            );
+        }
+    };
+
+    for fixed in crate::greedy_parity::FIXED_CORPUS {
+        let prompt_token_ids = match tokenizer.encode(fixed.prompt) {
+            Ok(ids) if !ids.is_empty() => ids,
+            Ok(_) => {
+                return fail_gpu_native_greedy_parity(
+                    report,
+                    QualificationFailure::new(
+                        FailureStage::Inference,
+                        "prompt-tokenization-empty",
+                        format!("fixed case {} encoded to zero tokens", fixed.name),
+                    ),
+                    args.report_out.as_deref(),
+                );
+            }
+            Err(error) => {
+                return fail_gpu_native_greedy_parity(
+                    report,
+                    QualificationFailure::new(
+                        FailureStage::Inference,
+                        "prompt-tokenization-failed",
+                        format!("fixed case {}: {error}", fixed.name),
+                    ),
+                    args.report_out.as_deref(),
+                );
+            }
+        };
+        let prompt_token_ids_sha256 = crate::greedy_parity::token_ids_sha256(&prompt_token_ids);
+        let authoritative_reference = match execute_greedy_parity_boundary_reference_plane(
+            &reference_spec,
+            tokenizer.clone(),
+            &prompt_token_ids,
+            &prompt_token_ids_sha256,
+            &reference_resolved_config_sha256,
+            &args.expected_adapter_name,
+            args.progress_watchdog,
+            fixed.name,
+        )
+        .await
+        {
+            Ok(reference) => reference,
+            Err(error) => {
+                return fail_gpu_native_greedy_parity(
+                    report,
+                    QualificationFailure::new(
+                        FailureStage::Inference,
+                        "authoritative-reference-failed",
+                        format!("fixed case {}: {error}", fixed.name),
+                    ),
+                    args.report_out.as_deref(),
+                );
+            }
+        };
+        if !authoritative_reference.cpu_q4_boundary_emulation.enabled
+            || authoritative_reference
+                .cpu_q4_boundary_emulation
+                .routed_expert_dispatches
+                == 0
+        {
+            return fail_gpu_native_greedy_parity(
+                report,
+                QualificationFailure::new(
+                    FailureStage::Postcondition,
+                    "authoritative-reference-boundary-missing",
+                    format!(
+                        "fixed case {} did not exercise the production Hybrid F16 boundary",
+                        fixed.name
+                    ),
+                ),
+                args.report_out.as_deref(),
+            );
+        }
+        let reference_routing = match execute_gpu_native_reference_routing_replay(
+            &reference_spec,
+            tokenizer.clone(),
+            &prompt_token_ids,
+            &prompt_token_ids_sha256,
+            &reference_resolved_config_sha256,
+            args.progress_watchdog,
+            fixed.name,
+        )
+        .await
+        {
+            Ok(capture) => capture,
+            Err(error) => {
+                return fail_gpu_native_greedy_parity(
+                    report,
+                    QualificationFailure::new(
+                        FailureStage::Inference,
+                        "reference-routing-replay-failed",
+                        format!("fixed case {}: {error}", fixed.name),
+                    ),
+                    args.report_out.as_deref(),
+                );
+            }
+        };
+        let reference_routing_matches = reference_routing.generation.generated_token_ids
+            == authoritative_reference.generation.generated_token_ids;
+        if !reference_routing_matches {
+            return fail_gpu_native_greedy_parity(
+                report,
+                QualificationFailure::new(
+                    FailureStage::Postcondition,
+                    "reference-routing-replay-token-mismatch",
+                    format!(
+                        "fixed case {} diagnostic routing replay drifted from the authoritative reference",
+                        fixed.name
+                    ),
+                ),
+                args.report_out.as_deref(),
+            );
+        }
+        let gpu_native = match execute_gpu_native_qualification_case(
+            &gpu_spec,
+            tokenizer.clone(),
+            &prompt_token_ids,
+            &prompt_token_ids_sha256,
+            &resolved_config_sha256,
+            &args.expected_adapter_name,
+            args.progress_watchdog,
+            fixed.name,
+        )
+        .await
+        {
+            Ok(capture) => capture,
+            Err(error) => {
+                return fail_gpu_native_greedy_parity(
+                    report,
+                    QualificationFailure::new(
+                        FailureStage::Inference,
+                        "gpu-native-candidate-failed",
+                        format!("fixed case {}: {error}", fixed.name),
+                    ),
+                    args.report_out.as_deref(),
+                );
+            }
+        };
+        if let Some(observed) = &report.actual_adapter {
+            if observed != &gpu_native.device {
+                return fail_gpu_native_greedy_parity(
+                    report,
+                    QualificationFailure::new(
+                        FailureStage::Postcondition,
+                        "adapter-identity-drift",
+                        format!("fixed case {} selected a different adapter", fixed.name),
+                    ),
+                    args.report_out.as_deref(),
+                );
+            }
+        } else {
+            report.actual_adapter = Some(gpu_native.device.clone());
+        }
+        if let Some(observed) = report.model_geometry {
+            if observed != gpu_native.model_geometry {
+                return fail_gpu_native_greedy_parity(
+                    report,
+                    QualificationFailure::new(
+                        FailureStage::Postcondition,
+                        "model-geometry-drift",
+                        format!(
+                            "fixed case {} observed different model geometry",
+                            fixed.name
+                        ),
+                    ),
+                    args.report_out.as_deref(),
+                );
+            }
+        } else {
+            report.model_geometry = Some(gpu_native.model_geometry);
+        }
+        let comparison = match crate::gpu_native_greedy_parity::compare_case_outputs(
+            fixed.name,
+            &prompt_token_ids,
+            &authoritative_reference.generation.generated_token_ids,
+            &gpu_native.evidence.generation.generated_token_ids,
+            &reference_routing.routes,
+            &gpu_native
+                .evidence
+                .selected_expert_ids_by_generated_position_layer,
+            crate::greedy_parity::OUTPUT_TOKEN_LIMIT,
+            gpu_native.model_geometry.num_layers,
+            gpu_native.model_geometry.top_k,
+        ) {
+            Ok(comparison) => comparison,
+            Err(detail) => {
+                return fail_gpu_native_greedy_parity(
+                    report,
+                    QualificationFailure::new(
+                        FailureStage::Postcondition,
+                        "comparison-evidence-invalid",
+                        detail,
+                    ),
+                    args.report_out.as_deref(),
+                );
+            }
+        };
+        let case = crate::gpu_native_greedy_parity::CaseReport {
+            name: fixed.name.to_string(),
+            behavior: fixed.behavior.to_string(),
+            prompt: fixed.prompt.to_string(),
+            prompt_sha256: crate::greedy_parity::sha256_hex(fixed.prompt.as_bytes()),
+            prompt_token_ids,
+            prompt_token_ids_sha256,
+            tokens_per_case: crate::greedy_parity::OUTPUT_TOKEN_LIMIT,
+            authoritative_reference,
+            reference_routing_replay:
+                crate::gpu_native_greedy_parity::ReferenceRoutingReplayEvidence {
+                    generation: reference_routing.generation,
+                    matches_authoritative_reference: reference_routing_matches,
+                    routing_positions_captured: reference_routing.routes.len(),
+                    routed_layers_per_position: gpu_native.model_geometry.num_layers,
+                    selected_expert_ids_by_generated_position_layer: reference_routing.routes,
+                    background_shutdown: reference_routing.background_shutdown,
+                },
+            gpu_native: gpu_native.evidence,
+            comparison,
+        };
+        if let Err(detail) = report.record_case(case) {
+            return fail_gpu_native_greedy_parity(
+                report,
+                QualificationFailure::new(
+                    FailureStage::Postcondition,
+                    "report-accounting-failed",
+                    detail,
+                ),
+                args.report_out.as_deref(),
+            );
+        }
+        if let Some(failure) = report.semantic_failure() {
+            return fail_gpu_native_greedy_parity(report, failure, args.report_out.as_deref());
+        }
+    }
+    if let Err(failure) = report.finalize() {
+        return fail_gpu_native_greedy_parity(report, failure, args.report_out.as_deref());
+    }
+    emit_gpu_native_greedy_parity_report(&report, args.report_out.as_deref())
+}
 
 async fn cmd_qualify_hybrid_q4_greedy_parity(
     args: QualifyHybridQ4GreedyParityArgs,
@@ -12350,6 +13190,32 @@ mod tests {
         ])
         .unwrap_err();
         assert!(error.to_string().contains("--cpu-config"));
+    }
+
+    #[test]
+    fn gpu_native_greedy_parity_cli_has_the_strict_minimum_surface() {
+        let cli = <Cli as clap::Parser>::try_parse_from([
+            "micro-expert-router",
+            "qualify-gpu-native-q4-greedy-parity",
+            "--config",
+            "strict-gpu-native.toml",
+            "--expected-adapter-name",
+            "NVIDIA L4",
+            "--report-out",
+            "gpu-native-report.json",
+        ])
+        .unwrap();
+        let Cmd::QualifyGpuNativeQ4GreedyParity {
+            config,
+            expected_adapter_name,
+            report_out,
+        } = cli.cmd
+        else {
+            panic!("expected qualify-gpu-native-q4-greedy-parity command");
+        };
+        assert_eq!(config, PathBuf::from("strict-gpu-native.toml"));
+        assert_eq!(expected_adapter_name, "NVIDIA L4");
+        assert_eq!(report_out, Some(PathBuf::from("gpu-native-report.json")));
     }
 
     #[test]

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -145,6 +145,7 @@ pub(crate) mod gpu_native_expert_permutation_semantic_parity;
 pub(crate) mod gpu_native_greedy_parity;
 pub(crate) mod gpu_native_layer0_diagnostics;
 pub(crate) mod gpu_native_router_rank_diagnostics;
+pub(crate) mod gpu_native_semantic_parity_corpus;
 
 pub(crate) mod gpu_native_token_loop;
 #[cfg(feature = "grpc")]
@@ -1004,6 +1005,18 @@ enum Cmd {
         #[arg(long)]
         report_out: PathBuf,
     },
+    /// Survey semantic parity across every routing event in the frozen greedy corpus without producing a qualification PASS.
+    DiagnoseGpuNativeSemanticParityCorpus {
+        /// Strict GPU-native Q4 configuration.
+        #[arg(long)]
+        config: PathBuf,
+        /// Exact required GPU adapter name (for example, "NVIDIA L4").
+        #[arg(long)]
+        expected_adapter_name: String,
+        /// Required versioned diagnostic JSON destination.
+        #[arg(long)]
+        report_out: PathBuf,
+    },
     /// Diagnose first internal mathematical divergence inside layer-0 attention between CPU reference and GPU-native execution.
     #[command(name = "diagnose-gpu-native-layer0-attention-first-divergence")]
     DiagnoseGpuNativeLayer0AttentionFirstDivergence {
@@ -1698,6 +1711,7 @@ fn startup_config_path(cmd: &Cmd) -> Option<&Path> {
         | Cmd::DiagnoseGpuNativeQ4FirstDivergence { config, .. }
         | Cmd::DiagnoseGpuNativeRouterRankDivergence { config, .. }
         | Cmd::DiagnoseGpuNativeExpertPermutationSemanticParity { config, .. }
+        | Cmd::DiagnoseGpuNativeSemanticParityCorpus { config, .. }
         | Cmd::DiagnoseGpuNativeLayer0AttentionFirstDivergence { config, .. }
         | Cmd::GreedyParityHybridWorkerInternal { config }
         | Cmd::GreedyParityLogitWorkerInternal { config } => Some(config.as_path()),
@@ -2279,6 +2293,26 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     progress_watchdog,
                 },
             ))
+        }
+        Cmd::DiagnoseGpuNativeSemanticParityCorpus {
+            config,
+            expected_adapter_name,
+            report_out,
+        } => {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()?;
+            rt.block_on(
+                crate::gpu_native_semantic_parity_corpus::run_diagnostic(
+                    config,
+                    startup_config.take().ok_or(
+                        "diagnose-gpu-native-semantic-parity-corpus startup config was not parsed",
+                    )?,
+                    expected_adapter_name,
+                    report_out,
+                    progress_watchdog,
+                ),
+            )
         }
         Cmd::DiagnoseGpuNativeLayer0AttentionFirstDivergence {
             config: _,
@@ -14607,6 +14641,39 @@ mod tests {
         assert_eq!(*generated_position, 5);
         assert_eq!(*layer, 44);
         assert_eq!(report_out, &PathBuf::from("semantic-witness.json"));
+        assert_eq!(
+            super::startup_config_path(&cli.cmd),
+            Some(Path::new("strict-gpu-native.toml"))
+        );
+    }
+
+    #[test]
+    fn semantic_parity_corpus_diagnostic_cli_has_frozen_corpus_surface() {
+        let cli = <Cli as clap::Parser>::try_parse_from([
+            "micro-expert-router",
+            "diagnose-gpu-native-semantic-parity-corpus",
+            "--config",
+            "strict-gpu-native.toml",
+            "--expected-adapter-name",
+            "NVIDIA L4",
+            "--report-out",
+            "semantic-corpus.json",
+            "--progress-timeout-secs",
+            "300",
+        ])
+        .unwrap();
+        assert_eq!(cli.progress_timeout_secs, Some(300));
+        let Cmd::DiagnoseGpuNativeSemanticParityCorpus {
+            config,
+            expected_adapter_name,
+            report_out,
+        } = &cli.cmd
+        else {
+            panic!("expected diagnose-gpu-native-semantic-parity-corpus command");
+        };
+        assert_eq!(config, &PathBuf::from("strict-gpu-native.toml"));
+        assert_eq!(expected_adapter_name, "NVIDIA L4");
+        assert_eq!(report_out, &PathBuf::from("semantic-corpus.json"));
         assert_eq!(
             super::startup_config_path(&cli.cmd),
             Some(Path::new("strict-gpu-native.toml"))

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -2620,23 +2620,91 @@ struct IsolatedRuntimeShutdownWitness {
     affinity: Option<std::sync::Weak<LayeredExpertAffinity>>,
 }
 
+/// Point-in-time strong-owner counts for every isolated mutable resource
+/// family. `Weak::strong_count` observes ownership without upgrading the weak
+/// reference, so polling this diagnostic never keeps a resource alive.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct IsolatedRuntimeLiveResources {
+    engine: usize,
+    model: usize,
+    cache: usize,
+    storage: usize,
+    predictor: usize,
+    execution_context: usize,
+    gpu_cache: usize,
+    speculator: Option<usize>,
+    affinity: Option<usize>,
+}
+
+#[derive(Debug)]
+struct IsolatedRuntimeShutdownError {
+    detail: String,
+}
+
+impl IsolatedRuntimeShutdownError {
+    fn new(detail: impl Into<String>) -> Self {
+        Self {
+            detail: detail.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for IsolatedRuntimeShutdownError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.detail)
+    }
+}
+
+impl std::error::Error for IsolatedRuntimeShutdownError {}
+
+impl IsolatedRuntimeLiveResources {
+    fn all_released(self) -> bool {
+        self.engine == 0
+            && self.model == 0
+            && self.cache == 0
+            && self.storage == 0
+            && self.predictor == 0
+            && self.execution_context == 0
+            && self.gpu_cache == 0
+            && self.speculator.is_none_or(|count| count == 0)
+            && self.affinity.is_none_or(|count| count == 0)
+    }
+}
+
+impl std::fmt::Display for IsolatedRuntimeLiveResources {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fn optional_count(value: Option<usize>) -> String {
+            value.map_or_else(|| "disabled".to_string(), |count| count.to_string())
+        }
+        write!(
+            f,
+            "engine={} model={} cache={} storage={} predictor={} execution_context={} gpu_cache={} speculator={} affinity={}",
+            self.engine,
+            self.model,
+            self.cache,
+            self.storage,
+            self.predictor,
+            self.execution_context,
+            self.gpu_cache,
+            optional_count(self.speculator),
+            optional_count(self.affinity),
+        )
+    }
+}
+
 impl IsolatedRuntimeShutdownWitness {
-    fn all_released(&self) -> bool {
-        self.engine.upgrade().is_none()
-            && self.model.upgrade().is_none()
-            && self.cache.upgrade().is_none()
-            && self.storage.upgrade().is_none()
-            && self.predictor.upgrade().is_none()
-            && self.execution_context.upgrade().is_none()
-            && self.gpu_cache.upgrade().is_none()
-            && self
-                .speculator
-                .as_ref()
-                .map_or(true, |weak| weak.upgrade().is_none())
-            && self
-                .affinity
-                .as_ref()
-                .map_or(true, |weak| weak.upgrade().is_none())
+    fn live_resources(&self) -> IsolatedRuntimeLiveResources {
+        IsolatedRuntimeLiveResources {
+            engine: self.engine.strong_count(),
+            model: self.model.strong_count(),
+            cache: self.cache.strong_count(),
+            storage: self.storage.strong_count(),
+            predictor: self.predictor.strong_count(),
+            execution_context: self.execution_context.strong_count(),
+            gpu_cache: self.gpu_cache.strong_count(),
+            speculator: self.speculator.as_ref().map(std::sync::Weak::strong_count),
+            affinity: self.affinity.as_ref().map(std::sync::Weak::strong_count),
+        }
     }
 
     async fn wait_for_release(
@@ -2644,28 +2712,24 @@ impl IsolatedRuntimeShutdownWitness {
     ) -> Result<crate::greedy_parity::BackgroundShutdownEvidence, String> {
         const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(10);
         const SHUTDOWN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
-        wait_for_isolated_release(
-            || self.all_released(),
-            POLL_INTERVAL,
-            SHUTDOWN_TIMEOUT,
-        )
-        .await
+        wait_for_isolated_release(|| self.live_resources(), POLL_INTERVAL, SHUTDOWN_TIMEOUT).await
     }
 }
 
 async fn wait_for_isolated_release<F>(
-    mut all_released: F,
+    mut live_resources: F,
     poll_interval: std::time::Duration,
     shutdown_timeout: std::time::Duration,
 ) -> Result<crate::greedy_parity::BackgroundShutdownEvidence, String>
 where
-    F: FnMut() -> bool,
+    F: FnMut() -> IsolatedRuntimeLiveResources,
 {
     let started = Instant::now();
     let mut poll_iterations = 0u32;
     loop {
         poll_iterations = poll_iterations.saturating_add(1);
-        if all_released() {
+        let live = live_resources();
+        if live.all_released() {
             return Ok(crate::greedy_parity::BackgroundShutdownEvidence {
                 controlled_shutdown_requested: true,
                 all_runtime_resources_released: true,
@@ -2674,8 +2738,8 @@ where
         }
         if started.elapsed() >= shutdown_timeout {
             return Err(format!(
-                "isolated runtime background resources remained live after {}s",
-                shutdown_timeout.as_secs_f64()
+                "isolated runtime background resources remained live after {}s: {live}",
+                shutdown_timeout.as_secs_f64(),
             ));
         }
         tokio::time::sleep(poll_interval).await;
@@ -2685,18 +2749,32 @@ where
 impl BenchRealRuntime {
     async fn shutdown_isolated(
         mut self,
-    ) -> Result<crate::greedy_parity::BackgroundShutdownEvidence, String> {
-        let witness = self
-            .isolated_shutdown
-            .take()
-            .ok_or_else(|| "runtime was not constructed by the isolated qualification factory".to_string())?;
-        // Dropping the Engine closes the GPU-promotion and neural-speculator
-        // producer channels. Affinity's owned handle joins its worker in Drop;
-        // outstanding prefetch work releases cache/storage/predictor Arcs when
-        // it completes. The weak witness below proves all of those resource
-        // families are gone before another case/plane is constructed.
+    ) -> Result<crate::greedy_parity::BackgroundShutdownEvidence, IsolatedRuntimeShutdownError>
+    {
+        let witness = self.isolated_shutdown.take().ok_or_else(|| {
+            IsolatedRuntimeShutdownError::new(
+                "runtime was not constructed by the isolated qualification factory",
+            )
+        })?;
+        // Stop producers and cancel/drain every engine-owned async background
+        // task before dropping the runtime's strong references. Affinity's
+        // owned thread handle is joined in Engine drop; the neural-speculator
+        // worker owns only a Weak and exits when its producer disappears. The
+        // witness remains an independent postcondition proving every mutable
+        // resource family is gone before another isolated runtime is built.
+        let controlled_shutdown = self.engine.shutdown_background_tasks().await;
         drop(self);
-        witness.wait_for_release().await
+        let released = witness.wait_for_release().await;
+        match (controlled_shutdown, released) {
+            (Ok(()), Ok(evidence)) => Ok(evidence),
+            (Err(error), Ok(_)) => Err(IsolatedRuntimeShutdownError::new(error)),
+            (Ok(()), Err(error)) => Err(IsolatedRuntimeShutdownError::new(error)),
+            (Err(controlled_error), Err(release_error)) => {
+                Err(IsolatedRuntimeShutdownError::new(format!(
+                    "{controlled_error}; weak release postcondition also failed: {release_error}"
+                )))
+            }
+        }
     }
 }
 
@@ -4185,9 +4263,10 @@ async fn execute_greedy_parity_plane_internal(
         }
         (Err(error), Ok(_)) => Err(error),
         (Ok(_), Err(shutdown_error)) => Err(shutdown_error.into()),
-        (Err(error), Err(shutdown_error)) => {
-            Err(format!("{error}; isolated shutdown also failed: {shutdown_error}").into())
-        }
+        (Err(error), Err(shutdown_error)) => Err(IsolatedRuntimeShutdownError::new(format!(
+            "{error}; isolated shutdown also failed: {shutdown_error}"
+        ))
+        .into()),
     }
 }
 
@@ -6115,10 +6194,31 @@ fn fail_gpu_native_greedy_parity(
     match emit_gpu_native_greedy_parity_report(&report, report_out) {
         Ok(()) => Err(summary.into()),
         Err(emit_error) => Err(format!(
-            "{summary}; additionally failed to emit GPU-native greedy-parity report: {emit_error}"
+            "{summary}; GPU-native greedy-parity report emission failed: {emit_error}"
         )
         .into()),
     }
+}
+
+fn gpu_native_case_execution_failure(
+    default_code: &'static str,
+    case_name: &str,
+    error: &(dyn std::error::Error + 'static),
+) -> crate::qualification::QualificationFailure {
+    let isolated_shutdown = error.is::<IsolatedRuntimeShutdownError>();
+    crate::qualification::QualificationFailure::new(
+        if isolated_shutdown {
+            crate::qualification::FailureStage::Postcondition
+        } else {
+            crate::qualification::FailureStage::Inference
+        },
+        if isolated_shutdown {
+            "isolated-runtime-shutdown-failed"
+        } else {
+            default_code
+        },
+        format!("fixed case {case_name}: {error}"),
+    )
 }
 
 fn gpu_native_generation_evidence(
@@ -6253,9 +6353,9 @@ async fn execute_gpu_native_reference_routing_replay(
         }
         (Err(error), Ok(_)) => Err(error),
         (Ok(_), Err(shutdown_error)) => Err(shutdown_error.into()),
-        (Err(error), Err(shutdown_error)) => Err(format!(
+        (Err(error), Err(shutdown_error)) => Err(IsolatedRuntimeShutdownError::new(format!(
             "{error}; reference routing replay shutdown also failed: {shutdown_error}"
-        )
+        ))
         .into()),
     }
 }
@@ -6453,9 +6553,9 @@ async fn execute_gpu_native_qualification_case(
         }
         (Err(error), Ok(_)) => Err(error),
         (Ok(_), Err(shutdown_error)) => Err(shutdown_error.into()),
-        (Err(error), Err(shutdown_error)) => Err(format!(
+        (Err(error), Err(shutdown_error)) => Err(IsolatedRuntimeShutdownError::new(format!(
             "{error}; GPU-native qualification shutdown also failed: {shutdown_error}"
-        )
+        ))
         .into()),
     }
 }
@@ -6675,10 +6775,10 @@ async fn cmd_qualify_gpu_native_q4_greedy_parity(
             Err(error) => {
                 return fail_gpu_native_greedy_parity(
                     report,
-                    QualificationFailure::new(
-                        FailureStage::Inference,
+                    gpu_native_case_execution_failure(
                         "authoritative-reference-failed",
-                        format!("fixed case {}: {error}", fixed.name),
+                        fixed.name,
+                        error.as_ref(),
                     ),
                     args.report_out.as_deref(),
                 );
@@ -6718,10 +6818,10 @@ async fn cmd_qualify_gpu_native_q4_greedy_parity(
             Err(error) => {
                 return fail_gpu_native_greedy_parity(
                     report,
-                    QualificationFailure::new(
-                        FailureStage::Inference,
+                    gpu_native_case_execution_failure(
                         "reference-routing-replay-failed",
-                        format!("fixed case {}: {error}", fixed.name),
+                        fixed.name,
+                        error.as_ref(),
                     ),
                     args.report_out.as_deref(),
                 );
@@ -6759,10 +6859,10 @@ async fn cmd_qualify_gpu_native_q4_greedy_parity(
             Err(error) => {
                 return fail_gpu_native_greedy_parity(
                     report,
-                    QualificationFailure::new(
-                        FailureStage::Inference,
+                    gpu_native_case_execution_failure(
                         "gpu-native-candidate-failed",
-                        format!("fixed case {}: {error}", fixed.name),
+                        fixed.name,
+                        error.as_ref(),
                     ),
                     args.report_out.as_deref(),
                 );
@@ -13282,6 +13382,90 @@ mod tests {
         let _ = std::fs::remove_dir_all(dir);
     }
 
+    fn gpu_native_greedy_parity_test_report(
+    ) -> crate::gpu_native_greedy_parity::GpuNativeGreedyParityReport {
+        crate::gpu_native_greedy_parity::GpuNativeGreedyParityReport::new(
+            crate::qualification::BuildProvenance {
+                git_sha: Some("0".repeat(40)),
+                dirty: Some(false),
+                package_version: "test".to_string(),
+            },
+            crate::qualification::QualificationArtifacts::default(),
+            None,
+            "NVIDIA L4".to_string(),
+            crate::gpu_native_greedy_parity::SourceConfigEvidence {
+                real_transformer_enabled: true,
+                gpu_native_enabled: true,
+                weights_dir_configured: true,
+                strict_weights: true,
+                allow_seeded_fallback: false,
+                allow_degraded_experts: false,
+                allow_nonfinite_attention_fallback: false,
+                allow_truncated_expert_payloads: false,
+                distributed_enabled: false,
+                gpu_cache_enabled: true,
+                gpu_expert_capacity_bytes: 1,
+                routed_expert_dtype: "q4_0".to_string(),
+            },
+        )
+    }
+
+    #[test]
+    fn gpu_native_isolated_shutdown_failure_report_is_durable_and_nonzero() {
+        let dir = tempdir_unique("gpu-native-shutdown-failure");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("report.json");
+        let teardown_error = IsolatedRuntimeShutdownError::new(
+            "isolated runtime background resources remained live after 30s: engine=1 storage=1",
+        );
+        let failure = gpu_native_case_execution_failure(
+            "gpu-native-candidate-failed",
+            "test-case",
+            &teardown_error,
+        );
+        let error = fail_gpu_native_greedy_parity(
+            gpu_native_greedy_parity_test_report(),
+            failure,
+            Some(&path),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("isolated-runtime-shutdown-failed"));
+        let json: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert_eq!(json["qualification_pass"], false);
+        assert_eq!(json["failure"]["code"], "isolated-runtime-shutdown-failed");
+        assert!(json["failure"]["detail"]
+            .as_str()
+            .unwrap()
+            .contains("engine=1 storage=1"));
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn gpu_native_report_write_failure_remains_nonzero_and_explicit() {
+        let dir = tempdir_unique("gpu-native-report-write-failure");
+        std::fs::create_dir_all(&dir).unwrap();
+        let failure = crate::qualification::QualificationFailure::new(
+            crate::qualification::FailureStage::Postcondition,
+            "isolated-runtime-shutdown-failed",
+            "forced teardown failure",
+        );
+        let error = fail_gpu_native_greedy_parity(
+            gpu_native_greedy_parity_test_report(),
+            failure,
+            Some(&dir),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("report emission failed"), "{error}");
+        assert!(
+            error.contains("isolated-runtime-shutdown-failed"),
+            "{error}"
+        );
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
     #[test]
     fn greedy_parity_isolated_contexts_are_distinct_and_cpu_exact() {
         let global_before = crate::backend::current_execution_context();
@@ -13333,7 +13517,10 @@ mod tests {
             drop(owner);
         });
         let evidence = wait_for_isolated_release(
-            || weak.upgrade().is_none(),
+            || IsolatedRuntimeLiveResources {
+                engine: weak.strong_count(),
+                ..IsolatedRuntimeLiveResources::default()
+            },
             std::time::Duration::from_millis(1),
             std::time::Duration::from_secs(1),
         )
@@ -13347,14 +13534,23 @@ mod tests {
 
     #[tokio::test]
     async fn greedy_parity_shutdown_timeout_fails_closed() {
+        let retained = Arc::new(());
+        let weak = Arc::downgrade(&retained);
         let error = wait_for_isolated_release(
-            || false,
+            || IsolatedRuntimeLiveResources {
+                storage: weak.strong_count(),
+                ..IsolatedRuntimeLiveResources::default()
+            },
             std::time::Duration::from_millis(1),
             std::time::Duration::from_millis(5),
         )
         .await
         .unwrap_err();
         assert!(error.contains("background resources remained live"));
+        assert!(error.contains("storage=1"), "{error}");
+        assert!(error.contains("engine=0"), "{error}");
+        assert!(error.contains("gpu_cache=0"), "{error}");
+        drop(retained);
     }
 
     #[test]

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -146,6 +146,7 @@ pub(crate) mod gpu_native_greedy_parity;
 pub(crate) mod gpu_native_layer0_diagnostics;
 pub(crate) mod gpu_native_router_rank_diagnostics;
 pub(crate) mod gpu_native_semantic_parity_corpus;
+pub(crate) mod gpu_native_semantic_parity_v2;
 
 pub(crate) mod gpu_native_token_loop;
 #[cfg(feature = "grpc")]
@@ -935,6 +936,20 @@ enum Cmd {
         report_out: Option<PathBuf>,
     },
 
+    /// Qualify GPU-native semantic correctness over the independent frozen v2 holdout corpus.
+    #[command(name = "qualify-gpu-native-semantic-parity-v2")]
+    QualifyGpuNativeSemanticParityV2 {
+        /// Path to the strict GPU-native Q4 TOML config.
+        #[arg(long)]
+        config: PathBuf,
+        /// Exact wgpu adapter name required for both isolated runtimes.
+        #[arg(long)]
+        expected_adapter_name: String,
+        /// Required versioned typed JSON qualification destination.
+        #[arg(long)]
+        report_out: PathBuf,
+    },
+
     /// Collect reproducibility and complete first-token CPU/Hybrid logit
     /// evidence for the fixed json-transformation case.
     DiagnoseHybridQ4GreedyDivergence {
@@ -1707,6 +1722,7 @@ fn startup_config_path(cmd: &Cmd) -> Option<&Path> {
         | Cmd::QualifyHybridQ4Parity { config, .. }
         | Cmd::QualifyHybridQ4GreedyParity { config, .. }
         | Cmd::QualifyGpuNativeQ4GreedyParity { config, .. }
+        | Cmd::QualifyGpuNativeSemanticParityV2 { config, .. }
         | Cmd::DiagnoseHybridQ4GreedyDivergence { config, .. }
         | Cmd::DiagnoseGpuNativeQ4FirstDivergence { config, .. }
         | Cmd::DiagnoseGpuNativeRouterRankDivergence { config, .. }
@@ -2173,6 +2189,24 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     report_out,
                     progress_watchdog,
                 },
+            ))
+        }
+        Cmd::QualifyGpuNativeSemanticParityV2 {
+            config,
+            expected_adapter_name,
+            report_out,
+        } => {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()?;
+            rt.block_on(crate::gpu_native_semantic_parity_v2::run_qualification(
+                config,
+                startup_config
+                    .take()
+                    .ok_or("qualify-gpu-native-semantic-parity-v2 startup config was not parsed")?,
+                expected_adapter_name,
+                report_out,
+                progress_watchdog,
             ))
         }
         Cmd::DiagnoseHybridQ4GreedyDivergence {
@@ -14674,6 +14708,39 @@ mod tests {
         assert_eq!(config, &PathBuf::from("strict-gpu-native.toml"));
         assert_eq!(expected_adapter_name, "NVIDIA L4");
         assert_eq!(report_out, &PathBuf::from("semantic-corpus.json"));
+        assert_eq!(
+            super::startup_config_path(&cli.cmd),
+            Some(Path::new("strict-gpu-native.toml"))
+        );
+    }
+
+    #[test]
+    fn semantic_parity_v2_qualifier_cli_has_versioned_strict_surface() {
+        let cli = <Cli as clap::Parser>::try_parse_from([
+            "micro-expert-router",
+            "qualify-gpu-native-semantic-parity-v2",
+            "--config",
+            "strict-gpu-native.toml",
+            "--expected-adapter-name",
+            "NVIDIA L4",
+            "--report-out",
+            "semantic-parity-v2.json",
+            "--progress-timeout-secs",
+            "300",
+        ])
+        .unwrap();
+        assert_eq!(cli.progress_timeout_secs, Some(300));
+        let Cmd::QualifyGpuNativeSemanticParityV2 {
+            config,
+            expected_adapter_name,
+            report_out,
+        } = &cli.cmd
+        else {
+            panic!("expected qualify-gpu-native-semantic-parity-v2 command");
+        };
+        assert_eq!(config, &PathBuf::from("strict-gpu-native.toml"));
+        assert_eq!(expected_adapter_name, "NVIDIA L4");
+        assert_eq!(report_out, &PathBuf::from("semantic-parity-v2.json"));
         assert_eq!(
             super::startup_config_path(&cli.cmd),
             Some(Path::new("strict-gpu-native.toml"))

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -140,6 +140,8 @@ mod gating;
 mod gguf;
 mod gguf_loader;
 mod gpu_native_residency;
+pub(crate) mod gpu_native_diagnostics;
+
 pub(crate) mod gpu_native_token_loop;
 #[cfg(feature = "grpc")]
 mod grpc;
@@ -926,6 +928,23 @@ enum Cmd {
         #[arg(long)]
         report_out: PathBuf,
     },
+    /// Diagnose first mathematical divergence between production Hybrid Q4 reference and full GPU-native execution.
+    DiagnoseGpuNativeQ4FirstDivergence {
+        /// Strict GPU-native Q4 configuration.
+        #[arg(long)]
+        config: PathBuf,
+        /// Expected GPU adapter name (e.g. "NVIDIA L4").
+        #[arg(long)]
+        expected_adapter_name: String,
+        /// Target case (e.g. "json-transformation").
+        #[arg(long)]
+        case: String,
+        /// Optional typed diagnostic report output path.
+        #[arg(long)]
+        report_out: Option<PathBuf>,
+    },
+
+
 
     /// Private same-binary worker for one strict-Hybrid greedy-parity plane.
     #[command(name = "greedy-parity-hybrid-worker-internal", hide = true)]
@@ -2076,6 +2095,28 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 },
             ))
         }
+        Cmd::DiagnoseGpuNativeQ4FirstDivergence {
+            config: _,
+            expected_adapter_name,
+            case,
+            report_out,
+        } => {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()?;
+            rt.block_on(cmd_diagnose_gpu_native_q4_first_divergence(
+                DiagnoseGpuNativeQ4FirstDivergenceArgs {
+                    parsed_config: startup_config
+                        .take()
+                        .ok_or("diagnose-gpu-native-q4-first-divergence startup config was not parsed")?,
+                    expected_adapter_name,
+                    case,
+                    report_out,
+                    progress_watchdog,
+                },
+            ))
+        }
+
         Cmd::MatvecMicrobench {
             backend,
             warmup_runs,
@@ -2326,6 +2367,15 @@ struct DiagnoseHybridQ4GreedyDivergenceArgs {
     progress_watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
 }
 
+struct DiagnoseGpuNativeQ4FirstDivergenceArgs {
+    parsed_config: crate::config::Config,
+    expected_adapter_name: String,
+    case: String,
+    report_out: Option<PathBuf>,
+    progress_watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+}
+
+
 struct MatvecMicrobenchArgs {
     backends: Vec<crate::parallel::DenseMatvecBackend>,
     warmup_runs: usize,
@@ -2443,6 +2493,8 @@ struct BenchRealRuntime {
     engine: Arc<Engine>,
     model: Arc<crate::model::RealModel>,
     tokenizer: Arc<crate::tokenizer::Tokenizer>,
+    gpu_native_token_loop: Option<Arc<crate::gpu_native_token_loop::GpuNativeTokenLoop>>,
+
     isolated_cache: Option<Arc<MultiLayerExpertCache>>,
     isolated_shutdown: Option<IsolatedRuntimeShutdownWitness>,
 }
@@ -5271,6 +5323,236 @@ async fn cmd_diagnose_hybrid_q4_greedy_divergence(
     emit_numerical_diagnostic_report(&report, &args.report_out)
 }
 
+fn emit_gpu_native_first_divergence_report(
+    report: &crate::gpu_native_diagnostics::GpuNativeFirstDivergenceReport,
+    out_path: Option<&std::path::Path>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let json = serde_json::to_string_pretty(report)?;
+    if let Some(path) = out_path {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(path, json)?;
+        info!(
+            report = %path.display(),
+            "GPU-native first-divergence diagnostic report written"
+        );
+    } else {
+        println!("{json}");
+    }
+    if let Some(ref failure) = report.failure {
+        Err(failure.clone().into())
+    } else {
+        Ok(())
+    }
+}
+
+fn fail_gpu_native_first_divergence(
+    mut report: crate::gpu_native_diagnostics::GpuNativeFirstDivergenceReport,
+    reason: String,
+    out_path: Option<&std::path::Path>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    report.fail(reason);
+    emit_gpu_native_first_divergence_report(&report, out_path)
+}
+
+async fn cmd_diagnose_gpu_native_q4_first_divergence(
+    args: DiagnoseGpuNativeQ4FirstDivergenceArgs,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use crate::qualification::BuildProvenance;
+
+    let provenance = BuildProvenance::embedded();
+    let build_git_sha = provenance
+        .git_sha
+        .clone()
+        .unwrap_or_else(|| "unknown".to_string());
+    let (_, executable_sha256) = current_executable_identity()?;
+
+    let cfg = args.parsed_config.clone();
+    let metadata_path = cfg.model.data_dir.join("metadata.json");
+    let expert_metadata = crate::qualification::read_expert_metadata(&metadata_path)
+        .map_err(|e| format!("failed to read expert metadata: {e}"))?;
+
+    let fixed_case = crate::greedy_parity::fixed_case(&args.case).ok_or_else(|| {
+        format!(
+            "unknown corpus case: {}; expected one of: rust-generation, rust-debugging, json-transformation, multilingual-spanish",
+            args.case
+        )
+    })?;
+
+    let prompt_sha256 = crate::greedy_parity::sha256_hex(fixed_case.prompt.as_bytes());
+
+    let mut gpu_spec = resolve_real_cli_spec_from_config(
+        cfg.clone(),
+        RealCliRuntimeMode::IsolatedGreedyParityHybrid,
+    )?;
+    gpu_spec.cfg.real_transformer.gpu_native = true;
+    gpu_spec.cfg.real_transformer.compute_offload = crate::backend::ComputeOffload::Hybrid;
+    gpu_spec.cfg.real_transformer.strict_weights = true;
+    gpu_spec.cfg.real_transformer.allow_degraded_experts = false;
+    gpu_spec.cfg.real_transformer.allow_seeded_fallback = false;
+
+    let resolved_config_sha256 = resolved_real_cli_spec_sha256(&gpu_spec)?;
+
+    // 1. Reference Phase (CPU with Hybrid boundary emulation)
+    let mut ref_spec = resolve_real_cli_spec_from_config(
+        cfg.clone(),
+        RealCliRuntimeMode::IsolatedGreedyParityCpu,
+    )?;
+    ref_spec.cfg.real_transformer.compute_offload = crate::backend::ComputeOffload::Cpu;
+    ref_spec.cfg.real_transformer.strict_weights = true;
+    ref_spec.cfg.real_transformer.allow_degraded_experts = false;
+    ref_spec.cfg.real_transformer.allow_seeded_fallback = false;
+
+    let ref_context =
+        resolve_isolated_real_cli_context(&ref_spec, crate::backend::ComputeOffload::Cpu)?;
+
+    let ref_runtime = build_real_cli_runtime_from_spec(
+        &ref_spec,
+        RealCliRuntimeMode::IsolatedGreedyParityCpu,
+        ref_context,
+        None,
+    )
+    .await?;
+
+    ref_runtime.engine.enable_cpu_q4_boundary_emulation()?;
+
+    let prompt_token_ids = ref_runtime.tokenizer.encode(fixed_case.prompt)?;
+    if prompt_token_ids.is_empty() {
+        return Err("prompt tokenized to zero tokens".into());
+    }
+
+    let mut ref_kv = ref_runtime.model.fresh_kv_caches();
+    let final_pos = prompt_token_ids.len() - 1;
+    let final_tid = prompt_token_ids[final_pos];
+
+    for (pos, &tid) in prompt_token_ids[..prompt_token_ids.len() - 1]
+        .iter()
+        .enumerate()
+    {
+        ref_runtime
+            .model
+            .forward_token_hidden(&ref_runtime.engine, tid, pos, &mut ref_kv)
+            .await?;
+    }
+
+    let ref_trace = ref_runtime
+        .model
+        .forward_token_diagnostic_trace(&ref_runtime.engine, final_tid, final_pos, &mut ref_kv, None)
+        .await?;
+
+    let _ = ref_runtime.shutdown_isolated().await;
+
+    // 2. GPU-Native Phase
+    let gpu_context =
+        resolve_isolated_real_cli_context(&gpu_spec, crate::backend::ComputeOffload::Hybrid)?;
+
+    let gpu_runtime = build_real_cli_runtime_from_spec(
+        &gpu_spec,
+        RealCliRuntimeMode::IsolatedGreedyParityHybrid,
+        gpu_context,
+        None,
+    )
+    .await?;
+
+    let device = gpu_runtime
+        .engine
+        .execution_context()
+        .gpu_device_identity()
+        .ok_or("GPU execution context has no active device identity")?;
+
+    let gpu_native_token_loop = gpu_runtime
+        .gpu_native_token_loop
+        .clone()
+        .ok_or("GPU-native token loop was not initialized on GPU runtime")?;
+
+    let model_geometry = gpu_native_token_loop.model_geometry();
+
+    let case_evidence = crate::gpu_native_diagnostics::CaseEvidence {
+        case_name: fixed_case.name.to_string(),
+        prompt_sha256,
+        prompt_token_count: prompt_token_ids.len(),
+    };
+
+    let mut report = crate::gpu_native_diagnostics::GpuNativeFirstDivergenceReport::new(
+        provenance,
+        build_git_sha,
+        executable_sha256,
+        resolved_config_sha256.clone(),
+        model_geometry,
+        expert_metadata,
+        case_evidence,
+        crate::greedy_parity::token_ids_sha256(&prompt_token_ids),
+        args.expected_adapter_name.clone(),
+    );
+
+    if device.name != args.expected_adapter_name {
+        return fail_gpu_native_first_divergence(
+            report,
+            format!(
+                "adapter mismatch: runtime has {:?}, expected {:?}",
+                device.name, args.expected_adapter_name
+            ),
+            args.report_out.as_deref(),
+        );
+    }
+    report.actual_adapter = Some(device);
+
+    let mut req_state = gpu_native_token_loop.create_request_state()?;
+    for (pos, &tid) in prompt_token_ids[..prompt_token_ids.len() - 1]
+        .iter()
+        .enumerate()
+    {
+        gpu_native_token_loop
+            .step_token(&gpu_runtime.engine, &mut req_state, tid, pos, false)
+            .await?;
+    }
+
+    let trace_layout = crate::gpu_native_diagnostics::GpuNativeDiagnosticTraceLayout::try_new(
+        cfg.model.num_layers,
+        cfg.model.d_model,
+        cfg.model.top_k,
+        cfg.real_transformer.vocab_size,
+    )?;
+    let staging_buffer = gpu_native_token_loop.create_diagnostic_staging_buffer(&trace_layout)?;
+
+    let (gpu_trace, attempts) = gpu_native_token_loop
+        .step_token_diagnostic(
+            &gpu_runtime.engine,
+            &mut req_state,
+            final_tid,
+            final_pos,
+            true,
+            &trace_layout,
+            &staging_buffer,
+        )
+        .await?;
+
+    let counters_delta = gpu_native_token_loop.snapshot();
+    drop(req_state);
+    drop(staging_buffer);
+    let _ = gpu_runtime.shutdown_isolated().await;
+
+    // 3. Comparison
+    let (first_exact_divergence, first_divergence, stages) =
+        crate::gpu_native_diagnostics::compare_diagnostic_traces(&ref_trace, &gpu_trace)?;
+
+    report.reference_sampled_token_id = Some(ref_trace.sampled_token);
+    report.gpu_native_sampled_token_id = Some(gpu_trace.sampled_token);
+    report.token_match = Some(ref_trace.sampled_token == gpu_trace.sampled_token);
+    report.first_exact_divergence = first_exact_divergence;
+    report.first_divergence = first_divergence;
+    report.stages = stages;
+    report.token_loop_counters_delta = counters_delta;
+    report.attempt_count = attempts;
+    report.diagnostic_complete = true;
+    report.qualification_pass = false;
+
+    emit_gpu_native_first_divergence_report(&report, args.report_out.as_deref())
+}
+
+
+
 async fn cmd_qualify_hybrid_q4_greedy_parity(
     args: QualifyHybridQ4GreedyParityArgs,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -7118,7 +7400,7 @@ async fn build_real_cli_runtime_from_spec(
             collect_route_profile: false,
             policy: cfg.real_transformer.inference_policy(),
         },
-        execution_context,
+        execution_context.clone(),
     );
     engine_builder = engine_builder.with_pipeline_depth(cfg.storage.pipeline_depth);
     if cfg.predictive.locality_enabled {
@@ -7183,7 +7465,46 @@ async fn build_real_cli_runtime_from_spec(
             crate::engine::RoutedExpertGpuFailurePolicy::StrictFailClosed,
         );
     }
-    let engine = Arc::new(engine_builder.with_metrics(metrics));
+    let (engine, gpu_native_token_loop) = if cfg.real_transformer.gpu_native {
+        let executor = Arc::new(
+            execution_context
+                .create_gpu_native_executor_context(cfg.model.d_model)
+                .map_err(|e| format!("failed to create GPU-native executor context: {e}"))?,
+        );
+        let total_expert_budget = (cfg.gpu_cache.vram_capacity_mb as u64) * 1024 * 1024;
+        let expert_geom = crate::backend::gpu_native::GpuNativeQ4ExpertGeometry::try_new(
+            cfg.model.d_model,
+            cfg.model.d_ff,
+            cfg.model.num_experts as usize,
+            cfg.model.top_k,
+        )
+        .map_err(|e| format!("invalid GPU-native Q4 expert geometry: {e}"))?;
+        let residency_manager = Arc::new(
+            crate::gpu_native_residency::GpuNativeTieredResidencyManager::try_new(
+                executor.clone(),
+                execution_context.gpu_expert_cache().clone(),
+                cfg.model.num_layers,
+                expert_geom,
+                total_expert_budget,
+            )
+            .map_err(|e| format!("failed to initialize tiered residency manager: {e}"))?,
+        );
+        engine_builder
+            .install_gpu_native_residency_manager(residency_manager.clone())
+            .map_err(|e| format!("failed to install tiered residency manager on engine: {e}"))?;
+        let token_loop = crate::gpu_native_token_loop::GpuNativeTokenLoop::try_new(
+            executor,
+            residency_manager,
+            &model,
+            cfg.real_transformer.gpu_native_max_seq_len,
+        )
+        .map_err(|e| format!("failed to initialize GPU-native token loop: {e}"))?;
+        let engine = Arc::new(engine_builder.with_metrics(metrics));
+        (engine, Some(token_loop))
+    } else {
+        let engine = Arc::new(engine_builder.with_metrics(metrics));
+        (engine, None)
+    };
 
     let tokenizer = match tokenizer_override {
         Some(tokenizer) => tokenizer,
@@ -7218,6 +7539,7 @@ async fn build_real_cli_runtime_from_spec(
         engine,
         model,
         tokenizer,
+        gpu_native_token_loop,
         isolated_cache: mode.is_isolated().then_some(cache),
         isolated_shutdown,
     })
@@ -12243,4 +12565,37 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(&dir);
     }
+
+    #[test]
+    fn gpu_native_first_divergence_cli_parses_expected_flags() {
+        let cli = <Cli as clap::Parser>::try_parse_from([
+            "micro-expert-router",
+            "diagnose-gpu-native-q4-first-divergence",
+            "--config",
+            "config.toml",
+            "--expected-adapter-name",
+            "NVIDIA L4",
+            "--case",
+            "json-transformation",
+            "--report-out",
+            "report.json",
+        ])
+        .unwrap();
+
+        match cli.cmd {
+            Cmd::DiagnoseGpuNativeQ4FirstDivergence {
+                config,
+                expected_adapter_name,
+                case,
+                report_out,
+            } => {
+                assert_eq!(config, PathBuf::from("config.toml"));
+                assert_eq!(expected_adapter_name, "NVIDIA L4");
+                assert_eq!(case, "json-transformation");
+                assert_eq!(report_out, Some(PathBuf::from("report.json")));
+            }
+            _ => panic!("unexpected command variant"),
+        }
+    }
+
 }

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -142,6 +142,7 @@ mod gguf_loader;
 mod gpu_native_residency;
 pub(crate) mod gpu_native_diagnostics;
 pub(crate) mod gpu_native_expert_permutation_semantic_parity;
+pub(crate) mod gpu_native_f32_reference_boundary_audit;
 pub(crate) mod gpu_native_greedy_parity;
 pub(crate) mod gpu_native_layer0_diagnostics;
 pub(crate) mod gpu_native_q4_expert_stage_attribution;
@@ -992,6 +993,29 @@ enum Cmd {
         report_out: PathBuf,
     },
 
+    /// Audit the frozen GPU-native Q4 evidence against ordinary exact-f32 CPU references.
+    #[command(name = "diagnose-gpu-native-f32-reference-boundary")]
+    DiagnoseGpuNativeF32ReferenceBoundary {
+        /// Path to the strict GPU-native Q4 TOML config used to build a CPU-only reference.
+        #[arg(long)]
+        config: PathBuf,
+        /// Exact frozen GPU-native semantic-parity v2 report.
+        #[arg(long)]
+        v2_report: PathBuf,
+        /// Required frozen SHA256 of the supplied v2 report.
+        #[arg(long)]
+        expected_v2_report_sha256: String,
+        /// Exact frozen GPU-native Q4 expert-stage attribution report.
+        #[arg(long)]
+        stage_report: PathBuf,
+        /// Required frozen SHA256 of the supplied stage report.
+        #[arg(long)]
+        expected_stage_report_sha256: String,
+        /// Required typed diagnostic JSON destination.
+        #[arg(long)]
+        report_out: PathBuf,
+    },
+
     /// Collect reproducibility and complete first-token CPU/Hybrid logit
     /// evidence for the fixed json-transformation case.
     DiagnoseHybridQ4GreedyDivergence {
@@ -1767,6 +1791,7 @@ fn startup_config_path(cmd: &Cmd) -> Option<&Path> {
         | Cmd::QualifyGpuNativeSemanticParityV2 { config, .. }
         | Cmd::DiagnoseGpuNativeV2HoldoutFailures { config, .. }
         | Cmd::DiagnoseGpuNativeQ4ExpertStages { config, .. }
+        | Cmd::DiagnoseGpuNativeF32ReferenceBoundary { config, .. }
         | Cmd::DiagnoseHybridQ4GreedyDivergence { config, .. }
         | Cmd::DiagnoseGpuNativeQ4FirstDivergence { config, .. }
         | Cmd::DiagnoseGpuNativeRouterRankDivergence { config, .. }
@@ -2296,6 +2321,32 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     expected_adapter_name,
                     bea_report,
                     expected_bea_report_sha256,
+                    report_out,
+                    progress_watchdog,
+                ),
+            )
+        }
+        Cmd::DiagnoseGpuNativeF32ReferenceBoundary {
+            config,
+            v2_report,
+            expected_v2_report_sha256,
+            stage_report,
+            expected_stage_report_sha256,
+            report_out,
+        } => {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()?;
+            rt.block_on(
+                crate::gpu_native_f32_reference_boundary_audit::run_diagnostic(
+                    config,
+                    startup_config.take().ok_or(
+                        "diagnose-gpu-native-f32-reference-boundary startup config was not parsed",
+                    )?,
+                    v2_report,
+                    expected_v2_report_sha256,
+                    stage_report,
+                    expected_stage_report_sha256,
                     report_out,
                     progress_watchdog,
                 ),
@@ -14927,6 +14978,70 @@ mod tests {
         assert_eq!(
             crate::gpu_native_q4_expert_stage_attribution::SCHEMA_VERSION,
             "mer.gpu-native-q4-expert-stage-attribution.v1"
+        );
+        assert_eq!(
+            super::startup_config_path(&cli.cmd),
+            Some(Path::new("strict-gpu-native.toml"))
+        );
+    }
+
+    #[test]
+    fn f32_reference_boundary_audit_cli_has_versioned_cpu_only_frozen_surface() {
+        let cli = <Cli as clap::Parser>::try_parse_from([
+            "micro-expert-router",
+            "diagnose-gpu-native-f32-reference-boundary",
+            "--config",
+            "strict-gpu-native.toml",
+            "--v2-report",
+            "gpu-native-semantic-parity-v2-300448ac.json",
+            "--expected-v2-report-sha256",
+            crate::gpu_native_f32_reference_boundary_audit::FROZEN_V2_REPORT_SHA256,
+            "--stage-report",
+            "gpu-native-q4-expert-stage-attribution-987e7e4b.json",
+            "--expected-stage-report-sha256",
+            crate::gpu_native_f32_reference_boundary_audit::FROZEN_STAGE_REPORT_SHA256,
+            "--report-out",
+            "f32-reference-boundary-audit.json",
+            "--progress-timeout-secs",
+            "300",
+        ])
+        .unwrap();
+        assert_eq!(cli.progress_timeout_secs, Some(300));
+        let Cmd::DiagnoseGpuNativeF32ReferenceBoundary {
+            config,
+            v2_report,
+            expected_v2_report_sha256,
+            stage_report,
+            expected_stage_report_sha256,
+            report_out,
+        } = &cli.cmd
+        else {
+            panic!("expected diagnose-gpu-native-f32-reference-boundary command");
+        };
+        assert_eq!(config, &PathBuf::from("strict-gpu-native.toml"));
+        assert_eq!(
+            v2_report,
+            &PathBuf::from("gpu-native-semantic-parity-v2-300448ac.json")
+        );
+        assert_eq!(
+            expected_v2_report_sha256,
+            crate::gpu_native_f32_reference_boundary_audit::FROZEN_V2_REPORT_SHA256
+        );
+        assert_eq!(
+            stage_report,
+            &PathBuf::from("gpu-native-q4-expert-stage-attribution-987e7e4b.json")
+        );
+        assert_eq!(
+            expected_stage_report_sha256,
+            crate::gpu_native_f32_reference_boundary_audit::FROZEN_STAGE_REPORT_SHA256
+        );
+        assert_eq!(
+            report_out,
+            &PathBuf::from("f32-reference-boundary-audit.json")
+        );
+        assert_eq!(
+            crate::gpu_native_f32_reference_boundary_audit::SCHEMA_VERSION,
+            "mer.gpu-native-f32-reference-boundary-audit.v1"
         );
         assert_eq!(
             super::startup_config_path(&cli.cmd),

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -1606,6 +1606,21 @@ fn parse_autotune_probe_output(
     None
 }
 
+fn startup_config_path(cmd: &Cmd) -> Option<&Path> {
+    match cmd {
+        Cmd::Serve { config }
+        | Cmd::BenchReal { config, .. }
+        | Cmd::QualifyHybridQ4 { config, .. }
+        | Cmd::QualifyHybridQ4Parity { config, .. }
+        | Cmd::QualifyHybridQ4GreedyParity { config, .. }
+        | Cmd::DiagnoseHybridQ4GreedyDivergence { config, .. }
+        | Cmd::DiagnoseGpuNativeQ4FirstDivergence { config, .. }
+        | Cmd::GreedyParityHybridWorkerInternal { config }
+        | Cmd::GreedyParityLogitWorkerInternal { config } => Some(config.as_path()),
+        _ => None,
+    }
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let raw_args: Vec<OsString> = std::env::args_os().collect();
     let cli = Cli::parse();
@@ -1620,18 +1635,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // runtime controls before CPU placement / Rayon exist. The command
     // handlers still own their normal config reconciliation and runtime
     // construction below.
-    let mut startup_config = match &cli.cmd {
-        Cmd::Serve { config }
-        | Cmd::BenchReal { config, .. }
-        | Cmd::QualifyHybridQ4 { config, .. }
-        | Cmd::QualifyHybridQ4Parity { config, .. }
-        | Cmd::QualifyHybridQ4GreedyParity { config, .. }
-        | Cmd::DiagnoseHybridQ4GreedyDivergence { config, .. }
-        | Cmd::GreedyParityHybridWorkerInternal { config }
-        | Cmd::GreedyParityLogitWorkerInternal { config } => {
-            Some(crate::config::Config::from_file(config)?)
-        }
-        _ => None,
+    let mut startup_config = match startup_config_path(&cli.cmd) {
+        Some(path) => Some(crate::config::Config::from_file(path)?),
+        None => None,
     };
 
     let config_cpu_mask = startup_config
@@ -12582,20 +12588,43 @@ mod tests {
         ])
         .unwrap();
 
-        match cli.cmd {
+        match &cli.cmd {
             Cmd::DiagnoseGpuNativeQ4FirstDivergence {
                 config,
                 expected_adapter_name,
                 case,
                 report_out,
             } => {
-                assert_eq!(config, PathBuf::from("config.toml"));
+                assert_eq!(config, &PathBuf::from("config.toml"));
                 assert_eq!(expected_adapter_name, "NVIDIA L4");
                 assert_eq!(case, "json-transformation");
-                assert_eq!(report_out, Some(PathBuf::from("report.json")));
+                assert_eq!(report_out, &Some(PathBuf::from("report.json")));
             }
             _ => panic!("unexpected command variant"),
         }
+        assert_eq!(
+            super::startup_config_path(&cli.cmd),
+            Some(Path::new("config.toml"))
+        );
     }
 
+    #[test]
+    fn startup_config_path_resolves_gpu_native_first_divergence() {
+        let cli = <Cli as clap::Parser>::try_parse_from([
+            "micro-expert-router",
+            "diagnose-gpu-native-q4-first-divergence",
+            "--config",
+            "config.toml",
+            "--expected-adapter-name",
+            "NVIDIA L4",
+            "--case",
+            "json-transformation",
+        ])
+        .unwrap();
+
+        assert_eq!(
+            super::startup_config_path(&cli.cmd),
+            Some(Path::new("config.toml"))
+        );
+    }
 }

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -5390,10 +5390,10 @@ async fn cmd_diagnose_gpu_native_q4_first_divergence(
 
     let mut gpu_spec = resolve_real_cli_spec_from_config(
         cfg.clone(),
-        RealCliRuntimeMode::IsolatedGreedyParityHybrid,
+        RealCliRuntimeMode::IsolatedGpuNativeDiagnostic,
     )?;
     gpu_spec.cfg.real_transformer.gpu_native = true;
-    gpu_spec.cfg.real_transformer.compute_offload = crate::backend::ComputeOffload::Hybrid;
+    gpu_spec.cfg.real_transformer.compute_offload = crate::backend::ComputeOffload::Gpu;
     gpu_spec.cfg.real_transformer.strict_weights = true;
     gpu_spec.cfg.real_transformer.allow_degraded_experts = false;
     gpu_spec.cfg.real_transformer.allow_seeded_fallback = false;
@@ -5405,6 +5405,7 @@ async fn cmd_diagnose_gpu_native_q4_first_divergence(
         cfg.clone(),
         RealCliRuntimeMode::IsolatedGreedyParityCpu,
     )?;
+    ref_spec.cfg.real_transformer.gpu_native = false;
     ref_spec.cfg.real_transformer.compute_offload = crate::backend::ComputeOffload::Cpu;
     ref_spec.cfg.real_transformer.strict_weights = true;
     ref_spec.cfg.real_transformer.allow_degraded_experts = false;
@@ -5451,11 +5452,11 @@ async fn cmd_diagnose_gpu_native_q4_first_divergence(
 
     // 2. GPU-Native Phase
     let gpu_context =
-        resolve_isolated_real_cli_context(&gpu_spec, crate::backend::ComputeOffload::Hybrid)?;
+        resolve_isolated_real_cli_context(&gpu_spec, crate::backend::ComputeOffload::Gpu)?;
 
     let gpu_runtime = build_real_cli_runtime_from_spec(
         &gpu_spec,
-        RealCliRuntimeMode::IsolatedGreedyParityHybrid,
+        RealCliRuntimeMode::IsolatedGpuNativeDiagnostic,
         gpu_context,
         None,
     )
@@ -6981,20 +6982,25 @@ enum RealCliRuntimeMode {
     StrictHybridQualification,
     IsolatedGreedyParityCpu,
     IsolatedGreedyParityHybrid,
+    IsolatedGpuNativeDiagnostic,
 }
 
 impl RealCliRuntimeMode {
     fn is_isolated(self) -> bool {
         matches!(
             self,
-            Self::IsolatedGreedyParityCpu | Self::IsolatedGreedyParityHybrid
+            Self::IsolatedGreedyParityCpu
+                | Self::IsolatedGreedyParityHybrid
+                | Self::IsolatedGpuNativeDiagnostic
         )
     }
 
     fn installs_logical_gpu_cache(self) -> bool {
         matches!(
             self,
-            Self::StrictHybridQualification | Self::IsolatedGreedyParityHybrid
+            Self::StrictHybridQualification
+                | Self::IsolatedGreedyParityHybrid
+                | Self::IsolatedGpuNativeDiagnostic
         )
     }
 
@@ -7005,6 +7011,7 @@ impl RealCliRuntimeMode {
             Self::IsolatedGreedyParityCpu | Self::IsolatedGreedyParityHybrid => {
                 "qualify-hybrid-q4-greedy-parity"
             }
+            Self::IsolatedGpuNativeDiagnostic => "diagnose-gpu-native-q4-first-divergence",
         }
     }
 }
@@ -7079,7 +7086,8 @@ async fn build_real_cli_runtime(
             context
         }
         RealCliRuntimeMode::IsolatedGreedyParityCpu
-        | RealCliRuntimeMode::IsolatedGreedyParityHybrid => {
+        | RealCliRuntimeMode::IsolatedGreedyParityHybrid
+        | RealCliRuntimeMode::IsolatedGpuNativeDiagnostic => {
             return Err("isolated qualification runtimes must use the private isolated factory".into());
         }
     };
@@ -7113,35 +7121,72 @@ fn resolve_real_cli_spec_from_config(
     })
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum IsolatedExecutionContextContract {
+    CpuReference,
+    HybridRoutedExperts,
+    GpuNativeAuthoritative,
+}
+
+fn isolated_execution_context_contract(
+    spec: &ResolvedRealCliSpec,
+    requested: crate::backend::ComputeOffload,
+) -> IsolatedExecutionContextContract {
+    if spec.cfg.real_transformer.gpu_native {
+        IsolatedExecutionContextContract::GpuNativeAuthoritative
+    } else if requested == crate::backend::ComputeOffload::Hybrid {
+        IsolatedExecutionContextContract::HybridRoutedExperts
+    } else {
+        IsolatedExecutionContextContract::CpuReference
+    }
+}
+
 fn resolve_isolated_real_cli_context(
     spec: &ResolvedRealCliSpec,
     requested: crate::backend::ComputeOffload,
 ) -> Result<Arc<crate::backend::ExecutionContext>, Box<dyn std::error::Error>> {
     let cfg = &spec.cfg;
-    let capacity_bytes = if requested == crate::backend::ComputeOffload::Hybrid {
-        cfg.gpu_cache
+    let contract = isolated_execution_context_contract(spec, requested);
+    let capacity_bytes = match contract {
+        IsolatedExecutionContextContract::HybridRoutedExperts
+        | IsolatedExecutionContextContract::GpuNativeAuthoritative => cfg
+            .gpu_cache
             .vram_capacity_mb
             .checked_mul(1024 * 1024)
-            .ok_or("gpu_cache.vram_capacity_mb overflows usize")?
-    } else {
-        0
+            .ok_or("gpu_cache.vram_capacity_mb overflows usize")?,
+        IsolatedExecutionContextContract::CpuReference => 0,
     };
     let gpu_cache = Arc::new(crate::expert_cache::GpuExpertCache::new(
         capacity_bytes,
         cfg.gpu_cache.vram_anchor_ratio,
         cfg.gpu_cache.promote_after_hits,
     ));
-    Ok(crate::backend::resolve_execution_context(
-        requested,
-        true,
-        strict_hybrid_gpu_geometry(cfg, &spec.advanced),
-        crate::backend::RoutedExpertGpuSpec {
-            dtype: cfg.model.dtype,
-            d_model: cfg.model.d_model,
-            d_ff: cfg.model.d_ff,
-        },
-        gpu_cache,
-    )?)
+    match contract {
+        IsolatedExecutionContextContract::GpuNativeAuthoritative => {
+            let mut geometry = strict_hybrid_gpu_geometry(cfg, &spec.advanced);
+            if cfg.real_transformer.gpu_native_max_seq_len > 0 {
+                geometry.max_seq_len = cfg.real_transformer.gpu_native_max_seq_len;
+            }
+            Ok(crate::backend::resolve_execution_context_for_gpu_native(
+                geometry,
+                gpu_cache,
+            )?)
+        }
+        IsolatedExecutionContextContract::HybridRoutedExperts
+        | IsolatedExecutionContextContract::CpuReference => {
+            Ok(crate::backend::resolve_execution_context(
+                requested,
+                true,
+                strict_hybrid_gpu_geometry(cfg, &spec.advanced),
+                crate::backend::RoutedExpertGpuSpec {
+                    dtype: cfg.model.dtype,
+                    d_model: cfg.model.d_model,
+                    d_ff: cfg.model.d_ff,
+                },
+                gpu_cache,
+            )?)
+        }
+    }
 }
 
 fn resolved_real_cli_spec_sha256(
@@ -7180,6 +7225,9 @@ async fn build_isolated_greedy_runtime(
         RealCliRuntimeMode::IsolatedGreedyParityCpu => crate::backend::ComputeOffload::Cpu,
         RealCliRuntimeMode::IsolatedGreedyParityHybrid => {
             crate::backend::ComputeOffload::Hybrid
+        }
+        RealCliRuntimeMode::IsolatedGpuNativeDiagnostic => {
+            crate::backend::ComputeOffload::Gpu
         }
         _ => return Err("non-isolated runtime mode passed to isolated factory".into()),
     };
@@ -12625,6 +12673,59 @@ mod tests {
         assert_eq!(
             super::startup_config_path(&cli.cmd),
             Some(Path::new("config.toml"))
+        );
+    }
+
+    #[test]
+    fn isolated_execution_context_contract_selects_expected_planes() {
+        let mut cfg = minimal_bench_cfg();
+        cfg.real_transformer.enabled = true;
+        cfg.real_transformer.gpu_native = true;
+        cfg.real_transformer.compute_offload = crate::backend::ComputeOffload::Gpu;
+        let gpu_spec = ResolvedRealCliSpec {
+            cfg: cfg.clone(),
+            architecture: crate::architecture::Architecture::Qwen3Moe,
+            first_k_dense_replace: 0,
+            advanced: crate::model::AdvancedConfig::default(),
+        };
+        assert_eq!(
+            isolated_execution_context_contract(&gpu_spec, crate::backend::ComputeOffload::Gpu),
+            IsolatedExecutionContextContract::GpuNativeAuthoritative
+        );
+
+        let mut cpu_cfg = cfg.clone();
+        cpu_cfg.real_transformer.gpu_native = false;
+        cpu_cfg.real_transformer.compute_offload = crate::backend::ComputeOffload::Cpu;
+        let ref_spec = ResolvedRealCliSpec {
+            cfg: cpu_cfg,
+            architecture: crate::architecture::Architecture::Qwen3Moe,
+            first_k_dense_replace: 0,
+            advanced: crate::model::AdvancedConfig::default(),
+        };
+        assert_eq!(
+            isolated_execution_context_contract(&ref_spec, crate::backend::ComputeOffload::Cpu),
+            IsolatedExecutionContextContract::CpuReference
+        );
+
+        let mut hybrid_cfg = cfg.clone();
+        hybrid_cfg.real_transformer.gpu_native = false;
+        hybrid_cfg.real_transformer.compute_offload = crate::backend::ComputeOffload::Hybrid;
+        let hybrid_spec = ResolvedRealCliSpec {
+            cfg: hybrid_cfg,
+            architecture: crate::architecture::Architecture::Qwen3Moe,
+            first_k_dense_replace: 0,
+            advanced: crate::model::AdvancedConfig::default(),
+        };
+        assert_eq!(
+            isolated_execution_context_contract(&hybrid_spec, crate::backend::ComputeOffload::Hybrid),
+            IsolatedExecutionContextContract::HybridRoutedExperts
+        );
+
+        assert!(RealCliRuntimeMode::IsolatedGpuNativeDiagnostic.is_isolated());
+        assert!(RealCliRuntimeMode::IsolatedGpuNativeDiagnostic.installs_logical_gpu_cache());
+        assert_eq!(
+            RealCliRuntimeMode::IsolatedGpuNativeDiagnostic.tokenizer_command(),
+            "diagnose-gpu-native-q4-first-divergence"
         );
     }
 }

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -149,6 +149,7 @@ pub(crate) mod gpu_native_q4_expert_stage_attribution;
 pub(crate) mod gpu_native_router_rank_diagnostics;
 pub(crate) mod gpu_native_semantic_parity_corpus;
 pub(crate) mod gpu_native_semantic_parity_v2;
+pub(crate) mod gpu_native_spanish_first_token_attribution;
 pub(crate) mod gpu_native_v2_holdout_failure_attribution;
 
 pub(crate) mod gpu_native_token_loop;
@@ -1016,6 +1017,38 @@ enum Cmd {
         report_out: PathBuf,
     },
 
+    /// Attribute the frozen Spanish first generated-token divergence across isolated exact-f32 CPU, historical-f16 CPU, and GPU-native planes.
+    #[command(name = "diagnose-gpu-native-spanish-first-token-attribution")]
+    DiagnoseGpuNativeSpanishFirstTokenAttribution {
+        /// Path to the strict GPU-native Q4 TOML configuration.
+        #[arg(long)]
+        config: PathBuf,
+        /// Exact frozen GPU-native semantic-parity v2 report.
+        #[arg(long)]
+        v2_report: PathBuf,
+        /// Required frozen SHA256 of the supplied v2 report.
+        #[arg(long)]
+        expected_v2_report_sha256: String,
+        /// Exact frozen GPU-native Q4 expert-stage attribution report.
+        #[arg(long)]
+        stage_report: PathBuf,
+        /// Required frozen SHA256 of the supplied stage report.
+        #[arg(long)]
+        expected_stage_report_sha256: String,
+        /// Exact frozen f32 reference-boundary audit report.
+        #[arg(long)]
+        boundary_audit_report: PathBuf,
+        /// Required frozen SHA256 of the supplied boundary-audit report.
+        #[arg(long)]
+        expected_boundary_audit_report_sha256: String,
+        /// Exact production GPU adapter name; this diagnostic requires NVIDIA L4.
+        #[arg(long)]
+        expected_adapter_name: String,
+        /// Required typed diagnostic JSON destination.
+        #[arg(long)]
+        report_out: PathBuf,
+    },
+
     /// Collect reproducibility and complete first-token CPU/Hybrid logit
     /// evidence for the fixed json-transformation case.
     DiagnoseHybridQ4GreedyDivergence {
@@ -1792,6 +1825,7 @@ fn startup_config_path(cmd: &Cmd) -> Option<&Path> {
         | Cmd::DiagnoseGpuNativeV2HoldoutFailures { config, .. }
         | Cmd::DiagnoseGpuNativeQ4ExpertStages { config, .. }
         | Cmd::DiagnoseGpuNativeF32ReferenceBoundary { config, .. }
+        | Cmd::DiagnoseGpuNativeSpanishFirstTokenAttribution { config, .. }
         | Cmd::DiagnoseHybridQ4GreedyDivergence { config, .. }
         | Cmd::DiagnoseGpuNativeQ4FirstDivergence { config, .. }
         | Cmd::DiagnoseGpuNativeRouterRankDivergence { config, .. }
@@ -2347,6 +2381,38 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     expected_v2_report_sha256,
                     stage_report,
                     expected_stage_report_sha256,
+                    report_out,
+                    progress_watchdog,
+                ),
+            )
+        }
+        Cmd::DiagnoseGpuNativeSpanishFirstTokenAttribution {
+            config,
+            v2_report,
+            expected_v2_report_sha256,
+            stage_report,
+            expected_stage_report_sha256,
+            boundary_audit_report,
+            expected_boundary_audit_report_sha256,
+            expected_adapter_name,
+            report_out,
+        } => {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()?;
+            rt.block_on(
+                crate::gpu_native_spanish_first_token_attribution::run_diagnostic(
+                    config,
+                    startup_config.take().ok_or(
+                        "diagnose-gpu-native-spanish-first-token-attribution startup config was not parsed",
+                    )?,
+                    v2_report,
+                    expected_v2_report_sha256,
+                    stage_report,
+                    expected_stage_report_sha256,
+                    boundary_audit_report,
+                    expected_boundary_audit_report_sha256,
+                    expected_adapter_name,
                     report_out,
                     progress_watchdog,
                 ),
@@ -15046,6 +15112,72 @@ mod tests {
         assert_eq!(
             super::startup_config_path(&cli.cmd),
             Some(Path::new("strict-gpu-native.toml"))
+        );
+    }
+
+    #[test]
+    fn spanish_first_token_attribution_cli_has_three_frozen_reports_and_l4_surface() {
+        let cli = Cli::try_parse_from([
+            "micro-expert-router",
+            "--progress-timeout-secs",
+            "300",
+            "diagnose-gpu-native-spanish-first-token-attribution",
+            "--config",
+            "config.toml",
+            "--v2-report",
+            "v2.json",
+            "--expected-v2-report-sha256",
+            crate::gpu_native_spanish_first_token_attribution::FROZEN_V2_REPORT_SHA256,
+            "--stage-report",
+            "stage.json",
+            "--expected-stage-report-sha256",
+            crate::gpu_native_spanish_first_token_attribution::FROZEN_STAGE_REPORT_SHA256,
+            "--boundary-audit-report",
+            "boundary.json",
+            "--expected-boundary-audit-report-sha256",
+            crate::gpu_native_spanish_first_token_attribution::FROZEN_BOUNDARY_AUDIT_REPORT_SHA256,
+            "--expected-adapter-name",
+            "NVIDIA L4",
+            "--report-out",
+            "spanish-first-token.json",
+        ])
+        .unwrap();
+        assert_eq!(cli.progress_timeout_secs, Some(300));
+        let Cmd::DiagnoseGpuNativeSpanishFirstTokenAttribution {
+            config,
+            v2_report,
+            expected_v2_report_sha256,
+            stage_report,
+            expected_stage_report_sha256,
+            boundary_audit_report,
+            expected_boundary_audit_report_sha256,
+            expected_adapter_name,
+            report_out,
+        } = &cli.cmd
+        else {
+            panic!("expected Spanish first-token attribution command");
+        };
+        assert_eq!(config, &PathBuf::from("config.toml"));
+        assert_eq!(v2_report, &PathBuf::from("v2.json"));
+        assert_eq!(
+            expected_v2_report_sha256,
+            crate::gpu_native_spanish_first_token_attribution::FROZEN_V2_REPORT_SHA256
+        );
+        assert_eq!(stage_report, &PathBuf::from("stage.json"));
+        assert_eq!(
+            expected_stage_report_sha256,
+            crate::gpu_native_spanish_first_token_attribution::FROZEN_STAGE_REPORT_SHA256
+        );
+        assert_eq!(boundary_audit_report, &PathBuf::from("boundary.json"));
+        assert_eq!(
+            expected_boundary_audit_report_sha256,
+            crate::gpu_native_spanish_first_token_attribution::FROZEN_BOUNDARY_AUDIT_REPORT_SHA256
+        );
+        assert_eq!(expected_adapter_name, "NVIDIA L4");
+        assert_eq!(report_out, &PathBuf::from("spanish-first-token.json"));
+        assert_eq!(
+            super::startup_config_path(&cli.cmd),
+            Some(Path::new("config.toml"))
         );
     }
 

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -147,6 +147,7 @@ pub(crate) mod gpu_native_layer0_diagnostics;
 pub(crate) mod gpu_native_router_rank_diagnostics;
 pub(crate) mod gpu_native_semantic_parity_corpus;
 pub(crate) mod gpu_native_semantic_parity_v2;
+pub(crate) mod gpu_native_v2_holdout_failure_attribution;
 
 pub(crate) mod gpu_native_token_loop;
 #[cfg(feature = "grpc")]
@@ -950,6 +951,26 @@ enum Cmd {
         report_out: PathBuf,
     },
 
+    /// Attribute the frozen first GPU-native semantic-parity v2 holdout failures.
+    #[command(name = "diagnose-gpu-native-v2-holdout-failures")]
+    DiagnoseGpuNativeV2HoldoutFailures {
+        /// Path to the strict GPU-native Q4 TOML config.
+        #[arg(long)]
+        config: PathBuf,
+        /// Exact wgpu adapter name required for the isolated GPU runtime.
+        #[arg(long)]
+        expected_adapter_name: String,
+        /// Exact frozen v2 qualification report to consume as immutable evidence.
+        #[arg(long)]
+        v2_report: PathBuf,
+        /// Required frozen SHA256 of the supplied v2 report.
+        #[arg(long)]
+        expected_v2_report_sha256: String,
+        /// Required typed diagnostic JSON destination.
+        #[arg(long)]
+        report_out: PathBuf,
+    },
+
     /// Collect reproducibility and complete first-token CPU/Hybrid logit
     /// evidence for the fixed json-transformation case.
     DiagnoseHybridQ4GreedyDivergence {
@@ -1723,6 +1744,7 @@ fn startup_config_path(cmd: &Cmd) -> Option<&Path> {
         | Cmd::QualifyHybridQ4GreedyParity { config, .. }
         | Cmd::QualifyGpuNativeQ4GreedyParity { config, .. }
         | Cmd::QualifyGpuNativeSemanticParityV2 { config, .. }
+        | Cmd::DiagnoseGpuNativeV2HoldoutFailures { config, .. }
         | Cmd::DiagnoseHybridQ4GreedyDivergence { config, .. }
         | Cmd::DiagnoseGpuNativeQ4FirstDivergence { config, .. }
         | Cmd::DiagnoseGpuNativeRouterRankDivergence { config, .. }
@@ -2208,6 +2230,30 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 report_out,
                 progress_watchdog,
             ))
+        }
+        Cmd::DiagnoseGpuNativeV2HoldoutFailures {
+            config,
+            expected_adapter_name,
+            v2_report,
+            expected_v2_report_sha256,
+            report_out,
+        } => {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()?;
+            rt.block_on(
+                crate::gpu_native_v2_holdout_failure_attribution::run_diagnostic(
+                    config,
+                    startup_config.take().ok_or(
+                        "diagnose-gpu-native-v2-holdout-failures startup config was not parsed",
+                    )?,
+                    expected_adapter_name,
+                    v2_report,
+                    expected_v2_report_sha256,
+                    report_out,
+                    progress_watchdog,
+                ),
+            )
         }
         Cmd::DiagnoseHybridQ4GreedyDivergence {
             config,
@@ -14741,6 +14787,53 @@ mod tests {
         assert_eq!(config, &PathBuf::from("strict-gpu-native.toml"));
         assert_eq!(expected_adapter_name, "NVIDIA L4");
         assert_eq!(report_out, &PathBuf::from("semantic-parity-v2.json"));
+        assert_eq!(
+            super::startup_config_path(&cli.cmd),
+            Some(Path::new("strict-gpu-native.toml"))
+        );
+    }
+
+    #[test]
+    fn v2_holdout_failure_attribution_cli_has_frozen_input_surface() {
+        let cli = <Cli as clap::Parser>::try_parse_from([
+            "micro-expert-router",
+            "diagnose-gpu-native-v2-holdout-failures",
+            "--config",
+            "strict-gpu-native.toml",
+            "--expected-adapter-name",
+            "NVIDIA L4",
+            "--v2-report",
+            "gpu-native-semantic-parity-v2-300448ac.json",
+            "--expected-v2-report-sha256",
+            crate::gpu_native_v2_holdout_failure_attribution::FROZEN_V2_REPORT_SHA256,
+            "--report-out",
+            "v2-holdout-attribution.json",
+            "--progress-timeout-secs",
+            "300",
+        ])
+        .unwrap();
+        assert_eq!(cli.progress_timeout_secs, Some(300));
+        let Cmd::DiagnoseGpuNativeV2HoldoutFailures {
+            config,
+            expected_adapter_name,
+            v2_report,
+            expected_v2_report_sha256,
+            report_out,
+        } = &cli.cmd
+        else {
+            panic!("expected diagnose-gpu-native-v2-holdout-failures command");
+        };
+        assert_eq!(config, &PathBuf::from("strict-gpu-native.toml"));
+        assert_eq!(expected_adapter_name, "NVIDIA L4");
+        assert_eq!(
+            v2_report,
+            &PathBuf::from("gpu-native-semantic-parity-v2-300448ac.json")
+        );
+        assert_eq!(
+            expected_v2_report_sha256,
+            crate::gpu_native_v2_holdout_failure_attribution::FROZEN_V2_REPORT_SHA256
+        );
+        assert_eq!(report_out, &PathBuf::from("v2-holdout-attribution.json"));
         assert_eq!(
             super::startup_config_path(&cli.cmd),
             Some(Path::new("strict-gpu-native.toml"))

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -5970,20 +5970,31 @@ async fn cmd_diagnose_gpu_native_layer0_attention_first_divergence(
         position_comparisons.push(pos_comp);
     }
 
-    let (earliest_divergent_position, first_internal_divergence) =
-        crate::gpu_native_layer0_diagnostics::first_layer0_divergence_across_positions(
-            &position_comparisons,
-        );
-
     drop(req_state);
     drop(staging_buffer);
     let _ = ref_runtime.shutdown_isolated().await;
     let _ = gpu_runtime.shutdown_isolated().await;
 
+    report.record_completed_position_evidence(position_comparisons, final_position_post_attention);
+
     // 4. Optional Slice 11B Cross-Check
     let slice11b_cross_check = if let Some(ref path) = args.slice11b_report {
-        let final_stage = final_position_post_attention.as_ref().ok_or("no final position post-attention evidence recorded")?;
-        let check = match crate::gpu_native_layer0_diagnostics::cross_check_slice11b_report(path, &report, final_stage) {
+        if report.final_position_post_attention.is_none() {
+            return fail_layer0_attention_first_divergence(
+                report,
+                "no final position post-attention evidence recorded".to_string(),
+                args.report_out.as_deref(),
+            );
+        }
+        let final_stage = report
+            .final_position_post_attention
+            .as_ref()
+            .expect("final position post-attention evidence checked above");
+        let check = match crate::gpu_native_layer0_diagnostics::cross_check_slice11b_report(
+            path,
+            &report,
+            final_stage,
+        ) {
             Ok(c) => c,
             Err(e) => {
                 return fail_layer0_attention_first_divergence(
@@ -6007,10 +6018,6 @@ async fn cmd_diagnose_gpu_native_layer0_attention_first_divergence(
         None
     };
 
-    report.earliest_divergent_position = earliest_divergent_position;
-    report.first_internal_divergence = first_internal_divergence;
-    report.position_comparisons = position_comparisons;
-    report.final_position_post_attention = final_position_post_attention;
     report.slice11b_cross_check = slice11b_cross_check;
     report.diagnostic_complete = true;
     report.qualification_pass = false;

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -5878,8 +5878,6 @@ async fn cmd_diagnose_gpu_native_layer0_attention_first_divergence(
     let ref_backend = ref_runtime.engine.execution_context().attention_backend();
 
     let mut position_comparisons = Vec::with_capacity(prompt_token_ids.len());
-    let mut earliest_divergent_position: Option<usize> = None;
-    let mut first_internal_divergence: Option<crate::gpu_native_layer0_diagnostics::Layer0AttentionFirstDivergenceEvidence> = None;
     let mut final_position_post_attention: Option<crate::gpu_native_layer0_diagnostics::Layer0AttentionStageComparison> = None;
 
     let mut ref_scratch = crate::transformer::TransformerLayerScratch::new();
@@ -5961,11 +5959,6 @@ async fn cmd_diagnose_gpu_native_layer0_attention_first_divergence(
             }
         };
 
-        if !pos_comp.exact_match && earliest_divergent_position.is_none() {
-            earliest_divergent_position = Some(pos);
-            first_internal_divergence = pos_comp.first_divergence.clone();
-        }
-
         if pos == prompt_token_ids.len() - 1 {
             final_position_post_attention = pos_comp
                 .stages
@@ -5977,6 +5970,11 @@ async fn cmd_diagnose_gpu_native_layer0_attention_first_divergence(
         position_comparisons.push(pos_comp);
     }
 
+    let (earliest_divergent_position, first_internal_divergence) =
+        crate::gpu_native_layer0_diagnostics::first_layer0_divergence_across_positions(
+            &position_comparisons,
+        );
+
     drop(req_state);
     drop(staging_buffer);
     let _ = ref_runtime.shutdown_isolated().await;
@@ -5985,7 +5983,7 @@ async fn cmd_diagnose_gpu_native_layer0_attention_first_divergence(
     // 4. Optional Slice 11B Cross-Check
     let slice11b_cross_check = if let Some(ref path) = args.slice11b_report {
         let final_stage = final_position_post_attention.as_ref().ok_or("no final position post-attention evidence recorded")?;
-        let check = match crate::gpu_native_layer0_diagnostics::cross_check_slice11b_report(path, final_stage) {
+        let check = match crate::gpu_native_layer0_diagnostics::cross_check_slice11b_report(path, &report, final_stage) {
             Ok(c) => c,
             Err(e) => {
                 return fail_layer0_attention_first_divergence(

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -146,6 +146,7 @@ pub(crate) mod gpu_native_f32_reference_boundary_audit;
 pub(crate) mod gpu_native_greedy_parity;
 pub(crate) mod gpu_native_layer0_diagnostics;
 pub(crate) mod gpu_native_q4_expert_stage_attribution;
+pub(crate) mod gpu_native_real_benchmark;
 pub(crate) mod gpu_native_router_rank_diagnostics;
 pub(crate) mod gpu_native_semantic_parity_corpus;
 pub(crate) mod gpu_native_semantic_parity_v2;
@@ -866,6 +867,44 @@ enum Cmd {
         /// Output format.
         #[arg(long, value_enum, default_value_t = BenchRealOutputFormat::Human)]
         format: BenchRealOutputFormat,
+    },
+
+    /// Benchmark the ordinary production GPU-native real-model token loop.
+    ///
+    /// This is throughput evidence only. It requires strict greedy execution,
+    /// exact hardware identity, and a complete real checkpoint, and it never
+    /// invokes diagnostic token-step variants.
+    BenchGpuNativeReal {
+        /// Path to the strict production GPU-native TOML config.
+        #[arg(long)]
+        config: PathBuf,
+        /// Prompt text to tokenize once and benchmark.
+        #[arg(long, conflicts_with = "request_json")]
+        prompt: Option<String>,
+        /// OpenAI-style request JSON containing `prompt` or chat `messages`.
+        #[arg(long, conflicts_with = "prompt")]
+        request_json: Option<PathBuf>,
+        /// Exact number of generated tokens; must be at least two.
+        #[arg(long)]
+        output_tokens: Option<usize>,
+        /// Warmup requests, excluded from measured aggregates.
+        #[arg(long, default_value_t = 1)]
+        warmup_runs: usize,
+        /// Measured requests retained individually in the report.
+        #[arg(long, default_value_t = 1)]
+        measured_runs: usize,
+        /// Cache/runtime reset policy.
+        #[arg(long, value_enum, default_value_t = BenchRealCacheReset::Keep)]
+        cache_reset: BenchRealCacheReset,
+        /// Required first-baseline sampling contract.
+        #[arg(long, required = true)]
+        greedy: bool,
+        /// Exact authoritative adapter name expected at runtime.
+        #[arg(long)]
+        expected_adapter_name: String,
+        /// Write the typed JSON benchmark report here instead of stdout.
+        #[arg(long)]
+        report_out: Option<PathBuf>,
     },
 
     /// Qualify strict real-checkpoint inference with CPU dense/attention/KV/
@@ -1817,6 +1856,7 @@ fn startup_config_path(cmd: &Cmd) -> Option<&Path> {
     match cmd {
         Cmd::Serve { config }
         | Cmd::BenchReal { config, .. }
+        | Cmd::BenchGpuNativeReal { config, .. }
         | Cmd::QualifyHybridQ4 { config, .. }
         | Cmd::QualifyHybridQ4Parity { config, .. }
         | Cmd::QualifyHybridQ4GreedyParity { config, .. }
@@ -2211,6 +2251,37 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 format,
                 progress_watchdog,
             }))
+        }
+        Cmd::BenchGpuNativeReal {
+            config,
+            prompt,
+            request_json,
+            output_tokens,
+            warmup_runs,
+            measured_runs,
+            cache_reset,
+            greedy,
+            expected_adapter_name,
+            report_out,
+        } => {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()?;
+            rt.block_on(crate::gpu_native_real_benchmark::run_command(
+                crate::gpu_native_real_benchmark::CommandArgs {
+                    config,
+                    prompt,
+                    request_json,
+                    output_tokens,
+                    warmup_runs,
+                    measured_runs,
+                    cache_reset,
+                    greedy,
+                    expected_adapter_name,
+                    report_out,
+                    progress_watchdog,
+                },
+            ))
         }
         Cmd::QualifyHybridQ4 {
             config,
@@ -9881,6 +9952,7 @@ enum RealCliRuntimeMode {
     IsolatedGreedyParityCpu,
     IsolatedGreedyParityHybrid,
     IsolatedGpuNativeDiagnostic,
+    IsolatedGpuNativeBenchmark,
 }
 
 impl RealCliRuntimeMode {
@@ -9890,6 +9962,7 @@ impl RealCliRuntimeMode {
             Self::IsolatedGreedyParityCpu
                 | Self::IsolatedGreedyParityHybrid
                 | Self::IsolatedGpuNativeDiagnostic
+                | Self::IsolatedGpuNativeBenchmark
         )
     }
 
@@ -9899,6 +9972,7 @@ impl RealCliRuntimeMode {
             Self::StrictHybridQualification
                 | Self::IsolatedGreedyParityHybrid
                 | Self::IsolatedGpuNativeDiagnostic
+                | Self::IsolatedGpuNativeBenchmark
         )
     }
 
@@ -9910,6 +9984,7 @@ impl RealCliRuntimeMode {
                 "qualify-hybrid-q4-greedy-parity"
             }
             Self::IsolatedGpuNativeDiagnostic => "diagnose-gpu-native-q4-first-divergence",
+            Self::IsolatedGpuNativeBenchmark => "bench-gpu-native-real",
         }
     }
 }
@@ -9985,7 +10060,8 @@ async fn build_real_cli_runtime(
         }
         RealCliRuntimeMode::IsolatedGreedyParityCpu
         | RealCliRuntimeMode::IsolatedGreedyParityHybrid
-        | RealCliRuntimeMode::IsolatedGpuNativeDiagnostic => {
+        | RealCliRuntimeMode::IsolatedGpuNativeDiagnostic
+        | RealCliRuntimeMode::IsolatedGpuNativeBenchmark => {
             return Err("isolated qualification runtimes must use the private isolated factory".into());
         }
     };
@@ -9999,6 +10075,8 @@ fn resolve_real_cli_spec_from_config(
     crate::parallel::set_dense_matvec_backend(cfg.real_transformer.dense_matvec_backend);
     if mode == RealCliRuntimeMode::BenchReal {
         validate_bench_real_policies(&cfg)?;
+    } else if mode == RealCliRuntimeMode::IsolatedGpuNativeBenchmark {
+        crate::gpu_native_real_benchmark::validate_source_config(&cfg)?;
     }
 
     let (resolved_architecture, resolved_first_k_dense_replace, resolved_advanced) =
@@ -10127,6 +10205,7 @@ async fn build_isolated_greedy_runtime(
         RealCliRuntimeMode::IsolatedGpuNativeDiagnostic => {
             crate::backend::ComputeOffload::Gpu
         }
+        RealCliRuntimeMode::IsolatedGpuNativeBenchmark => crate::backend::ComputeOffload::Gpu,
         _ => return Err("non-isolated runtime mode passed to isolated factory".into()),
     };
     let context = resolve_isolated_real_cli_context(spec, requested)?;

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -141,6 +141,7 @@ mod gguf;
 mod gguf_loader;
 mod gpu_native_residency;
 pub(crate) mod gpu_native_diagnostics;
+pub(crate) mod gpu_native_expert_permutation_semantic_parity;
 pub(crate) mod gpu_native_greedy_parity;
 pub(crate) mod gpu_native_layer0_diagnostics;
 pub(crate) mod gpu_native_router_rank_diagnostics;
@@ -982,6 +983,27 @@ enum Cmd {
         #[arg(long)]
         report_out: PathBuf,
     },
+    /// Measure the semantic effect of a target GPU-native expert-rank permutation without changing inference or qualification semantics.
+    DiagnoseGpuNativeExpertPermutationSemanticParity {
+        /// Strict GPU-native Q4 configuration.
+        #[arg(long)]
+        config: PathBuf,
+        /// Exact required GPU adapter name (for example, "NVIDIA L4").
+        #[arg(long)]
+        expected_adapter_name: String,
+        /// Fixed-corpus case name.
+        #[arg(long)]
+        case: String,
+        /// Zero-based generated-token position to capture.
+        #[arg(long)]
+        generated_position: usize,
+        /// Zero-based transformer layer to capture.
+        #[arg(long)]
+        layer: usize,
+        /// Required versioned diagnostic JSON destination.
+        #[arg(long)]
+        report_out: PathBuf,
+    },
     /// Diagnose first internal mathematical divergence inside layer-0 attention between CPU reference and GPU-native execution.
     #[command(name = "diagnose-gpu-native-layer0-attention-first-divergence")]
     DiagnoseGpuNativeLayer0AttentionFirstDivergence {
@@ -1675,6 +1697,7 @@ fn startup_config_path(cmd: &Cmd) -> Option<&Path> {
         | Cmd::DiagnoseHybridQ4GreedyDivergence { config, .. }
         | Cmd::DiagnoseGpuNativeQ4FirstDivergence { config, .. }
         | Cmd::DiagnoseGpuNativeRouterRankDivergence { config, .. }
+        | Cmd::DiagnoseGpuNativeExpertPermutationSemanticParity { config, .. }
         | Cmd::DiagnoseGpuNativeLayer0AttentionFirstDivergence { config, .. }
         | Cmd::GreedyParityHybridWorkerInternal { config }
         | Cmd::GreedyParityLogitWorkerInternal { config } => Some(config.as_path()),
@@ -2231,6 +2254,32 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 },
             ))
         }
+        Cmd::DiagnoseGpuNativeExpertPermutationSemanticParity {
+            config,
+            expected_adapter_name,
+            case,
+            generated_position,
+            layer,
+            report_out,
+        } => {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()?;
+            rt.block_on(cmd_diagnose_gpu_native_expert_permutation_semantic_parity(
+                DiagnoseGpuNativeExpertPermutationSemanticParityArgs {
+                    config,
+                    parsed_config: startup_config.take().ok_or(
+                        "diagnose-gpu-native-expert-permutation-semantic-parity startup config was not parsed",
+                    )?,
+                    expected_adapter_name,
+                    case,
+                    generated_position,
+                    layer,
+                    report_out,
+                    progress_watchdog,
+                },
+            ))
+        }
         Cmd::DiagnoseGpuNativeLayer0AttentionFirstDivergence {
             config: _,
             expected_adapter_name,
@@ -2522,6 +2571,17 @@ struct DiagnoseGpuNativeQ4FirstDivergenceArgs {
 }
 
 struct DiagnoseGpuNativeRouterRankDivergenceArgs {
+    config: PathBuf,
+    parsed_config: crate::config::Config,
+    expected_adapter_name: String,
+    case: String,
+    generated_position: usize,
+    layer: usize,
+    report_out: PathBuf,
+    progress_watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+}
+
+struct DiagnoseGpuNativeExpertPermutationSemanticParityArgs {
     config: PathBuf,
     parsed_config: crate::config::Config,
     expected_adapter_name: String,
@@ -6228,6 +6288,8 @@ struct RouterRankReferenceCapture {
     target_trace: crate::gpu_native_diagnostics::ModelDiagnosticTrace,
     gate: crate::gating::LinearGate,
     gate_identity: crate::gpu_native_router_rank_diagnostics::GateTensorIdentity,
+    same_input_routed_moe:
+        Option<crate::gpu_native_expert_permutation_semantic_parity::CpuSameInputRoutedMoeCapture>,
     model_load: crate::greedy_parity::ModelLoadEvidence,
     background_shutdown: crate::greedy_parity::BackgroundShutdownEvidence,
 }
@@ -6235,6 +6297,16 @@ struct RouterRankReferenceCapture {
 struct RouterRankGpuCapture {
     generated_token_ids: Vec<u32>,
     target_trace: crate::gpu_native_router_rank_diagnostics::RouterRankGpuTrace,
+    gate_identity: crate::gpu_native_router_rank_diagnostics::GateTensorIdentity,
+    model_load: crate::greedy_parity::ModelLoadEvidence,
+    device: crate::backend::GpuDeviceIdentity,
+    model_geometry: crate::gpu_native_token_loop::GpuNativeModelGeometry,
+    background_shutdown: crate::greedy_parity::BackgroundShutdownEvidence,
+}
+
+struct SemanticGpuCapture {
+    generated_token_ids: Vec<u32>,
+    target_trace: crate::gpu_native_expert_permutation_semantic_parity::SemanticGpuTrace,
     gate_identity: crate::gpu_native_router_rank_diagnostics::GateTensorIdentity,
     model_load: crate::greedy_parity::ModelLoadEvidence,
     device: crate::backend::GpuDeviceIdentity,
@@ -6647,6 +6719,7 @@ async fn execute_router_rank_reference(
     resolved_config_sha256: &str,
     generated_position: usize,
     layer: usize,
+    same_input_router_input: Option<&[f32]>,
     watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
 ) -> Result<RouterRankReferenceCapture, Box<dyn std::error::Error>> {
     let runtime =
@@ -6724,6 +6797,42 @@ async fn execute_router_rank_reference(
             },
         )
         .await?;
+        let same_input_routed_moe = if let Some(input) = same_input_router_input {
+            if input.len() != runtime.model.config.d_model {
+                return Err("semantic same-input router/MoE input has invalid width".into());
+            }
+            let input = input.to_vec();
+            let routing = gate.route(&input);
+            let global_ids = routing
+                .experts
+                .iter()
+                .map(|&expert| runtime.model.global_expert_id(layer, expert))
+                .collect::<Vec<_>>();
+            let expert_outputs = runtime
+                .engine
+                .moe_step_with_timing(
+                    (generated_position as u64)
+                        .wrapping_mul(runtime.model.config.num_layers as u64)
+                        .wrapping_add(layer as u64),
+                    layer as u32,
+                    &input,
+                    &global_ids,
+                    None,
+                )
+                .await?;
+            let routed_moe_output =
+                crate::inference::combine_outputs(&expert_outputs, &routing.weights);
+            Some(
+                crate::gpu_native_expert_permutation_semantic_parity::CpuSameInputRoutedMoeCapture {
+                    selected_ids: routing.experts,
+                    selected_weights: routing.weights,
+                    expert_outputs,
+                    routed_moe_output,
+                },
+            )
+        } else {
+            None
+        };
         let boundary_after = runtime.engine.cpu_q4_boundary_emulation_snapshot();
         if !boundary_after.enabled || boundary_after.routed_expert_dispatches == 0 {
             return Err("router-rank reference did not exercise the Hybrid F16 boundary".into());
@@ -6744,6 +6853,7 @@ async fn execute_router_rank_reference(
             target_trace,
             gate,
             gate_identity,
+            same_input_routed_moe,
             model_load,
             background_shutdown: crate::greedy_parity::BackgroundShutdownEvidence::default(),
         })
@@ -6956,6 +7066,208 @@ async fn execute_router_rank_gpu(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
+async fn execute_expert_permutation_semantic_gpu(
+    spec: &ResolvedRealCliSpec,
+    tokenizer: Arc<crate::tokenizer::Tokenizer>,
+    prompt_token_ids: &[u32],
+    resolved_config_sha256: &str,
+    expected_adapter_name: &str,
+    case: &str,
+    generated_position: usize,
+    layer: usize,
+    watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+) -> Result<SemanticGpuCapture, Box<dyn std::error::Error>> {
+    let runtime = build_isolated_greedy_runtime(
+        spec,
+        RealCliRuntimeMode::IsolatedGpuNativeDiagnostic,
+        tokenizer,
+    )
+    .await?;
+    let attempt = async {
+        let observed_config_sha256 = resolved_real_runtime_identity_sha256(
+            &runtime.cfg,
+            runtime.model.config.architecture,
+            runtime.model.config.first_k_dense_replace,
+            &runtime.model.config.advanced,
+        )?;
+        if observed_config_sha256 != resolved_config_sha256 {
+            return Err(format!(
+                "expert-permutation semantic GPU identity {observed_config_sha256} drifted from {resolved_config_sha256}"
+            )
+            .into());
+        }
+        let device = runtime
+            .engine
+            .gpu_device_identity()
+            .ok_or("expert-permutation semantic GPU runtime has no authoritative adapter identity")?;
+        if device.name != expected_adapter_name {
+            return Err(format!(
+                "expert-permutation semantic GPU runtime selected adapter {:?}, expected {:?}",
+                device.name, expected_adapter_name
+            )
+            .into());
+        }
+        if device.software_adapter || device.device_type.eq_ignore_ascii_case("cpu") {
+            return Err(format!(
+                "expert-permutation semantic GPU runtime selected software adapter {:?}",
+                device.name
+            )
+            .into());
+        }
+        let token_loop = runtime
+            .gpu_native_token_loop
+            .as_ref()
+            .ok_or("GPU-native token loop was not initialized")?;
+        let model_geometry = token_loop.model_geometry();
+        crate::gpu_native_router_rank_diagnostics::validate_target(
+            case,
+            generated_position,
+            layer,
+            expected_adapter_name,
+            model_geometry,
+        )?;
+        if layer >= runtime.model.layers.len() {
+            return Err(format!("target layer {layer} is outside loaded GPU model").into());
+        }
+        let gate_identity =
+            crate::gpu_native_router_rank_diagnostics::GateTensorIdentity::from_gate(
+                layer,
+                &runtime.model.layers[layer].gate,
+            );
+        let model_load = greedy_parity_model_load(&runtime);
+        let counters_before = token_loop.snapshot();
+        if counters_before != crate::gpu_native_token_loop::GpuNativeTokenLoopSnapshot::default() {
+            return Err("expert-permutation semantic GPU token-loop counters did not start at zero"
+                .into());
+        }
+        let routed_before = runtime.engine.routed_expert_execution_snapshot();
+        let attention_before = crate::transformer::nonfinite_softmax_fallbacks();
+        let mut request = token_loop
+            .create_expert_permutation_semantic_diagnostic_request_state()?;
+        let trace_layout =
+            crate::gpu_native_expert_permutation_semantic_parity::SemanticTraceLayout::try_new(
+                model_geometry,
+                layer,
+            )?;
+        let staging = token_loop
+            .create_expert_permutation_semantic_diagnostic_staging_buffer(&trace_layout)?;
+        let (generated_token_ids, target_trace) = with_progress_timeout(
+            "GPU-native expert-permutation semantic candidate".to_string(),
+            watchdog,
+            async {
+                let prefix_count = prompt_token_ids.len().saturating_sub(1);
+                for (position, &token_id) in prompt_token_ids[..prefix_count].iter().enumerate() {
+                    token_loop
+                        .step_token(&runtime.engine, &mut request, token_id, position, false)
+                        .await?;
+                }
+                let mut input_token = *prompt_token_ids
+                    .last()
+                    .ok_or("expert-permutation semantic GPU prompt is empty")?;
+                let mut position = prefix_count;
+                let mut generated_token_ids = Vec::with_capacity(generated_position + 1);
+                let mut target_trace = None;
+                for index in 0..=generated_position {
+                    if index == generated_position {
+                        let (trace, sampled_token, _) = token_loop
+                            .step_token_expert_permutation_semantic_diagnostic(
+                                &runtime.engine,
+                                &mut request,
+                                input_token,
+                                position,
+                                &trace_layout,
+                                &staging,
+                            )
+                            .await?;
+                        generated_token_ids.push(sampled_token);
+                        target_trace = Some(trace);
+                    } else {
+                        let sampled_token = token_loop
+                            .step_token(
+                                &runtime.engine,
+                                &mut request,
+                                input_token,
+                                position,
+                                true,
+                            )
+                            .await?
+                            .ok_or("expert-permutation semantic GPU generation produced no token")?;
+                        input_token = sampled_token;
+                        generated_token_ids.push(sampled_token);
+                    }
+                    position = position
+                        .checked_add(1)
+                        .ok_or("expert-permutation semantic GPU position overflowed")?;
+                }
+                Ok::<_, Box<dyn std::error::Error>>((
+                    generated_token_ids,
+                    target_trace
+                        .ok_or("expert-permutation semantic GPU target trace was not captured")?,
+                ))
+            },
+        )
+        .await?;
+        let expected_completed = prompt_token_ids
+            .len()
+            .saturating_sub(1)
+            .checked_add(generated_position + 1)
+            .ok_or("expert-permutation semantic expected completion count overflowed")?;
+        let counters_after = token_loop.snapshot();
+        if request.committed_position() != expected_completed
+            || counters_after.tokens_completed != expected_completed as u64
+            || counters_after.fatal_failures != 0
+            || counters_after.no_progress_failures != 0
+        {
+            return Err(
+                "expert-permutation semantic GPU request completion/counter evidence is invalid"
+                    .into(),
+            );
+        }
+        let routed_delta = crate::qualification::routed_execution_delta(
+            routed_before,
+            runtime.engine.routed_expert_execution_snapshot(),
+        )
+        .map_err(|failure| failure.detail)?;
+        if routed_delta.degraded_expert_substitutions != 0
+            || routed_delta.gpu_cpu_fallbacks != 0
+            || routed_delta.gpu_dispatch_failures != 0
+            || crate::transformer::nonfinite_softmax_fallbacks().saturating_sub(attention_before)
+                != 0
+        {
+            return Err(
+                "expert-permutation semantic GPU run recorded a fallback or dispatch failure"
+                    .into(),
+            );
+        }
+        drop(request);
+        drop(staging);
+        Ok::<_, Box<dyn std::error::Error>>(SemanticGpuCapture {
+            generated_token_ids,
+            target_trace,
+            gate_identity,
+            model_load,
+            device,
+            model_geometry,
+            background_shutdown: crate::greedy_parity::BackgroundShutdownEvidence::default(),
+        })
+    }
+    .await;
+    let shutdown = runtime.shutdown_isolated().await;
+    match (attempt, shutdown) {
+        (Ok(mut capture), Ok(shutdown)) => {
+            capture.background_shutdown = shutdown;
+            Ok(capture)
+        }
+        (Err(error), Ok(_)) => Err(error),
+        (Ok(_), Err(shutdown_error)) => Err(shutdown_error.into()),
+        (Err(error), Err(shutdown_error)) => Err(IsolatedRuntimeShutdownError::new(format!(
+            "{error}; expert-permutation semantic GPU shutdown also failed: {shutdown_error}"
+        ))
+        .into()),
+    }
+}
+
 fn emit_router_rank_divergence_report(
     report: &crate::gpu_native_router_rank_diagnostics::RouterRankDivergenceReport,
     report_out: &Path,
@@ -7075,6 +7387,7 @@ async fn cmd_diagnose_gpu_native_router_rank_divergence(
         &reference_resolved_config_sha256,
         args.generated_position,
         args.layer,
+        None,
         args.progress_watchdog,
     )
     .await?;
@@ -7177,6 +7490,282 @@ async fn cmd_diagnose_gpu_native_router_rank_divergence(
     )?;
     let failure = report.failure.clone();
     emit_router_rank_divergence_report(&report, &args.report_out)?;
+    if let Some(failure) = failure {
+        return Err(failure.into());
+    }
+    Ok(())
+}
+
+fn emit_expert_permutation_semantic_parity_report(
+    report: &crate::gpu_native_expert_permutation_semantic_parity::ExpertPermutationSemanticParityReport,
+    report_out: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if report.qualification_pass() {
+        return Err(
+            "expert-permutation semantic diagnostic cannot claim qualification PASS".into(),
+        );
+    }
+    if let Some(parent) = report_out.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut json = serde_json::to_vec_pretty(report)?;
+    json.push(b'\n');
+    std::fs::write(report_out, json)?;
+    eprintln!(
+        "GPU-native expert-permutation semantic diagnostic report written to {}",
+        report_out.display()
+    );
+    Ok(())
+}
+
+async fn cmd_diagnose_gpu_native_expert_permutation_semantic_parity(
+    args: DiagnoseGpuNativeExpertPermutationSemanticParityArgs,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use crate::qualification::BuildProvenance;
+
+    let cfg = args.parsed_config;
+    let provenance = BuildProvenance::embedded();
+    let (artifacts, artifact_errors) = qualification_artifacts(&args.config, &cfg);
+    if !artifact_errors.is_empty() {
+        return Err(format!(
+            "expert-permutation semantic diagnostic artifact preflight failed: {}",
+            artifact_errors.join("; ")
+        )
+        .into());
+    }
+    if args.progress_watchdog.timeout.is_none() {
+        return Err(
+            "expert-permutation semantic diagnostic requires a positive progress timeout".into(),
+        );
+    }
+    if provenance.dirty != Some(false)
+        || provenance
+            .git_sha
+            .as_deref()
+            .is_none_or(|sha| sha.len() != 40 || !sha.bytes().all(|byte| byte.is_ascii_hexdigit()))
+    {
+        return Err(
+            "expert-permutation semantic diagnostic requires clean embedded 40-hex Git provenance"
+                .into(),
+        );
+    }
+    let capacity_bytes = cfg
+        .gpu_cache
+        .vram_capacity_mb
+        .checked_mul(1024 * 1024)
+        .and_then(|bytes| u64::try_from(bytes).ok())
+        .unwrap_or(0);
+    let source_config = crate::gpu_native_greedy_parity::SourceConfigEvidence {
+        real_transformer_enabled: cfg.real_transformer.enabled,
+        gpu_native_enabled: cfg.real_transformer.gpu_native,
+        weights_dir_configured: cfg.real_transformer.weights_dir.is_some(),
+        strict_weights: cfg.real_transformer.strict_weights,
+        allow_seeded_fallback: cfg.real_transformer.allow_seeded_fallback,
+        allow_degraded_experts: cfg.real_transformer.allow_degraded_experts,
+        allow_nonfinite_attention_fallback: cfg.real_transformer.allow_nonfinite_attention_fallback,
+        allow_truncated_expert_payloads: cfg.real_transformer.allow_truncated_expert_payloads,
+        distributed_enabled: cfg.distributed.enabled,
+        gpu_cache_enabled: cfg.gpu_cache.enabled,
+        gpu_expert_capacity_bytes: capacity_bytes,
+        routed_expert_dtype: cfg.model.dtype.as_str().to_string(),
+    };
+    if !source_config.is_strict() {
+        return Err(
+            "expert-permutation semantic diagnostic requires the strict GPU-native Q4 qualifier configuration"
+                .into(),
+        );
+    }
+    let expert_metadata =
+        crate::qualification::read_expert_metadata(&cfg.model.data_dir.join("metadata.json"))
+            .map_err(|error| {
+                format!("expert-permutation semantic expert metadata preflight failed: {error}")
+            })?;
+    if expert_metadata.q4_0_layout.as_deref() != Some(crate::inference::Q4_0_LAYOUT_STANDARD_V1)
+        || expert_metadata.explicitly_synthetic
+    {
+        return Err(
+            "expert-permutation semantic diagnostic requires canonical nonsynthetic Q4_0 metadata"
+                .into(),
+        );
+    }
+    let fixed_case = crate::greedy_parity::fixed_case(&args.case)
+        .ok_or_else(|| format!("unknown fixed corpus case {:?}", args.case))?;
+    if args.generated_position >= crate::greedy_parity::OUTPUT_TOKEN_LIMIT
+        || args.layer >= cfg.model.num_layers
+        || cfg.model.num_experts <= crate::gpu_native_router_rank_diagnostics::HIGHER_EXPERT_ID
+        || cfg.model.top_k != crate::gpu_native_router_rank_diagnostics::REQUIRED_TOP_K
+        || args.expected_adapter_name.trim().is_empty()
+    {
+        return Err(
+            "expert-permutation semantic target, expert geometry, or adapter is invalid".into(),
+        );
+    }
+
+    let mut gpu_spec =
+        resolve_real_cli_spec_from_config(cfg, RealCliRuntimeMode::IsolatedGpuNativeDiagnostic)?;
+    gpu_spec.cfg.real_transformer.gpu_native = true;
+    gpu_spec.cfg.real_transformer.compute_offload = crate::backend::ComputeOffload::Gpu;
+    let model_identity = greedy_parity_model_identity(&gpu_spec);
+    if !model_identity.is_qwen3_coder_30b_a3b_q4_0() {
+        return Err(
+            "expert-permutation semantic diagnostic requires exact Qwen3-Coder 30B-A3B Q4_0 geometry"
+                .into(),
+        );
+    }
+    let gpu_resolved_config_sha256 = resolved_real_cli_spec_sha256(&gpu_spec)?;
+    let mut reference_spec = gpu_spec.clone();
+    reference_spec.cfg.real_transformer.gpu_native = false;
+    reference_spec.cfg.real_transformer.compute_offload = crate::backend::ComputeOffload::Cpu;
+    let reference_resolved_config_sha256 = resolved_real_cli_spec_sha256(&reference_spec)?;
+    let tokenizer = load_real_cli_tokenizer(
+        &gpu_spec.cfg,
+        RealCliRuntimeMode::IsolatedGpuNativeDiagnostic,
+    )?;
+    let prompt_token_ids = tokenizer.encode(fixed_case.prompt)?;
+    if prompt_token_ids.is_empty() {
+        return Err("expert-permutation semantic fixed prompt encoded to zero tokens".into());
+    }
+
+    // The exact GPU-produced target input is required before the isolated CPU
+    // reference runtime can execute the same-input routed-MoE witness.
+    let gpu = execute_expert_permutation_semantic_gpu(
+        &gpu_spec,
+        tokenizer.clone(),
+        &prompt_token_ids,
+        &gpu_resolved_config_sha256,
+        &args.expected_adapter_name,
+        fixed_case.name,
+        args.generated_position,
+        args.layer,
+        args.progress_watchdog,
+    )
+    .await?;
+    let reference = execute_router_rank_reference(
+        &reference_spec,
+        tokenizer,
+        &prompt_token_ids,
+        &reference_resolved_config_sha256,
+        args.generated_position,
+        args.layer,
+        Some(&gpu.target_trace.router_input),
+        args.progress_watchdog,
+    )
+    .await?;
+    crate::gpu_native_router_rank_diagnostics::validate_target(
+        fixed_case.name,
+        args.generated_position,
+        args.layer,
+        &args.expected_adapter_name,
+        gpu.model_geometry,
+    )?;
+
+    let reference_router_input = reference
+        .target_trace
+        .layer_router_input
+        .get(args.layer)
+        .ok_or("reference target router input is missing")?;
+    let reference_routed_moe_output = reference
+        .target_trace
+        .layer_routed_moe_output
+        .get(args.layer)
+        .ok_or("reference target routed-MoE output is missing")?;
+    let reference_router = crate::gpu_native_router_rank_diagnostics::evaluate_cpu_router(
+        "reference-hidden-to-cpu-production-router",
+        &reference.gate,
+        reference_router_input,
+    )?;
+    let captured_reference_ids = reference
+        .target_trace
+        .layer_selected_ids
+        .get(args.layer)
+        .ok_or("reference target selected IDs are missing")?;
+    let captured_reference_weights = reference
+        .target_trace
+        .layer_selected_weights
+        .get(args.layer)
+        .ok_or("reference target selected weights are missing")?;
+    if captured_reference_ids != &reference_router.top_8_ids
+        || captured_reference_weights
+            .iter()
+            .map(|value| value.to_bits())
+            .ne(reference_router
+                .top_8_weights
+                .iter()
+                .map(|value| value.bits))
+    {
+        return Err(
+            "recomputed reference router evidence differs from the captured production decision"
+                .into(),
+        );
+    }
+    let cpu_on_gpu_input = crate::gpu_native_router_rank_diagnostics::evaluate_cpu_router(
+        "gpu-hidden-to-cpu-production-router",
+        &reference.gate,
+        &gpu.target_trace.router_input,
+    )?;
+    let same_input = reference
+        .same_input_routed_moe
+        .as_ref()
+        .ok_or("same-input CPU routed-MoE witness was not captured")?;
+    if same_input.selected_ids != cpu_on_gpu_input.top_8_ids
+        || same_input
+            .selected_weights
+            .iter()
+            .map(|value| value.to_bits())
+            .ne(cpu_on_gpu_input
+                .top_8_weights
+                .iter()
+                .map(|value| value.bits))
+        || same_input.expert_outputs.len() != same_input.selected_ids.len()
+    {
+        return Err(
+            "same-input CPU routed-MoE capture differs from CPU production routing evidence".into(),
+        );
+    }
+    let actual_gpu_router = crate::gpu_native_router_rank_diagnostics::evaluate_actual_gpu_router(
+        gpu.target_trace.raw_logits.clone(),
+        gpu.target_trace.selected_ids.clone(),
+        gpu.target_trace.selected_weights.clone(),
+    )?;
+    let gate_identity = crate::gpu_native_router_rank_diagnostics::GateIdentityEvidence::new(
+        reference.gate_identity,
+        gpu.gate_identity,
+    );
+    let (_, executable_sha256) = current_executable_identity()?;
+    let report = crate::gpu_native_expert_permutation_semantic_parity::ExpertPermutationSemanticParityReport::build(
+        crate::gpu_native_router_rank_diagnostics::DiagnosticProvenance {
+            build: provenance,
+            executable_sha256,
+            artifacts,
+            gpu_resolved_config_sha256,
+            reference_resolved_config_sha256,
+            model_identity,
+            reference_model_load: reference.model_load,
+            gpu_native_model_load: gpu.model_load,
+            reference_background_shutdown: reference.background_shutdown,
+            gpu_native_background_shutdown: gpu.background_shutdown,
+            expert_metadata,
+            device: gpu.device,
+        },
+        fixed_case.name,
+        args.generated_position,
+        args.layer,
+        prompt_token_ids,
+        reference.generated_token_ids,
+        gpu.generated_token_ids,
+        reference_router_input,
+        &gpu.target_trace.router_input,
+        gate_identity,
+        reference_router,
+        cpu_on_gpu_input,
+        actual_gpu_router,
+        reference_routed_moe_output,
+        &same_input.routed_moe_output,
+        &gpu.target_trace.routed_moe_output,
+        &gpu.target_trace.route_outputs,
+    )?;
+    let failure = report.failure.clone();
+    emit_expert_permutation_semantic_parity_report(&report, &args.report_out)?;
     if let Some(failure) = failure {
         return Err(failure.into());
     }
@@ -13977,6 +14566,51 @@ mod tests {
         assert_eq!(generated_position, 5);
         assert_eq!(layer, 44);
         assert_eq!(report_out, PathBuf::from("router-rank.json"));
+    }
+
+    #[test]
+    fn expert_permutation_semantic_diagnostic_cli_has_required_target_surface() {
+        let cli = <Cli as clap::Parser>::try_parse_from([
+            "micro-expert-router",
+            "diagnose-gpu-native-expert-permutation-semantic-parity",
+            "--config",
+            "strict-gpu-native.toml",
+            "--expected-adapter-name",
+            "NVIDIA L4",
+            "--case",
+            "rust-generation",
+            "--generated-position",
+            "5",
+            "--layer",
+            "44",
+            "--report-out",
+            "semantic-witness.json",
+            "--progress-timeout-secs",
+            "300",
+        ])
+        .unwrap();
+        assert_eq!(cli.progress_timeout_secs, Some(300));
+        let Cmd::DiagnoseGpuNativeExpertPermutationSemanticParity {
+            config,
+            expected_adapter_name,
+            case,
+            generated_position,
+            layer,
+            report_out,
+        } = &cli.cmd
+        else {
+            panic!("expected diagnose-gpu-native-expert-permutation-semantic-parity command");
+        };
+        assert_eq!(config, &PathBuf::from("strict-gpu-native.toml"));
+        assert_eq!(expected_adapter_name, "NVIDIA L4");
+        assert_eq!(case, "rust-generation");
+        assert_eq!(*generated_position, 5);
+        assert_eq!(*layer, 44);
+        assert_eq!(report_out, &PathBuf::from("semantic-witness.json"));
+        assert_eq!(
+            super::startup_config_path(&cli.cmd),
+            Some(Path::new("strict-gpu-native.toml"))
+        );
     }
 
     #[test]

--- a/rust-engine/src/model.rs
+++ b/rust-engine/src/model.rs
@@ -2788,6 +2788,168 @@ impl RealModel {
         ))
     }
 
+    /// Diagnostic variant of token forward pass that captures intermediate activation traces at each layer boundary.
+    pub async fn forward_token_diagnostic_trace(
+        &self,
+        engine: &Arc<Engine>,
+        token_id: u32,
+        pos: usize,
+        kv: &mut [KvCache],
+        timings: Option<&crate::stage_timing::StageTimings>,
+    ) -> Result<crate::gpu_native_diagnostics::ModelDiagnosticTrace, RealInferenceError> {
+        assert_eq!(
+            kv.len(),
+            self.config.num_layers,
+            "kv cache slice must have one entry per layer"
+        );
+        let mut x =
+            crate::stage_timing::time_optional(timings, crate::stage_timing::EMBEDDING, || {
+                self.try_embed(token_id)
+            })?;
+        let embedding_trace = x.clone();
+
+        let backend = engine.execution_context().attention_backend();
+        let mut layer_scratch = crate::transformer::TransformerLayerScratch::new();
+        let mut next_x = Vec::with_capacity(self.config.d_model);
+        let strict_numerics = !engine.allow_nonfinite_attention_fallback();
+        let allow_degraded = engine.allow_degraded_experts();
+
+        let mut layer_post_attn = Vec::with_capacity(self.layers.len());
+        let mut layer_router_input = Vec::with_capacity(self.layers.len());
+        let mut layer_selected_ids = Vec::with_capacity(self.layers.len());
+        let mut layer_selected_weights = Vec::with_capacity(self.layers.len());
+        let mut layer_post_moe = Vec::with_capacity(self.layers.len());
+
+        for (layer_idx, layer) in self.layers.iter().enumerate() {
+            // Attention sub-block.
+            if strict_numerics {
+                layer
+                    .try_attn_block_into_with_timing(
+                        &x,
+                        pos,
+                        layer_idx,
+                        &mut kv[layer_idx],
+                        &**backend,
+                        &mut layer_scratch,
+                        &mut next_x,
+                        timings,
+                    )
+                    .map_err(|e| RealInferenceError::NonFiniteAttention {
+                        layer: layer_idx,
+                        head: e.head,
+                        pos: e.pos,
+                        architecture: self.config.architecture,
+                        kind: e.kind,
+                    })?;
+            } else {
+                layer.attn_block_into_with_timing(
+                    &x,
+                    pos,
+                    layer_idx,
+                    &mut kv[layer_idx],
+                    &**backend,
+                    &mut layer_scratch,
+                    &mut next_x,
+                    timings,
+                );
+            }
+            std::mem::swap(&mut x, &mut next_x);
+            next_x.clear();
+            if let crate::architecture::AttentionMode::SlidingWindow { window } =
+                layer.attn.attention_mode()
+            {
+                kv[layer_idx].evict_before(pos.saturating_sub(window));
+            }
+            layer_post_attn.push(x.clone());
+            // MoE sub-block: route, await SSD-streamed expert FFNs, combine.
+            let routing = layer.moe_pre_into_with_timing(&x, &mut layer_scratch, timings);
+            layer_scratch.global_expert_ids.clear();
+            layer_scratch
+                .global_expert_ids
+                .extend(
+                    routing
+                        .experts
+                        .iter()
+                        .map(|&local| self.global_expert_id(layer_idx, local)),
+                );
+            let normed = &layer_scratch.moe_normed;
+            layer_router_input.push(normed.clone());
+            layer_selected_ids.push(routing.experts.clone());
+            layer_selected_weights.push(routing.weights.clone());
+
+            let token_idx =
+                (pos as u64).wrapping_mul(self.config.num_layers as u64) + layer_idx as u64;
+            engine
+                .moe_step_weighted_into_with_timing(
+                    token_idx,
+                    layer_idx as u32,
+                    normed,
+                    &layer_scratch.global_expert_ids,
+                    &routing.weights,
+                    &mut layer_scratch.moe_accum,
+                    timings,
+                )
+                .await?;
+            layer.moe_accumulated_into_with_timing(
+                &x,
+                &layer_scratch.moe_accum,
+                &mut next_x,
+                timings,
+            );
+            std::mem::swap(&mut x, &mut next_x);
+            next_x.clear();
+            layer_scratch.routing.recycle_decision(routing);
+
+            match layer.shared_expert_forward_with_timing(normed, timings) {
+                Ok(Some(shared)) => {
+                    crate::transformer::add_residual_into(&x, &shared, &mut next_x);
+                    std::mem::swap(&mut x, &mut next_x);
+                    next_x.clear();
+                }
+                Ok(None) => {}
+                Err(source) => {
+                    if !allow_degraded {
+                        return Err(RealInferenceError::ResidentFfn {
+                            layer: layer_idx,
+                            role: ResidentFfnRole::Shared,
+                            source,
+                        });
+                    }
+                    engine.record_degraded_expert_substitution();
+                    tracing::warn!(
+                        layer = layer_idx,
+                        error = %source,
+                        "DEGRADED MODE: shared expert failed; dropping its \
+                         contribution (allow_degraded_experts = true, output is \
+                         non-authoritative)"
+                    );
+                }
+            }
+            layer_post_moe.push(x.clone());
+        }
+
+        let final_norm = crate::stage_timing::time_optional(
+            timings,
+            crate::stage_timing::FINAL_RMS_NORM,
+            || self.final_rms.forward(&x),
+        );
+        let logits = self.lm_head.diagnostic_greedy_logits(&final_norm);
+        let sampled_token =
+            self.sample_hidden(&final_norm, &crate::sampling::SamplingParams::greedy(), pos);
+
+        Ok(crate::gpu_native_diagnostics::ModelDiagnosticTrace {
+            embedding: embedding_trace,
+            layer_post_attn,
+            layer_router_input,
+            layer_selected_ids,
+            layer_selected_weights,
+            layer_post_moe,
+            final_norm,
+            logits,
+            sampled_token,
+        })
+    }
+
     /// Sample a next-token id from an already-computed final hidden state.
     ///
     /// Sampling is delegated to [`crate::sampling::sample`], so

--- a/rust-engine/src/model.rs
+++ b/rust-engine/src/model.rs
@@ -2818,6 +2818,7 @@ impl RealModel {
         let mut layer_router_input = Vec::with_capacity(self.layers.len());
         let mut layer_selected_ids = Vec::with_capacity(self.layers.len());
         let mut layer_selected_weights = Vec::with_capacity(self.layers.len());
+        let mut layer_routed_moe_output = Vec::with_capacity(self.layers.len());
         let mut layer_post_moe = Vec::with_capacity(self.layers.len());
 
         for (layer_idx, layer) in self.layers.iter().enumerate() {
@@ -2890,6 +2891,7 @@ impl RealModel {
                     timings,
                 )
                 .await?;
+            layer_routed_moe_output.push(layer_scratch.moe_accum.clone());
             layer.moe_accumulated_into_with_timing(
                 &x,
                 &layer_scratch.moe_accum,
@@ -2943,6 +2945,7 @@ impl RealModel {
             layer_router_input,
             layer_selected_ids,
             layer_selected_weights,
+            layer_routed_moe_output,
             layer_post_moe,
             final_norm,
             logits,

--- a/rust-engine/src/model.rs
+++ b/rust-engine/src/model.rs
@@ -2953,6 +2953,19 @@ impl RealModel {
         })
     }
 
+    /// Diagnostic-only replay of the production final RMSNorm on a
+    /// caller-supplied hidden vector. Ordinary inference does not call this
+    /// observation seam.
+    pub(crate) fn diagnostic_final_rms_norm(&self, hidden: &[f32]) -> Vec<f32> {
+        self.final_rms.forward(hidden)
+    }
+
+    /// Diagnostic-only full-logit view using the same per-row dot contract as
+    /// the production greedy argmax path.
+    pub(crate) fn diagnostic_greedy_logits(&self, hidden: &[f32]) -> Vec<f32> {
+        self.lm_head.diagnostic_greedy_logits(hidden)
+    }
+
     /// Sample a next-token id from an already-computed final hidden state.
     ///
     /// Sampling is delegated to [`crate::sampling::sample`], so

--- a/rust-engine/src/server.rs
+++ b/rust-engine/src/server.rs
@@ -559,6 +559,7 @@ pub(crate) fn map_gpu_native_token_loop_error(
         | GpuNativeTokenLoopError::AttemptBoundExceeded { .. }
         | GpuNativeTokenLoopError::NoProgress { .. }
         | GpuNativeTokenLoopError::FatalNumericalFailure { .. }
+        | GpuNativeTokenLoopError::UnknownStatusBits { .. }
         | GpuNativeTokenLoopError::ResidencyServiceFailed(_)
         | GpuNativeTokenLoopError::Bootstrap(_)
         | GpuNativeTokenLoopError::InvalidBoundaryReport { .. }
@@ -3848,6 +3849,16 @@ mod tests {
         assert!(matches!(gen_err3, GenerateError::Inference(_)));
         let resp3 = error_response(gen_err3);
         assert_eq!(resp3.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+        let unknown_status_err = GpuNativeTokenLoopError::UnknownStatusBits {
+            layer_index: Some(0),
+            status_bits: 1 << 31,
+            unknown_bits: 1 << 31,
+        };
+        let gen_err_unknown = map_gpu_native_token_loop_error(unknown_status_err);
+        assert!(matches!(gen_err_unknown, GenerateError::Inference(_)));
+        let resp_unknown = error_response(gen_err_unknown);
+        assert_eq!(resp_unknown.status(), StatusCode::INTERNAL_SERVER_ERROR);
 
         let map_failed_err = GpuNativeTokenLoopError::MapFailed("device lost".into());
         let gen_err4 = map_gpu_native_token_loop_error(map_failed_err);

--- a/rust-engine/src/transformer.rs
+++ b/rust-engine/src/transformer.rs
@@ -997,6 +997,19 @@ impl MultiHeadSelfAttention {
         v: &mut Vec<f32>,
         timings: Option<&crate::stage_timing::StageTimings>,
     ) {
+        self.project_kv_into_impl(x, pos, k, v, timings, None)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn project_kv_into_impl(
+        &self,
+        x: &[f32],
+        pos: usize,
+        k: &mut Vec<f32>,
+        v: &mut Vec<f32>,
+        timings: Option<&crate::stage_timing::StageTimings>,
+        mut diagnostic_sink: Option<&mut Layer0AttentionCpuDiagnosticSink>,
+    ) {
         k.resize(self.kv_dim(), 0.0);
         v.resize(self.v_proj_dim(), 0.0);
         crate::stage_timing::time_optional(timings, crate::stage_timing::K_PROJECTION, || {
@@ -1015,15 +1028,25 @@ impl MultiHeadSelfAttention {
                 *vi += bi;
             }
         }
+        if let Some(sink) = diagnostic_sink.as_deref_mut() {
+            sink.k_raw = Some(k.clone());
+            sink.v_raw = Some(v.clone());
+        }
         crate::stage_timing::time_optional(timings, crate::stage_timing::RMS_NORM, || {
             self.apply_k_norm(k.as_mut_slice())
         });
+        if let Some(sink) = diagnostic_sink.as_deref_mut() {
+            sink.k_after_norm = Some(k.clone());
+        }
         crate::stage_timing::time_optional(timings, crate::stage_timing::ROPE, || {
             for h in 0..self.num_kv_heads {
                 let s = h * self.head_dim;
                 self.apply_rope_to(&mut k[s..s + self.rope_dim], pos);
             }
         });
+        if let Some(sink) = diagnostic_sink {
+            sink.k_after_rope = Some(k.clone());
+        }
     }
 
     /// Forward one token at absolute position `pos`. Updates `kv` with
@@ -1436,8 +1459,10 @@ impl MultiHeadSelfAttention {
         out: &mut Vec<f32>,
         timings: Option<&crate::stage_timing::StageTimings>,
     ) {
-        self.forward_into_impl(x, pos, layer_idx, kv, backend, scratch, out, timings, false)
-            .expect("legacy attention path is infallible (uniform softmax fallback)");
+        self.forward_into_impl(
+            x, pos, layer_idx, kv, backend, scratch, out, timings, false, None,
+        )
+        .expect("legacy attention path is infallible (uniform softmax fallback)");
     }
 
     /// Strict variant of [`Self::forward_into_with_timing`] (A3
@@ -1456,7 +1481,9 @@ impl MultiHeadSelfAttention {
         out: &mut Vec<f32>,
         timings: Option<&crate::stage_timing::StageTimings>,
     ) -> Result<(), AttentionNumericalError> {
-        self.forward_into_impl(x, pos, layer_idx, kv, backend, scratch, out, timings, true)
+        self.forward_into_impl(
+            x, pos, layer_idx, kv, backend, scratch, out, timings, true, None,
+        )
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1471,6 +1498,7 @@ impl MultiHeadSelfAttention {
         out: &mut Vec<f32>,
         timings: Option<&crate::stage_timing::StageTimings>,
         strict: bool,
+        mut diagnostic_sink: Option<&mut Layer0AttentionCpuDiagnosticSink>,
     ) -> Result<(), AttentionNumericalError> {
         // The scratch path is the CPU-production path. Keep GPU behaviour
         // byte-for-byte by delegating to the existing allocating path when a
@@ -1500,22 +1528,32 @@ impl MultiHeadSelfAttention {
                 *qi += bi;
             }
         }
+        if let Some(sink) = diagnostic_sink.as_deref_mut() {
+            sink.q_raw = Some(scratch.q.clone());
+        }
         crate::stage_timing::time_optional(timings, crate::stage_timing::RMS_NORM, || {
             self.apply_q_norm(&mut scratch.q)
         });
+        if let Some(sink) = diagnostic_sink.as_deref_mut() {
+            sink.q_after_norm = Some(scratch.q.clone());
+        }
         crate::stage_timing::time_optional(timings, crate::stage_timing::ROPE, || {
             for h in 0..self.num_heads {
                 let s = h * self.head_dim;
                 self.apply_rope_to(&mut scratch.q[s..s + self.rope_dim], pos);
             }
         });
+        if let Some(sink) = diagnostic_sink.as_deref_mut() {
+            sink.q_after_rope = Some(scratch.q.clone());
+        }
 
-        self.project_kv_into_with_timing(
+        self.project_kv_into_impl(
             x,
             pos,
             &mut scratch.k,
             &mut scratch.v,
             timings,
+            diagnostic_sink.as_deref_mut(),
         );
         debug_assert_eq!(pos, kv.seq_len);
         kv.append(&scratch.k, &scratch.v);
@@ -1535,12 +1573,18 @@ impl MultiHeadSelfAttention {
             },
         )?;
         self.apply_value_scale(&mut scratch.attn_out);
+        if let Some(sink) = diagnostic_sink.as_deref_mut() {
+            sink.attention_context = Some(scratch.attn_out.clone());
+        }
 
         out.resize(self.d_model, 0.0);
         crate::stage_timing::time_optional(timings, crate::stage_timing::O_PROJECTION, || {
             self.wo.matvec_into(&scratch.attn_out, out);
             self.apply_o_bias(out);
         });
+        if let Some(sink) = diagnostic_sink {
+            sink.o_projection = Some(out.clone());
+        }
         Ok(())
     }
 
@@ -1604,8 +1648,7 @@ impl MultiHeadSelfAttention {
             for (idx, score) in scores.iter().enumerate() {
                 let t = t_start + idx;
                 let v_t = kv.value(t);
-                let v_h =
-                    &v_t[kv_head * self.v_head_dim..(kv_head + 1) * self.v_head_dim];
+                let v_h = &v_t[kv_head * self.v_head_dim..(kv_head + 1) * self.v_head_dim];
                 for j in 0..self.v_head_dim {
                     out_h[j] += score * v_h[j];
                 }
@@ -2284,6 +2327,22 @@ pub struct TransformerLayer {
     pub dense_ffn: Option<SharedExpert>,
 }
 
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Layer0AttentionCpuDiagnosticSink {
+    pub embedding: Option<Vec<f32>>,
+    pub attention_pre_norm: Option<Vec<f32>>,
+    pub q_raw: Option<Vec<f32>>,
+    pub k_raw: Option<Vec<f32>>,
+    pub v_raw: Option<Vec<f32>>,
+    pub q_after_norm: Option<Vec<f32>>,
+    pub k_after_norm: Option<Vec<f32>>,
+    pub q_after_rope: Option<Vec<f32>>,
+    pub k_after_rope: Option<Vec<f32>>,
+    pub attention_context: Option<Vec<f32>>,
+    pub o_projection: Option<Vec<f32>>,
+    pub post_attention_residual: Option<Vec<f32>>,
+}
+
 #[derive(Debug, Default)]
 pub struct TransformerLayerScratch {
     pub(crate) attn_normed: Vec<f32>,
@@ -2353,7 +2412,7 @@ impl TransformerLayer {
         timings: Option<&crate::stage_timing::StageTimings>,
     ) {
         self.attn_block_into_impl(
-            hidden, pos, layer_idx, kv, backend, scratch, out, timings, false,
+            hidden, pos, layer_idx, kv, backend, scratch, out, timings, false, None,
         )
         .expect("legacy attention path is infallible (uniform softmax fallback)");
     }
@@ -2375,7 +2434,36 @@ impl TransformerLayer {
         timings: Option<&crate::stage_timing::StageTimings>,
     ) -> Result<(), AttentionNumericalError> {
         self.attn_block_into_impl(
-            hidden, pos, layer_idx, kv, backend, scratch, out, timings, true,
+            hidden, pos, layer_idx, kv, backend, scratch, out, timings, true, None,
+        )
+    }
+
+    /// Diagnostic variant of [`Self::try_attn_block_into_with_timing`] that records
+    /// intermediate layer-0 attention activations into `diagnostic_sink`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn try_attn_block_into_layer0_diagnostic(
+        &self,
+        hidden: &[f32],
+        pos: usize,
+        layer_idx: usize,
+        kv: &mut KvCache,
+        backend: &crate::backend::BackendBox,
+        scratch: &mut TransformerLayerScratch,
+        out: &mut Vec<f32>,
+        timings: Option<&crate::stage_timing::StageTimings>,
+        diagnostic_sink: &mut Layer0AttentionCpuDiagnosticSink,
+    ) -> Result<(), AttentionNumericalError> {
+        self.attn_block_into_impl(
+            hidden,
+            pos,
+            layer_idx,
+            kv,
+            backend,
+            scratch,
+            out,
+            timings,
+            true,
+            Some(diagnostic_sink),
         )
     }
 
@@ -2391,10 +2479,14 @@ impl TransformerLayer {
         out: &mut Vec<f32>,
         timings: Option<&crate::stage_timing::StageTimings>,
         strict: bool,
+        mut diagnostic_sink: Option<&mut Layer0AttentionCpuDiagnosticSink>,
     ) -> Result<(), AttentionNumericalError> {
         crate::stage_timing::time_optional(timings, crate::stage_timing::RMS_NORM, || {
             self.rms_attn.forward_into(hidden, &mut scratch.attn_normed)
         });
+        if let Some(sink) = diagnostic_sink.as_deref_mut() {
+            sink.attention_pre_norm = Some(scratch.attn_normed.clone());
+        }
         let normed = &scratch.attn_normed;
         match self.mla.as_ref() {
             // DeepSeek-V3 multi-head latent attention runs on CPU against
@@ -2415,6 +2507,9 @@ impl TransformerLayer {
                     },
                 )?;
                 add_residual_into(hidden, &attn_out, out);
+                if let Some(sink) = diagnostic_sink {
+                    sink.post_attention_residual = Some(out.clone());
+                }
             }
             None => {
                 self.attn.forward_into_impl(
@@ -2427,10 +2522,14 @@ impl TransformerLayer {
                     out,
                     timings,
                     strict,
+                    diagnostic_sink.as_deref_mut(),
                 )?;
                 debug_assert_eq!(hidden.len(), out.len());
                 for (oi, hi) in out.iter_mut().zip(hidden.iter()) {
                     *oi += hi;
+                }
+                if let Some(sink) = diagnostic_sink {
+                    sink.post_attention_residual = Some(out.clone());
                 }
             }
         }
@@ -4072,7 +4171,10 @@ mod tests {
         boundary_ns.sort_unstable();
         let p50 = boundary_ns[boundary_ns.len() / 2];
         let p99 = boundary_ns[boundary_ns.len() * 99 / 100];
-        println!("kv block-boundary append+evict: p50={p50}ns p99={p99}ns (n={})", boundary_ns.len());
+        println!(
+            "kv block-boundary append+evict: p50={p50}ns p99={p99}ns (n={})",
+            boundary_ns.len()
+        );
     }
 
     #[test]
@@ -4207,6 +4309,95 @@ mod tests {
                     "block {i} element {j} not zeroised: {v}"
                 );
             }
+        }
+    }
+
+    #[test]
+    fn layer0_attention_cpu_diagnostic_sink_preserves_production_output() {
+        let d_model = 16;
+        let layer = make_layer(d_model, 4, 2);
+        let backend = cpu_backend();
+
+        let mut kv_prod = KvCache::new(layer.attn.kv_dim());
+        let mut kv_diag = KvCache::new(layer.attn.kv_dim());
+
+        let mut scratch_prod = TransformerLayerScratch::new();
+        let mut scratch_diag = TransformerLayerScratch::new();
+
+        let x0: Vec<f32> = (0..d_model).map(|i| 0.1 * i as f32 - 0.5).collect();
+        let x1: Vec<f32> = (0..d_model).map(|i| 0.05 * i as f32 + 0.2).collect();
+
+        for (pos, x) in [x0, x1].iter().enumerate() {
+            let mut out_prod = Vec::with_capacity(d_model);
+            let mut out_diag = Vec::with_capacity(d_model);
+            let mut sink = Layer0AttentionCpuDiagnosticSink::default();
+
+            layer
+                .try_attn_block_into_with_timing(
+                    x,
+                    pos,
+                    0,
+                    &mut kv_prod,
+                    &backend,
+                    &mut scratch_prod,
+                    &mut out_prod,
+                    None,
+                )
+                .unwrap();
+
+            layer
+                .try_attn_block_into_layer0_diagnostic(
+                    x,
+                    pos,
+                    0,
+                    &mut kv_diag,
+                    &backend,
+                    &mut scratch_diag,
+                    &mut out_diag,
+                    None,
+                    &mut sink,
+                )
+                .unwrap();
+
+            // 1. Output must be identical bit-for-bit
+            assert_eq!(out_prod, out_diag);
+            assert_eq!(out_diag, sink.post_attention_residual.clone().unwrap());
+
+            // 2. All sink fields must be populated with correct lengths
+            assert_eq!(sink.attention_pre_norm.as_ref().unwrap().len(), d_model);
+            assert_eq!(sink.q_raw.as_ref().unwrap().len(), layer.attn.q_dim());
+            assert_eq!(sink.k_raw.as_ref().unwrap().len(), layer.attn.kv_dim());
+            assert_eq!(sink.v_raw.as_ref().unwrap().len(), layer.attn.v_proj_dim());
+            assert_eq!(
+                sink.q_after_norm.as_ref().unwrap().len(),
+                layer.attn.q_dim()
+            );
+            assert_eq!(
+                sink.k_after_norm.as_ref().unwrap().len(),
+                layer.attn.kv_dim()
+            );
+            assert_eq!(
+                sink.q_after_rope.as_ref().unwrap().len(),
+                layer.attn.q_dim()
+            );
+            assert_eq!(
+                sink.k_after_rope.as_ref().unwrap().len(),
+                layer.attn.kv_dim()
+            );
+            assert_eq!(
+                sink.attention_context.as_ref().unwrap().len(),
+                layer.attn.attn_out_dim()
+            );
+            assert_eq!(sink.o_projection.as_ref().unwrap().len(), d_model);
+            assert_eq!(
+                sink.post_attention_residual.as_ref().unwrap().len(),
+                d_model
+            );
+
+            // 3. KV sequence length and contents must match
+            assert_eq!(kv_prod.seq_len, kv_diag.seq_len);
+            assert_eq!(kv_prod.key(pos), kv_diag.key(pos));
+            assert_eq!(kv_prod.value(pos), kv_diag.value(pos));
         }
     }
 }


### PR DESCRIPTION
## Summary

Integrates the exact post-PR160 GPU-native Qwen qualification/performance lineage through PR1B-B at `c7006c5c6fbcee74c91526f89a8c2b5b06d8a9c5`.

This PR intentionally preserves the complete tested commit lineage rather than squashing/cherry-picking it. `main` remains the exact merge-base `5677b0b66e687ff052dc3149291ef840495b37cc`, so the PR tree is the exact tree independently reviewed and exercised on NVIDIA L4.

The lineage includes the correctness/diagnostic harnesses used to localize GPU-native real-Qwen behavior, PR1 resumable recovery, and PR1B-B physical-residency source-of-truth semantics. The null PR1B-A actual-route-recency branch is not in this ancestry.

## Hardware evidence

### Original clean GPU-native baseline
- Commit: `db0664159fe4a57e5b630984b9229e233fa21487`
- Decode TPS: `0.09482027836627438`

### PR1 resumable recovery
- Commit: `a39c58062ce167773248d3fa5618ac5fd55e54ba`
- Decode TPS: `0.6266293678294312`
- Speedup vs original: ~6.61x
- Generated-token parity: exact
- Full-token replay attempts: 0

### PR1B-B physical source of truth
- Exact tested head: `c7006c5c6fbcee74c91526f89a8c2b5b06d8a9c5`
- Frozen report SHA-256: `82317ad85ba29da1401abf3041ebbb7c2ca72c039c1be0c5f2ea53df9e9fc529`
- Frozen log SHA-256: `7b7955557a42ea066debee7faa32b954a0297b5e61b2d0a7f0b742c7dbf45fde`
- Decode TPS: `0.7759898298420689`
- Speedup vs PR1: `1.2383553495585506x` (+23.84%)
- Speedup vs original baseline: ~8.18x
- Generated-token parity with PR1: YES
- Full-token replay attempts: 0
- Stale-generation rejections: 0
- Per-run VRAM misses: 7754 -> 6089
- Per-run VRAM hits: 3150 -> 4815
- Per-run NVMe reads: 7405 -> 5892
- Per-run NVMe bytes: 19,684,741,120 -> 15,662,727,168

## PR1B-B contract

Already-installed internally valid GPU-native physical expert bytes remain authoritative after host logical-admission LRU eviction because the source audit proved expert payload identity is immutable for the lifetime of a supported runtime.

Logical admission generation remains mandatory for new installation/source authorization and race/stale-requester safety. Physical identity still validates context, layer, expert ID, location, install generation, slot epoch, and exact live arena ownership. Legacy routed-expert generation behavior is unchanged.

## Validation

At PR1B-B head:
- focused GPU-native residency/token-loop/benchmark/generation/demand-source tests passed
- `cargo test --features tokenizer`: 1,277 passed, 0 failed, 14 ignored
- concurrency suite: 4 passed
- release build: passed
- `git diff --check`: passed
- shader diff for PR1B-B from PR1: empty
- first authoritative L4 benchmark: exit 0, exact generated-token parity, clean worktree

## Claim boundary

This is a performance/residency integration, not a declaration of final semantic qualification. Benchmark reporting continues to set `qualification_pass=false` and `correctness_qualification_pending=true` until the separate semantic qualification track closes.