### PR TITLE
PR2-B-B: Productionize concurrent GPU-native physical installs

### DIFF
--- a/rust-engine/src/backend/gpu_native.rs
+++ b/rust-engine/src/backend/gpu_native.rs
@@ -2266,6 +2266,16 @@ pub(crate) struct GpuNativePhysicalInstallEvidence {
     pub(crate) mapping_publication_us: u64,
 }
 
+/// Qualification-only half-transaction produced after an exact physical slot
+/// has been filled through `Queue::write_buffer_with`, but before its logical
+/// mapping or host arena residency has been published. The embedded permit
+/// remains active, so dropping an uncommitted value cancels the reservation.
+pub(crate) struct GpuNativeQ4ExpertPreparedInstall<'a, B = wgpu::Buffer> {
+    permit: GpuNativeQ4ExpertInstallPermit<'a, B>,
+    mapping: GpuNativeQ4ExpertMappingEntry,
+    mapping_offset: u64,
+}
+
 /// Compact cumulative telemetry for the ordinary production demand-install
 /// implementation. Setup uploads, the explicit qualifier control, and the
 /// unchanged speculative Vec path do not contribute to these counters.
@@ -3441,13 +3451,81 @@ pub(crate) struct GpuNativeQ4ExpertInstallPermit<'a, B = wgpu::Buffer> {
     active: bool,
 }
 
-impl<B> GpuNativeQ4ExpertInstallPermit<'_, B> {
+impl<'arena, B> GpuNativeQ4ExpertInstallPermit<'arena, B> {
     pub(crate) const fn key(&self) -> GpuNativeQ4ExpertKey {
         self.key
     }
 
     pub(crate) const fn reserved_residency(&self) -> GpuNativeQ4ExpertResidency {
         self.residency
+    }
+
+    pub(crate) const fn install_ticket(&self) -> u64 {
+        self.install_ticket
+    }
+
+    fn reservation_current(&self, state: &GpuNativeQ4ExpertArenaState) -> bool {
+        let logical_id = self.key.expert_id as usize;
+        state.latest_generations.get(logical_id).copied().flatten()
+            == Some(self.key.logical_generation)
+            && state.logical_slots.get(logical_id).copied().flatten() == Some(self.flat_slot)
+            && matches!(
+                state.slots.get(self.flat_slot).map(|slot| slot.owner),
+                Some(GpuNativeQ4ExpertSlotOwner::Installing {
+                    key,
+                    slot_epoch,
+                    install_ticket,
+                }) if key == self.key
+                    && slot_epoch == self.residency.slot_epoch
+                    && install_ticket == self.install_ticket
+            )
+    }
+
+    /// Qualification-only staging half of an install transaction. Validation
+    /// and an exact reservation check happen before the arena lock is released;
+    /// the potentially multi-megabyte fill then runs without `arena.state`.
+    fn stage_with_checked_physical_writer<PhysicalWrite>(
+        self,
+        payload: &[u8],
+        mut physical_write: PhysicalWrite,
+    ) -> Result<GpuNativeQ4ExpertPreparedInstall<'arena, B>, GpuNativeBootstrapError>
+    where
+        PhysicalWrite:
+            FnMut(u32, u64, CheckedPhysicalQ4ExpertSlot<'_>) -> Result<(), GpuNativeBootstrapError>,
+    {
+        let checked = CheckedPhysicalQ4ExpertSlot::new(
+            self.arena.geometry,
+            self.key.expert_id,
+            self.residency.slot_epoch,
+            payload,
+        )?;
+        let mapping = self.residency.mapping_entry()?;
+        let logical_id = self.key.expert_id as usize;
+        let physical_offset = u64::from(self.residency.location.slot)
+            .checked_mul(self.arena.geometry.slot_stride_bytes as u64)
+            .ok_or(GpuNativeBootstrapError::ExpertArenaBudgetOverflow)?;
+        let mapping_offset = u64::try_from(logical_id)
+            .ok()
+            .and_then(|id| id.checked_mul(GPU_NATIVE_EXPERT_MAPPING_ENTRY_BYTES as u64))
+            .ok_or(GpuNativeBootstrapError::ExpertArenaBudgetOverflow)?;
+
+        {
+            let mut state = self.arena.state.lock();
+            if !self.reservation_current(&state) {
+                state.counters.expert_stale_install_rejections = state
+                    .counters
+                    .expert_stale_install_rejections
+                    .saturating_add(1);
+                return Err(GpuNativeBootstrapError::ExpertInstallReservationLost);
+            }
+        }
+
+        physical_write(self.residency.location.bank, physical_offset, checked)?;
+        Ok(GpuNativeQ4ExpertPreparedInstall {
+            permit: self,
+            mapping,
+            mapping_offset,
+        })
     }
 
     fn install_with_writes<PhysicalWrite, MappingWrite>(
@@ -3535,20 +3613,7 @@ impl<B> GpuNativeQ4ExpertInstallPermit<'_, B> {
             .ok_or(GpuNativeBootstrapError::ExpertArenaBudgetOverflow)?;
 
         let mut state = self.arena.state.lock();
-        let reservation_current = state.latest_generations.get(logical_id).copied().flatten()
-            == Some(self.key.logical_generation)
-            && state.logical_slots.get(logical_id).copied().flatten() == Some(self.flat_slot)
-            && matches!(
-                state.slots.get(self.flat_slot).map(|slot| slot.owner),
-                Some(GpuNativeQ4ExpertSlotOwner::Installing {
-                    key,
-                    slot_epoch,
-                    install_ticket,
-                }) if key == self.key
-                    && slot_epoch == self.residency.slot_epoch
-                    && install_ticket == self.install_ticket
-            );
-        if !reservation_current {
+        if !self.reservation_current(&state) {
             state.counters.expert_stale_install_rejections = state
                 .counters
                 .expert_stale_install_rejections
@@ -3569,6 +3634,49 @@ impl<B> GpuNativeQ4ExpertInstallPermit<'_, B> {
             state.counters.expert_mapping_publications.saturating_add(1);
         self.active = false;
         Ok(self.residency)
+    }
+}
+
+impl<B> GpuNativeQ4ExpertPreparedInstall<'_, B> {
+    pub(crate) const fn key(&self) -> GpuNativeQ4ExpertKey {
+        self.permit.key
+    }
+
+    pub(crate) const fn residency(&self) -> GpuNativeQ4ExpertResidency {
+        self.permit.residency
+    }
+
+    /// Publish and commit one already-staged slot. Rechecking the complete
+    /// reservation identity here prevents staged-but-stale bytes from ever
+    /// becoming executable.
+    fn commit_with_mapping_writer<MappingWrite>(
+        mut self,
+        mut mapping_write: MappingWrite,
+    ) -> Result<GpuNativeQ4ExpertResidency, GpuNativeBootstrapError>
+    where
+        MappingWrite: FnMut(u64, GpuNativeQ4ExpertMappingEntry),
+    {
+        let mut state = self.permit.arena.state.lock();
+        if !self.permit.reservation_current(&state) {
+            state.counters.expert_stale_install_rejections = state
+                .counters
+                .expert_stale_install_rejections
+                .saturating_add(1);
+            return Err(GpuNativeBootstrapError::ExpertInstallReservationLost);
+        }
+
+        mapping_write(self.mapping_offset, self.mapping);
+        state.slots[self.permit.flat_slot].owner =
+            GpuNativeQ4ExpertSlotOwner::Resident(self.permit.residency);
+        state.slots[self.permit.flat_slot].ever_installed = true;
+        state.counters.expert_slot_installs = state.counters.expert_slot_installs.saturating_add(1);
+        if self.permit.reused {
+            state.counters.expert_slot_reuses = state.counters.expert_slot_reuses.saturating_add(1);
+        }
+        state.counters.expert_mapping_publications =
+            state.counters.expert_mapping_publications.saturating_add(1);
+        self.permit.active = false;
+        Ok(self.permit.residency)
     }
 }
 
@@ -7239,6 +7347,99 @@ impl GpuNativeExecutorContext {
                 mapping_publication_us: mapping_us.get(),
             },
         ))
+    }
+
+    /// Qualification-only physical staging phase. This deliberately does not
+    /// update ordinary production-install counters or publish a logical
+    /// mapping. The returned active permit must be committed in request order
+    /// or dropped to cancel its exact reservation.
+    pub(crate) fn stage_q4_expert_residency_qualification<'a>(
+        &self,
+        permit: GpuNativeQ4ExpertInstallPermit<'a>,
+        payload: &[u8],
+    ) -> Result<
+        (
+            GpuNativeQ4ExpertPreparedInstall<'a>,
+            GpuNativePhysicalInstallEvidence,
+        ),
+        GpuNativeBootstrapError,
+    > {
+        let gpu = self.authoritative_gpu()?;
+        if permit.arena.context_id != self.context_id {
+            return Err(GpuNativeBootstrapError::ForeignExpertArena);
+        }
+        let arena = permit.arena;
+        let upload_bytes = arena.geometry.slot_stride_bytes as u64;
+        let prepare_us = std::cell::Cell::new(0u64);
+        let queue_staging_us = std::cell::Cell::new(0u64);
+        let validate_started = Instant::now();
+        let result = permit.stage_with_checked_physical_writer(payload, |bank, offset, checked| {
+            prepare_us.set(elapsed_us(validate_started));
+            let size = wgpu::BufferSize::new(upload_bytes)
+                .expect("validated physical expert slot is nonempty");
+            let queue_started = Instant::now();
+            let Some(mut view) =
+                gpu.queue
+                    .write_buffer_with(&arena.banks[bank as usize], offset, size)
+            else {
+                return Err(GpuNativeBootstrapError::ExpertDirectStagingUnavailable {
+                    bank,
+                    offset,
+                    bytes: upload_bytes,
+                });
+            };
+            queue_staging_us.set(elapsed_us(queue_started));
+            let fill_started = Instant::now();
+            checked.fill(view.as_mut())?;
+            prepare_us.set(prepare_us.get().saturating_add(elapsed_us(fill_started)));
+            let drop_started = Instant::now();
+            drop(view);
+            queue_staging_us.set(
+                queue_staging_us
+                    .get()
+                    .saturating_add(elapsed_us(drop_started)),
+            );
+            Ok(())
+        });
+        result.map(|prepared| {
+            (
+                prepared,
+                GpuNativePhysicalInstallEvidence {
+                    full_slot_vec_materializations: 0,
+                    direct_staging_writes: 1,
+                    physical_slot_bytes_staged: upload_bytes,
+                    physical_slot_prepare_us: prepare_us.get(),
+                    physical_queue_staging_us: queue_staging_us.get(),
+                    mapping_publication_us: 0,
+                },
+            )
+        })
+    }
+
+    /// Qualification-only ordered publication/arena-commit phase for an
+    /// already-staged direct-write transaction.
+    pub(crate) fn commit_q4_expert_residency_qualification(
+        &self,
+        prepared: GpuNativeQ4ExpertPreparedInstall<'_>,
+        mut evidence: GpuNativePhysicalInstallEvidence,
+    ) -> Result<
+        (GpuNativeQ4ExpertResidency, GpuNativePhysicalInstallEvidence),
+        GpuNativeBootstrapError,
+    > {
+        let gpu = self.authoritative_gpu()?;
+        if prepared.permit.arena.context_id != self.context_id {
+            return Err(GpuNativeBootstrapError::ForeignExpertArena);
+        }
+        let arena = prepared.permit.arena;
+        let upload_bytes = arena.geometry.slot_stride_bytes as u64;
+        let mapping_started = Instant::now();
+        let residency = prepared.commit_with_mapping_writer(|offset, entry| {
+            gpu.queue
+                .write_buffer(&arena.mapping, offset, bytemuck::bytes_of(&entry));
+        })?;
+        evidence.mapping_publication_us = elapsed_us(mapping_started);
+        self.counters.record_expert_residency_upload(upload_bytes);
+        Ok((residency, evidence))
     }
 
     /// Preserve the pre-PR2-B-A.1 full-slot Vec implementation for the
@@ -10959,6 +11160,282 @@ pub(crate) mod tests {
         assert_eq!(reservation_arena.residency_snapshot().installing_slots, 1);
         drop(new_permit);
         assert_eq!(reservation_arena.residency_snapshot().free_slots, 1);
+    }
+
+    #[test]
+    fn native_direct_staging_worker_types_are_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        fn assert_send<T: Send>() {}
+
+        assert_send_sync::<wgpu::Queue>();
+        assert_send_sync::<wgpu::Buffer>();
+        assert_send_sync::<wgpu::QueueWriteBufferView<'static>>();
+        assert_send::<GpuNativeQ4ExpertInstallPermit<'static>>();
+        assert_send::<GpuNativeQ4ExpertPreparedInstall<'static>>();
+    }
+
+    #[test]
+    fn split_physical_install_stages_without_publication_then_commits_once() {
+        use std::cell::RefCell;
+
+        let arena = test_mutable_expert_arena(1);
+        let payload = q4_uniform_expert(arena.geometry(), 0.01, -0.02, 0.005);
+        let key = GpuNativeQ4ExpertKey::new(3, 7, 10);
+        let permit = expect_expert_install(arena.acquire_with_unpublish(key, |_, _| {}).unwrap());
+        let physical = RefCell::new(Vec::new());
+        let prepared = permit
+            .stage_with_checked_physical_writer(&payload, |_, _, checked| {
+                let mut destination = vec![0xa5; arena.geometry().slot_stride_bytes()];
+                checked.fill(&mut destination)?;
+                *physical.borrow_mut() = destination;
+                Ok(())
+            })
+            .unwrap();
+        assert_eq!(prepared.key(), key);
+        assert_eq!(arena.residency_snapshot().installing_slots, 1);
+        assert_eq!(arena.residency_snapshot().resident_slots, 0);
+        assert_eq!(arena.residency_snapshot().expert_mapping_publications, 0);
+        assert_eq!(physical.borrow()[..4], 1u32.to_le_bytes());
+
+        let mappings = RefCell::new(Vec::new());
+        let residency = prepared
+            .commit_with_mapping_writer(|offset, entry| {
+                mappings.borrow_mut().push((offset, entry));
+            })
+            .unwrap();
+        assert_eq!(mappings.borrow().len(), 1);
+        assert_eq!(mappings.borrow()[0].1, residency.mapping_entry().unwrap());
+        assert!(arena.contains_exact_residency(7, residency));
+        let snapshot = arena.residency_snapshot();
+        assert_eq!(snapshot.resident_slots, 1);
+        assert_eq!(snapshot.expert_slot_installs, 1);
+        assert_eq!(snapshot.expert_mapping_publications, 1);
+    }
+
+    #[test]
+    fn reversed_stage_completion_preserves_reservation_and_publication_order() {
+        use std::cell::RefCell;
+
+        let arena = test_mutable_expert_arena(2);
+        let payload = q4_uniform_expert(arena.geometry(), 0.01, 0.02, 0.005);
+        let key_a = GpuNativeQ4ExpertKey::new(3, 7, 10);
+        let key_b = GpuNativeQ4ExpertKey::new(3, 8, 11);
+        let permit_a =
+            expect_expert_install(arena.acquire_with_unpublish(key_a, |_, _| {}).unwrap());
+        let permit_b =
+            expect_expert_install(arena.acquire_with_unpublish(key_b, |_, _| {}).unwrap());
+        let residency_a = permit_a.reserved_residency();
+        let residency_b = permit_b.reserved_residency();
+        assert_eq!(residency_a.location().slot(), 0);
+        assert_eq!(residency_b.location().slot(), 1);
+        assert_eq!(residency_a.slot_epoch(), 1);
+        assert_eq!(residency_b.slot_epoch(), 1);
+        let stride = arena.geometry().slot_stride_bytes() as u64;
+        assert!(
+            u64::from(residency_a.location().slot()) * stride + stride
+                <= u64::from(residency_b.location().slot()) * stride
+        );
+
+        // Finish B's physical work before A's to model reversed workers.
+        let prepared_b = permit_b
+            .stage_with_checked_physical_writer(&payload, |_, _, checked| {
+                let mut destination = vec![0; arena.geometry().slot_stride_bytes()];
+                checked.fill(&mut destination)
+            })
+            .unwrap();
+        let prepared_a = permit_a
+            .stage_with_checked_physical_writer(&payload, |_, _, checked| {
+                let mut destination = vec![0; arena.geometry().slot_stride_bytes()];
+                checked.fill(&mut destination)
+            })
+            .unwrap();
+        let publications = RefCell::new(Vec::new());
+        let committed_a = prepared_a
+            .commit_with_mapping_writer(|_, entry| publications.borrow_mut().push(entry))
+            .unwrap();
+        let committed_b = prepared_b
+            .commit_with_mapping_writer(|_, entry| publications.borrow_mut().push(entry))
+            .unwrap();
+        assert_eq!(
+            publications.borrow().as_slice(),
+            &[
+                committed_a.mapping_entry().unwrap(),
+                committed_b.mapping_entry().unwrap(),
+            ]
+        );
+        assert_eq!(arena.residency_snapshot().expert_mapping_publications, 2);
+    }
+
+    #[test]
+    fn split_install_widths_one_through_eight_match_sequential_slot_identity_and_order() {
+        for width in 1usize..=8 {
+            let control = test_mutable_expert_arena(width);
+            let treatment = test_mutable_expert_arena(width);
+            let payload = q4_uniform_expert(control.geometry(), 0.01, -0.02, 0.005);
+            let keys = (0..width as u32)
+                .map(|expert_id| GpuNativeQ4ExpertKey::new(3, expert_id, 10 + expert_id as u64))
+                .collect::<Vec<_>>();
+
+            let mut control_residencies = Vec::with_capacity(width);
+            for &key in &keys {
+                let permit = expect_expert_install(
+                    control.acquire_with_unpublish(key, |_, _| {}).unwrap(),
+                );
+                control_residencies.push(
+                    permit
+                        .install_with_checked_physical_writer(
+                            &payload,
+                            |_, _, checked| {
+                                let mut destination =
+                                    vec![0xa5; control.geometry().slot_stride_bytes()];
+                                checked.fill(&mut destination)
+                            },
+                            |_, _| {},
+                        )
+                        .unwrap(),
+                );
+            }
+
+            let permits = keys
+                .iter()
+                .map(|&key| {
+                    expect_expert_install(
+                        treatment.acquire_with_unpublish(key, |_, _| {}).unwrap(),
+                    )
+                })
+                .collect::<Vec<_>>();
+            let mut prepared = permits
+                .into_iter()
+                .rev()
+                .map(|permit| {
+                    permit
+                        .stage_with_checked_physical_writer(&payload, |_, _, checked| {
+                            let mut destination =
+                                vec![0xa5; treatment.geometry().slot_stride_bytes()];
+                            checked.fill(&mut destination)
+                        })
+                        .unwrap()
+                })
+                .collect::<Vec<_>>();
+            prepared.sort_by_key(|install| install.key().expert_id());
+            let treatment_residencies = prepared
+                .into_iter()
+                .map(|install| install.commit_with_mapping_writer(|_, _| {}).unwrap())
+                .collect::<Vec<_>>();
+
+            assert_eq!(treatment_residencies, control_residencies);
+            assert_eq!(treatment.residency_snapshot(), control.residency_snapshot());
+            for (index, residency) in treatment_residencies.iter().enumerate() {
+                assert_eq!(residency.location().slot(), index as u32);
+                assert_eq!(residency.slot_epoch(), 1);
+            }
+        }
+    }
+
+    #[test]
+    fn split_install_failed_and_later_prepared_permits_cancel_without_publication() {
+        use std::cell::Cell;
+
+        let arena = test_mutable_expert_arena(3);
+        let payload = q4_uniform_expert(arena.geometry(), 0.01, -0.02, 0.005);
+        let permits = (0..3u32)
+            .map(|expert_id| {
+                expect_expert_install(
+                    arena
+                        .acquire_with_unpublish(
+                            GpuNativeQ4ExpertKey::new(3, expert_id, 10),
+                            |_, _| {},
+                        )
+                        .unwrap(),
+                )
+            })
+            .collect::<Vec<_>>();
+        let physical_attempts = Cell::new(0u64);
+        let mut results = permits
+            .into_iter()
+            .enumerate()
+            .map(|(index, permit)| {
+                permit.stage_with_checked_physical_writer(&payload, |bank, offset, checked| {
+                    physical_attempts.set(physical_attempts.get() + 1);
+                    if index == 1 {
+                        return Err(GpuNativeBootstrapError::ExpertDirectStagingUnavailable {
+                            bank,
+                            offset,
+                            bytes: arena.geometry().slot_stride_bytes() as u64,
+                        });
+                    }
+                    let mut destination = vec![0; arena.geometry().slot_stride_bytes()];
+                    checked.fill(&mut destination)
+                })
+            })
+            .collect::<Vec<_>>();
+        let first = results.remove(0).unwrap();
+        assert!(matches!(
+            results.remove(0),
+            Err(GpuNativeBootstrapError::ExpertDirectStagingUnavailable { .. })
+        ));
+        let later = results.remove(0).unwrap();
+
+        first.commit_with_mapping_writer(|_, _| {}).unwrap();
+        drop(later);
+        assert_eq!(physical_attempts.get(), 3);
+        let snapshot = arena.residency_snapshot();
+        assert_eq!(snapshot.resident_slots, 1);
+        assert_eq!(snapshot.free_slots, 2);
+        assert_eq!(snapshot.expert_slot_installs, 1);
+        assert_eq!(snapshot.expert_mapping_publications, 1);
+        assert_eq!(snapshot.expert_install_cancellations, 2);
+    }
+
+    #[test]
+    fn split_install_reservation_loss_before_stage_or_commit_never_publishes() {
+        use std::cell::Cell;
+
+        let arena = test_mutable_expert_arena(1);
+        let payload = q4_uniform_expert(arena.geometry(), 0.01, 0.02, 0.005);
+        let old_key = GpuNativeQ4ExpertKey::new(3, 7, 10);
+        let newer_key = GpuNativeQ4ExpertKey::new(3, 7, 11);
+
+        let before_stage =
+            expect_expert_install(arena.acquire_with_unpublish(old_key, |_, _| {}).unwrap());
+        let newer =
+            expect_expert_install(arena.acquire_with_unpublish(newer_key, |_, _| {}).unwrap());
+        let writes = Cell::new(0);
+        assert!(matches!(
+            before_stage.stage_with_checked_physical_writer(&payload, |_, _, _| {
+                writes.set(writes.get() + 1);
+                Ok(())
+            }),
+            Err(GpuNativeBootstrapError::ExpertInstallReservationLost)
+        ));
+        assert_eq!(writes.get(), 0);
+        drop(newer);
+
+        let stage_key = GpuNativeQ4ExpertKey::new(3, 7, 12);
+        let superseding_key = GpuNativeQ4ExpertKey::new(3, 7, 13);
+        let stage_permit =
+            expect_expert_install(arena.acquire_with_unpublish(stage_key, |_, _| {}).unwrap());
+        let prepared = stage_permit
+            .stage_with_checked_physical_writer(&payload, |_, _, checked| {
+                writes.set(writes.get() + 1);
+                let mut destination = vec![0; arena.geometry().slot_stride_bytes()];
+                checked.fill(&mut destination)
+            })
+            .unwrap();
+        let superseding = expect_expert_install(
+            arena
+                .acquire_with_unpublish(superseding_key, |_, _| {})
+                .unwrap(),
+        );
+        let mappings = Cell::new(0);
+        assert_eq!(
+            prepared.commit_with_mapping_writer(|_, _| mappings.set(mappings.get() + 1)),
+            Err(GpuNativeBootstrapError::ExpertInstallReservationLost)
+        );
+        assert_eq!(mappings.get(), 0);
+        assert_eq!(arena.residency_snapshot().resident_slots, 0);
+        assert_eq!(arena.residency_snapshot().expert_mapping_publications, 0);
+        drop(superseding);
     }
 
     #[test]

--- a/rust-engine/src/backend/gpu_native.rs
+++ b/rust-engine/src/backend/gpu_native.rs
@@ -2266,8 +2266,8 @@ pub(crate) struct GpuNativePhysicalInstallEvidence {
     pub(crate) mapping_publication_us: u64,
 }
 
-/// Qualification-only half-transaction produced after an exact physical slot
-/// has been filled through `Queue::write_buffer_with`, but before its logical
+/// Unpublished half-transaction produced after an exact physical slot has
+/// been filled through `Queue::write_buffer_with`, but before its logical
 /// mapping or host arena residency has been published. The embedded permit
 /// remains active, so dropping an uncommitted value cancels the reservation.
 pub(crate) struct GpuNativeQ4ExpertPreparedInstall<'a, B = wgpu::Buffer> {
@@ -2281,39 +2281,202 @@ pub(crate) struct GpuNativeQ4ExpertPreparedInstall<'a, B = wgpu::Buffer> {
 /// unchanged speculative Vec path do not contribute to these counters.
 #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub(crate) struct GpuNativeProductionPhysicalInstallSnapshot {
+    pub(crate) physical_install_sets: u64,
+    pub(crate) physical_install_experts: u64,
+    pub(crate) parallel_eligible_sets: u64,
+    pub(crate) parallel_staging_sets: u64,
+    pub(crate) parallel_staging_experts: u64,
+    pub(crate) singleton_staging_sets: u64,
+    pub(crate) reservation_attempts: u64,
+    pub(crate) reservation_successes: u64,
+    pub(crate) reservation_failures: u64,
     pub(crate) physical_install_attempts: u64,
+    pub(crate) physical_stage_attempts: u64,
+    pub(crate) physical_stage_completions: u64,
+    pub(crate) physical_stage_failures: u64,
     pub(crate) direct_staging_successes: u64,
     pub(crate) direct_staging_unavailable: u64,
     pub(crate) direct_staging_allocation_fallbacks: u64,
+    pub(crate) ordered_commit_attempts: u64,
+    pub(crate) ordered_commit_completions: u64,
+    pub(crate) ordered_commit_failures: u64,
+    pub(crate) ordered_commit_violations: u64,
+    pub(crate) unpublished_physical_writes_after_failure: u64,
+    pub(crate) max_in_flight_physical_staging: u64,
     pub(crate) physical_install_failures: u64,
 }
 
 #[derive(Debug, Default)]
 struct GpuNativeProductionPhysicalInstallCounters {
+    physical_install_sets: AtomicU64,
+    physical_install_experts: AtomicU64,
+    parallel_eligible_sets: AtomicU64,
+    parallel_staging_sets: AtomicU64,
+    parallel_staging_experts: AtomicU64,
+    singleton_staging_sets: AtomicU64,
+    reservation_attempts: AtomicU64,
+    reservation_successes: AtomicU64,
+    reservation_failures: AtomicU64,
     physical_install_attempts: AtomicU64,
+    physical_stage_attempts: AtomicU64,
+    physical_stage_completions: AtomicU64,
+    physical_stage_failures: AtomicU64,
+    active_physical_staging: AtomicU64,
+    max_in_flight_physical_staging: AtomicU64,
     direct_staging_successes: AtomicU64,
     direct_staging_unavailable: AtomicU64,
+    ordered_commit_attempts: AtomicU64,
+    ordered_commit_completions: AtomicU64,
+    ordered_commit_failures: AtomicU64,
+    ordered_commit_violations: AtomicU64,
+    unpublished_physical_writes_after_failure: AtomicU64,
     physical_install_failures: AtomicU64,
 }
 
 impl GpuNativeProductionPhysicalInstallCounters {
     fn reset(&self) {
+        self.physical_install_sets.store(0, Ordering::Relaxed);
+        self.physical_install_experts.store(0, Ordering::Relaxed);
+        self.parallel_eligible_sets.store(0, Ordering::Relaxed);
+        self.parallel_staging_sets.store(0, Ordering::Relaxed);
+        self.parallel_staging_experts.store(0, Ordering::Relaxed);
+        self.singleton_staging_sets.store(0, Ordering::Relaxed);
+        self.reservation_attempts.store(0, Ordering::Relaxed);
+        self.reservation_successes.store(0, Ordering::Relaxed);
+        self.reservation_failures.store(0, Ordering::Relaxed);
         self.physical_install_attempts.store(0, Ordering::Relaxed);
+        self.physical_stage_attempts.store(0, Ordering::Relaxed);
+        self.physical_stage_completions.store(0, Ordering::Relaxed);
+        self.physical_stage_failures.store(0, Ordering::Relaxed);
+        self.active_physical_staging.store(0, Ordering::Relaxed);
+        self.max_in_flight_physical_staging
+            .store(0, Ordering::Relaxed);
         self.direct_staging_successes.store(0, Ordering::Relaxed);
         self.direct_staging_unavailable.store(0, Ordering::Relaxed);
+        self.ordered_commit_attempts.store(0, Ordering::Relaxed);
+        self.ordered_commit_completions.store(0, Ordering::Relaxed);
+        self.ordered_commit_failures.store(0, Ordering::Relaxed);
+        self.ordered_commit_violations.store(0, Ordering::Relaxed);
+        self.unpublished_physical_writes_after_failure
+            .store(0, Ordering::Relaxed);
         self.physical_install_failures.store(0, Ordering::Relaxed);
     }
 
     fn snapshot(&self) -> GpuNativeProductionPhysicalInstallSnapshot {
         GpuNativeProductionPhysicalInstallSnapshot {
+            physical_install_sets: self.physical_install_sets.load(Ordering::Relaxed),
+            physical_install_experts: self.physical_install_experts.load(Ordering::Relaxed),
+            parallel_eligible_sets: self.parallel_eligible_sets.load(Ordering::Relaxed),
+            parallel_staging_sets: self.parallel_staging_sets.load(Ordering::Relaxed),
+            parallel_staging_experts: self.parallel_staging_experts.load(Ordering::Relaxed),
+            singleton_staging_sets: self.singleton_staging_sets.load(Ordering::Relaxed),
+            reservation_attempts: self.reservation_attempts.load(Ordering::Relaxed),
+            reservation_successes: self.reservation_successes.load(Ordering::Relaxed),
+            reservation_failures: self.reservation_failures.load(Ordering::Relaxed),
             physical_install_attempts: self.physical_install_attempts.load(Ordering::Relaxed),
+            physical_stage_attempts: self.physical_stage_attempts.load(Ordering::Relaxed),
+            physical_stage_completions: self.physical_stage_completions.load(Ordering::Relaxed),
+            physical_stage_failures: self.physical_stage_failures.load(Ordering::Relaxed),
             direct_staging_successes: self.direct_staging_successes.load(Ordering::Relaxed),
             direct_staging_unavailable: self.direct_staging_unavailable.load(Ordering::Relaxed),
             // Schema-v2 compatibility: production deliberately has no fallback,
             // so retaining a permanent atomic for this impossible count would
             // provide no operational signal.
             direct_staging_allocation_fallbacks: 0,
+            ordered_commit_attempts: self.ordered_commit_attempts.load(Ordering::Relaxed),
+            ordered_commit_completions: self.ordered_commit_completions.load(Ordering::Relaxed),
+            ordered_commit_failures: self.ordered_commit_failures.load(Ordering::Relaxed),
+            ordered_commit_violations: self.ordered_commit_violations.load(Ordering::Relaxed),
+            unpublished_physical_writes_after_failure: self
+                .unpublished_physical_writes_after_failure
+                .load(Ordering::Relaxed),
+            max_in_flight_physical_staging: self
+                .max_in_flight_physical_staging
+                .load(Ordering::Relaxed),
             physical_install_failures: self.physical_install_failures.load(Ordering::Relaxed),
+        }
+    }
+
+    fn record_install_set(&self, width: usize) {
+        let width = width as u64;
+        self.physical_install_sets.fetch_add(1, Ordering::Relaxed);
+        self.physical_install_experts
+            .fetch_add(width, Ordering::Relaxed);
+        if width >= 2 {
+            self.parallel_eligible_sets.fetch_add(1, Ordering::Relaxed);
+            self.parallel_staging_sets.fetch_add(1, Ordering::Relaxed);
+            self.parallel_staging_experts
+                .fetch_add(width, Ordering::Relaxed);
+        } else if width == 1 {
+            self.singleton_staging_sets.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn record_reservation_attempt(&self) {
+        self.reservation_attempts.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_reservation_success(&self) {
+        self.reservation_successes.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_reservation_failure(&self) {
+        self.reservation_failures.fetch_add(1, Ordering::Relaxed);
+        self.physical_install_failures
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_unpublished_physical_writes_after_failure(&self, count: u64) {
+        self.unpublished_physical_writes_after_failure
+            .fetch_add(count, Ordering::Relaxed);
+    }
+
+    fn begin_stage(&self) -> ProductionPhysicalStageGuard<'_> {
+        self.physical_install_attempts
+            .fetch_add(1, Ordering::Relaxed);
+        self.physical_stage_attempts.fetch_add(1, Ordering::Relaxed);
+        let active = self
+            .active_physical_staging
+            .fetch_add(1, Ordering::AcqRel)
+            .saturating_add(1);
+        self.max_in_flight_physical_staging
+            .fetch_max(active, Ordering::Relaxed);
+        ProductionPhysicalStageGuard {
+            counters: self,
+            succeeded: false,
+        }
+    }
+}
+
+struct ProductionPhysicalStageGuard<'a> {
+    counters: &'a GpuNativeProductionPhysicalInstallCounters,
+    succeeded: bool,
+}
+
+impl ProductionPhysicalStageGuard<'_> {
+    fn succeed(mut self) {
+        self.counters
+            .physical_stage_completions
+            .fetch_add(1, Ordering::Relaxed);
+        self.counters
+            .direct_staging_successes
+            .fetch_add(1, Ordering::Relaxed);
+        self.succeeded = true;
+    }
+}
+
+impl Drop for ProductionPhysicalStageGuard<'_> {
+    fn drop(&mut self) {
+        self.counters
+            .active_physical_staging
+            .fetch_sub(1, Ordering::AcqRel);
+        if !self.succeeded {
+            self.counters
+                .physical_stage_failures
+                .fetch_add(1, Ordering::Relaxed);
+            self.counters
+                .physical_install_failures
+                .fetch_add(1, Ordering::Relaxed);
         }
     }
 }
@@ -3481,7 +3644,7 @@ impl<'arena, B> GpuNativeQ4ExpertInstallPermit<'arena, B> {
             )
     }
 
-    /// Qualification-only staging half of an install transaction. Validation
+    /// Staging half of an install transaction. Validation
     /// and an exact reservation check happen before the arena lock is released;
     /// the potentially multi-megabyte fill then runs without `arena.state`.
     fn stage_with_checked_physical_writer<PhysicalWrite>(
@@ -7199,10 +7362,7 @@ impl GpuNativeExecutorContext {
         })
     }
 
-    /// Ordinary production demand install: validate the canonical physical
-    /// slot layout, fill one exact direct queue staging view, publish the
-    /// mapping, then commit the host arena state. No qualification timer or
-    /// report operation is performed on this path.
+    /// Pre-B-B sequential direct-staging primitive retained for focused tests.
     pub(crate) fn install_q4_expert_residency(
         &self,
         permit: GpuNativeQ4ExpertInstallPermit<'_>,
@@ -7210,15 +7370,14 @@ impl GpuNativeExecutorContext {
     ) -> Result<GpuNativeQ4ExpertResidency, GpuNativeBootstrapError> {
         self.install_q4_expert_residency_production_inner::<{
             NORMAL_PRODUCTION_MEASURES_PHYSICAL_INSTALL_SUBPHASES
-        }>(
+        }, true>(
             permit,
             payload,
         )
         .map(|(residency, _)| residency)
     }
 
-    /// The v2 treatment observes the exact ordinary production primitive; its
-    /// timing-enabled monomorphization is confined to the dedicated qualifier.
+    /// Timing-enabled observation of the pre-B-B sequential primitive.
     pub(crate) fn install_q4_expert_residency_production_observed(
         &self,
         permit: GpuNativeQ4ExpertInstallPermit<'_>,
@@ -7227,13 +7386,30 @@ impl GpuNativeExecutorContext {
         (GpuNativeQ4ExpertResidency, GpuNativePhysicalInstallEvidence),
         GpuNativeBootstrapError,
     > {
-        self.install_q4_expert_residency_production_inner::<true>(permit, payload)
+        self.install_q4_expert_residency_production_inner::<true, true>(permit, payload)
     }
 
-    /// `MEASURE=false` is the ordinary production monomorphization: its timing
-    /// branches and `Instant` construction are compile-time dead. The v2
-    /// qualifier alone instantiates `MEASURE=true`.
-    fn install_q4_expert_residency_production_inner<const MEASURE: bool>(
+    /// Explicit PR2-B-B.1 control: the pre-B-B sequential direct-staging
+    /// primitive with qualification timing but without ordinary-production
+    /// telemetry. Normal serving never selects this wrapper.
+    pub(crate) fn install_q4_expert_residency_sequential_control_observed(
+        &self,
+        permit: GpuNativeQ4ExpertInstallPermit<'_>,
+        payload: &[u8],
+    ) -> Result<
+        (GpuNativeQ4ExpertResidency, GpuNativePhysicalInstallEvidence),
+        GpuNativeBootstrapError,
+    > {
+        self.install_q4_expert_residency_production_inner::<true, false>(permit, payload)
+    }
+
+    /// Shared sequential primitive. `MEASURE=false` removes all subphase
+    /// timers; `RECORD_PRODUCTION=false` keeps the explicit B-B.1 control out
+    /// of ordinary-production telemetry.
+    fn install_q4_expert_residency_production_inner<
+        const MEASURE: bool,
+        const RECORD_PRODUCTION: bool,
+    >(
         &self,
         permit: GpuNativeQ4ExpertInstallPermit<'_>,
         payload: &[u8],
@@ -7245,9 +7421,11 @@ impl GpuNativeExecutorContext {
         if permit.arena.context_id != self.context_id {
             return Err(GpuNativeBootstrapError::ForeignExpertArena);
         }
-        self.production_physical_install
-            .physical_install_attempts
-            .fetch_add(1, Ordering::Relaxed);
+        if RECORD_PRODUCTION {
+            self.production_physical_install
+                .physical_install_attempts
+                .fetch_add(1, Ordering::Relaxed);
+        }
         let arena = permit.arena;
         let upload_bytes = arena.geometry.slot_stride_bytes as u64;
         let prepare_us = std::cell::Cell::new(0u64);
@@ -7262,9 +7440,11 @@ impl GpuNativeExecutorContext {
         ) {
             Ok(checked) => checked,
             Err(error) => {
-                self.production_physical_install
-                    .physical_install_failures
-                    .fetch_add(1, Ordering::Relaxed);
+                if RECORD_PRODUCTION {
+                    self.production_physical_install
+                        .physical_install_failures
+                        .fetch_add(1, Ordering::Relaxed);
+                }
                 return Err(error);
             }
         };
@@ -7318,23 +7498,29 @@ impl GpuNativeExecutorContext {
         let residency = match result {
             Ok(residency) => residency,
             Err(error) => {
-                if matches!(
-                    error,
-                    GpuNativeBootstrapError::ExpertDirectStagingUnavailable { .. }
-                ) {
+                if RECORD_PRODUCTION
+                    && matches!(
+                        error,
+                        GpuNativeBootstrapError::ExpertDirectStagingUnavailable { .. }
+                    )
+                {
                     self.production_physical_install
                         .direct_staging_unavailable
                         .fetch_add(1, Ordering::Relaxed);
                 }
-                self.production_physical_install
-                    .physical_install_failures
-                    .fetch_add(1, Ordering::Relaxed);
+                if RECORD_PRODUCTION {
+                    self.production_physical_install
+                        .physical_install_failures
+                        .fetch_add(1, Ordering::Relaxed);
+                }
                 return Err(error);
             }
         };
-        self.production_physical_install
-            .direct_staging_successes
-            .fetch_add(1, Ordering::Relaxed);
+        if RECORD_PRODUCTION {
+            self.production_physical_install
+                .direct_staging_successes
+                .fetch_add(1, Ordering::Relaxed);
+        }
         self.counters.record_expert_residency_upload(upload_bytes);
         Ok((
             residency,
@@ -7349,11 +7535,46 @@ impl GpuNativeExecutorContext {
         ))
     }
 
-    /// Qualification-only physical staging phase. This deliberately does not
-    /// update ordinary production-install counters or publish a logical
-    /// mapping. The returned active permit must be committed in request order
-    /// or dropped to cancel its exact reservation.
+    pub(crate) fn stage_q4_expert_residency_production<'a>(
+        &self,
+        permit: GpuNativeQ4ExpertInstallPermit<'a>,
+        payload: &[u8],
+    ) -> Result<GpuNativeQ4ExpertPreparedInstall<'a>, GpuNativeBootstrapError> {
+        self.stage_q4_expert_residency_inner::<false, true>(permit, payload)
+            .map(|(prepared, _)| prepared)
+    }
+
+    pub(crate) fn stage_q4_expert_residency_production_observed<'a>(
+        &self,
+        permit: GpuNativeQ4ExpertInstallPermit<'a>,
+        payload: &[u8],
+    ) -> Result<
+        (
+            GpuNativeQ4ExpertPreparedInstall<'a>,
+            GpuNativePhysicalInstallEvidence,
+        ),
+        GpuNativeBootstrapError,
+    > {
+        self.stage_q4_expert_residency_inner::<true, true>(permit, payload)
+    }
+
+    /// Historical qualification wrapper retained for focused PR2-B-B tests.
     pub(crate) fn stage_q4_expert_residency_qualification<'a>(
+        &self,
+        permit: GpuNativeQ4ExpertInstallPermit<'a>,
+        payload: &[u8],
+    ) -> Result<
+        (
+            GpuNativeQ4ExpertPreparedInstall<'a>,
+            GpuNativePhysicalInstallEvidence,
+        ),
+        GpuNativeBootstrapError,
+    > {
+        self.stage_q4_expert_residency_inner::<true, false>(permit, payload)
+    }
+
+    /// `MEASURE=false` removes subphase timers from normal serving.
+    fn stage_q4_expert_residency_inner<'a, const MEASURE: bool, const RECORD_PRODUCTION: bool>(
         &self,
         permit: GpuNativeQ4ExpertInstallPermit<'a>,
         payload: &[u8],
@@ -7368,16 +7589,19 @@ impl GpuNativeExecutorContext {
         if permit.arena.context_id != self.context_id {
             return Err(GpuNativeBootstrapError::ForeignExpertArena);
         }
+        let stage_guard = RECORD_PRODUCTION.then(|| self.production_physical_install.begin_stage());
         let arena = permit.arena;
         let upload_bytes = arena.geometry.slot_stride_bytes as u64;
         let prepare_us = std::cell::Cell::new(0u64);
         let queue_staging_us = std::cell::Cell::new(0u64);
-        let validate_started = Instant::now();
+        let validate_started = MEASURE.then(Instant::now);
         let result = permit.stage_with_checked_physical_writer(payload, |bank, offset, checked| {
-            prepare_us.set(elapsed_us(validate_started));
+            if let Some(started) = validate_started {
+                prepare_us.set(elapsed_us(started));
+            }
             let size = wgpu::BufferSize::new(upload_bytes)
                 .expect("validated physical expert slot is nonempty");
-            let queue_started = Instant::now();
+            let queue_started = MEASURE.then(Instant::now);
             let Some(mut view) =
                 gpu.queue
                     .write_buffer_with(&arena.banks[bank as usize], offset, size)
@@ -7388,37 +7612,89 @@ impl GpuNativeExecutorContext {
                     bytes: upload_bytes,
                 });
             };
-            queue_staging_us.set(elapsed_us(queue_started));
-            let fill_started = Instant::now();
+            if let Some(started) = queue_started {
+                queue_staging_us.set(elapsed_us(started));
+            }
+            let fill_started = MEASURE.then(Instant::now);
             checked.fill(view.as_mut())?;
-            prepare_us.set(prepare_us.get().saturating_add(elapsed_us(fill_started)));
-            let drop_started = Instant::now();
+            if let Some(started) = fill_started {
+                prepare_us.set(prepare_us.get().saturating_add(elapsed_us(started)));
+            }
+            let drop_started = MEASURE.then(Instant::now);
             drop(view);
-            queue_staging_us.set(
-                queue_staging_us
-                    .get()
-                    .saturating_add(elapsed_us(drop_started)),
-            );
+            if let Some(started) = drop_started {
+                queue_staging_us.set(queue_staging_us.get().saturating_add(elapsed_us(started)));
+            }
             Ok(())
         });
-        result.map(|prepared| {
-            (
-                prepared,
-                GpuNativePhysicalInstallEvidence {
-                    full_slot_vec_materializations: 0,
-                    direct_staging_writes: 1,
-                    physical_slot_bytes_staged: upload_bytes,
-                    physical_slot_prepare_us: prepare_us.get(),
-                    physical_queue_staging_us: queue_staging_us.get(),
-                    mapping_publication_us: 0,
-                },
-            )
-        })
+        match result {
+            Ok(prepared) => {
+                if let Some(stage_guard) = stage_guard {
+                    stage_guard.succeed();
+                }
+                Ok((
+                    prepared,
+                    GpuNativePhysicalInstallEvidence {
+                        full_slot_vec_materializations: 0,
+                        direct_staging_writes: 1,
+                        physical_slot_bytes_staged: upload_bytes,
+                        physical_slot_prepare_us: prepare_us.get(),
+                        physical_queue_staging_us: queue_staging_us.get(),
+                        mapping_publication_us: 0,
+                    },
+                ))
+            }
+            Err(error) => {
+                if RECORD_PRODUCTION
+                    && matches!(
+                        error,
+                        GpuNativeBootstrapError::ExpertDirectStagingUnavailable { .. }
+                    )
+                {
+                    self.production_physical_install
+                        .direct_staging_unavailable
+                        .fetch_add(1, Ordering::Relaxed);
+                }
+                Err(error)
+            }
+        }
     }
 
-    /// Qualification-only ordered publication/arena-commit phase for an
-    /// already-staged direct-write transaction.
+    pub(crate) fn commit_q4_expert_residency_production(
+        &self,
+        prepared: GpuNativeQ4ExpertPreparedInstall<'_>,
+    ) -> Result<GpuNativeQ4ExpertResidency, GpuNativeBootstrapError> {
+        self.commit_q4_expert_residency_inner::<false, true>(
+            prepared,
+            GpuNativePhysicalInstallEvidence::default(),
+        )
+        .map(|(residency, _)| residency)
+    }
+
+    pub(crate) fn commit_q4_expert_residency_production_observed(
+        &self,
+        prepared: GpuNativeQ4ExpertPreparedInstall<'_>,
+        evidence: GpuNativePhysicalInstallEvidence,
+    ) -> Result<
+        (GpuNativeQ4ExpertResidency, GpuNativePhysicalInstallEvidence),
+        GpuNativeBootstrapError,
+    > {
+        self.commit_q4_expert_residency_inner::<true, true>(prepared, evidence)
+    }
+
+    /// Historical no-production-counter wrapper retained for focused tests.
     pub(crate) fn commit_q4_expert_residency_qualification(
+        &self,
+        prepared: GpuNativeQ4ExpertPreparedInstall<'_>,
+        evidence: GpuNativePhysicalInstallEvidence,
+    ) -> Result<
+        (GpuNativeQ4ExpertResidency, GpuNativePhysicalInstallEvidence),
+        GpuNativeBootstrapError,
+    > {
+        self.commit_q4_expert_residency_inner::<true, false>(prepared, evidence)
+    }
+
+    fn commit_q4_expert_residency_inner<const MEASURE: bool, const RECORD_PRODUCTION: bool>(
         &self,
         prepared: GpuNativeQ4ExpertPreparedInstall<'_>,
         mut evidence: GpuNativePhysicalInstallEvidence,
@@ -7430,14 +7706,45 @@ impl GpuNativeExecutorContext {
         if prepared.permit.arena.context_id != self.context_id {
             return Err(GpuNativeBootstrapError::ForeignExpertArena);
         }
+        if RECORD_PRODUCTION {
+            self.production_physical_install
+                .ordered_commit_attempts
+                .fetch_add(1, Ordering::Relaxed);
+        }
         let arena = prepared.permit.arena;
         let upload_bytes = arena.geometry.slot_stride_bytes as u64;
-        let mapping_started = Instant::now();
-        let residency = prepared.commit_with_mapping_writer(|offset, entry| {
+        let mapping_started = MEASURE.then(Instant::now);
+        let result = prepared.commit_with_mapping_writer(|offset, entry| {
             gpu.queue
                 .write_buffer(&arena.mapping, offset, bytemuck::bytes_of(&entry));
-        })?;
-        evidence.mapping_publication_us = elapsed_us(mapping_started);
+        });
+        let residency = match result {
+            Ok(residency) => residency,
+            Err(error) => {
+                if RECORD_PRODUCTION {
+                    self.production_physical_install
+                        .ordered_commit_failures
+                        .fetch_add(1, Ordering::Relaxed);
+                    if matches!(error, GpuNativeBootstrapError::ExpertInstallReservationLost) {
+                        self.production_physical_install
+                            .ordered_commit_violations
+                            .fetch_add(1, Ordering::Relaxed);
+                    }
+                    self.production_physical_install
+                        .physical_install_failures
+                        .fetch_add(1, Ordering::Relaxed);
+                }
+                return Err(error);
+            }
+        };
+        if let Some(started) = mapping_started {
+            evidence.mapping_publication_us = elapsed_us(started);
+        }
+        if RECORD_PRODUCTION {
+            self.production_physical_install
+                .ordered_commit_completions
+                .fetch_add(1, Ordering::Relaxed);
+        }
         self.counters.record_expert_residency_upload(upload_bytes);
         Ok((residency, evidence))
     }
@@ -9366,6 +9673,44 @@ impl GpuNativeExecutorContext {
         &self,
     ) -> GpuNativeProductionPhysicalInstallSnapshot {
         self.production_physical_install.snapshot()
+    }
+
+    pub(crate) fn record_production_physical_install_set(&self, width: usize) {
+        self.production_physical_install.record_install_set(width);
+    }
+
+    pub(crate) fn record_production_physical_reservation_attempt(&self) {
+        self.production_physical_install
+            .record_reservation_attempt();
+    }
+
+    pub(crate) fn record_production_physical_reservation_success(&self) {
+        self.production_physical_install
+            .record_reservation_success();
+    }
+
+    pub(crate) fn record_production_physical_reservation_failure(&self) {
+        self.production_physical_install
+            .record_reservation_failure();
+    }
+
+    pub(crate) fn record_production_ordered_commit_failure(&self, violation: bool) {
+        self.production_physical_install
+            .ordered_commit_failures
+            .fetch_add(1, Ordering::Relaxed);
+        if violation {
+            self.production_physical_install
+                .ordered_commit_violations
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        self.production_physical_install
+            .physical_install_failures
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn record_production_unpublished_physical_writes_after_failure(&self, count: u64) {
+        self.production_physical_install
+            .record_unpublished_physical_writes_after_failure(count);
     }
 
     pub(crate) fn reset_production_physical_install_telemetry(&self) {
@@ -11461,6 +11806,7 @@ pub(crate) mod tests {
                 direct_staging_unavailable: 1,
                 direct_staging_allocation_fallbacks: 0,
                 physical_install_failures: 1,
+                ..GpuNativeProductionPhysicalInstallSnapshot::default()
             }
         );
         counters.reset();
@@ -11469,6 +11815,35 @@ pub(crate) mod tests {
             GpuNativeProductionPhysicalInstallSnapshot::default()
         );
         assert!(!NORMAL_PRODUCTION_MEASURES_PHYSICAL_INSTALL_SUBPHASES);
+    }
+
+    #[test]
+    fn production_concurrency_telemetry_distinguishes_singletons_and_parallel_overlap() {
+        let counters = GpuNativeProductionPhysicalInstallCounters::default();
+        counters.record_install_set(1);
+        counters.record_install_set(4);
+        for _ in 0..5 {
+            counters.record_reservation_attempt();
+            counters.record_reservation_success();
+        }
+        let first = counters.begin_stage();
+        let second = counters.begin_stage();
+        second.succeed();
+        first.succeed();
+        let snapshot = counters.snapshot();
+
+        assert_eq!(snapshot.physical_install_sets, 2);
+        assert_eq!(snapshot.physical_install_experts, 5);
+        assert_eq!(snapshot.parallel_eligible_sets, 1);
+        assert_eq!(snapshot.parallel_staging_sets, 1);
+        assert_eq!(snapshot.parallel_staging_experts, 4);
+        assert_eq!(snapshot.singleton_staging_sets, 1);
+        assert_eq!(snapshot.reservation_attempts, 5);
+        assert_eq!(snapshot.reservation_successes, 5);
+        assert_eq!(snapshot.max_in_flight_physical_staging, 2);
+        assert_eq!(snapshot.physical_stage_attempts, 2);
+        assert_eq!(snapshot.physical_stage_completions, 2);
+        assert_eq!(snapshot.physical_stage_failures, 0);
     }
 
     #[test]

--- a/rust-engine/src/engine.rs
+++ b/rust-engine/src/engine.rs
@@ -511,10 +511,20 @@ pub(crate) enum GpuNativePhysicalInstallStagingQualificationArm {
     Treatment,
 }
 
+/// Explicit PR2-B-B arm. The treatment seam is qualification-only and cannot
+/// be selected through `EngineOptions` or TOML.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum GpuNativePhysicalInstallConcurrencyQualificationArm {
+    Control,
+    Treatment,
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum GpuNativeQualificationPurpose {
     DemandSource(GpuNativeDemandSourceQualificationArm),
     PhysicalInstallStaging(GpuNativePhysicalInstallStagingQualificationArm),
+    PhysicalInstallConcurrency(GpuNativePhysicalInstallConcurrencyQualificationArm),
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -564,6 +574,85 @@ pub(crate) struct GpuNativePhysicalInstallStagingQualificationSnapshot {
     pub(crate) physical_queue_staging_us: u64,
     pub(crate) mapping_publication_us: u64,
     pub(crate) physical_install_total_us: u64,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct GpuNativePhysicalInstallConcurrencyQualificationSnapshot {
+    pub(crate) arm: GpuNativePhysicalInstallConcurrencyQualificationArm,
+    pub(crate) qualification_only: bool,
+    pub(crate) normal_production_default_changed: bool,
+    pub(crate) control_uses_ordinary_sequential_direct_staging: bool,
+    pub(crate) treatment_uses_qualification_only_parallel_direct_staging: bool,
+    pub(crate) single_request_stream: bool,
+    pub(crate) overlapping_demand_sets: u64,
+    pub(crate) primary_pool_capacity: usize,
+    pub(crate) shadow_pool_capacity: usize,
+    pub(crate) demand_sets: u64,
+    pub(crate) physical_missing_experts: u64,
+    pub(crate) physical_probe_us: u64,
+    pub(crate) source_sets: u64,
+    pub(crate) source_experts: u64,
+    pub(crate) demand_source_requests: u64,
+    pub(crate) source_ram_hits: u64,
+    pub(crate) source_ram_misses: u64,
+    pub(crate) source_nvme_reads: u64,
+    pub(crate) source_nvme_bytes: u64,
+    pub(crate) source_acquisition_wall_us: u64,
+    pub(crate) logical_demand_admission_us: u64,
+    pub(crate) physical_demand_install_us: u64,
+    pub(crate) total_residency_service_us: u64,
+    pub(crate) ram_cache_inserts: u64,
+    pub(crate) ram_cache_evictions: u64,
+    pub(crate) selected_route_ids_sha256: String,
+    pub(crate) physical_missing_ids_sha256: String,
+    pub(crate) demand_source_request_ids_sha256: String,
+    pub(crate) demand_ram_insert_ids_sha256: String,
+    pub(crate) demand_ram_eviction_ids_sha256: String,
+    pub(crate) physical_victim_ids_sha256: String,
+    pub(crate) physical_residency_identity_sha256: String,
+    pub(crate) reservation_identity_sha256: String,
+    pub(crate) physical_install_attempts: u64,
+    pub(crate) physical_install_completions: u64,
+    pub(crate) full_slot_vec_materializations: u64,
+    pub(crate) direct_staging_writes: u64,
+    pub(crate) direct_staging_failures: u64,
+    pub(crate) physical_slot_bytes_staged: u64,
+    pub(crate) mapping_publications: u64,
+    pub(crate) mapping_unpublications: u64,
+    pub(crate) physical_slot_prepare_us: u64,
+    pub(crate) physical_queue_staging_us: u64,
+    pub(crate) mapping_publication_us: u64,
+    pub(crate) physical_install_total_us: u64,
+    pub(crate) physical_install_sets: u64,
+    pub(crate) physical_install_experts: u64,
+    pub(crate) install_set_width_min: u64,
+    pub(crate) install_set_width_max: u64,
+    pub(crate) install_set_width_mean: f64,
+    pub(crate) parallel_eligible_sets: u64,
+    pub(crate) parallel_eligible_experts: u64,
+    pub(crate) parallel_staging_sets: u64,
+    pub(crate) parallel_staging_experts: u64,
+    pub(crate) singleton_staging_sets: u64,
+    pub(crate) reservation_attempts: u64,
+    pub(crate) reservation_successes: u64,
+    pub(crate) reservation_failures: u64,
+    pub(crate) physical_stage_attempts: u64,
+    pub(crate) physical_stage_completions: u64,
+    pub(crate) physical_stage_failures: u64,
+    pub(crate) physical_bytes_staged: u64,
+    pub(crate) ordered_commit_attempts: u64,
+    pub(crate) ordered_commit_completions: u64,
+    pub(crate) ordered_commit_failures: u64,
+    pub(crate) ordered_commit_violations: u64,
+    pub(crate) max_in_flight_physical_staging: u64,
+    pub(crate) physical_reservation_us: u64,
+    pub(crate) physical_parallel_stage_wall_us: u64,
+    pub(crate) sum_individual_physical_stage_us: u64,
+    pub(crate) physical_ordered_commit_us: u64,
+    pub(crate) physical_install_transaction_us: u64,
+    pub(crate) unpublished_physical_writes_after_failure: u64,
+    pub(crate) rayon_num_threads: u64,
+    pub(crate) caller_was_already_rayon_worker: bool,
 }
 
 /// Cumulative production-path evidence. These atomics are always present and
@@ -816,6 +905,22 @@ impl QualificationOrderedHasher {
         self.inner.update(residency.slot_epoch().to_le_bytes());
     }
 
+    fn record_reservation_identity(
+        &mut self,
+        global_id: u32,
+        residency: GpuNativeQ4ExpertResidency,
+        install_ticket: u64,
+    ) {
+        self.inner.update([0x51]);
+        self.inner.update(global_id.to_le_bytes());
+        self.inner
+            .update(residency.key().logical_generation().to_le_bytes());
+        self.inner.update(residency.location().bank().to_le_bytes());
+        self.inner.update(residency.location().slot().to_le_bytes());
+        self.inner.update(residency.slot_epoch().to_le_bytes());
+        self.inner.update(install_ticket.to_le_bytes());
+    }
+
     fn hex(&self) -> String {
         format!("{:x}", self.inner.clone().finalize())
     }
@@ -910,6 +1015,38 @@ struct GpuNativeDemandSourceQualification {
     physical_queue_staging_us: AtomicU64,
     mapping_publication_us: AtomicU64,
     physical_install_total_us: AtomicU64,
+    physical_install_sets: AtomicU64,
+    physical_install_experts: AtomicU64,
+    install_set_width_min: AtomicU64,
+    install_set_width_max: AtomicU64,
+    install_set_width_sum: AtomicU64,
+    parallel_eligible_sets: AtomicU64,
+    parallel_eligible_experts: AtomicU64,
+    parallel_staging_sets: AtomicU64,
+    parallel_staging_experts: AtomicU64,
+    singleton_staging_sets: AtomicU64,
+    reservation_attempts: AtomicU64,
+    reservation_successes: AtomicU64,
+    reservation_failures: AtomicU64,
+    physical_stage_attempts: AtomicU64,
+    physical_stage_completions: AtomicU64,
+    physical_stage_failures: AtomicU64,
+    physical_bytes_staged: AtomicU64,
+    ordered_commit_attempts: AtomicU64,
+    ordered_commit_completions: AtomicU64,
+    ordered_commit_failures: AtomicU64,
+    ordered_commit_violations: AtomicU64,
+    active_physical_staging: AtomicU64,
+    max_in_flight_physical_staging: AtomicU64,
+    physical_reservation_us: AtomicU64,
+    physical_parallel_stage_wall_us: AtomicU64,
+    sum_individual_physical_stage_us: AtomicU64,
+    physical_ordered_commit_us: AtomicU64,
+    physical_install_transaction_us: AtomicU64,
+    unpublished_physical_writes_after_failure: AtomicU64,
+    rayon_num_threads: AtomicU64,
+    caller_was_already_rayon_worker: AtomicBool,
+    reservation_identities: parking_lot::Mutex<QualificationOrderedHasher>,
 }
 
 impl GpuNativeDemandSourceQualification {
@@ -971,6 +1108,38 @@ impl GpuNativeDemandSourceQualification {
             physical_queue_staging_us: AtomicU64::new(0),
             mapping_publication_us: AtomicU64::new(0),
             physical_install_total_us: AtomicU64::new(0),
+            physical_install_sets: AtomicU64::new(0),
+            physical_install_experts: AtomicU64::new(0),
+            install_set_width_min: AtomicU64::new(u64::MAX),
+            install_set_width_max: AtomicU64::new(0),
+            install_set_width_sum: AtomicU64::new(0),
+            parallel_eligible_sets: AtomicU64::new(0),
+            parallel_eligible_experts: AtomicU64::new(0),
+            parallel_staging_sets: AtomicU64::new(0),
+            parallel_staging_experts: AtomicU64::new(0),
+            singleton_staging_sets: AtomicU64::new(0),
+            reservation_attempts: AtomicU64::new(0),
+            reservation_successes: AtomicU64::new(0),
+            reservation_failures: AtomicU64::new(0),
+            physical_stage_attempts: AtomicU64::new(0),
+            physical_stage_completions: AtomicU64::new(0),
+            physical_stage_failures: AtomicU64::new(0),
+            physical_bytes_staged: AtomicU64::new(0),
+            ordered_commit_attempts: AtomicU64::new(0),
+            ordered_commit_completions: AtomicU64::new(0),
+            ordered_commit_failures: AtomicU64::new(0),
+            ordered_commit_violations: AtomicU64::new(0),
+            active_physical_staging: AtomicU64::new(0),
+            max_in_flight_physical_staging: AtomicU64::new(0),
+            physical_reservation_us: AtomicU64::new(0),
+            physical_parallel_stage_wall_us: AtomicU64::new(0),
+            sum_individual_physical_stage_us: AtomicU64::new(0),
+            physical_ordered_commit_us: AtomicU64::new(0),
+            physical_install_transaction_us: AtomicU64::new(0),
+            unpublished_physical_writes_after_failure: AtomicU64::new(0),
+            rayon_num_threads: AtomicU64::new(0),
+            caller_was_already_rayon_worker: AtomicBool::new(false),
+            reservation_identities: parking_lot::Mutex::new(QualificationOrderedHasher::default()),
         }
     }
 
@@ -985,6 +1154,20 @@ impl GpuNativeDemandSourceQualification {
             shadow_pool_capacity,
         );
         state.purpose = GpuNativeQualificationPurpose::PhysicalInstallStaging(arm);
+        state
+    }
+
+    fn new_physical_install_concurrency(
+        arm: GpuNativePhysicalInstallConcurrencyQualificationArm,
+        primary_pool_capacity: usize,
+        shadow_pool_capacity: usize,
+    ) -> Self {
+        let mut state = Self::new(
+            GpuNativeDemandSourceQualificationArm::Treatment,
+            primary_pool_capacity,
+            shadow_pool_capacity,
+        );
+        state.purpose = GpuNativeQualificationPurpose::PhysicalInstallConcurrency(arm);
         state
     }
 
@@ -1148,6 +1331,121 @@ impl GpuNativeDemandSourceQualification {
             physical_install_total_us: self.physical_install_total_us.load(Ordering::Relaxed),
         }
     }
+
+    fn physical_install_concurrency_snapshot(
+        &self,
+    ) -> GpuNativePhysicalInstallConcurrencyQualificationSnapshot {
+        let GpuNativeQualificationPurpose::PhysicalInstallConcurrency(arm) = self.purpose else {
+            unreachable!("physical-install concurrency snapshot requested for another qualifier")
+        };
+        let sets = self.physical_install_sets.load(Ordering::Relaxed);
+        let width_min = self.install_set_width_min.load(Ordering::Relaxed);
+        GpuNativePhysicalInstallConcurrencyQualificationSnapshot {
+            arm,
+            qualification_only: true,
+            normal_production_default_changed: false,
+            control_uses_ordinary_sequential_direct_staging: matches!(
+                arm,
+                GpuNativePhysicalInstallConcurrencyQualificationArm::Control
+            ),
+            treatment_uses_qualification_only_parallel_direct_staging: matches!(
+                arm,
+                GpuNativePhysicalInstallConcurrencyQualificationArm::Treatment
+            ),
+            single_request_stream: self.overlapping_demand_sets.load(Ordering::Relaxed) == 0,
+            overlapping_demand_sets: self.overlapping_demand_sets.load(Ordering::Relaxed),
+            primary_pool_capacity: self.primary_pool_capacity,
+            shadow_pool_capacity: self.shadow_pool_capacity,
+            demand_sets: self.demand_sets.load(Ordering::Relaxed),
+            physical_missing_experts: self.physical_missing_experts.load(Ordering::Relaxed),
+            physical_probe_us: self.physical_probe_us.load(Ordering::Relaxed),
+            source_sets: self.source_sets.load(Ordering::Relaxed),
+            source_experts: self.source_experts.load(Ordering::Relaxed),
+            demand_source_requests: self.demand_source_requests.load(Ordering::Relaxed),
+            source_ram_hits: self.source_ram_hits.load(Ordering::Relaxed),
+            source_ram_misses: self.source_ram_misses.load(Ordering::Relaxed),
+            source_nvme_reads: self.source_nvme_reads.load(Ordering::Relaxed),
+            source_nvme_bytes: self.source_nvme_bytes.load(Ordering::Relaxed),
+            source_acquisition_wall_us: self.source_acquisition_wall_us.load(Ordering::Relaxed),
+            logical_demand_admission_us: self.logical_demand_admission_us.load(Ordering::Relaxed),
+            physical_demand_install_us: self.physical_demand_install_us.load(Ordering::Relaxed),
+            total_residency_service_us: self.total_residency_service_us.load(Ordering::Relaxed),
+            ram_cache_inserts: self.ram_cache_inserts.load(Ordering::Relaxed),
+            ram_cache_evictions: self.ram_cache_evictions.load(Ordering::Relaxed),
+            selected_route_ids_sha256: self.selected_route_ids.lock().hex(),
+            physical_missing_ids_sha256: self.physical_missing_ids.lock().hex(),
+            demand_source_request_ids_sha256: self.demand_source_request_ids.lock().hex(),
+            demand_ram_insert_ids_sha256: self.demand_ram_insert_ids.lock().hex(),
+            demand_ram_eviction_ids_sha256: self.demand_ram_eviction_ids.lock().hex(),
+            physical_victim_ids_sha256: self.physical_victim_ids.lock().hex(),
+            physical_residency_identity_sha256: self.physical_residency_identities.lock().hex(),
+            reservation_identity_sha256: self.reservation_identities.lock().hex(),
+            physical_install_attempts: self.physical_install_attempts.load(Ordering::Relaxed),
+            physical_install_completions: self.physical_install_completions.load(Ordering::Relaxed),
+            full_slot_vec_materializations: self
+                .full_slot_vec_materializations
+                .load(Ordering::Relaxed),
+            direct_staging_writes: self.direct_staging_writes.load(Ordering::Relaxed),
+            direct_staging_failures: self.direct_staging_failures.load(Ordering::Relaxed),
+            physical_slot_bytes_staged: self.physical_slot_bytes_staged.load(Ordering::Relaxed),
+            mapping_publications: self.mapping_publications.load(Ordering::Relaxed),
+            mapping_unpublications: self.mapping_unpublications.load(Ordering::Relaxed),
+            physical_slot_prepare_us: self.physical_slot_prepare_us.load(Ordering::Relaxed),
+            physical_queue_staging_us: self.physical_queue_staging_us.load(Ordering::Relaxed),
+            mapping_publication_us: self.mapping_publication_us.load(Ordering::Relaxed),
+            physical_install_total_us: self.physical_install_total_us.load(Ordering::Relaxed),
+            physical_install_sets: sets,
+            physical_install_experts: self.physical_install_experts.load(Ordering::Relaxed),
+            install_set_width_min: if sets == 0 || width_min == u64::MAX {
+                0
+            } else {
+                width_min
+            },
+            install_set_width_max: self.install_set_width_max.load(Ordering::Relaxed),
+            install_set_width_mean: if sets == 0 {
+                0.0
+            } else {
+                self.install_set_width_sum.load(Ordering::Relaxed) as f64 / sets as f64
+            },
+            parallel_eligible_sets: self.parallel_eligible_sets.load(Ordering::Relaxed),
+            parallel_eligible_experts: self.parallel_eligible_experts.load(Ordering::Relaxed),
+            parallel_staging_sets: self.parallel_staging_sets.load(Ordering::Relaxed),
+            parallel_staging_experts: self.parallel_staging_experts.load(Ordering::Relaxed),
+            singleton_staging_sets: self.singleton_staging_sets.load(Ordering::Relaxed),
+            reservation_attempts: self.reservation_attempts.load(Ordering::Relaxed),
+            reservation_successes: self.reservation_successes.load(Ordering::Relaxed),
+            reservation_failures: self.reservation_failures.load(Ordering::Relaxed),
+            physical_stage_attempts: self.physical_stage_attempts.load(Ordering::Relaxed),
+            physical_stage_completions: self.physical_stage_completions.load(Ordering::Relaxed),
+            physical_stage_failures: self.physical_stage_failures.load(Ordering::Relaxed),
+            physical_bytes_staged: self.physical_bytes_staged.load(Ordering::Relaxed),
+            ordered_commit_attempts: self.ordered_commit_attempts.load(Ordering::Relaxed),
+            ordered_commit_completions: self.ordered_commit_completions.load(Ordering::Relaxed),
+            ordered_commit_failures: self.ordered_commit_failures.load(Ordering::Relaxed),
+            ordered_commit_violations: self.ordered_commit_violations.load(Ordering::Relaxed),
+            max_in_flight_physical_staging: self
+                .max_in_flight_physical_staging
+                .load(Ordering::Relaxed),
+            physical_reservation_us: self.physical_reservation_us.load(Ordering::Relaxed),
+            physical_parallel_stage_wall_us: self
+                .physical_parallel_stage_wall_us
+                .load(Ordering::Relaxed),
+            sum_individual_physical_stage_us: self
+                .sum_individual_physical_stage_us
+                .load(Ordering::Relaxed),
+            physical_ordered_commit_us: self.physical_ordered_commit_us.load(Ordering::Relaxed),
+            physical_install_transaction_us: self
+                .physical_install_transaction_us
+                .load(Ordering::Relaxed),
+            unpublished_physical_writes_after_failure: self
+                .unpublished_physical_writes_after_failure
+                .load(Ordering::Relaxed),
+            rayon_num_threads: self.rayon_num_threads.load(Ordering::Relaxed),
+            caller_was_already_rayon_worker: self
+                .caller_was_already_rayon_worker
+                .load(Ordering::Relaxed),
+        }
+    }
 }
 
 impl GpuNativePhysicalInstallObserver for GpuNativeDemandSourceQualification {
@@ -1160,10 +1458,28 @@ impl GpuNativePhysicalInstallObserver for GpuNativeDemandSourceQualification {
     fn record_physical_install_attempt(&self) {
         self.physical_install_attempts
             .fetch_add(1, Ordering::Relaxed);
+        if matches!(
+            self.purpose,
+            GpuNativeQualificationPurpose::PhysicalInstallConcurrency(
+                GpuNativePhysicalInstallConcurrencyQualificationArm::Control
+            )
+        ) {
+            self.physical_stage_attempts.fetch_add(1, Ordering::Relaxed);
+            self.max_in_flight_physical_staging
+                .fetch_max(1, Ordering::Relaxed);
+        }
     }
 
     fn record_direct_staging_failure(&self) {
         self.direct_staging_failures.fetch_add(1, Ordering::Relaxed);
+        if matches!(
+            self.purpose,
+            GpuNativeQualificationPurpose::PhysicalInstallConcurrency(
+                GpuNativePhysicalInstallConcurrencyQualificationArm::Control
+            )
+        ) {
+            self.physical_stage_failures.fetch_add(1, Ordering::Relaxed);
+        }
     }
 
     fn record_physical_install_completion(
@@ -1193,6 +1509,239 @@ impl GpuNativePhysicalInstallObserver for GpuNativeDemandSourceQualification {
         self.physical_residency_identities
             .lock()
             .record_residency_identity(global_id, residency);
+        if matches!(
+            self.purpose,
+            GpuNativeQualificationPurpose::PhysicalInstallConcurrency(
+                GpuNativePhysicalInstallConcurrencyQualificationArm::Control
+            )
+        ) {
+            let stage_us = evidence
+                .physical_slot_prepare_us
+                .saturating_add(evidence.physical_queue_staging_us);
+            self.physical_stage_completions
+                .fetch_add(1, Ordering::Relaxed);
+            self.physical_bytes_staged
+                .fetch_add(evidence.physical_slot_bytes_staged, Ordering::Relaxed);
+            self.sum_individual_physical_stage_us
+                .fetch_add(stage_us, Ordering::Relaxed);
+            self.physical_parallel_stage_wall_us
+                .fetch_add(stage_us, Ordering::Relaxed);
+            self.ordered_commit_attempts.fetch_add(1, Ordering::Relaxed);
+            self.ordered_commit_completions
+                .fetch_add(1, Ordering::Relaxed);
+            self.physical_ordered_commit_us
+                .fetch_add(evidence.mapping_publication_us, Ordering::Relaxed);
+        }
+    }
+
+    fn record_physical_install_set(
+        &self,
+        width: usize,
+        parallel: bool,
+        caller_in_rayon_worker: bool,
+        rayon_threads: usize,
+    ) {
+        if !matches!(
+            self.purpose,
+            GpuNativeQualificationPurpose::PhysicalInstallConcurrency(_)
+        ) {
+            return;
+        }
+        let width = width as u64;
+        self.physical_install_sets.fetch_add(1, Ordering::Relaxed);
+        self.physical_install_experts
+            .fetch_add(width, Ordering::Relaxed);
+        self.install_set_width_min
+            .fetch_min(width, Ordering::Relaxed);
+        self.install_set_width_max
+            .fetch_max(width, Ordering::Relaxed);
+        self.install_set_width_sum
+            .fetch_add(width, Ordering::Relaxed);
+        if width >= 2 {
+            self.parallel_eligible_sets.fetch_add(1, Ordering::Relaxed);
+            self.parallel_eligible_experts
+                .fetch_add(width, Ordering::Relaxed);
+        }
+        if parallel {
+            self.parallel_staging_sets.fetch_add(1, Ordering::Relaxed);
+            self.parallel_staging_experts
+                .fetch_add(width, Ordering::Relaxed);
+        } else if width == 1 {
+            self.singleton_staging_sets.fetch_add(1, Ordering::Relaxed);
+        }
+        self.rayon_num_threads
+            .fetch_max(rayon_threads as u64, Ordering::Relaxed);
+        if caller_in_rayon_worker {
+            self.caller_was_already_rayon_worker
+                .store(true, Ordering::Relaxed);
+        }
+    }
+
+    fn record_reservation_attempt(&self) {
+        if matches!(
+            self.purpose,
+            GpuNativeQualificationPurpose::PhysicalInstallConcurrency(_)
+        ) {
+            self.reservation_attempts.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn record_reservation_success(
+        &self,
+        global_id: u32,
+        residency: GpuNativeQ4ExpertResidency,
+        install_ticket: u64,
+    ) {
+        if matches!(
+            self.purpose,
+            GpuNativeQualificationPurpose::PhysicalInstallConcurrency(_)
+        ) {
+            self.reservation_successes.fetch_add(1, Ordering::Relaxed);
+            self.reservation_identities
+                .lock()
+                .record_reservation_identity(global_id, residency, install_ticket);
+        }
+    }
+
+    fn record_reservation_failure(&self) {
+        if matches!(
+            self.purpose,
+            GpuNativeQualificationPurpose::PhysicalInstallConcurrency(_)
+        ) {
+            self.reservation_failures.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn record_physical_stage_started(&self) {
+        if !matches!(
+            self.purpose,
+            GpuNativeQualificationPurpose::PhysicalInstallConcurrency(
+                GpuNativePhysicalInstallConcurrencyQualificationArm::Treatment
+            )
+        ) {
+            return;
+        }
+        self.physical_stage_attempts.fetch_add(1, Ordering::Relaxed);
+        let active = self
+            .active_physical_staging
+            .fetch_add(1, Ordering::AcqRel)
+            .saturating_add(1);
+        self.max_in_flight_physical_staging
+            .fetch_max(active, Ordering::Relaxed);
+    }
+
+    fn record_physical_stage_completed(
+        &self,
+        evidence: GpuNativePhysicalInstallEvidence,
+        individual_stage_us: u64,
+    ) {
+        if !matches!(
+            self.purpose,
+            GpuNativeQualificationPurpose::PhysicalInstallConcurrency(
+                GpuNativePhysicalInstallConcurrencyQualificationArm::Treatment
+            )
+        ) {
+            return;
+        }
+        self.physical_stage_completions
+            .fetch_add(1, Ordering::Relaxed);
+        self.physical_bytes_staged
+            .fetch_add(evidence.physical_slot_bytes_staged, Ordering::Relaxed);
+        self.sum_individual_physical_stage_us
+            .fetch_add(individual_stage_us, Ordering::Relaxed);
+        self.active_physical_staging.fetch_sub(1, Ordering::AcqRel);
+    }
+
+    fn record_physical_stage_failed(&self) {
+        if matches!(
+            self.purpose,
+            GpuNativeQualificationPurpose::PhysicalInstallConcurrency(
+                GpuNativePhysicalInstallConcurrencyQualificationArm::Treatment
+            )
+        ) {
+            self.physical_stage_failures.fetch_add(1, Ordering::Relaxed);
+            self.active_physical_staging.fetch_sub(1, Ordering::AcqRel);
+        }
+    }
+
+    fn record_parallel_stage_wall(&self, wall_us: u64) {
+        if matches!(
+            self.purpose,
+            GpuNativeQualificationPurpose::PhysicalInstallConcurrency(
+                GpuNativePhysicalInstallConcurrencyQualificationArm::Treatment
+            )
+        ) {
+            self.physical_parallel_stage_wall_us
+                .fetch_add(wall_us, Ordering::Relaxed);
+        }
+    }
+
+    fn record_ordered_commit_attempt(&self) {
+        if matches!(
+            self.purpose,
+            GpuNativeQualificationPurpose::PhysicalInstallConcurrency(
+                GpuNativePhysicalInstallConcurrencyQualificationArm::Treatment
+            )
+        ) {
+            self.ordered_commit_attempts.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn record_ordered_commit_completed(&self, commit_us: u64) {
+        if matches!(
+            self.purpose,
+            GpuNativeQualificationPurpose::PhysicalInstallConcurrency(
+                GpuNativePhysicalInstallConcurrencyQualificationArm::Treatment
+            )
+        ) {
+            self.ordered_commit_completions
+                .fetch_add(1, Ordering::Relaxed);
+            self.physical_ordered_commit_us
+                .fetch_add(commit_us, Ordering::Relaxed);
+        }
+    }
+
+    fn record_ordered_commit_failed(&self, violation: bool) {
+        if matches!(
+            self.purpose,
+            GpuNativeQualificationPurpose::PhysicalInstallConcurrency(_)
+        ) {
+            self.ordered_commit_failures.fetch_add(1, Ordering::Relaxed);
+            if violation {
+                self.ordered_commit_violations
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
+
+    fn record_physical_reservation_wall(&self, wall_us: u64) {
+        if matches!(
+            self.purpose,
+            GpuNativeQualificationPurpose::PhysicalInstallConcurrency(_)
+        ) {
+            self.physical_reservation_us
+                .fetch_add(wall_us, Ordering::Relaxed);
+        }
+    }
+
+    fn record_physical_install_transaction_wall(&self, wall_us: u64) {
+        if matches!(
+            self.purpose,
+            GpuNativeQualificationPurpose::PhysicalInstallConcurrency(_)
+        ) {
+            self.physical_install_transaction_us
+                .fetch_add(wall_us, Ordering::Relaxed);
+        }
+    }
+
+    fn record_unpublished_physical_writes_after_failure(&self, count: u64) {
+        if matches!(
+            self.purpose,
+            GpuNativeQualificationPurpose::PhysicalInstallConcurrency(_)
+        ) {
+            self.unpublished_physical_writes_after_failure
+                .fetch_add(count, Ordering::Relaxed);
+        }
     }
 }
 
@@ -3930,11 +4479,19 @@ impl Engine {
                     shadow_pool_capacity,
                 )
             }
+            GpuNativeQualificationPurpose::PhysicalInstallConcurrency(arm) => {
+                GpuNativeDemandSourceQualification::new_physical_install_concurrency(
+                    arm,
+                    primary_pool_capacity,
+                    shadow_pool_capacity,
+                )
+            }
         }));
         self.production_demand_source.reset();
         if matches!(
             purpose,
             GpuNativeQualificationPurpose::PhysicalInstallStaging(_)
+                | GpuNativeQualificationPurpose::PhysicalInstallConcurrency(_)
         ) {
             if let Some(manager) = self.core.gpu_native_residency.as_ref() {
                 manager.reset_production_physical_install_telemetry();
@@ -4001,6 +4558,49 @@ impl Engine {
                     GpuNativeQualificationPurpose::PhysicalInstallStaging(_)
                 )
                 .then(|| state.physical_install_staging_snapshot())
+            })
+    }
+
+    pub(crate) fn enable_gpu_native_physical_install_concurrency_qualification(
+        &self,
+        arm: GpuNativePhysicalInstallConcurrencyQualificationArm,
+    ) -> Result<(), String> {
+        if !self.core.in_flight.is_empty() || self.core.cache.reserved_slots() != 0 {
+            return Err(
+                "cannot enable physical-install concurrency qualification with active singleflight entries or cache reservations"
+                    .into(),
+            );
+        }
+        let mut slot = self.gpu_native_demand_source_qualification.write();
+        if slot.is_some() {
+            return Err("a GPU-native residency qualification is already enabled".into());
+        }
+        *slot = Some(Arc::new(
+            GpuNativeDemandSourceQualification::new_physical_install_concurrency(
+                arm,
+                self.core.pool.capacity(),
+                self.core.pool.shadow_capacity(),
+            ),
+        ));
+        self.production_demand_source.reset();
+        if let Some(manager) = self.core.gpu_native_residency.as_ref() {
+            manager.reset_production_physical_install_telemetry();
+        }
+        Ok(())
+    }
+
+    pub(crate) fn gpu_native_physical_install_concurrency_qualification_snapshot(
+        &self,
+    ) -> Option<GpuNativePhysicalInstallConcurrencyQualificationSnapshot> {
+        self.gpu_native_demand_source_qualification
+            .read()
+            .as_ref()
+            .and_then(|state| {
+                matches!(
+                    state.purpose,
+                    GpuNativeQualificationPurpose::PhysicalInstallConcurrency(_)
+                )
+                .then(|| state.physical_install_concurrency_snapshot())
             })
     }
 
@@ -5165,6 +5765,7 @@ impl Engine {
                 GpuNativeDemandSourceQualificationArm::Treatment,
             ))
             | Some(GpuNativeQualificationPurpose::PhysicalInstallStaging(_))
+            | Some(GpuNativeQualificationPurpose::PhysicalInstallConcurrency(_))
             | None => {
                 self.gpu_native_production_source_physical_missing_set(global_ids, residents)
                     .await
@@ -5670,6 +6271,27 @@ impl Engine {
                                 state.as_ref(),
                             )
                         }
+                        }
+                    }
+                Some(GpuNativeQualificationPurpose::PhysicalInstallConcurrency(arm)) => {
+                    let state = qualification
+                        .as_ref()
+                        .expect("physical-install concurrency qualification state is present");
+                    match arm {
+                        GpuNativePhysicalInstallConcurrencyQualificationArm::Control => manager
+                            .ensure_demand_set_physical_install_concurrency_control(
+                                GpuNativeResidencyPriority::Demand,
+                                layer_index,
+                                &demands,
+                                state.as_ref(),
+                            ),
+                        GpuNativePhysicalInstallConcurrencyQualificationArm::Treatment => manager
+                            .ensure_demand_set_physical_install_concurrency_treatment(
+                                GpuNativeResidencyPriority::Demand,
+                                layer_index,
+                                &demands,
+                                state.as_ref(),
+                            ),
                     }
                 }
                 Some(GpuNativeQualificationPurpose::DemandSource(_)) | None => manager

--- a/rust-engine/src/engine.rs
+++ b/rust-engine/src/engine.rs
@@ -1515,9 +1515,9 @@ impl GpuNativePhysicalInstallObserver for GpuNativeDemandSourceQualification {
                 GpuNativePhysicalInstallConcurrencyQualificationArm::Control
             )
         ) {
-            let stage_us = evidence
-                .physical_slot_prepare_us
-                .saturating_add(evidence.physical_queue_staging_us);
+            let stage_us = physical_stage_service_us(evidence);
+            let control_commit_us =
+                control_ordered_commit_service_us(physical_install_total_us, evidence);
             self.physical_stage_completions
                 .fetch_add(1, Ordering::Relaxed);
             self.physical_bytes_staged
@@ -1530,7 +1530,7 @@ impl GpuNativePhysicalInstallObserver for GpuNativeDemandSourceQualification {
             self.ordered_commit_completions
                 .fetch_add(1, Ordering::Relaxed);
             self.physical_ordered_commit_us
-                .fetch_add(evidence.mapping_publication_us, Ordering::Relaxed);
+                .fetch_add(control_commit_us, Ordering::Relaxed);
         }
     }
 
@@ -1743,6 +1743,19 @@ impl GpuNativePhysicalInstallObserver for GpuNativeDemandSourceQualification {
                 .fetch_add(count, Ordering::Relaxed);
         }
     }
+}
+
+fn physical_stage_service_us(evidence: GpuNativePhysicalInstallEvidence) -> u64 {
+    evidence
+        .physical_slot_prepare_us
+        .saturating_add(evidence.physical_queue_staging_us)
+}
+
+fn control_ordered_commit_service_us(
+    physical_install_total_us: u64,
+    evidence: GpuNativePhysicalInstallEvidence,
+) -> u64 {
+    physical_install_total_us.saturating_sub(physical_stage_service_us(evidence))
 }
 
 fn qualification_elapsed_us(start: Instant) -> u64 {
@@ -9045,6 +9058,24 @@ mod tests {
         fn drop(&mut self) {
             let _ = std::fs::remove_dir_all(&self.path);
         }
+    }
+
+    #[test]
+    fn control_ordered_commit_service_excludes_stage_and_is_not_mapping_only() {
+        let evidence = GpuNativePhysicalInstallEvidence {
+            physical_slot_prepare_us: 31,
+            physical_queue_staging_us: 7,
+            mapping_publication_us: 3,
+            ..GpuNativePhysicalInstallEvidence::default()
+        };
+
+        assert_eq!(physical_stage_service_us(evidence), 38);
+        assert_eq!(control_ordered_commit_service_us(55, evidence), 17);
+        assert_ne!(
+            control_ordered_commit_service_us(55, evidence),
+            evidence.mapping_publication_us
+        );
+        assert_eq!(control_ordered_commit_service_us(20, evidence), 0);
     }
 
     #[test]

--- a/rust-engine/src/engine.rs
+++ b/rust-engine/src/engine.rs
@@ -511,8 +511,8 @@ pub(crate) enum GpuNativePhysicalInstallStagingQualificationArm {
     Treatment,
 }
 
-/// Explicit PR2-B-B arm. The treatment seam is qualification-only and cannot
-/// be selected through `EngineOptions` or TOML.
+/// Explicit PR2-B-B.1 production qualification arm. Control alone selects the
+/// pre-B-B sequential seam; treatment observes ordinary production.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum GpuNativePhysicalInstallConcurrencyQualificationArm {
@@ -579,10 +579,10 @@ pub(crate) struct GpuNativePhysicalInstallStagingQualificationSnapshot {
 #[derive(Clone, Debug, Serialize)]
 pub(crate) struct GpuNativePhysicalInstallConcurrencyQualificationSnapshot {
     pub(crate) arm: GpuNativePhysicalInstallConcurrencyQualificationArm,
-    pub(crate) qualification_only: bool,
-    pub(crate) normal_production_default_changed: bool,
-    pub(crate) control_uses_ordinary_sequential_direct_staging: bool,
-    pub(crate) treatment_uses_qualification_only_parallel_direct_staging: bool,
+    pub(crate) production_physical_install_concurrency_changed: bool,
+    pub(crate) normal_production_uses_concurrent_physical_staging: bool,
+    pub(crate) control_forces_sequential_direct_staging: bool,
+    pub(crate) treatment_uses_ordinary_production_path: bool,
     pub(crate) single_request_stream: bool,
     pub(crate) overlapping_demand_sets: u64,
     pub(crate) primary_pool_capacity: usize,
@@ -1342,13 +1342,13 @@ impl GpuNativeDemandSourceQualification {
         let width_min = self.install_set_width_min.load(Ordering::Relaxed);
         GpuNativePhysicalInstallConcurrencyQualificationSnapshot {
             arm,
-            qualification_only: true,
-            normal_production_default_changed: false,
-            control_uses_ordinary_sequential_direct_staging: matches!(
+            production_physical_install_concurrency_changed: true,
+            normal_production_uses_concurrent_physical_staging: true,
+            control_forces_sequential_direct_staging: matches!(
                 arm,
                 GpuNativePhysicalInstallConcurrencyQualificationArm::Control
             ),
-            treatment_uses_qualification_only_parallel_direct_staging: matches!(
+            treatment_uses_ordinary_production_path: matches!(
                 arm,
                 GpuNativePhysicalInstallConcurrencyQualificationArm::Treatment
             ),
@@ -6299,7 +6299,7 @@ impl Engine {
                                 state.as_ref(),
                             ),
                         GpuNativePhysicalInstallConcurrencyQualificationArm::Treatment => manager
-                            .ensure_demand_set_physical_install_concurrency_treatment(
+                            .ensure_demand_set_production_observed(
                                 GpuNativeResidencyPriority::Demand,
                                 layer_index,
                                 &demands,

--- a/rust-engine/src/gpu_native_physical_install_staging.rs
+++ b/rust-engine/src/gpu_native_physical_install_staging.rs
@@ -32,6 +32,11 @@ pub(crate) const FROZEN_MEASURED_RUNS: usize = 3;
 pub(crate) const FROZEN_CONFIG_SHA256: &str =
     "33d7cf96328d9c68b0ff45448d91d597d2e3a757cb99e6e61c72998ceabdd056";
 pub(crate) const FROZEN_CONFIG_PATH: &str = "/home/randyap8/slice11-qwen3-coder-gpu-native.toml";
+const CONCURRENCY_PHYSICAL_INSTALL_TOTAL_DEFINITION: &str = "sum of per-expert post-reservation physical staging plus commit service; control uses the existing ordinary direct-install timer and treatment sums each individual staging service with its ordered commit service; reservation time is reported separately";
+const CONCURRENCY_PHYSICAL_ORDERED_COMMIT_DEFINITION: &str = "sum of per-expert post-staging reservation recheck plus logical mapping publication plus arena Resident commit service";
+const CONCURRENCY_PHYSICAL_TRANSACTION_DEFINITION: &str = "complete per-set wall-clock from before sequential reservation through parallel staging and ordered commit; this is the primary mechanism-wall diagnostic";
+const CONCURRENCY_PARALLEL_STAGE_WALL_DEFINITION: &str = "per-set physical staging critical-path wall after reservation and before ordered commit";
+const CONCURRENCY_INDIVIDUAL_STAGE_SUM_DEFINITION: &str = "sum of individual per-expert physical staging service; its ratio to parallel stage wall measures host preparation overlap, not DMA parallelism";
 
 #[derive(Clone, Debug)]
 pub(crate) struct CommandArgs {
@@ -313,6 +318,32 @@ pub(crate) struct TimingDefinitions {
 }
 
 #[derive(Clone, Debug, Serialize)]
+struct ConcurrencyTimingDefinitions {
+    #[serde(flatten)]
+    common: TimingDefinitions,
+    physical_parallel_stage_wall_us: &'static str,
+    sum_individual_physical_stage_us: &'static str,
+    physical_ordered_commit_us: &'static str,
+    physical_install_transaction_us: &'static str,
+}
+
+fn concurrency_timing_definitions() -> ConcurrencyTimingDefinitions {
+    ConcurrencyTimingDefinitions {
+        common: TimingDefinitions {
+            physical_slot_prepare_us: "sum of qualification-only per-expert canonical validation plus unchanged whole-slot zero/fill time",
+            physical_queue_staging_us: "sum of qualification-only Queue::write_buffer_with view acquisition plus Drop scheduling time",
+            mapping_publication_us: "ordered logical mapping Queue::write_buffer time after all treatment staging jobs finish",
+            physical_install_total_us: CONCURRENCY_PHYSICAL_INSTALL_TOTAL_DEFINITION,
+            physical_demand_install_us: "existing aggregate Engine wall timer around the complete residency-manager demand-set transaction",
+        },
+        physical_parallel_stage_wall_us: CONCURRENCY_PARALLEL_STAGE_WALL_DEFINITION,
+        sum_individual_physical_stage_us: CONCURRENCY_INDIVIDUAL_STAGE_SUM_DEFINITION,
+        physical_ordered_commit_us: CONCURRENCY_PHYSICAL_ORDERED_COMMIT_DEFINITION,
+        physical_install_transaction_us: CONCURRENCY_PHYSICAL_TRANSACTION_DEFINITION,
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
 pub(crate) struct WgpuApiAudit {
     requested_version: &'static str,
     resolved_version: &'static str,
@@ -448,7 +479,7 @@ struct PhysicalInstallConcurrencyQualificationReport {
     pinned_wgpu_audit: PinnedWgpuConcurrencyAudit,
     rayon_integration: RayonIntegrationAudit,
     qwen_physical_slot_geometry: QwenPhysicalSlotGeometry,
-    timing_definitions: TimingDefinitions,
+    timing_definitions: ConcurrencyTimingDefinitions,
     benchmark_complete: bool,
     qualification_pass: bool,
     performance_result: &'static str,
@@ -2196,13 +2227,7 @@ pub(crate) async fn run_concurrency_command(
             physical_tail_bytes: 0,
             destination_fill_zero_unchanged: true,
         },
-        timing_definitions: TimingDefinitions {
-            physical_slot_prepare_us: "sum of qualification-only per-expert canonical validation plus unchanged whole-slot zero/fill time",
-            physical_queue_staging_us: "sum of qualification-only Queue::write_buffer_with view acquisition plus Drop scheduling time",
-            mapping_publication_us: "ordered logical mapping Queue::write_buffer time after all treatment staging jobs finish",
-            physical_install_total_us: "sum of per-expert reservation-through-ordered-host-commit wall observations",
-            physical_demand_install_us: "existing aggregate Engine wall timer around the complete residency-manager demand-set transaction",
-        },
+        timing_definitions: concurrency_timing_definitions(),
         benchmark_complete: false,
         qualification_pass: false,
         performance_result: "not_measured",
@@ -2389,5 +2414,82 @@ mod tests {
         assert_eq!(logical, 2_654_208);
         assert_eq!(stride, 2_654_212);
         assert_eq!(stride - 4 - logical, 0);
+    }
+
+    #[test]
+    fn pr2bb_timing_definitions_separate_per_expert_service_from_set_wall() {
+        let definitions = concurrency_timing_definitions();
+
+        assert_eq!(
+            definitions.common.physical_install_total_us,
+            CONCURRENCY_PHYSICAL_INSTALL_TOTAL_DEFINITION
+        );
+        assert_eq!(
+            definitions.physical_ordered_commit_us,
+            CONCURRENCY_PHYSICAL_ORDERED_COMMIT_DEFINITION
+        );
+        assert_eq!(
+            definitions.physical_install_transaction_us,
+            CONCURRENCY_PHYSICAL_TRANSACTION_DEFINITION
+        );
+        assert_eq!(
+            definitions.physical_parallel_stage_wall_us,
+            CONCURRENCY_PARALLEL_STAGE_WALL_DEFINITION
+        );
+        assert_eq!(
+            definitions.sum_individual_physical_stage_us,
+            CONCURRENCY_INDIVIDUAL_STAGE_SUM_DEFINITION
+        );
+        assert!(!definitions
+            .common
+            .physical_install_total_us
+            .contains("reservation-through"));
+        assert!(definitions
+            .physical_install_transaction_us
+            .contains("complete per-set wall-clock"));
+        assert!(definitions
+            .sum_individual_physical_stage_us
+            .contains("not DMA parallelism"));
+    }
+
+    #[test]
+    fn pr2bb_timing_metrics_do_not_enter_the_mechanism_gate_schema() {
+        let serialized = serde_json::to_value(ConcurrencyMechanismGate {
+            warmup_mechanism_reconciled: false,
+            control_direct_staging_writes_gt_zero: false,
+            control_full_slot_vec_materializations_zero: false,
+            control_parallel_staging_sets_zero: false,
+            control_max_in_flight_lte_one: false,
+            treatment_direct_staging_writes_gt_zero: false,
+            treatment_full_slot_vec_materializations_zero: false,
+            treatment_parallel_staging_sets_gt_zero: false,
+            treatment_parallel_staging_experts_gt_zero: false,
+            treatment_max_in_flight_gte_two: false,
+            reservation_failures_zero: false,
+            physical_stage_failures_zero: false,
+            ordered_commit_failures_zero: false,
+            ordered_commit_violations_zero: false,
+            unpublished_physical_writes_after_failure_zero: false,
+            attempts_and_completions_reconcile: false,
+            staged_bytes_exact: false,
+            mapping_publications_exact: false,
+            mapping_unpublications_exact: false,
+            victim_sequence_exact: false,
+            reservation_identity_exact: false,
+            ordered_physical_identity_exact: false,
+            passed: false,
+        })
+        .unwrap();
+        let fields = serialized.as_object().unwrap();
+
+        assert_eq!(fields.len(), 23);
+        assert!(fields.contains_key("warmup_mechanism_reconciled"));
+        assert!(fields.contains_key("control_parallel_staging_sets_zero"));
+        assert!(fields.contains_key("treatment_parallel_staging_sets_gt_zero"));
+        assert!(fields.contains_key("attempts_and_completions_reconcile"));
+        assert!(fields.contains_key("reservation_identity_exact"));
+        assert!(fields.contains_key("ordered_physical_identity_exact"));
+        assert!(fields.contains_key("passed"));
+        assert!(fields.keys().all(|field| !field.ends_with("_us")));
     }
 }

--- a/rust-engine/src/gpu_native_physical_install_staging.rs
+++ b/rust-engine/src/gpu_native_physical_install_staging.rs
@@ -22,6 +22,8 @@ use std::sync::Arc;
 
 pub(crate) const PRODUCTION_SCHEMA: &str = "mer.gpu-native-physical-install-staging.v2";
 pub(crate) const PRODUCTION_MODE: &str = "qualify-gpu-native-physical-install-staging-production";
+pub(crate) const CONCURRENCY_SCHEMA: &str = "mer.gpu-native-physical-install-concurrency.v1";
+pub(crate) const CONCURRENCY_MODE: &str = "qualify-gpu-native-physical-install-concurrency";
 pub(crate) const FROZEN_PROMPT: &str =
     "Write a Rust function that adds two i32 values and returns the result.";
 pub(crate) const FROZEN_OUTPUT_TOKENS: usize = 128;
@@ -209,6 +211,14 @@ pub(crate) struct ProductionReconciliation {
 }
 
 #[derive(Clone, Debug, Serialize)]
+struct ConcurrencyReconciliation {
+    production_and_work: ProductionReconciliation,
+    warmup_generated_text_hashes_exact: bool,
+    measured_generated_text_hashes_exact: bool,
+    all_invariants_pass: bool,
+}
+
+#[derive(Clone, Debug, Serialize)]
 pub(crate) struct ProductionMechanismGate {
     warmup_mechanism_reconciled: bool,
     control_vec_materializations_gt_zero: bool,
@@ -315,6 +325,141 @@ pub(crate) struct WgpuApiAudit {
     adds_map_async: bool,
     adds_readback: bool,
     uses_unsafe_internals: bool,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct ConcurrencyArmReport {
+    #[serde(flatten)]
+    common: ArmReport,
+    warmup_mechanism:
+        Option<crate::engine::GpuNativePhysicalInstallConcurrencyQualificationSnapshot>,
+    mechanism: Option<crate::engine::GpuNativePhysicalInstallConcurrencyQualificationSnapshot>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct ConcurrencyMechanismGate {
+    warmup_mechanism_reconciled: bool,
+    control_direct_staging_writes_gt_zero: bool,
+    control_full_slot_vec_materializations_zero: bool,
+    control_parallel_staging_sets_zero: bool,
+    control_max_in_flight_lte_one: bool,
+    treatment_direct_staging_writes_gt_zero: bool,
+    treatment_full_slot_vec_materializations_zero: bool,
+    treatment_parallel_staging_sets_gt_zero: bool,
+    treatment_parallel_staging_experts_gt_zero: bool,
+    treatment_max_in_flight_gte_two: bool,
+    reservation_failures_zero: bool,
+    physical_stage_failures_zero: bool,
+    ordered_commit_failures_zero: bool,
+    ordered_commit_violations_zero: bool,
+    unpublished_physical_writes_after_failure_zero: bool,
+    attempts_and_completions_reconcile: bool,
+    staged_bytes_exact: bool,
+    mapping_publications_exact: bool,
+    mapping_unpublications_exact: bool,
+    victim_sequence_exact: bool,
+    reservation_identity_exact: bool,
+    ordered_physical_identity_exact: bool,
+    passed: bool,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct ConcurrencyGates {
+    behavioral: BehavioralGate,
+    warmup_generated_text_hashes_exact: bool,
+    measured_generated_text_hashes_exact: bool,
+    text_hashes_passed: bool,
+    work_equivalence: WorkEquivalenceGate,
+    mechanism: ConcurrencyMechanismGate,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct ConcurrencyPerformanceComparison {
+    #[serde(flatten)]
+    common: ProductionPerformanceComparison,
+    physical_reservation_us: MetricComparison,
+    physical_parallel_stage_wall_us: MetricComparison,
+    sum_individual_physical_stage_us: MetricComparison,
+    physical_ordered_commit_us: MetricComparison,
+    physical_install_transaction_us: MetricComparison,
+    control_stage_overlap_ratio: f64,
+    treatment_stage_overlap_ratio: f64,
+    overlap_ratio_definition: &'static str,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct PinnedWgpuConcurrencyAudit {
+    requested_version: &'static str,
+    resolved_version: &'static str,
+    native_queue_send_sync: bool,
+    native_buffer_send_sync: bool,
+    native_queue_write_buffer_view_send_sync: bool,
+    validates_destination_before_staging_creation: bool,
+    drop_schedules_buffer_write: bool,
+    scheduled_writes_begin_at_next_submit: bool,
+    concurrent_calls_use_internal_pending_write_lock: bool,
+    distinct_reserved_slot_ranges_do_not_alias: bool,
+    adds_queue_submit: bool,
+    adds_device_poll: bool,
+    adds_map_async: bool,
+    adds_readback: bool,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct RayonIntegrationAudit {
+    existing_process_wide_pool: bool,
+    creates_new_thread_pool: bool,
+    spawns_os_threads_per_set: bool,
+    uses_tokio_spawn_blocking_per_expert: bool,
+    changes_pool_sizing: bool,
+    changes_rayon_num_threads: bool,
+    parallel_width_is_exact_install_set_width: bool,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct QwenPhysicalSlotGeometry {
+    d_model: usize,
+    d_ff: usize,
+    q4_block_elements: usize,
+    q4_block_bytes: usize,
+    logical_expert_bytes: usize,
+    slot_stride_bytes: usize,
+    physical_tail_bytes: usize,
+    destination_fill_zero_unchanged: bool,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct PhysicalInstallConcurrencyQualificationReport {
+    schema: &'static str,
+    mode: &'static str,
+    normal_production_default_changed: bool,
+    control_uses_ordinary_sequential_direct_staging: bool,
+    treatment_uses_qualification_only_parallel_direct_staging: bool,
+    both_arms_use_ordinary_production_source: bool,
+    victim_policy_changed: bool,
+    slot_assignment_policy_changed: bool,
+    mapping_publication_order_changed: bool,
+    expert_compute_changed: bool,
+    adds_queue_submit: bool,
+    adds_device_poll: bool,
+    adds_map_async: bool,
+    adds_readback: bool,
+    wgpu_version_changed: bool,
+    pinned_wgpu_audit: PinnedWgpuConcurrencyAudit,
+    rayon_integration: RayonIntegrationAudit,
+    qwen_physical_slot_geometry: QwenPhysicalSlotGeometry,
+    timing_definitions: TimingDefinitions,
+    benchmark_complete: bool,
+    qualification_pass: bool,
+    performance_result: &'static str,
+    failure: Option<BenchmarkFailure>,
+    frozen_workload: FrozenWorkload,
+    provenance: BenchmarkProvenance,
+    control: Option<ConcurrencyArmReport>,
+    treatment: Option<ConcurrencyArmReport>,
+    reconciliation: Option<ConcurrencyReconciliation>,
+    gates: Option<ConcurrencyGates>,
+    performance: Option<ConcurrencyPerformanceComparison>,
 }
 
 struct Prepared {
@@ -656,14 +801,106 @@ fn benchmark_report(prepared: &Prepared) -> BenchmarkReport {
     )
 }
 
-async fn run_arm(
+#[derive(Clone, Copy)]
+enum PhysicalInstallQualificationRun {
+    Staging(GpuNativePhysicalInstallStagingQualificationArm),
+    Concurrency(crate::engine::GpuNativePhysicalInstallConcurrencyQualificationArm),
+}
+
+struct PhysicalInstallArmRun {
+    common: ArmReport,
+    warmup_concurrency:
+        Option<crate::engine::GpuNativePhysicalInstallConcurrencyQualificationSnapshot>,
+    concurrency: Option<crate::engine::GpuNativePhysicalInstallConcurrencyQualificationSnapshot>,
+}
+
+fn concurrency_common_snapshot(
+    source: &crate::engine::GpuNativePhysicalInstallConcurrencyQualificationSnapshot,
+) -> GpuNativePhysicalInstallStagingQualificationSnapshot {
+    GpuNativePhysicalInstallStagingQualificationSnapshot {
+        arm: match source.arm {
+            crate::engine::GpuNativePhysicalInstallConcurrencyQualificationArm::Control => {
+                GpuNativePhysicalInstallStagingQualificationArm::Control
+            }
+            crate::engine::GpuNativePhysicalInstallConcurrencyQualificationArm::Treatment => {
+                GpuNativePhysicalInstallStagingQualificationArm::Treatment
+            }
+        },
+        qualification_telemetry_only: true,
+        production_physical_install_changed: false,
+        control_forces_legacy_full_slot_vec: false,
+        treatment_uses_ordinary_production_path: false,
+        normal_production_uses_direct_queue_staging: true,
+        single_request_stream: source.single_request_stream,
+        overlapping_demand_sets: source.overlapping_demand_sets,
+        primary_pool_capacity: source.primary_pool_capacity,
+        shadow_pool_capacity: source.shadow_pool_capacity,
+        demand_sets: source.demand_sets,
+        physical_missing_experts: source.physical_missing_experts,
+        physical_probe_us: source.physical_probe_us,
+        source_sets: source.source_sets,
+        source_experts: source.source_experts,
+        demand_source_requests: source.demand_source_requests,
+        source_ram_hits: source.source_ram_hits,
+        source_ram_misses: source.source_ram_misses,
+        source_nvme_reads: source.source_nvme_reads,
+        source_nvme_bytes: source.source_nvme_bytes,
+        source_acquisition_wall_us: source.source_acquisition_wall_us,
+        logical_demand_admission_us: source.logical_demand_admission_us,
+        physical_demand_install_us: source.physical_demand_install_us,
+        total_residency_service_us: source.total_residency_service_us,
+        ram_cache_inserts: source.ram_cache_inserts,
+        ram_cache_evictions: source.ram_cache_evictions,
+        selected_route_ids_sha256: source.selected_route_ids_sha256.clone(),
+        physical_missing_ids_sha256: source.physical_missing_ids_sha256.clone(),
+        demand_source_request_ids_sha256: source.demand_source_request_ids_sha256.clone(),
+        demand_ram_insert_ids_sha256: source.demand_ram_insert_ids_sha256.clone(),
+        demand_ram_eviction_ids_sha256: source.demand_ram_eviction_ids_sha256.clone(),
+        physical_victim_ids_sha256: source.physical_victim_ids_sha256.clone(),
+        physical_residency_identity_sha256: source.physical_residency_identity_sha256.clone(),
+        physical_install_attempts: source.physical_install_attempts,
+        physical_install_completions: source.physical_install_completions,
+        full_slot_vec_materializations: source.full_slot_vec_materializations,
+        direct_staging_writes: source.direct_staging_writes,
+        direct_staging_failures: source.direct_staging_failures,
+        physical_slot_bytes_staged: source.physical_slot_bytes_staged,
+        mapping_publications: source.mapping_publications,
+        mapping_unpublications: source.mapping_unpublications,
+        physical_slot_prepare_us: source.physical_slot_prepare_us,
+        physical_queue_staging_us: source.physical_queue_staging_us,
+        mapping_publication_us: source.mapping_publication_us,
+        physical_install_total_us: source.physical_install_total_us,
+    }
+}
+
+async fn run_physical_install_arm(
     prepared: &Prepared,
     args: &CommandArgs,
-    arm: GpuNativePhysicalInstallStagingQualificationArm,
-) -> Result<ArmReport, BenchmarkFailure> {
-    let arm_name = match arm {
-        GpuNativePhysicalInstallStagingQualificationArm::Control => "control",
-        GpuNativePhysicalInstallStagingQualificationArm::Treatment => "treatment",
+    run: PhysicalInstallQualificationRun,
+) -> Result<PhysicalInstallArmRun, BenchmarkFailure> {
+    let (arm_name, arm) = match run {
+        PhysicalInstallQualificationRun::Staging(
+            GpuNativePhysicalInstallStagingQualificationArm::Control,
+        )
+        | PhysicalInstallQualificationRun::Concurrency(
+            crate::engine::GpuNativePhysicalInstallConcurrencyQualificationArm::Control,
+        ) => (
+            "control",
+            GpuNativePhysicalInstallStagingQualificationArm::Control,
+        ),
+        PhysicalInstallQualificationRun::Staging(
+            GpuNativePhysicalInstallStagingQualificationArm::Treatment,
+        )
+        | PhysicalInstallQualificationRun::Concurrency(
+            crate::engine::GpuNativePhysicalInstallConcurrencyQualificationArm::Treatment,
+        ) => (
+            "treatment",
+            GpuNativePhysicalInstallStagingQualificationArm::Treatment,
+        ),
+    };
+    let mode_name = match run {
+        PhysicalInstallQualificationRun::Staging(_) => PRODUCTION_MODE,
+        PhysicalInstallQualificationRun::Concurrency(_) => CONCURRENCY_MODE,
     };
     let mut benchmark = benchmark_report(prepared);
     let runtime = crate::gpu_native_real_benchmark::construct_runtime(
@@ -674,9 +911,14 @@ async fn run_arm(
         &mut benchmark,
     )
     .await?;
-    let enable_result = runtime
+    let enable_result = match run {
+        PhysicalInstallQualificationRun::Staging(arm) => runtime
+            .engine
+            .enable_gpu_native_physical_install_staging_qualification(arm),
+        PhysicalInstallQualificationRun::Concurrency(arm) => runtime
         .engine
-        .enable_gpu_native_physical_install_staging_qualification(arm);
+            .enable_gpu_native_physical_install_concurrency_qualification(arm),
+    };
     if let Err(error) = enable_result {
         let failure = BenchmarkFailure::new("startup", "qualification-arm-enable-failed", error);
         let _ = crate::gpu_native_real_benchmark::shutdown_runtime(
@@ -723,7 +965,7 @@ async fn run_arm(
     if execution_failure.is_none() {
         for index in 0..FROZEN_WARMUP_RUNS {
             let result = crate::with_progress_timeout(
-                format!("{PRODUCTION_MODE} {arm_name} warmup {index}"),
+                format!("{mode_name} {arm_name} warmup {index}"),
                 args.progress_watchdog,
                 crate::gpu_native_real_benchmark::execute_request(
                     &runtime,
@@ -756,14 +998,25 @@ async fn run_arm(
     }
 
     let mut warmup_source = None;
+    let mut warmup_concurrency = None;
     let mut warmup_production_physical_install = None;
     let mut warmup_production = None;
     let mut warmup_ram_cache_state_sha256 = None;
     let mut warmup_work = None;
     if execution_failure.is_none() {
+        match run {
+            PhysicalInstallQualificationRun::Staging(_) => {
         warmup_source = runtime
             .engine
             .gpu_native_physical_install_staging_qualification_snapshot();
+            }
+            PhysicalInstallQualificationRun::Concurrency(_) => {
+                warmup_concurrency = runtime
+                    .engine
+                    .gpu_native_physical_install_concurrency_qualification_snapshot();
+                warmup_source = warmup_concurrency.as_ref().map(concurrency_common_snapshot);
+            }
+        }
         if warmup_source.is_none() {
             execution_failure = Some(BenchmarkFailure::new(
                 "postcondition",
@@ -830,7 +1083,7 @@ async fn run_arm(
     if execution_failure.is_none() {
         for index in 0..FROZEN_MEASURED_RUNS {
             let result = crate::with_progress_timeout(
-                format!("{PRODUCTION_MODE} {arm_name} measured {index}"),
+                format!("{mode_name} {arm_name} measured {index}"),
                 args.progress_watchdog,
                 crate::gpu_native_real_benchmark::execute_request(
                     &runtime,
@@ -854,9 +1107,23 @@ async fn run_arm(
         }
     }
 
-    let source = runtime
+    let (source, concurrency) = match run {
+        PhysicalInstallQualificationRun::Staging(_) => (
+            runtime
         .engine
-        .gpu_native_physical_install_staging_qualification_snapshot();
+                .gpu_native_physical_install_staging_qualification_snapshot(),
+            None,
+        ),
+        PhysicalInstallQualificationRun::Concurrency(_) => {
+            let concurrency = runtime
+                .engine
+                .gpu_native_physical_install_concurrency_qualification_snapshot();
+            (
+                concurrency.as_ref().map(concurrency_common_snapshot),
+                concurrency,
+            )
+        }
+    };
     let production_physical_install = runtime.engine.production_physical_install_snapshot();
     if execution_failure.is_none() && production_physical_install.is_none() {
         execution_failure = Some(BenchmarkFailure::new(
@@ -900,7 +1167,8 @@ async fn run_arm(
     if let Some(failure) = execution_failure.clone() {
         benchmark.fail(failure.clone());
     }
-    Ok(ArmReport {
+    Ok(PhysicalInstallArmRun {
+        common: ArmReport {
         arm,
         complete: execution_failure.is_none(),
         failure: execution_failure,
@@ -916,7 +1184,24 @@ async fn run_arm(
         production,
         work,
         benchmark,
+        },
+        warmup_concurrency,
+        concurrency,
     })
+}
+
+async fn run_arm(
+    prepared: &Prepared,
+    args: &CommandArgs,
+    arm: GpuNativePhysicalInstallStagingQualificationArm,
+) -> Result<ArmReport, BenchmarkFailure> {
+    Ok(run_physical_install_arm(
+        prepared,
+        args,
+        PhysicalInstallQualificationRun::Staging(arm),
+    )
+    .await?
+    .common)
 }
 
 fn generated_results(arm: &ArmReport) -> &[PerRunResult] {
@@ -1548,7 +1833,7 @@ fn emit_report<T: Serialize>(report: &T, path: &Path) -> Result<(), Box<dyn std:
         std::fs::create_dir_all(parent)?;
     }
     std::fs::write(path, json)?;
-    eprintln!("PR2-B-A qualification report written to {}", path.display());
+    eprintln!("GPU-native physical-install qualification report written to {}", path.display());
     Ok(())
 }
 
@@ -1672,6 +1957,385 @@ pub(crate) async fn run_command(args: CommandArgs) -> Result<(), Box<dyn std::er
     }
 }
 
+fn concurrency_mechanism_gate(
+    control: &ConcurrencyArmReport,
+    treatment: &ConcurrencyArmReport,
+) -> ConcurrencyMechanismGate {
+    use crate::engine::GpuNativePhysicalInstallConcurrencyQualificationSnapshot as Snapshot;
+
+    fn internally_reconciles(source: &Snapshot) -> bool {
+        source.physical_install_attempts == source.reservation_attempts
+            && source.reservation_attempts == source.reservation_successes
+            && source.reservation_failures == 0
+            && source.physical_stage_attempts == source.physical_stage_completions
+            && source.physical_stage_failures == 0
+            && source.physical_stage_completions == source.direct_staging_writes
+            && source.physical_stage_completions == source.physical_install_completions
+            && source.physical_stage_completions == source.ordered_commit_attempts
+            && source.ordered_commit_attempts == source.ordered_commit_completions
+            && source.ordered_commit_failures == 0
+            && source.ordered_commit_violations == 0
+            && source.physical_bytes_staged == source.physical_slot_bytes_staged
+            && source.mapping_publications == source.ordered_commit_completions
+            && source.unpublished_physical_writes_after_failure == 0
+    }
+
+    fn pair_reconciles(control: &Snapshot, treatment: &Snapshot) -> bool {
+        internally_reconciles(control)
+            && internally_reconciles(treatment)
+            && control.physical_install_completions == treatment.physical_install_completions
+            && control.physical_slot_bytes_staged == treatment.physical_slot_bytes_staged
+            && control.mapping_publications == treatment.mapping_publications
+            && control.mapping_unpublications == treatment.mapping_unpublications
+            && control.physical_victim_ids_sha256 == treatment.physical_victim_ids_sha256
+            && control.reservation_identity_sha256 == treatment.reservation_identity_sha256
+            && control.physical_residency_identity_sha256
+                == treatment.physical_residency_identity_sha256
+    }
+
+    let c = control
+        .mechanism
+        .as_ref()
+        .expect("complete control mechanism");
+    let t = treatment
+        .mechanism
+        .as_ref()
+        .expect("complete treatment mechanism");
+    let cw = control
+        .warmup_mechanism
+        .as_ref()
+        .expect("complete control warmup mechanism");
+    let tw = treatment
+        .warmup_mechanism
+        .as_ref()
+        .expect("complete treatment warmup mechanism");
+    let warmup_mechanism_reconciled = pair_reconciles(cw, tw)
+        && cw.parallel_staging_sets == 0
+        && cw.max_in_flight_physical_staging <= 1
+        && tw.parallel_staging_sets > 0
+        && tw.max_in_flight_physical_staging >= 2;
+    let control_direct_staging_writes_gt_zero = c.direct_staging_writes > 0;
+    let control_full_slot_vec_materializations_zero = c.full_slot_vec_materializations == 0;
+    let control_parallel_staging_sets_zero = c.parallel_staging_sets == 0;
+    let control_max_in_flight_lte_one = c.max_in_flight_physical_staging <= 1;
+    let treatment_direct_staging_writes_gt_zero = t.direct_staging_writes > 0;
+    let treatment_full_slot_vec_materializations_zero = t.full_slot_vec_materializations == 0;
+    let treatment_parallel_staging_sets_gt_zero = t.parallel_staging_sets > 0;
+    let treatment_parallel_staging_experts_gt_zero = t.parallel_staging_experts > 0;
+    let treatment_max_in_flight_gte_two = t.max_in_flight_physical_staging >= 2;
+    let reservation_failures_zero = c.reservation_failures == 0 && t.reservation_failures == 0;
+    let physical_stage_failures_zero =
+        c.physical_stage_failures == 0 && t.physical_stage_failures == 0;
+    let ordered_commit_failures_zero =
+        c.ordered_commit_failures == 0 && t.ordered_commit_failures == 0;
+    let ordered_commit_violations_zero =
+        c.ordered_commit_violations == 0 && t.ordered_commit_violations == 0;
+    let unpublished_physical_writes_after_failure_zero =
+        c.unpublished_physical_writes_after_failure == 0
+            && t.unpublished_physical_writes_after_failure == 0;
+    let attempts_and_completions_reconcile = pair_reconciles(c, t);
+    let staged_bytes_exact = c.physical_bytes_staged == t.physical_bytes_staged;
+    let mapping_publications_exact = c.mapping_publications == t.mapping_publications;
+    let mapping_unpublications_exact = c.mapping_unpublications == t.mapping_unpublications;
+    let victim_sequence_exact = c.physical_victim_ids_sha256 == t.physical_victim_ids_sha256;
+    let reservation_identity_exact =
+        c.reservation_identity_sha256 == t.reservation_identity_sha256;
+    let ordered_physical_identity_exact =
+        c.physical_residency_identity_sha256 == t.physical_residency_identity_sha256;
+    let passed = warmup_mechanism_reconciled
+        && control_direct_staging_writes_gt_zero
+        && control_full_slot_vec_materializations_zero
+        && control_parallel_staging_sets_zero
+        && control_max_in_flight_lte_one
+        && treatment_direct_staging_writes_gt_zero
+        && treatment_full_slot_vec_materializations_zero
+        && treatment_parallel_staging_sets_gt_zero
+        && treatment_parallel_staging_experts_gt_zero
+        && treatment_max_in_flight_gte_two
+        && reservation_failures_zero
+        && physical_stage_failures_zero
+        && ordered_commit_failures_zero
+        && ordered_commit_violations_zero
+        && unpublished_physical_writes_after_failure_zero
+        && attempts_and_completions_reconcile
+        && staged_bytes_exact
+        && mapping_publications_exact
+        && mapping_unpublications_exact
+        && victim_sequence_exact
+        && reservation_identity_exact
+        && ordered_physical_identity_exact;
+    ConcurrencyMechanismGate {
+        warmup_mechanism_reconciled,
+        control_direct_staging_writes_gt_zero,
+        control_full_slot_vec_materializations_zero,
+        control_parallel_staging_sets_zero,
+        control_max_in_flight_lte_one,
+        treatment_direct_staging_writes_gt_zero,
+        treatment_full_slot_vec_materializations_zero,
+        treatment_parallel_staging_sets_gt_zero,
+        treatment_parallel_staging_experts_gt_zero,
+        treatment_max_in_flight_gte_two,
+        reservation_failures_zero,
+        physical_stage_failures_zero,
+        ordered_commit_failures_zero,
+        ordered_commit_violations_zero,
+        unpublished_physical_writes_after_failure_zero,
+        attempts_and_completions_reconcile,
+        staged_bytes_exact,
+        mapping_publications_exact,
+        mapping_unpublications_exact,
+        victim_sequence_exact,
+        reservation_identity_exact,
+        ordered_physical_identity_exact,
+        passed,
+    }
+}
+
+fn concurrency_performance(
+    control: &ConcurrencyArmReport,
+    treatment: &ConcurrencyArmReport,
+) -> Result<ConcurrencyPerformanceComparison, BenchmarkFailure> {
+    let common = production_performance(&control.common, &treatment.common)?;
+    let c = control
+        .mechanism
+        .as_ref()
+        .expect("complete control mechanism");
+    let t = treatment
+        .mechanism
+        .as_ref()
+        .expect("complete treatment mechanism");
+    let overlap =
+        |source: &crate::engine::GpuNativePhysicalInstallConcurrencyQualificationSnapshot| {
+            if source.physical_parallel_stage_wall_us == 0 {
+                0.0
+            } else {
+                source.sum_individual_physical_stage_us as f64
+                    / source.physical_parallel_stage_wall_us as f64
+            }
+        };
+    Ok(ConcurrencyPerformanceComparison {
+        physical_reservation_us: comparison(
+            c.physical_reservation_us as f64,
+            t.physical_reservation_us as f64,
+        ),
+        physical_parallel_stage_wall_us: comparison(
+            c.physical_parallel_stage_wall_us as f64,
+            t.physical_parallel_stage_wall_us as f64,
+        ),
+        sum_individual_physical_stage_us: comparison(
+            c.sum_individual_physical_stage_us as f64,
+            t.sum_individual_physical_stage_us as f64,
+        ),
+        physical_ordered_commit_us: comparison(
+            c.physical_ordered_commit_us as f64,
+            t.physical_ordered_commit_us as f64,
+        ),
+        physical_install_transaction_us: comparison(
+            c.physical_install_transaction_us as f64,
+            t.physical_install_transaction_us as f64,
+        ),
+        control_stage_overlap_ratio: overlap(c),
+        treatment_stage_overlap_ratio: overlap(t),
+        overlap_ratio_definition: "sum of per-expert direct-staging preparation wall times divided by install-set staging critical-path wall; this is host preparation overlap, not hardware DMA parallelism",
+        common,
+    })
+}
+
+pub(crate) async fn run_concurrency_command(
+    args: CommandArgs,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let prepared = prepare(&args)?;
+    let mut report = PhysicalInstallConcurrencyQualificationReport {
+        schema: CONCURRENCY_SCHEMA,
+        mode: CONCURRENCY_MODE,
+        normal_production_default_changed: false,
+        control_uses_ordinary_sequential_direct_staging: true,
+        treatment_uses_qualification_only_parallel_direct_staging: true,
+        both_arms_use_ordinary_production_source: true,
+        victim_policy_changed: false,
+        slot_assignment_policy_changed: false,
+        mapping_publication_order_changed: false,
+        expert_compute_changed: false,
+        adds_queue_submit: false,
+        adds_device_poll: false,
+        adds_map_async: false,
+        adds_readback: false,
+        wgpu_version_changed: false,
+        pinned_wgpu_audit: PinnedWgpuConcurrencyAudit {
+            requested_version: "0.20",
+            resolved_version: "0.20.1",
+            native_queue_send_sync: true,
+            native_buffer_send_sync: true,
+            native_queue_write_buffer_view_send_sync: true,
+            validates_destination_before_staging_creation: true,
+            drop_schedules_buffer_write: true,
+            scheduled_writes_begin_at_next_submit: true,
+            concurrent_calls_use_internal_pending_write_lock: true,
+            distinct_reserved_slot_ranges_do_not_alias: true,
+            adds_queue_submit: false,
+            adds_device_poll: false,
+            adds_map_async: false,
+            adds_readback: false,
+        },
+        rayon_integration: RayonIntegrationAudit {
+            existing_process_wide_pool: true,
+            creates_new_thread_pool: false,
+            spawns_os_threads_per_set: false,
+            uses_tokio_spawn_blocking_per_expert: false,
+            changes_pool_sizing: false,
+            changes_rayon_num_threads: false,
+            parallel_width_is_exact_install_set_width: true,
+        },
+        qwen_physical_slot_geometry: QwenPhysicalSlotGeometry {
+            d_model: 2048,
+            d_ff: 768,
+            q4_block_elements: 32,
+            q4_block_bytes: 18,
+            logical_expert_bytes: 2_654_208,
+            slot_stride_bytes: 2_654_212,
+            physical_tail_bytes: 0,
+            destination_fill_zero_unchanged: true,
+        },
+        timing_definitions: TimingDefinitions {
+            physical_slot_prepare_us: "sum of qualification-only per-expert canonical validation plus unchanged whole-slot zero/fill time",
+            physical_queue_staging_us: "sum of qualification-only Queue::write_buffer_with view acquisition plus Drop scheduling time",
+            mapping_publication_us: "ordered logical mapping Queue::write_buffer time after all treatment staging jobs finish",
+            physical_install_total_us: "sum of per-expert reservation-through-ordered-host-commit wall observations",
+            physical_demand_install_us: "existing aggregate Engine wall timer around the complete residency-manager demand-set transaction",
+        },
+        benchmark_complete: false,
+        qualification_pass: false,
+        performance_result: "not_measured",
+        failure: None,
+        frozen_workload: frozen_workload(args.expected_adapter_name.clone()),
+        provenance: prepared.provenance.clone(),
+        control: None,
+        treatment: None,
+        reconciliation: None,
+        gates: None,
+        performance: None,
+    };
+
+    let control = match run_physical_install_arm(
+        &prepared,
+        &args,
+        PhysicalInstallQualificationRun::Concurrency(
+            crate::engine::GpuNativePhysicalInstallConcurrencyQualificationArm::Control,
+        ),
+    )
+    .await
+    {
+        Ok(control) => control,
+        Err(failure) => {
+            report.failure = Some(failure.clone());
+            emit_report(&report, &args.report_out)?;
+            return Err(failure.to_string().into());
+        }
+    };
+    let control_failure = control.common.failure.clone();
+    report.control = Some(ConcurrencyArmReport {
+        common: control.common,
+        warmup_mechanism: control.warmup_concurrency,
+        mechanism: control.concurrency,
+    });
+    if let Some(failure) = control_failure {
+        report.failure = Some(failure.clone());
+        emit_report(&report, &args.report_out)?;
+        return Err(failure.to_string().into());
+    }
+
+    let treatment = match run_physical_install_arm(
+        &prepared,
+        &args,
+        PhysicalInstallQualificationRun::Concurrency(
+            crate::engine::GpuNativePhysicalInstallConcurrencyQualificationArm::Treatment,
+        ),
+    )
+    .await
+    {
+        Ok(treatment) => treatment,
+        Err(failure) => {
+            report.failure = Some(failure.clone());
+            emit_report(&report, &args.report_out)?;
+            return Err(failure.to_string().into());
+        }
+    };
+    let treatment_failure = treatment.common.failure.clone();
+    report.treatment = Some(ConcurrencyArmReport {
+        common: treatment.common,
+        warmup_mechanism: treatment.warmup_concurrency,
+        mechanism: treatment.concurrency,
+    });
+    if let Some(failure) = treatment_failure {
+        report.failure = Some(failure.clone());
+        emit_report(&report, &args.report_out)?;
+        return Err(failure.to_string().into());
+    }
+
+    let control = report.control.as_ref().expect("control stored");
+    let treatment = report.treatment.as_ref().expect("treatment stored");
+    let production_and_work = production_reconciliation(
+        reconcile(&control.common, &treatment.common),
+        &control.common,
+        &treatment.common,
+    );
+    let warmup_generated_text_hashes_exact = control
+        .common
+        .warmup_results
+        .iter()
+        .map(|run| &run.generated_text_sha256)
+        .eq(treatment
+            .common
+            .warmup_results
+            .iter()
+            .map(|run| &run.generated_text_sha256));
+    let measured_generated_text_hashes_exact = generated_results(&control.common)
+        .iter()
+        .map(|run| &run.generated_text_sha256)
+        .eq(generated_results(&treatment.common)
+            .iter()
+            .map(|run| &run.generated_text_sha256));
+    let reconciliation = ConcurrencyReconciliation {
+        all_invariants_pass: production_and_work.all_invariants_pass
+            && warmup_generated_text_hashes_exact
+            && measured_generated_text_hashes_exact,
+        production_and_work,
+        warmup_generated_text_hashes_exact,
+        measured_generated_text_hashes_exact,
+    };
+    let (behavioral, work_equivalence) =
+        common_gates(&reconciliation.production_and_work.common);
+    let mechanism = concurrency_mechanism_gate(control, treatment);
+    let text_hashes_passed = reconciliation.warmup_generated_text_hashes_exact
+        && reconciliation.measured_generated_text_hashes_exact;
+    let gates = ConcurrencyGates {
+        behavioral,
+        warmup_generated_text_hashes_exact,
+        measured_generated_text_hashes_exact,
+        text_hashes_passed,
+        work_equivalence,
+        mechanism,
+    };
+    let performance = concurrency_performance(control, treatment)?;
+    let qualification_pass = reconciliation.all_invariants_pass
+        && gates.behavioral.passed
+        && gates.text_hashes_passed
+        && gates.work_equivalence.passed
+        && gates.mechanism.passed;
+    report.benchmark_complete = true;
+    report.qualification_pass = qualification_pass;
+    report.performance_result = performance.common.performance_result;
+    report.reconciliation = Some(reconciliation);
+    report.gates = Some(gates);
+    report.performance = Some(performance);
+    emit_report(&report, &args.report_out)?;
+    if qualification_pass {
+        Ok(())
+    } else {
+        Err("PR2-B-B physical-install concurrency qualification gates did not all pass; see emitted report".into())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1708,5 +2372,22 @@ mod tests {
         assert_eq!(comparison(10.0, 12.0).delta_percent, 20.0);
         assert_eq!(comparison(10.0, 8.0).delta_percent, -20.0);
         assert_eq!(comparison(0.0, 8.0).delta_percent, 0.0);
+    }
+
+    #[test]
+    fn pr2bb_contract_is_qualification_only_and_versioned_separately() {
+        assert_eq!(
+            CONCURRENCY_SCHEMA,
+            "mer.gpu-native-physical-install-concurrency.v1"
+        );
+        assert_eq!(
+            CONCURRENCY_MODE,
+            "qualify-gpu-native-physical-install-concurrency"
+        );
+        let logical = (2048usize * 768 / 32) * 3 * 18;
+        let stride = (4 + logical + 3) & !3;
+        assert_eq!(logical, 2_654_208);
+        assert_eq!(stride, 2_654_212);
+        assert_eq!(stride - 4 - logical, 0);
     }
 }

--- a/rust-engine/src/gpu_native_physical_install_staging.rs
+++ b/rust-engine/src/gpu_native_physical_install_staging.rs
@@ -22,8 +22,8 @@ use std::sync::Arc;
 
 pub(crate) const PRODUCTION_SCHEMA: &str = "mer.gpu-native-physical-install-staging.v2";
 pub(crate) const PRODUCTION_MODE: &str = "qualify-gpu-native-physical-install-staging-production";
-pub(crate) const CONCURRENCY_SCHEMA: &str = "mer.gpu-native-physical-install-concurrency.v1";
-pub(crate) const CONCURRENCY_MODE: &str = "qualify-gpu-native-physical-install-concurrency";
+pub(crate) const CONCURRENCY_SCHEMA: &str = "mer.gpu-native-physical-install-concurrency-production.v1";
+pub(crate) const CONCURRENCY_MODE: &str = "qualify-gpu-native-physical-install-concurrency-production";
 pub(crate) const FROZEN_PROMPT: &str =
     "Write a Rust function that adds two i32 values and returns the result.";
 pub(crate) const FROZEN_OUTPUT_TOKENS: usize = 128;
@@ -370,6 +370,10 @@ struct ConcurrencyArmReport {
 #[derive(Clone, Debug, Serialize)]
 struct ConcurrencyMechanismGate {
     warmup_mechanism_reconciled: bool,
+    control_production_parallel_staging_sets_zero: bool,
+    treatment_ordinary_production_path_exercised: bool,
+    treatment_production_parallel_staging_sets_gt_zero: bool,
+    treatment_production_counters_reconcile: bool,
     control_direct_staging_writes_gt_zero: bool,
     control_full_slot_vec_materializations_zero: bool,
     control_parallel_staging_sets_zero: bool,
@@ -463,19 +467,23 @@ struct QwenPhysicalSlotGeometry {
 struct PhysicalInstallConcurrencyQualificationReport {
     schema: &'static str,
     mode: &'static str,
-    normal_production_default_changed: bool,
-    control_uses_ordinary_sequential_direct_staging: bool,
-    treatment_uses_qualification_only_parallel_direct_staging: bool,
+    production_physical_install_concurrency_changed: bool,
+    normal_production_uses_concurrent_physical_staging: bool,
+    control_forces_sequential_direct_staging: bool,
+    treatment_uses_ordinary_production_path: bool,
+    speculative_physical_install_changed: bool,
     both_arms_use_ordinary_production_source: bool,
     victim_policy_changed: bool,
     slot_assignment_policy_changed: bool,
     mapping_publication_order_changed: bool,
+    source_acquisition_changed: bool,
     expert_compute_changed: bool,
     adds_queue_submit: bool,
     adds_device_poll: bool,
     adds_map_async: bool,
     adds_readback: bool,
     wgpu_version_changed: bool,
+    rayon_pool_sizing_changed: bool,
     pinned_wgpu_audit: PinnedWgpuConcurrencyAudit,
     rayon_integration: RayonIntegrationAudit,
     qwen_physical_slot_geometry: QwenPhysicalSlotGeometry,
@@ -858,9 +866,9 @@ fn concurrency_common_snapshot(
             }
         },
         qualification_telemetry_only: true,
-        production_physical_install_changed: false,
+        production_physical_install_changed: true,
         control_forces_legacy_full_slot_vec: false,
-        treatment_uses_ordinary_production_path: false,
+        treatment_uses_ordinary_production_path: source.treatment_uses_ordinary_production_path,
         normal_production_uses_direct_queue_staging: true,
         single_request_stream: source.single_request_stream,
         overlapping_demand_sets: source.overlapping_demand_sets,
@@ -1988,6 +1996,39 @@ pub(crate) async fn run_command(args: CommandArgs) -> Result<(), Box<dyn std::er
     }
 }
 
+fn production_physical_install_counters_reconcile(
+    source: &GpuNativeProductionPhysicalInstallSnapshot,
+) -> bool {
+    source.physical_install_sets > 0
+        && source.physical_install_experts == source.reservation_attempts
+        && source.reservation_attempts == source.reservation_successes
+        && source.reservation_failures == 0
+        && source.physical_install_attempts == source.physical_stage_attempts
+        && source.physical_stage_attempts == source.physical_stage_completions
+        && source.physical_stage_failures == 0
+        && source.physical_stage_completions == source.direct_staging_successes
+        && source.direct_staging_unavailable == 0
+        && source.direct_staging_allocation_fallbacks == 0
+        && source.ordered_commit_attempts == source.ordered_commit_completions
+        && source.ordered_commit_completions == source.physical_stage_completions
+        && source.ordered_commit_failures == 0
+        && source.ordered_commit_violations == 0
+        && source.unpublished_physical_writes_after_failure == 0
+        && source.physical_install_failures == 0
+        && source.parallel_eligible_sets == source.parallel_staging_sets
+        && source.physical_install_experts
+            == source
+                .parallel_staging_experts
+                .saturating_add(source.singleton_staging_sets)
+}
+
+fn production_concurrency_exercised(source: &GpuNativeProductionPhysicalInstallSnapshot) -> bool {
+    production_physical_install_counters_reconcile(source)
+        && source.parallel_staging_sets > 0
+        && source.parallel_staging_experts > 0
+        && source.max_in_flight_physical_staging >= 2
+}
+
 fn concurrency_mechanism_gate(
     control: &ConcurrencyArmReport,
     treatment: &ConcurrencyArmReport,
@@ -2040,11 +2081,46 @@ fn concurrency_mechanism_gate(
         .warmup_mechanism
         .as_ref()
         .expect("complete treatment warmup mechanism");
+    let cwpi = control
+        .common
+        .warmup_production_physical_install
+        .as_ref()
+        .expect("complete control warmup production physical-install telemetry");
+    let twpi = treatment
+        .common
+        .warmup_production_physical_install
+        .as_ref()
+        .expect("complete treatment warmup production physical-install telemetry");
+    let cpi = control
+        .common
+        .production_physical_install
+        .as_ref()
+        .expect("complete control production physical-install telemetry");
+    let tpi = treatment
+        .common
+        .production_physical_install
+        .as_ref()
+        .expect("complete treatment production physical-install telemetry");
     let warmup_mechanism_reconciled = pair_reconciles(cw, tw)
         && cw.parallel_staging_sets == 0
         && cw.max_in_flight_physical_staging <= 1
         && tw.parallel_staging_sets > 0
-        && tw.max_in_flight_physical_staging >= 2;
+        && tw.max_in_flight_physical_staging >= 2
+        && cwpi.physical_install_sets == 0
+        && cwpi.parallel_staging_sets == 0
+        && production_concurrency_exercised(twpi);
+    let control_production_parallel_staging_sets_zero = cpi.physical_install_sets == 0
+        && cpi.parallel_staging_sets == 0
+        && cpi.physical_install_attempts == 0;
+    let treatment_ordinary_production_path_exercised = t.treatment_uses_ordinary_production_path
+        && t.production_physical_install_concurrency_changed
+        && t.normal_production_uses_concurrent_physical_staging
+        && !c.treatment_uses_ordinary_production_path
+        && c.control_forces_sequential_direct_staging
+        && tpi.physical_install_sets > 0;
+    let treatment_production_parallel_staging_sets_gt_zero = production_concurrency_exercised(tpi);
+    let treatment_production_counters_reconcile =
+        production_physical_install_counters_reconcile(tpi);
     let control_direct_staging_writes_gt_zero = c.direct_staging_writes > 0;
     let control_full_slot_vec_materializations_zero = c.full_slot_vec_materializations == 0;
     let control_parallel_staging_sets_zero = c.parallel_staging_sets == 0;
@@ -2074,6 +2150,10 @@ fn concurrency_mechanism_gate(
     let ordered_physical_identity_exact =
         c.physical_residency_identity_sha256 == t.physical_residency_identity_sha256;
     let passed = warmup_mechanism_reconciled
+        && control_production_parallel_staging_sets_zero
+        && treatment_ordinary_production_path_exercised
+        && treatment_production_parallel_staging_sets_gt_zero
+        && treatment_production_counters_reconcile
         && control_direct_staging_writes_gt_zero
         && control_full_slot_vec_materializations_zero
         && control_parallel_staging_sets_zero
@@ -2097,6 +2177,10 @@ fn concurrency_mechanism_gate(
         && ordered_physical_identity_exact;
     ConcurrencyMechanismGate {
         warmup_mechanism_reconciled,
+        control_production_parallel_staging_sets_zero,
+        treatment_ordinary_production_path_exercised,
+        treatment_production_parallel_staging_sets_gt_zero,
+        treatment_production_counters_reconcile,
         control_direct_staging_writes_gt_zero,
         control_full_slot_vec_materializations_zero,
         control_parallel_staging_sets_zero,
@@ -2179,19 +2263,23 @@ pub(crate) async fn run_concurrency_command(
     let mut report = PhysicalInstallConcurrencyQualificationReport {
         schema: CONCURRENCY_SCHEMA,
         mode: CONCURRENCY_MODE,
-        normal_production_default_changed: false,
-        control_uses_ordinary_sequential_direct_staging: true,
-        treatment_uses_qualification_only_parallel_direct_staging: true,
+        production_physical_install_concurrency_changed: true,
+        normal_production_uses_concurrent_physical_staging: true,
+        control_forces_sequential_direct_staging: true,
+        treatment_uses_ordinary_production_path: true,
+        speculative_physical_install_changed: false,
         both_arms_use_ordinary_production_source: true,
         victim_policy_changed: false,
         slot_assignment_policy_changed: false,
         mapping_publication_order_changed: false,
+        source_acquisition_changed: false,
         expert_compute_changed: false,
         adds_queue_submit: false,
         adds_device_poll: false,
         adds_map_async: false,
         adds_readback: false,
         wgpu_version_changed: false,
+        rayon_pool_sizing_changed: false,
         pinned_wgpu_audit: PinnedWgpuConcurrencyAudit {
             requested_version: "0.20",
             resolved_version: "0.20.1",
@@ -2357,7 +2445,7 @@ pub(crate) async fn run_concurrency_command(
     if qualification_pass {
         Ok(())
     } else {
-        Err("PR2-B-B physical-install concurrency qualification gates did not all pass; see emitted report".into())
+        Err("PR2-B-B.1 production physical-install concurrency qualification gates did not all pass; see emitted report".into())
     }
 }
 
@@ -2400,14 +2488,14 @@ mod tests {
     }
 
     #[test]
-    fn pr2bb_contract_is_qualification_only_and_versioned_separately() {
+    fn pr2bb1_production_contract_is_literal_and_versioned_separately() {
         assert_eq!(
             CONCURRENCY_SCHEMA,
-            "mer.gpu-native-physical-install-concurrency.v1"
+            "mer.gpu-native-physical-install-concurrency-production.v1"
         );
         assert_eq!(
             CONCURRENCY_MODE,
-            "qualify-gpu-native-physical-install-concurrency"
+            "qualify-gpu-native-physical-install-concurrency-production"
         );
         let logical = (2048usize * 768 / 32) * 3 * 18;
         let stride = (4 + logical + 3) & !3;
@@ -2456,6 +2544,10 @@ mod tests {
     fn pr2bb_timing_metrics_do_not_enter_the_mechanism_gate_schema() {
         let serialized = serde_json::to_value(ConcurrencyMechanismGate {
             warmup_mechanism_reconciled: false,
+            control_production_parallel_staging_sets_zero: false,
+            treatment_ordinary_production_path_exercised: false,
+            treatment_production_parallel_staging_sets_gt_zero: false,
+            treatment_production_counters_reconcile: false,
             control_direct_staging_writes_gt_zero: false,
             control_full_slot_vec_materializations_zero: false,
             control_parallel_staging_sets_zero: false,
@@ -2482,8 +2574,9 @@ mod tests {
         .unwrap();
         let fields = serialized.as_object().unwrap();
 
-        assert_eq!(fields.len(), 23);
+        assert_eq!(fields.len(), 27);
         assert!(fields.contains_key("warmup_mechanism_reconciled"));
+        assert!(fields.contains_key("treatment_ordinary_production_path_exercised"));
         assert!(fields.contains_key("control_parallel_staging_sets_zero"));
         assert!(fields.contains_key("treatment_parallel_staging_sets_gt_zero"));
         assert!(fields.contains_key("attempts_and_completions_reconcile"));
@@ -2491,5 +2584,47 @@ mod tests {
         assert!(fields.contains_key("ordered_physical_identity_exact"));
         assert!(fields.contains_key("passed"));
         assert!(fields.keys().all(|field| !field.ends_with("_us")));
+    }
+
+    #[test]
+    fn production_qualifier_fails_closed_without_observed_concurrency() {
+        let sequential_only = GpuNativeProductionPhysicalInstallSnapshot {
+            physical_install_sets: 2,
+            physical_install_experts: 2,
+            singleton_staging_sets: 2,
+            reservation_attempts: 2,
+            reservation_successes: 2,
+            physical_install_attempts: 2,
+            physical_stage_attempts: 2,
+            physical_stage_completions: 2,
+            direct_staging_successes: 2,
+            ordered_commit_attempts: 2,
+            ordered_commit_completions: 2,
+            max_in_flight_physical_staging: 1,
+            ..GpuNativeProductionPhysicalInstallSnapshot::default()
+        };
+        assert!(production_physical_install_counters_reconcile(
+            &sequential_only
+        ));
+        assert!(!production_concurrency_exercised(&sequential_only));
+
+        let concurrent = GpuNativeProductionPhysicalInstallSnapshot {
+            physical_install_sets: 1,
+            physical_install_experts: 2,
+            parallel_eligible_sets: 1,
+            parallel_staging_sets: 1,
+            parallel_staging_experts: 2,
+            reservation_attempts: 2,
+            reservation_successes: 2,
+            physical_install_attempts: 2,
+            physical_stage_attempts: 2,
+            physical_stage_completions: 2,
+            direct_staging_successes: 2,
+            ordered_commit_attempts: 2,
+            ordered_commit_completions: 2,
+            max_in_flight_physical_staging: 2,
+            ..GpuNativeProductionPhysicalInstallSnapshot::default()
+        };
+        assert!(production_concurrency_exercised(&concurrent));
     }
 }

--- a/rust-engine/src/gpu_native_residency.rs
+++ b/rust-engine/src/gpu_native_residency.rs
@@ -27,6 +27,13 @@ fn qualification_elapsed_us(start: Instant) -> u64 {
     u64::try_from(start.elapsed().as_micros()).unwrap_or(u64::MAX)
 }
 
+fn post_reservation_physical_install_total_us(
+    individual_stage_us: u64,
+    commit_us: u64,
+) -> u64 {
+    individual_stage_us.saturating_add(commit_us)
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum GpuNativeTieredResidencyError {
     InvalidModelLayerCount,
@@ -413,7 +420,6 @@ struct ReservedPhysicalInstall<'a> {
     admission: GpuAdmission,
     key: GpuNativeQ4ExpertKey,
     permit: crate::backend::gpu_native::GpuNativeQ4ExpertInstallPermit<'a>,
-    transaction_started: Instant,
 }
 
 struct StagedPhysicalInstall<'a> {
@@ -423,7 +429,7 @@ struct StagedPhysicalInstall<'a> {
     key: GpuNativeQ4ExpertKey,
     prepared: GpuNativeQ4ExpertPreparedInstall<'a>,
     evidence: GpuNativePhysicalInstallEvidence,
-    transaction_started: Instant,
+    individual_stage_us: u64,
 }
 
 /// Rayon indexed collection retains the input order even when workers finish
@@ -1072,7 +1078,6 @@ impl GpuNativeTieredResidencyManager {
                 admission: admission.clone(),
                 key,
                 permit,
-                transaction_started,
             });
         }
         observer.record_physical_reservation_wall(qualification_elapsed_us(reservation_started));
@@ -1085,10 +1090,8 @@ impl GpuNativeTieredResidencyManager {
                 .stage_q4_expert_residency_qualification(reserved.permit, reserved.resident.data())
             {
                 Ok((prepared, evidence)) => {
-                    observer.record_physical_stage_completed(
-                        evidence,
-                        qualification_elapsed_us(stage_started),
-                    );
+                    let individual_stage_us = qualification_elapsed_us(stage_started);
+                    observer.record_physical_stage_completed(evidence, individual_stage_us);
                     Ok(StagedPhysicalInstall {
                         demand_index: reserved.demand_index,
                         global_id: reserved.global_id,
@@ -1096,7 +1099,7 @@ impl GpuNativeTieredResidencyManager {
                         key: reserved.key,
                         prepared,
                         evidence,
-                        transaction_started: reserved.transaction_started,
+                        individual_stage_us,
                     })
                 }
                 Err(error) => {
@@ -1194,12 +1197,16 @@ impl GpuNativeTieredResidencyManager {
                     .physical_reinstalls
                     .fetch_add(1, Ordering::Relaxed);
             }
-            observer.record_ordered_commit_completed(qualification_elapsed_us(commit_started));
+            let commit_us = qualification_elapsed_us(commit_started);
+            observer.record_ordered_commit_completed(commit_us);
             observer.record_physical_install_completion(
                 staged.global_id,
                 residency,
                 evidence,
-                qualification_elapsed_us(staged.transaction_started),
+                post_reservation_physical_install_total_us(
+                    staged.individual_stage_us,
+                    commit_us,
+                ),
             );
             resolved[staged.demand_index] = Some(residency);
         }
@@ -1615,6 +1622,22 @@ mod tests {
         assert_ne!(
             speculative_install_path(),
             DemandPhysicalInstallPath::QualificationParallelDirectStaging
+        );
+    }
+
+    #[test]
+    fn treatment_physical_install_total_is_post_reservation_stage_plus_commit() {
+        let demand_set_transaction_us = 10_000;
+        let individual_stage_us = 37;
+        let commit_us = 11;
+        let per_expert_total =
+            post_reservation_physical_install_total_us(individual_stage_us, commit_us);
+
+        assert_eq!(per_expert_total, 48);
+        assert_ne!(per_expert_total, demand_set_transaction_us);
+        assert_eq!(
+            post_reservation_physical_install_total_us(u64::MAX, 1),
+            u64::MAX
         );
     }
 

--- a/rust-engine/src/gpu_native_residency.rs
+++ b/rust-engine/src/gpu_native_residency.rs
@@ -355,13 +355,17 @@ pub(crate) enum GpuNativeResidencyPriority {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum DemandPhysicalInstallPath {
-    Production,
+    ProductionConcurrentDirectStaging,
+    SequentialDirectStagingControl,
     LegacyFullSlotVecControl,
-    QualificationParallelDirectStaging,
 }
 
 const fn ordinary_demand_install_path() -> DemandPhysicalInstallPath {
-    DemandPhysicalInstallPath::Production
+    DemandPhysicalInstallPath::ProductionConcurrentDirectStaging
+}
+
+const fn production_concurrency_control_path() -> DemandPhysicalInstallPath {
+    DemandPhysicalInstallPath::SequentialDirectStagingControl
 }
 
 const fn speculative_install_path() -> DemandPhysicalInstallPath {
@@ -746,7 +750,7 @@ impl GpuNativeTieredResidencyManager {
         layer_index: usize,
         demands: &[GpuNativeDemandExpert],
     ) -> Result<Vec<GpuNativeQ4ExpertResidency>, GpuNativeTieredResidencyError> {
-        self.ensure_demand_set_inner(
+        self.ensure_demand_set_inner::<false>(
             priority,
             layer_index,
             demands,
@@ -762,7 +766,7 @@ impl GpuNativeTieredResidencyManager {
         demands: &[GpuNativeDemandExpert],
         observer: &dyn GpuNativePhysicalInstallObserver,
     ) -> Result<Vec<GpuNativeQ4ExpertResidency>, GpuNativeTieredResidencyError> {
-        self.ensure_demand_set_inner(
+        self.ensure_demand_set_inner::<true>(
             priority,
             layer_index,
             demands,
@@ -778,7 +782,7 @@ impl GpuNativeTieredResidencyManager {
         demands: &[GpuNativeDemandExpert],
         observer: &dyn GpuNativePhysicalInstallObserver,
     ) -> Result<Vec<GpuNativeQ4ExpertResidency>, GpuNativeTieredResidencyError> {
-        self.ensure_demand_set_inner(
+        self.ensure_demand_set_inner::<true>(
             priority,
             layer_index,
             demands,
@@ -787,8 +791,8 @@ impl GpuNativeTieredResidencyManager {
         )
     }
 
-    /// PR2-B-B control: the exact ordinary sequential production direct-
-    /// staging path, observed only by the dedicated qualifier.
+    /// PR2-B-B.1 control: the exact pre-B-B sequential production direct-
+    /// staging path, observed only by the dedicated production qualifier.
     pub(crate) fn ensure_demand_set_physical_install_concurrency_control(
         &self,
         priority: GpuNativeResidencyPriority,
@@ -796,35 +800,16 @@ impl GpuNativeTieredResidencyManager {
         demands: &[GpuNativeDemandExpert],
         observer: &dyn GpuNativePhysicalInstallObserver,
     ) -> Result<Vec<GpuNativeQ4ExpertResidency>, GpuNativeTieredResidencyError> {
-        self.ensure_demand_set_inner(
+        self.ensure_demand_set_inner::<true>(
             priority,
             layer_index,
             demands,
-            ordinary_demand_install_path(),
+            production_concurrency_control_path(),
             Some(observer),
         )
     }
 
-    /// PR2-B-B treatment: retain the complete layer lock and deterministic
-    /// miss/victim order while splitting each install set into sequential
-    /// reservation, parallel direct staging, and ordered publication/commit.
-    pub(crate) fn ensure_demand_set_physical_install_concurrency_treatment(
-        &self,
-        priority: GpuNativeResidencyPriority,
-        layer_index: usize,
-        demands: &[GpuNativeDemandExpert],
-        observer: &dyn GpuNativePhysicalInstallObserver,
-    ) -> Result<Vec<GpuNativeQ4ExpertResidency>, GpuNativeTieredResidencyError> {
-        self.ensure_demand_set_inner(
-            priority,
-            layer_index,
-            demands,
-            DemandPhysicalInstallPath::QualificationParallelDirectStaging,
-            Some(observer),
-        )
-    }
-
-    fn ensure_demand_set_inner(
+    fn ensure_demand_set_inner<const OBSERVE: bool>(
         &self,
         priority: GpuNativeResidencyPriority,
         layer_index: usize,
@@ -912,19 +897,19 @@ impl GpuNativeTieredResidencyManager {
 
         if matches!(
             install_path,
-            DemandPhysicalInstallPath::QualificationParallelDirectStaging
+            DemandPhysicalInstallPath::ProductionConcurrentDirectStaging
         ) {
-            self.install_parallel_physical_misses_locked(
+            self.install_parallel_physical_misses_locked::<OBSERVE>(
                 demands,
                 &misses,
                 layer,
                 &mut state,
                 &mut resolved,
-                observer.expect("qualification treatment requires an observer"),
+                observer,
             )?;
         } else {
-            let transaction_started = (!misses.is_empty()).then(Instant::now);
-            if !misses.is_empty() {
+            let transaction_started = (OBSERVE && !misses.is_empty()).then(Instant::now);
+            if OBSERVE && !misses.is_empty() {
                 if let Some(observer) = observer {
                     observer.record_physical_install_set(
                         misses.len(),
@@ -943,7 +928,7 @@ impl GpuNativeTieredResidencyManager {
                 else {
                     unreachable!("miss list contains only install sources")
                 };
-                let residency = self.install_locked(
+                let residency = self.install_locked::<OBSERVE>(
                     *global_id,
                     resident,
                     admission,
@@ -971,28 +956,34 @@ impl GpuNativeTieredResidencyManager {
             .collect()
     }
 
-    fn install_parallel_physical_misses_locked<'a>(
+    fn install_parallel_physical_misses_locked<'a, const OBSERVE: bool>(
         &self,
         demands: &[GpuNativeDemandExpert],
         misses: &[usize],
         layer: &'a LayerResidency,
         state: &mut MutexGuard<'_, LayerResidencyState>,
         resolved: &mut [Option<GpuNativeQ4ExpertResidency>],
-        observer: &dyn GpuNativePhysicalInstallObserver,
+        observer: Option<&dyn GpuNativePhysicalInstallObserver>,
     ) -> Result<(), GpuNativeTieredResidencyError> {
         if misses.is_empty() {
             return Ok(());
         }
-        let transaction_started = Instant::now();
+        let transaction_started = OBSERVE.then(Instant::now);
         let parallel = misses.len() >= 2;
-        observer.record_physical_install_set(
-            misses.len(),
-            parallel,
-            crate::parallel::in_rayon_worker(),
-            rayon::current_num_threads(),
-        );
+        self.executor
+            .record_production_physical_install_set(misses.len());
+        if OBSERVE {
+            observer
+                .expect("observed production install has an observer")
+                .record_physical_install_set(
+                    misses.len(),
+                    parallel,
+                    crate::parallel::in_rayon_worker(),
+                    rayon::current_num_threads(),
+                );
+        }
 
-        let reservation_started = Instant::now();
+        let reservation_started = OBSERVE.then(Instant::now);
         let mut reserved = Vec::with_capacity(misses.len());
         for &demand_index in misses {
             let GpuNativeDemandExpert::Install {
@@ -1010,67 +1001,118 @@ impl GpuNativeTieredResidencyManager {
                 self.plan.num_layers(),
                 self.plan.geometry().num_experts() as u32,
             )?;
-            observer.record_physical_install_attempt();
-            observer.record_reservation_attempt();
+            self.executor
+                .record_production_physical_reservation_attempt();
+            if OBSERVE {
+                let observer = observer.expect("observed production install has an observer");
+                observer.record_physical_install_attempt();
+                observer.record_reservation_attempt();
+            }
             let acquired = match self.executor.acquire_q4_expert_residency(&layer.arena, key) {
                 Ok(acquired) => acquired,
                 Err(error) => {
-                    observer.record_reservation_failure();
-                    observer.record_physical_install_transaction_wall(qualification_elapsed_us(
-                        transaction_started,
-                    ));
+                    self.executor
+                        .record_production_physical_reservation_failure();
+                    if OBSERVE {
+                        let observer =
+                            observer.expect("observed production install has an observer");
+                        observer.record_reservation_failure();
+                        observer.record_physical_install_transaction_wall(
+                            qualification_elapsed_us(
+                                transaction_started.expect("observed transaction has a timer"),
+                            ),
+                        );
+                    }
                     return Err(error.into());
                 }
             };
             let permit = match acquired {
                 GpuNativeQ4ExpertAcquire::Install(permit) => permit,
                 GpuNativeQ4ExpertAcquire::Hit(_) => {
-                    observer.record_reservation_failure();
-                    observer.record_physical_install_transaction_wall(qualification_elapsed_us(
-                        transaction_started,
-                    ));
+                    self.executor
+                        .record_production_physical_reservation_failure();
+                    if OBSERVE {
+                        let observer =
+                            observer.expect("observed production install has an observer");
+                        observer.record_reservation_failure();
+                        observer.record_physical_install_transaction_wall(
+                            qualification_elapsed_us(
+                                transaction_started.expect("observed transaction has a timer"),
+                            ),
+                        );
+                    }
                     return Err(GpuNativeTieredResidencyError::PhysicalIdentityCorrupt {
                         global_id: *global_id,
                     });
                 }
                 GpuNativeQ4ExpertAcquire::InstallInProgress => {
-                    observer.record_reservation_failure();
-                    observer.record_physical_install_transaction_wall(qualification_elapsed_us(
-                        transaction_started,
-                    ));
+                    self.executor
+                        .record_production_physical_reservation_failure();
+                    if OBSERVE {
+                        let observer =
+                            observer.expect("observed production install has an observer");
+                        observer.record_reservation_failure();
+                        observer.record_physical_install_transaction_wall(
+                            qualification_elapsed_us(
+                                transaction_started.expect("observed transaction has a timer"),
+                            ),
+                        );
+                    }
                     return Err(GpuNativeTieredResidencyError::InstallInProgress {
                         global_id: *global_id,
                         generation: admission.generation(),
                     });
                 }
                 GpuNativeQ4ExpertAcquire::StaleRequester => {
-                    observer.record_reservation_failure();
+                    self.executor
+                        .record_production_physical_reservation_failure();
                     self.counters
                         .stale_generation_rejections
                         .fetch_add(1, Ordering::Relaxed);
-                    observer.record_physical_install_transaction_wall(qualification_elapsed_us(
-                        transaction_started,
-                    ));
+                    if OBSERVE {
+                        let observer =
+                            observer.expect("observed production install has an observer");
+                        observer.record_reservation_failure();
+                        observer.record_physical_install_transaction_wall(
+                            qualification_elapsed_us(
+                                transaction_started.expect("observed transaction has a timer"),
+                            ),
+                        );
+                    }
                     return Err(GpuNativeTieredResidencyError::StalePhysicalRequester {
                         global_id: *global_id,
                         generation: admission.generation(),
                     });
                 }
                 GpuNativeQ4ExpertAcquire::NoPhysicalSlot => {
-                    observer.record_reservation_failure();
-                    observer.record_physical_install_transaction_wall(qualification_elapsed_us(
-                        transaction_started,
-                    ));
+                    self.executor
+                        .record_production_physical_reservation_failure();
+                    if OBSERVE {
+                        let observer =
+                            observer.expect("observed production install has an observer");
+                        observer.record_reservation_failure();
+                        observer.record_physical_install_transaction_wall(
+                            qualification_elapsed_us(
+                                transaction_started.expect("observed transaction has a timer"),
+                            ),
+                        );
+                    }
                     return Err(GpuNativeTieredResidencyError::NoPhysicalSlot {
                         layer_index: identity.layer_index,
                     });
                 }
             };
-            observer.record_reservation_success(
-                *global_id,
-                permit.reserved_residency(),
-                permit.install_ticket(),
-            );
+            self.executor
+                .record_production_physical_reservation_success();
+            if OBSERVE {
+                observer
+                    .expect("observed production install has an observer")
+                    .record_reservation_success(
+                        *global_id,
+                        permit.reserved_residency(),
+                        permit.install_ticket(),
+                    );
+            }
             reserved.push(ReservedPhysicalInstall {
                 demand_index,
                 global_id: *global_id,
@@ -1080,18 +1122,39 @@ impl GpuNativeTieredResidencyManager {
                 permit,
             });
         }
-        observer.record_physical_reservation_wall(qualification_elapsed_us(reservation_started));
+        if OBSERVE {
+            observer
+                .expect("observed production install has an observer")
+                .record_physical_reservation_wall(qualification_elapsed_us(
+                    reservation_started.expect("observed reservation has a timer"),
+                ));
+        }
 
         let stage_one = |reserved: ReservedPhysicalInstall<'a>| {
-            observer.record_physical_stage_started();
-            let stage_started = Instant::now();
-            match self
-                .executor
-                .stage_q4_expert_residency_qualification(reserved.permit, reserved.resident.data())
-            {
+            if OBSERVE {
+                observer
+                    .expect("observed production install has an observer")
+                    .record_physical_stage_started();
+            }
+            let stage_started = OBSERVE.then(Instant::now);
+            let result = if OBSERVE {
+                self.executor.stage_q4_expert_residency_production_observed(
+                    reserved.permit,
+                    reserved.resident.data(),
+                )
+            } else {
+                self.executor
+                    .stage_q4_expert_residency_production(reserved.permit, reserved.resident.data())
+                    .map(|prepared| (prepared, GpuNativePhysicalInstallEvidence::default()))
+            };
+            match result {
                 Ok((prepared, evidence)) => {
-                    let individual_stage_us = qualification_elapsed_us(stage_started);
-                    observer.record_physical_stage_completed(evidence, individual_stage_us);
+                    let individual_stage_us = stage_started.map_or(0, qualification_elapsed_us);
+                    if OBSERVE {
+                        observer
+                            .expect("observed production install has an observer")
+                            .record_physical_stage_completed(evidence, individual_stage_us);
+                    }
                     Ok(StagedPhysicalInstall {
                         demand_index: reserved.demand_index,
                         global_id: reserved.global_id,
@@ -1103,22 +1166,27 @@ impl GpuNativeTieredResidencyManager {
                     })
                 }
                 Err(error) => {
-                    observer.record_physical_stage_failed();
+                    if OBSERVE {
+                        observer
+                            .expect("observed production install has an observer")
+                            .record_physical_stage_failed();
+                    }
                     Err(GpuNativeTieredResidencyError::from(error))
                 }
             }
         };
-        let parallel_stage_started = Instant::now();
-        let staged =
-            collect_physical_stage_results_in_request_order(reserved, parallel, stage_one);
-        observer.record_parallel_stage_wall(qualification_elapsed_us(parallel_stage_started));
+        let parallel_stage_started = OBSERVE.then(Instant::now);
+        let staged = collect_physical_stage_results_in_request_order(reserved, parallel, stage_one);
+        if OBSERVE {
+            observer
+                .expect("observed production install has an observer")
+                .record_parallel_stage_wall(qualification_elapsed_us(
+                    parallel_stage_started.expect("observed stage has a timer"),
+                ));
+        }
 
         let first_stage_failure = staged.iter().position(Result::is_err);
-        let mut successful_stage_suffix = vec![0u64; staged.len() + 1];
-        for position in (0..staged.len()).rev() {
-            successful_stage_suffix[position] = successful_stage_suffix[position + 1]
-                .saturating_add(u64::from(staged[position].is_ok()));
-        }
+        let mut remaining_successful = staged.iter().filter(|result| result.is_ok()).count() as u64;
         for (position, staged_result) in staged.into_iter().enumerate() {
             if first_stage_failure.is_some_and(|failed| position >= failed) {
                 if position == first_stage_failure.expect("failure position is present") {
@@ -1126,36 +1194,69 @@ impl GpuNativeTieredResidencyManager {
                         Err(error) => error,
                         Ok(_) => unreachable!("earliest failed stage is an error"),
                     };
-                    let unpublished = successful_stage_suffix[position + 1];
-                    observer.record_unpublished_physical_writes_after_failure(unpublished);
-                    observer.record_physical_install_transaction_wall(qualification_elapsed_us(
-                        transaction_started,
-                    ));
+                    self.executor
+                        .record_production_unpublished_physical_writes_after_failure(
+                            remaining_successful,
+                        );
+                    if OBSERVE {
+                        let observer =
+                            observer.expect("observed production install has an observer");
+                        observer
+                            .record_unpublished_physical_writes_after_failure(remaining_successful);
+                        observer.record_physical_install_transaction_wall(
+                            qualification_elapsed_us(
+                                transaction_started.expect("observed transaction has a timer"),
+                            ),
+                        );
+                    }
                     return Err(error);
                 }
                 unreachable!("earliest stage failure returns before later entries")
             }
             let staged = staged_result.expect("successful prefix precedes first stage failure");
-            observer.record_ordered_commit_attempt();
-            let commit_started = Instant::now();
-            let (residency, evidence) = match self
-                .executor
-                .commit_q4_expert_residency_qualification(staged.prepared, staged.evidence)
-            {
+            if OBSERVE {
+                observer
+                    .expect("observed production install has an observer")
+                    .record_ordered_commit_attempt();
+            }
+            let commit_started = OBSERVE.then(Instant::now);
+            let commit_result = if OBSERVE {
+                self.executor
+                    .commit_q4_expert_residency_production_observed(
+                        staged.prepared,
+                        staged.evidence,
+                    )
+            } else {
+                self.executor
+                    .commit_q4_expert_residency_production(staged.prepared)
+                    .map(|residency| (residency, staged.evidence))
+            };
+            let (residency, evidence) = match commit_result {
                 Ok(committed) => committed,
                 Err(error) => {
-                    observer.record_ordered_commit_failed(matches!(
-                        error,
-                        GpuNativeBootstrapError::ExpertInstallReservationLost
-                    ));
-                    let unpublished = successful_stage_suffix[position];
-                    observer.record_unpublished_physical_writes_after_failure(unpublished);
-                    observer.record_physical_install_transaction_wall(qualification_elapsed_us(
-                        transaction_started,
-                    ));
+                    self.executor
+                        .record_production_unpublished_physical_writes_after_failure(
+                            remaining_successful,
+                        );
+                    if OBSERVE {
+                        let observer =
+                            observer.expect("observed production install has an observer");
+                        observer.record_ordered_commit_failed(matches!(
+                            error,
+                            GpuNativeBootstrapError::ExpertInstallReservationLost
+                        ));
+                        observer
+                            .record_unpublished_physical_writes_after_failure(remaining_successful);
+                        observer.record_physical_install_transaction_wall(
+                            qualification_elapsed_us(
+                                transaction_started.expect("observed transaction has a timer"),
+                            ),
+                        );
+                    }
                     return Err(error.into());
                 }
             };
+            remaining_successful = remaining_successful.saturating_sub(1);
             if !self
                 .gpu_cache
                 .contains_generation(staged.global_id, staged.admission.generation())
@@ -1166,13 +1267,20 @@ impl GpuNativeTieredResidencyManager {
                 self.counters
                     .stale_generation_rejections
                     .fetch_add(1, Ordering::Relaxed);
-                observer.record_ordered_commit_failed(false);
-                observer.record_unpublished_physical_writes_after_failure(
-                    successful_stage_suffix[position + 1],
-                );
-                observer.record_physical_install_transaction_wall(qualification_elapsed_us(
-                    transaction_started,
-                ));
+                self.executor
+                    .record_production_ordered_commit_failure(false);
+                self.executor
+                    .record_production_unpublished_physical_writes_after_failure(
+                        remaining_successful,
+                    );
+                if OBSERVE {
+                    let observer = observer.expect("observed production install has an observer");
+                    observer.record_ordered_commit_failed(false);
+                    observer.record_unpublished_physical_writes_after_failure(remaining_successful);
+                    observer.record_physical_install_transaction_wall(qualification_elapsed_us(
+                        transaction_started.expect("observed transaction has a timer"),
+                    ));
+                }
                 return Err(GpuNativeTieredResidencyError::LogicalAdmissionStale {
                     global_id: staged.global_id,
                     generation: staged.admission.generation(),
@@ -1197,22 +1305,30 @@ impl GpuNativeTieredResidencyManager {
                     .physical_reinstalls
                     .fetch_add(1, Ordering::Relaxed);
             }
-            let commit_us = qualification_elapsed_us(commit_started);
-            observer.record_ordered_commit_completed(commit_us);
-            observer.record_physical_install_completion(
-                staged.global_id,
-                residency,
-                evidence,
-                post_reservation_physical_install_total_us(
-                    staged.individual_stage_us,
-                    commit_us,
-                ),
-            );
+            if OBSERVE {
+                let commit_us =
+                    qualification_elapsed_us(commit_started.expect("observed commit has a timer"));
+                let observer = observer.expect("observed production install has an observer");
+                observer.record_ordered_commit_completed(commit_us);
+                observer.record_physical_install_completion(
+                    staged.global_id,
+                    residency,
+                    evidence,
+                    post_reservation_physical_install_total_us(
+                        staged.individual_stage_us,
+                        commit_us,
+                    ),
+                );
+            }
             resolved[staged.demand_index] = Some(residency);
         }
-        observer.record_physical_install_transaction_wall(qualification_elapsed_us(
-            transaction_started,
-        ));
+        if OBSERVE {
+            observer
+                .expect("observed production install has an observer")
+                .record_physical_install_transaction_wall(qualification_elapsed_us(
+                    transaction_started.expect("observed transaction has a timer"),
+                ));
+        }
         Ok(())
     }
 
@@ -1261,7 +1377,7 @@ impl GpuNativeTieredResidencyManager {
             self.record_speculative_drop();
             return Ok(GpuNativeSpeculativeInstall::DroppedCapacityOrPressure);
         }
-        let residency = match self.install_locked(
+        let residency = match self.install_locked::<false>(
             global_id,
             resident,
             admission,
@@ -1416,7 +1532,7 @@ impl GpuNativeTieredResidencyManager {
         Ok(())
     }
 
-    fn install_locked(
+    fn install_locked<const OBSERVE: bool>(
         &self,
         global_id: u32,
         resident: &Arc<ExpertResident>,
@@ -1434,14 +1550,15 @@ impl GpuNativeTieredResidencyManager {
             self.plan.num_layers(),
             self.plan.geometry().num_experts() as u32,
         )?;
-        let reservation_started = observer.map(|_| Instant::now());
+        let reservation_started = OBSERVE.then(Instant::now);
         let (residency, installed) = match self
             .executor
             .acquire_q4_expert_residency(&layer.arena, key)?
         {
             GpuNativeQ4ExpertAcquire::Hit(hit) => (hit, false),
             GpuNativeQ4ExpertAcquire::Install(permit) => {
-                if let Some(observer) = observer {
+                if OBSERVE {
+                    let observer = observer.expect("observed sequential install has an observer");
                     observer.record_physical_install_attempt();
                     observer.record_reservation_attempt();
                     observer.record_reservation_success(
@@ -1450,23 +1567,21 @@ impl GpuNativeTieredResidencyManager {
                         permit.install_ticket(),
                     );
                     observer.record_physical_reservation_wall(qualification_elapsed_us(
-                        reservation_started.expect("observed acquire has a start time"),
+                        reservation_started.expect("observed reservation has a timer"),
                     ));
                     let started = Instant::now();
                     let result = match install_path {
-                        DemandPhysicalInstallPath::Production => self
+                        DemandPhysicalInstallPath::SequentialDirectStagingControl => self
                             .executor
-                            .install_q4_expert_residency_production_observed(
+                            .install_q4_expert_residency_sequential_control_observed(
                                 permit,
                                 resident.data(),
                             ),
                         DemandPhysicalInstallPath::LegacyFullSlotVecControl => self
                             .executor
                             .install_q4_expert_residency_legacy_observed(permit, resident.data()),
-                        DemandPhysicalInstallPath::QualificationParallelDirectStaging => {
-                            unreachable!(
-                                "parallel qualification installs use the split transaction"
-                            )
+                        DemandPhysicalInstallPath::ProductionConcurrentDirectStaging => {
+                            unreachable!("ordinary production installs use the split transaction")
                         }
                     };
                     match result {
@@ -1491,16 +1606,14 @@ impl GpuNativeTieredResidencyManager {
                     }
                 } else {
                     let residency = match install_path {
-                        DemandPhysicalInstallPath::Production => self
-                            .executor
-                            .install_q4_expert_residency(permit, resident.data())?,
                         DemandPhysicalInstallPath::LegacyFullSlotVecControl => self
                             .executor
                             .install_q4_expert_residency_legacy(permit, resident.data())?,
-                        DemandPhysicalInstallPath::QualificationParallelDirectStaging => {
-                            unreachable!(
-                                "parallel qualification installs use the split transaction"
-                            )
+                        DemandPhysicalInstallPath::SequentialDirectStagingControl => {
+                            unreachable!("sequential control is qualifier-only")
+                        }
+                        DemandPhysicalInstallPath::ProductionConcurrentDirectStaging => {
+                            unreachable!("ordinary production installs use the split transaction")
                         }
                     };
                     (residency, true)
@@ -1606,22 +1719,22 @@ mod tests {
     }
 
     #[test]
-    fn ordinary_and_qualification_paths_keep_production_and_speculation_frozen() {
+    fn ordinary_and_qualification_paths_select_production_concurrency_and_legacy_speculation() {
         assert_eq!(
             ordinary_demand_install_path(),
-            DemandPhysicalInstallPath::Production
+            DemandPhysicalInstallPath::ProductionConcurrentDirectStaging
+        );
+        assert_eq!(
+            production_concurrency_control_path(),
+            DemandPhysicalInstallPath::SequentialDirectStagingControl
         );
         assert_eq!(
             speculative_install_path(),
             DemandPhysicalInstallPath::LegacyFullSlotVecControl
         );
         assert_ne!(
-            ordinary_demand_install_path(),
-            DemandPhysicalInstallPath::QualificationParallelDirectStaging
-        );
-        assert_ne!(
-            speculative_install_path(),
-            DemandPhysicalInstallPath::QualificationParallelDirectStaging
+            production_concurrency_control_path(),
+            speculative_install_path()
         );
     }
 

--- a/rust-engine/src/gpu_native_residency.rs
+++ b/rust-engine/src/gpu_native_residency.rs
@@ -10,8 +10,8 @@
 use crate::backend::gpu_native::{
     GpuNativeBootstrapError, GpuNativeExecutorContext, GpuNativePhysicalInstallEvidence,
     GpuNativeProductionPhysicalInstallSnapshot, GpuNativeQ4ExpertAcquire, GpuNativeQ4ExpertArena,
-    GpuNativeQ4ExpertGeometry, GpuNativeQ4ExpertKey, GpuNativeQ4ExpertResidency,
-    GpuNativeQ4ExpertRetire, GpuNativeQ4ExpertVramPlan,
+    GpuNativeQ4ExpertGeometry, GpuNativeQ4ExpertKey, GpuNativeQ4ExpertPreparedInstall,
+    GpuNativeQ4ExpertResidency, GpuNativeQ4ExpertRetire, GpuNativeQ4ExpertVramPlan,
 };
 use crate::expert_cache::{ExpertResident, GpuAdmission, GpuExpertCache};
 use lru::LruCache;
@@ -22,6 +22,10 @@ use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
+
+fn qualification_elapsed_us(start: Instant) -> u64 {
+    u64::try_from(start.elapsed().as_micros()).unwrap_or(u64::MAX)
+}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum GpuNativeTieredResidencyError {
@@ -346,6 +350,7 @@ pub(crate) enum GpuNativeResidencyPriority {
 enum DemandPhysicalInstallPath {
     Production,
     LegacyFullSlotVecControl,
+    QualificationParallelDirectStaging,
 }
 
 const fn ordinary_demand_install_path() -> DemandPhysicalInstallPath {
@@ -370,6 +375,76 @@ pub(crate) trait GpuNativePhysicalInstallObserver: Send + Sync {
         evidence: GpuNativePhysicalInstallEvidence,
         physical_install_total_us: u64,
     );
+    fn record_physical_install_set(
+        &self,
+        width: usize,
+        parallel: bool,
+        caller_in_rayon_worker: bool,
+        rayon_threads: usize,
+    );
+    fn record_reservation_attempt(&self);
+    fn record_reservation_success(
+        &self,
+        global_id: u32,
+        residency: GpuNativeQ4ExpertResidency,
+        install_ticket: u64,
+    );
+    fn record_reservation_failure(&self);
+    fn record_physical_stage_started(&self);
+    fn record_physical_stage_completed(
+        &self,
+        evidence: GpuNativePhysicalInstallEvidence,
+        individual_stage_us: u64,
+    );
+    fn record_physical_stage_failed(&self);
+    fn record_parallel_stage_wall(&self, wall_us: u64);
+    fn record_ordered_commit_attempt(&self);
+    fn record_ordered_commit_completed(&self, commit_us: u64);
+    fn record_ordered_commit_failed(&self, violation: bool);
+    fn record_physical_reservation_wall(&self, wall_us: u64);
+    fn record_physical_install_transaction_wall(&self, wall_us: u64);
+    fn record_unpublished_physical_writes_after_failure(&self, count: u64);
+}
+
+struct ReservedPhysicalInstall<'a> {
+    demand_index: usize,
+    global_id: u32,
+    resident: Arc<ExpertResident>,
+    admission: GpuAdmission,
+    key: GpuNativeQ4ExpertKey,
+    permit: crate::backend::gpu_native::GpuNativeQ4ExpertInstallPermit<'a>,
+    transaction_started: Instant,
+}
+
+struct StagedPhysicalInstall<'a> {
+    demand_index: usize,
+    global_id: u32,
+    admission: GpuAdmission,
+    key: GpuNativeQ4ExpertKey,
+    prepared: GpuNativeQ4ExpertPreparedInstall<'a>,
+    evidence: GpuNativePhysicalInstallEvidence,
+    transaction_started: Instant,
+}
+
+/// Rayon indexed collection retains the input order even when workers finish
+/// out of order. Keeping this seam small makes that ordering contract directly
+/// testable and ensures the task count is exactly the install-set width.
+fn collect_physical_stage_results_in_request_order<T, R, F>(
+    reserved: Vec<T>,
+    parallel: bool,
+    stage_one: F,
+) -> Vec<R>
+where
+    T: Send,
+    R: Send,
+    F: Fn(T) -> R + Send + Sync,
+{
+    if parallel {
+        use rayon::prelude::*;
+        reserved.into_par_iter().map(stage_one).collect()
+    } else {
+        reserved.into_iter().map(stage_one).collect()
+    }
 }
 
 #[derive(Clone)]
@@ -706,6 +781,43 @@ impl GpuNativeTieredResidencyManager {
         )
     }
 
+    /// PR2-B-B control: the exact ordinary sequential production direct-
+    /// staging path, observed only by the dedicated qualifier.
+    pub(crate) fn ensure_demand_set_physical_install_concurrency_control(
+        &self,
+        priority: GpuNativeResidencyPriority,
+        layer_index: usize,
+        demands: &[GpuNativeDemandExpert],
+        observer: &dyn GpuNativePhysicalInstallObserver,
+    ) -> Result<Vec<GpuNativeQ4ExpertResidency>, GpuNativeTieredResidencyError> {
+        self.ensure_demand_set_inner(
+            priority,
+            layer_index,
+            demands,
+            ordinary_demand_install_path(),
+            Some(observer),
+        )
+    }
+
+    /// PR2-B-B treatment: retain the complete layer lock and deterministic
+    /// miss/victim order while splitting each install set into sequential
+    /// reservation, parallel direct staging, and ordered publication/commit.
+    pub(crate) fn ensure_demand_set_physical_install_concurrency_treatment(
+        &self,
+        priority: GpuNativeResidencyPriority,
+        layer_index: usize,
+        demands: &[GpuNativeDemandExpert],
+        observer: &dyn GpuNativePhysicalInstallObserver,
+    ) -> Result<Vec<GpuNativeQ4ExpertResidency>, GpuNativeTieredResidencyError> {
+        self.ensure_demand_set_inner(
+            priority,
+            layer_index,
+            demands,
+            DemandPhysicalInstallPath::QualificationParallelDirectStaging,
+            Some(observer),
+        )
+    }
+
     fn ensure_demand_set_inner(
         &self,
         priority: GpuNativeResidencyPriority,
@@ -792,26 +904,55 @@ impl GpuNativeTieredResidencyManager {
             }
         }
 
-        for index in misses {
-            let GpuNativeDemandExpert::Install {
-                global_id,
-                resident,
-                admission,
-            } = &demands[index]
-            else {
-                unreachable!("miss list contains only install sources")
-            };
-            let residency = self.install_locked(
-                *global_id,
-                resident,
-                admission,
+        if matches!(
+            install_path,
+            DemandPhysicalInstallPath::QualificationParallelDirectStaging
+        ) {
+            self.install_parallel_physical_misses_locked(
+                demands,
+                &misses,
                 layer,
                 &mut state,
-                false,
-                install_path,
-                observer,
+                &mut resolved,
+                observer.expect("qualification treatment requires an observer"),
             )?;
-            resolved[index] = Some(residency);
+        } else {
+            let transaction_started = (!misses.is_empty()).then(Instant::now);
+            if !misses.is_empty() {
+                if let Some(observer) = observer {
+                    observer.record_physical_install_set(
+                        misses.len(),
+                        false,
+                        crate::parallel::in_rayon_worker(),
+                        rayon::current_num_threads(),
+                    );
+                }
+            }
+            for index in misses {
+                let GpuNativeDemandExpert::Install {
+                    global_id,
+                    resident,
+                    admission,
+                } = &demands[index]
+                else {
+                    unreachable!("miss list contains only install sources")
+                };
+                let residency = self.install_locked(
+                    *global_id,
+                    resident,
+                    admission,
+                    layer,
+                    &mut state,
+                    false,
+                    install_path,
+                    observer,
+                )?;
+                resolved[index] = Some(residency);
+            }
+            if let (Some(observer), Some(started)) = (observer, transaction_started) {
+                observer
+                    .record_physical_install_transaction_wall(qualification_elapsed_us(started));
+            }
         }
         resolved
             .into_iter()
@@ -822,6 +963,250 @@ impl GpuNativeTieredResidencyManager {
                 })
             })
             .collect()
+    }
+
+    fn install_parallel_physical_misses_locked<'a>(
+        &self,
+        demands: &[GpuNativeDemandExpert],
+        misses: &[usize],
+        layer: &'a LayerResidency,
+        state: &mut MutexGuard<'_, LayerResidencyState>,
+        resolved: &mut [Option<GpuNativeQ4ExpertResidency>],
+        observer: &dyn GpuNativePhysicalInstallObserver,
+    ) -> Result<(), GpuNativeTieredResidencyError> {
+        if misses.is_empty() {
+            return Ok(());
+        }
+        let transaction_started = Instant::now();
+        let parallel = misses.len() >= 2;
+        observer.record_physical_install_set(
+            misses.len(),
+            parallel,
+            crate::parallel::in_rayon_worker(),
+            rayon::current_num_threads(),
+        );
+
+        let reservation_started = Instant::now();
+        let mut reserved = Vec::with_capacity(misses.len());
+        for &demand_index in misses {
+            let GpuNativeDemandExpert::Install {
+                global_id,
+                resident,
+                admission,
+            } = &demands[demand_index]
+            else {
+                unreachable!("miss list contains only install sources")
+            };
+            let identity = self.identity(*global_id)?;
+            let key = global_to_q4_expert_key(
+                *global_id,
+                admission.generation(),
+                self.plan.num_layers(),
+                self.plan.geometry().num_experts() as u32,
+            )?;
+            observer.record_physical_install_attempt();
+            observer.record_reservation_attempt();
+            let acquired = match self.executor.acquire_q4_expert_residency(&layer.arena, key) {
+                Ok(acquired) => acquired,
+                Err(error) => {
+                    observer.record_reservation_failure();
+                    observer.record_physical_install_transaction_wall(qualification_elapsed_us(
+                        transaction_started,
+                    ));
+                    return Err(error.into());
+                }
+            };
+            let permit = match acquired {
+                GpuNativeQ4ExpertAcquire::Install(permit) => permit,
+                GpuNativeQ4ExpertAcquire::Hit(_) => {
+                    observer.record_reservation_failure();
+                    observer.record_physical_install_transaction_wall(qualification_elapsed_us(
+                        transaction_started,
+                    ));
+                    return Err(GpuNativeTieredResidencyError::PhysicalIdentityCorrupt {
+                        global_id: *global_id,
+                    });
+                }
+                GpuNativeQ4ExpertAcquire::InstallInProgress => {
+                    observer.record_reservation_failure();
+                    observer.record_physical_install_transaction_wall(qualification_elapsed_us(
+                        transaction_started,
+                    ));
+                    return Err(GpuNativeTieredResidencyError::InstallInProgress {
+                        global_id: *global_id,
+                        generation: admission.generation(),
+                    });
+                }
+                GpuNativeQ4ExpertAcquire::StaleRequester => {
+                    observer.record_reservation_failure();
+                    self.counters
+                        .stale_generation_rejections
+                        .fetch_add(1, Ordering::Relaxed);
+                    observer.record_physical_install_transaction_wall(qualification_elapsed_us(
+                        transaction_started,
+                    ));
+                    return Err(GpuNativeTieredResidencyError::StalePhysicalRequester {
+                        global_id: *global_id,
+                        generation: admission.generation(),
+                    });
+                }
+                GpuNativeQ4ExpertAcquire::NoPhysicalSlot => {
+                    observer.record_reservation_failure();
+                    observer.record_physical_install_transaction_wall(qualification_elapsed_us(
+                        transaction_started,
+                    ));
+                    return Err(GpuNativeTieredResidencyError::NoPhysicalSlot {
+                        layer_index: identity.layer_index,
+                    });
+                }
+            };
+            observer.record_reservation_success(
+                *global_id,
+                permit.reserved_residency(),
+                permit.install_ticket(),
+            );
+            reserved.push(ReservedPhysicalInstall {
+                demand_index,
+                global_id: *global_id,
+                resident: resident.clone(),
+                admission: admission.clone(),
+                key,
+                permit,
+                transaction_started,
+            });
+        }
+        observer.record_physical_reservation_wall(qualification_elapsed_us(reservation_started));
+
+        let stage_one = |reserved: ReservedPhysicalInstall<'a>| {
+            observer.record_physical_stage_started();
+            let stage_started = Instant::now();
+            match self
+                .executor
+                .stage_q4_expert_residency_qualification(reserved.permit, reserved.resident.data())
+            {
+                Ok((prepared, evidence)) => {
+                    observer.record_physical_stage_completed(
+                        evidence,
+                        qualification_elapsed_us(stage_started),
+                    );
+                    Ok(StagedPhysicalInstall {
+                        demand_index: reserved.demand_index,
+                        global_id: reserved.global_id,
+                        admission: reserved.admission,
+                        key: reserved.key,
+                        prepared,
+                        evidence,
+                        transaction_started: reserved.transaction_started,
+                    })
+                }
+                Err(error) => {
+                    observer.record_physical_stage_failed();
+                    Err(GpuNativeTieredResidencyError::from(error))
+                }
+            }
+        };
+        let parallel_stage_started = Instant::now();
+        let staged =
+            collect_physical_stage_results_in_request_order(reserved, parallel, stage_one);
+        observer.record_parallel_stage_wall(qualification_elapsed_us(parallel_stage_started));
+
+        let first_stage_failure = staged.iter().position(Result::is_err);
+        let mut successful_stage_suffix = vec![0u64; staged.len() + 1];
+        for position in (0..staged.len()).rev() {
+            successful_stage_suffix[position] = successful_stage_suffix[position + 1]
+                .saturating_add(u64::from(staged[position].is_ok()));
+        }
+        for (position, staged_result) in staged.into_iter().enumerate() {
+            if first_stage_failure.is_some_and(|failed| position >= failed) {
+                if position == first_stage_failure.expect("failure position is present") {
+                    let error = match staged_result {
+                        Err(error) => error,
+                        Ok(_) => unreachable!("earliest failed stage is an error"),
+                    };
+                    let unpublished = successful_stage_suffix[position + 1];
+                    observer.record_unpublished_physical_writes_after_failure(unpublished);
+                    observer.record_physical_install_transaction_wall(qualification_elapsed_us(
+                        transaction_started,
+                    ));
+                    return Err(error);
+                }
+                unreachable!("earliest stage failure returns before later entries")
+            }
+            let staged = staged_result.expect("successful prefix precedes first stage failure");
+            observer.record_ordered_commit_attempt();
+            let commit_started = Instant::now();
+            let (residency, evidence) = match self
+                .executor
+                .commit_q4_expert_residency_qualification(staged.prepared, staged.evidence)
+            {
+                Ok(committed) => committed,
+                Err(error) => {
+                    observer.record_ordered_commit_failed(matches!(
+                        error,
+                        GpuNativeBootstrapError::ExpertInstallReservationLost
+                    ));
+                    let unpublished = successful_stage_suffix[position];
+                    observer.record_unpublished_physical_writes_after_failure(unpublished);
+                    observer.record_physical_install_transaction_wall(qualification_elapsed_us(
+                        transaction_started,
+                    ));
+                    return Err(error.into());
+                }
+            };
+            if !self
+                .gpu_cache
+                .contains_generation(staged.global_id, staged.admission.generation())
+            {
+                let _ = self
+                    .executor
+                    .retire_q4_expert_residency(&layer.arena, staged.key)?;
+                self.counters
+                    .stale_generation_rejections
+                    .fetch_add(1, Ordering::Relaxed);
+                observer.record_ordered_commit_failed(false);
+                observer.record_unpublished_physical_writes_after_failure(
+                    successful_stage_suffix[position + 1],
+                );
+                observer.record_physical_install_transaction_wall(qualification_elapsed_us(
+                    transaction_started,
+                ));
+                return Err(GpuNativeTieredResidencyError::LogicalAdmissionStale {
+                    global_id: staged.global_id,
+                    generation: staged.admission.generation(),
+                });
+            }
+            let reinstall = state
+                .last_installed_generations
+                .insert(staged.global_id, staged.admission.generation())
+                == Some(staged.admission.generation());
+            state.residents.put(
+                staged.global_id,
+                PhysicalRecord {
+                    key: staged.key,
+                    residency,
+                },
+            );
+            self.counters
+                .ram_to_vram_installs
+                .fetch_add(1, Ordering::Relaxed);
+            if reinstall {
+                self.counters
+                    .physical_reinstalls
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+            observer.record_ordered_commit_completed(qualification_elapsed_us(commit_started));
+            observer.record_physical_install_completion(
+                staged.global_id,
+                residency,
+                evidence,
+                qualification_elapsed_us(staged.transaction_started),
+            );
+            resolved[staged.demand_index] = Some(residency);
+        }
+        observer.record_physical_install_transaction_wall(qualification_elapsed_us(
+            transaction_started,
+        ));
+        Ok(())
     }
 
     pub(crate) fn ensure_speculative_resident(
@@ -1042,6 +1427,7 @@ impl GpuNativeTieredResidencyManager {
             self.plan.num_layers(),
             self.plan.geometry().num_experts() as u32,
         )?;
+        let reservation_started = observer.map(|_| Instant::now());
         let (residency, installed) = match self
             .executor
             .acquire_q4_expert_residency(&layer.arena, key)?
@@ -1050,6 +1436,15 @@ impl GpuNativeTieredResidencyManager {
             GpuNativeQ4ExpertAcquire::Install(permit) => {
                 if let Some(observer) = observer {
                     observer.record_physical_install_attempt();
+                    observer.record_reservation_attempt();
+                    observer.record_reservation_success(
+                        global_id,
+                        permit.reserved_residency(),
+                        permit.install_ticket(),
+                    );
+                    observer.record_physical_reservation_wall(qualification_elapsed_us(
+                        reservation_started.expect("observed acquire has a start time"),
+                    ));
                     let started = Instant::now();
                     let result = match install_path {
                         DemandPhysicalInstallPath::Production => self
@@ -1061,6 +1456,11 @@ impl GpuNativeTieredResidencyManager {
                         DemandPhysicalInstallPath::LegacyFullSlotVecControl => self
                             .executor
                             .install_q4_expert_residency_legacy_observed(permit, resident.data()),
+                        DemandPhysicalInstallPath::QualificationParallelDirectStaging => {
+                            unreachable!(
+                                "parallel qualification installs use the split transaction"
+                            )
+                        }
                     };
                     match result {
                         Ok((residency, evidence)) => {
@@ -1090,6 +1490,11 @@ impl GpuNativeTieredResidencyManager {
                         DemandPhysicalInstallPath::LegacyFullSlotVecControl => self
                             .executor
                             .install_q4_expert_residency_legacy(permit, resident.data())?,
+                        DemandPhysicalInstallPath::QualificationParallelDirectStaging => {
+                            unreachable!(
+                                "parallel qualification installs use the split transaction"
+                            )
+                        }
                     };
                     (residency, true)
                 }
@@ -1194,7 +1599,7 @@ mod tests {
     }
 
     #[test]
-    fn ordinary_and_v2_treatment_share_production_while_speculation_stays_legacy() {
+    fn ordinary_and_qualification_paths_keep_production_and_speculation_frozen() {
         assert_eq!(
             ordinary_demand_install_path(),
             DemandPhysicalInstallPath::Production
@@ -1203,6 +1608,41 @@ mod tests {
             speculative_install_path(),
             DemandPhysicalInstallPath::LegacyFullSlotVecControl
         );
+        assert_ne!(
+            ordinary_demand_install_path(),
+            DemandPhysicalInstallPath::QualificationParallelDirectStaging
+        );
+        assert_ne!(
+            speculative_install_path(),
+            DemandPhysicalInstallPath::QualificationParallelDirectStaging
+        );
+    }
+
+    #[test]
+    fn treatment_widths_one_through_eight_collect_and_touch_lru_in_request_order() {
+        for width in 1usize..=8 {
+            let task_count = AtomicU64::new(0);
+            let request_order = (0..width as u32).collect::<Vec<_>>();
+            let staged = collect_physical_stage_results_in_request_order(
+                request_order.clone(),
+                width >= 2,
+                |global_id| {
+                    task_count.fetch_add(1, Ordering::Relaxed);
+                    global_id
+                },
+            );
+            assert_eq!(task_count.load(Ordering::Relaxed), width as u64);
+            assert_eq!(staged, request_order);
+
+            let mut residents = LruCache::unbounded();
+            for global_id in staged {
+                residents.put(global_id, ());
+            }
+            assert_eq!(
+                residents.iter().map(|(&id, _)| id).collect::<Vec<_>>(),
+                request_order.into_iter().rev().collect::<Vec<_>>()
+            );
+        }
     }
 
     #[test]

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -940,18 +940,18 @@ enum Cmd {
         report_out: PathBuf,
     },
 
-    /// PR2-B-B qualification-only control/treatment experiment. Control uses
-    /// ordinary sequential direct staging; treatment reserves deterministically,
-    /// stages independent slots on the shared Rayon pool, and commits in order.
-    #[command(name = "qualify-gpu-native-physical-install-concurrency")]
-    QualifyGpuNativePhysicalInstallConcurrency {
+    /// PR2-B-B.1 production-path qualification. Control forces the frozen
+    /// sequential direct-staging implementation; treatment exercises ordinary
+    /// production concurrent staging and deterministic ordered commit.
+    #[command(name = "qualify-gpu-native-physical-install-concurrency-production")]
+    QualifyGpuNativePhysicalInstallConcurrencyProduction {
         /// Exact frozen PR2 GPU-native TOML config path.
         #[arg(long)]
         config: PathBuf,
         /// Exact authoritative adapter name required for both isolated arms.
         #[arg(long)]
         expected_adapter_name: String,
-        /// Required destination for the typed v1 qualification report.
+        /// Required destination for the typed production-v1 qualification report.
         #[arg(long)]
         report_out: PathBuf,
     },
@@ -1908,7 +1908,7 @@ fn startup_config_path(cmd: &Cmd) -> Option<&Path> {
         | Cmd::BenchGpuNativeReal { config, .. }
         | Cmd::QualifyGpuNativeDemandSourceConcurrencyProduction { config, .. }
         | Cmd::QualifyGpuNativePhysicalInstallStagingProduction { config, .. }
-        | Cmd::QualifyGpuNativePhysicalInstallConcurrency { config, .. }
+        | Cmd::QualifyGpuNativePhysicalInstallConcurrencyProduction { config, .. }
         | Cmd::QualifyHybridQ4 { config, .. }
         | Cmd::QualifyHybridQ4Parity { config, .. }
         | Cmd::QualifyHybridQ4GreedyParity { config, .. }
@@ -2371,7 +2371,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 },
             ))
         }
-        Cmd::QualifyGpuNativePhysicalInstallConcurrency {
+        Cmd::QualifyGpuNativePhysicalInstallConcurrencyProduction {
             config,
             expected_adapter_name,
             report_out,
@@ -16389,10 +16389,10 @@ mod tests {
     }
 
     #[test]
-    fn gpu_native_physical_install_concurrency_cli_parses_qualified_command() {
+    fn gpu_native_physical_install_concurrency_production_cli_parses_qualified_command() {
         let cli = <Cli as clap::Parser>::try_parse_from([
             "micro-expert-router",
-            "qualify-gpu-native-physical-install-concurrency",
+            "qualify-gpu-native-physical-install-concurrency-production",
             "--config",
             "/home/randyap8/slice11-qwen3-coder-gpu-native.toml",
             "--expected-adapter-name",
@@ -16403,7 +16403,7 @@ mod tests {
         .unwrap();
 
         match &cli.cmd {
-            Cmd::QualifyGpuNativePhysicalInstallConcurrency {
+            Cmd::QualifyGpuNativePhysicalInstallConcurrencyProduction {
                 config,
                 expected_adapter_name,
                 report_out,

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -940,6 +940,22 @@ enum Cmd {
         report_out: PathBuf,
     },
 
+    /// PR2-B-B qualification-only control/treatment experiment. Control uses
+    /// ordinary sequential direct staging; treatment reserves deterministically,
+    /// stages independent slots on the shared Rayon pool, and commits in order.
+    #[command(name = "qualify-gpu-native-physical-install-concurrency")]
+    QualifyGpuNativePhysicalInstallConcurrency {
+        /// Exact frozen PR2 GPU-native TOML config path.
+        #[arg(long)]
+        config: PathBuf,
+        /// Exact authoritative adapter name required for both isolated arms.
+        #[arg(long)]
+        expected_adapter_name: String,
+        /// Required destination for the typed v1 qualification report.
+        #[arg(long)]
+        report_out: PathBuf,
+    },
+
     /// Qualify strict real-checkpoint inference with CPU dense/attention/KV/
     /// router/head planes and native-Q4_0 routed experts on a hardware GPU.
     QualifyHybridQ4 {
@@ -1892,6 +1908,7 @@ fn startup_config_path(cmd: &Cmd) -> Option<&Path> {
         | Cmd::BenchGpuNativeReal { config, .. }
         | Cmd::QualifyGpuNativeDemandSourceConcurrencyProduction { config, .. }
         | Cmd::QualifyGpuNativePhysicalInstallStagingProduction { config, .. }
+        | Cmd::QualifyGpuNativePhysicalInstallConcurrency { config, .. }
         | Cmd::QualifyHybridQ4 { config, .. }
         | Cmd::QualifyHybridQ4Parity { config, .. }
         | Cmd::QualifyHybridQ4GreedyParity { config, .. }
@@ -2353,6 +2370,25 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     progress_watchdog,
                 },
             ))
+        }
+        Cmd::QualifyGpuNativePhysicalInstallConcurrency {
+            config,
+            expected_adapter_name,
+            report_out,
+        } => {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()?;
+            rt.block_on(
+                crate::gpu_native_physical_install_staging::run_concurrency_command(
+                    crate::gpu_native_physical_install_staging::CommandArgs {
+                        config,
+                        expected_adapter_name,
+                        report_out,
+                        progress_watchdog,
+                    },
+                ),
+            )
         }
         Cmd::QualifyHybridQ4 {
             config,
@@ -16341,6 +16377,43 @@ mod tests {
                 );
                 assert_eq!(expected_adapter_name, "NVIDIA L4");
                 assert_eq!(report_out, &PathBuf::from("pr2ba-report.json"));
+            }
+            _ => panic!("unexpected command variant"),
+        }
+        assert_eq!(
+            super::startup_config_path(&cli.cmd),
+            Some(Path::new(
+                "/home/randyap8/slice11-qwen3-coder-gpu-native.toml"
+            ))
+        );
+    }
+
+    #[test]
+    fn gpu_native_physical_install_concurrency_cli_parses_qualified_command() {
+        let cli = <Cli as clap::Parser>::try_parse_from([
+            "micro-expert-router",
+            "qualify-gpu-native-physical-install-concurrency",
+            "--config",
+            "/home/randyap8/slice11-qwen3-coder-gpu-native.toml",
+            "--expected-adapter-name",
+            "NVIDIA L4",
+            "--report-out",
+            "pr2bb-report.json",
+        ])
+        .unwrap();
+
+        match &cli.cmd {
+            Cmd::QualifyGpuNativePhysicalInstallConcurrency {
+                config,
+                expected_adapter_name,
+                report_out,
+            } => {
+                assert_eq!(
+                    config,
+                    &PathBuf::from("/home/randyap8/slice11-qwen3-coder-gpu-native.toml")
+                );
+                assert_eq!(expected_adapter_name, "NVIDIA L4");
+                assert_eq!(report_out, &PathBuf::from("pr2bb-report.json"));
             }
             _ => panic!("unexpected command variant"),
         }


### PR DESCRIPTION
## Summary

Productionizes the PR2-B-B deterministic physical-install concurrency mechanism for ordinary GPU-native demand installs:

- sequential deterministic slot reservation
- parallel direct staging on the existing process-wide Rayon pool for install-set width >= 2
- deterministic ordered mapping/host commit
- unchanged speculative legacy full-slot Vec path
- unchanged source acquisition, expert compute, victim policy, WGPU version, Rayon pool sizing, queue submission and device synchronization

## Hardware-qualified production SHA

`5640b9018573c5e6432d069cac79e8d3b67b3778`

Parent qualified experiment SHA:
`17ae8eb41f66db5e03be91fbec1b50a00daf3f11`

Authoritative first L4 production qualifier:
- schema: `mer.gpu-native-physical-install-concurrency-production.v1`
- qualification: PASS
- performance result: improved
- report SHA256: `1831346ae2abd711ab3ac031a236b49689baf8eff23fcc1656f4bb2746008514`
- log SHA256: `7b4a8323d80fbb4daa304d836296ef193cc096a929c8bc2032b20efa7dbf4714`

## Production L4 result

- decode TPS: 0.950875 -> 1.025194 (+7.82%)
- E2E TPS: 0.858112 -> 0.923320 (+7.60%)
- mean request wall: 149.167s -> 138.633s (-7.06%)
- physical demand install: -72.46%
- physical stage critical-path wall: -73.63%
- physical install transaction wall: -73.15%
- total residency service: -13.96%
- host-stage overlap: 1.00x -> 4.04x

All behavioral, generated-text, work-equivalence, victim/reservation/residency identity, mapping, failure and production-path mechanism gates passed. Treatment exercised ordinary production with 18,564 parallel staging sets / 90,168 experts and max in-flight staging 8, with zero reservation/stage/commit failures or ordering violations.

Merge with a merge commit to preserve the exact hardware-qualified SHA in `main` ancestry. Do not squash or rebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added concurrent GPU-native physical installation with reservation, staged writes, and ordered commits.
  - Added a qualification mode comparing sequential and concurrent installation performance and behavior.
  - Added the CLI command `qualify-gpu-native-physical-install-concurrency-production`.
  - Added qualification reports covering staging concurrency, commit ordering, timing, and failure outcomes.

- **Bug Fixes**
  - Improved handling of reservation loss and failed installations to prevent unpublished physical writes.
  - Added validation for installation identity, byte consistency, ordering, and concurrency metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->