### PR TITLE
PR2-C/C.1: Productionize route-parallel GPU-native Q4 experts

### DIFF
--- a/rust-engine/src/backend/gpu_native.rs
+++ b/rust-engine/src/backend/gpu_native.rs
@@ -6667,6 +6667,7 @@ pub(crate) struct GpuNativeExecutorContext {
     attention_pipelines: GpuNativeAttentionPipelines,
     router_pipeline: GpuNativeRouterPipeline,
     q4_expert_pipelines: GpuNativeQ4ExpertPipelines,
+    q4_route_parallel_pipelines: q4_route_parallel::GpuNativeQ4RouteParallelPipelines,
     status_control_pipeline: GpuNativeStatusControlPipeline,
     greedy_argmax_pipeline: GpuNativeGreedyArgmaxPipeline,
     counters: GpuNativeExecutionCounters,
@@ -6699,6 +6700,11 @@ impl GpuNativeExecutorContext {
         let attention_pipelines = GpuNativeAttentionPipelines::new(&gpu.device);
         let router_pipeline = GpuNativeRouterPipeline::new(&gpu.device);
         let q4_expert_pipelines = GpuNativeQ4ExpertPipelines::try_new(&gpu.device)?;
+        let q4_route_parallel_pipelines =
+            q4_route_parallel::GpuNativeQ4RouteParallelPipelines::create_for_executor(
+                &gpu.device,
+                &q4_expert_pipelines,
+            );
         let status_control_pipeline = GpuNativeStatusControlPipeline::new(&gpu.device);
         let greedy_argmax_pipeline = GpuNativeGreedyArgmaxPipeline::new(&gpu.device);
 
@@ -6713,6 +6719,7 @@ impl GpuNativeExecutorContext {
             attention_pipelines,
             router_pipeline,
             q4_expert_pipelines,
+            q4_route_parallel_pipelines,
             status_control_pipeline,
             greedy_argmax_pipeline,
             counters: GpuNativeExecutionCounters::default(),

--- a/rust-engine/src/backend/gpu_native.rs
+++ b/rust-engine/src/backend/gpu_native.rs
@@ -11,6 +11,8 @@
 // GPU-native slices remain intentionally unreachable from production token entrypoints.
 #![allow(dead_code)]
 
+pub(crate) mod q4_route_parallel;
+
 use super::{create_startup_buffer, BackendBox, GpuDeviceIdentity, GpuStartupAllocationError};
 use crate::dense_tensor::{DenseDType, DenseWeight};
 use crate::inference::{Q4_0_BLOCK_BYTES, Q4_0_BLOCK_ELEMS, Q8_0_BLOCK_BYTES, Q8_0_BLOCK_ELEMS};

--- a/rust-engine/src/backend/gpu_native/q4_route_parallel.rs
+++ b/rust-engine/src/backend/gpu_native/q4_route_parallel.rs
@@ -1,8 +1,9 @@
-//! Isolated PR2-C route scheduling. Production serial encoding stays in the parent.
+//! Production Q4 route scheduling replicated from the hardware-qualified PR2-C.
+//! The frozen serial control encoder stays unchanged in the parent.
 use super::*;
 
-// Compile treatment as the exact unchanged production shader plus isolated
-// entrypoints. The production shader hash and all historical pins stay intact.
+// Compile the exact qualified shader sources. Historical serial entrypoints
+// and arithmetic pins stay intact for the frozen control.
 const ROUTE_PARALLEL_SHADER: &str = concat!(
     include_str!("../wgpu_shaders/gpu_native_q4_expert.wgsl"),
     include_str!("../wgpu_shaders/gpu_native_q4_expert_route_parallel.wgsl"),
@@ -57,8 +58,8 @@ impl RouteParallelGeometry {
     }
 }
 
-/// Only the treatment owns this storage-only top_k*d_ff activation and its
-/// two pipelines. Locations, outputs, status and combined remain shared scratch.
+/// Production request storage-only top_k*d_ff activation and its two pipelines.
+/// Locations, outputs, status and combined remain shared scratch.
 pub(crate) struct GpuNativeQ4RouteParallelScratch {
     context_id: u64,
     geometry: GpuNativeQ4ExpertGeometry,
@@ -88,8 +89,8 @@ pub(crate) struct DispatchEvidence {
     pub(crate) contain_dispatches: u64,
 }
 
-// Identical, bounded observation cost in both qualifier arms. Ordinary
-// serving does not call this helper or take qualification snapshots.
+// Preserve the qualified bounded counter accounting in the production encoder.
+// Only an installed qualification observer aggregates the returned evidence.
 #[derive(Clone, Copy)]
 struct Q4DispatchCounters {
     resolve: u64,
@@ -130,7 +131,7 @@ impl Q4DispatchCounters {
 }
 
 impl GpuNativeExecutorContext {
-    pub(crate) fn create_q4_route_parallel_qualification_scratch(
+    pub(crate) fn create_q4_route_parallel_scratch(
         &self,
         geometry: GpuNativeQ4ExpertGeometry,
     ) -> Result<GpuNativeQ4RouteParallelScratch, GpuNativeBootstrapError> {
@@ -172,8 +173,8 @@ impl GpuNativeExecutorContext {
         })
     }
 
-    /// Qualification observes the existing production counters surrounding the
-    /// exact ordinary serial encoder. No synthetic serial implementation.
+    /// Control observes the counters surrounding the exact frozen pre-C serial
+    /// encoder. No synthetic serial implementation.
     pub(crate) fn encode_q4_expert_serial_qualification(
         &self,
         encoder: &mut wgpu::CommandEncoder,
@@ -211,7 +212,8 @@ impl GpuNativeExecutorContext {
         })
     }
 
-    pub(crate) fn encode_q4_expert_route_parallel_qualification(
+    /// The single production encoder, also called by qualification treatment.
+    pub(crate) fn encode_q4_expert_route_parallel(
         &self,
         encoder: &mut wgpu::CommandEncoder,
         router_plan: &GpuNativeRouterPlan,
@@ -225,9 +227,12 @@ impl GpuNativeExecutorContext {
         let gpu = self.authoritative_gpu()?;
         let limits = gpu.device.limits();
         let geometry = RouteParallelGeometry::try_new(arena.geometry, &limits)?;
-        if parallel.context_id != self.context_id || parallel.geometry != arena.geometry {
-            return Err(GpuNativeBootstrapError::ForeignTokenState);
-        }
+        validate_route_parallel_scratch_identity(
+            self.context_id,
+            arena.geometry,
+            parallel.context_id,
+            parallel.geometry,
+        )?;
         let mut evidence = DispatchEvidence::default();
         validate_token_state_owner(self.context_id, state.context_id)?;
         let _gate = validate_router_plan_with_registry(
@@ -465,7 +470,7 @@ impl GpuNativeExecutorContext {
         self.counters.record_expert_dispatches(1);
         let delta = Q4DispatchCounters::capture(self).delta(before);
         // Fail mechanism accounting closed if the ordinary counters disagree
-        // with the dispatches actually recorded at the treatment seam.
+        // with the dispatches actually recorded at the production seam.
         evidence.accounting_mismatch = delta.gate_up != evidence.parallel_gate_up_dispatches
             || delta.down != evidence.parallel_down_dispatches
             || delta.resolve != 1
@@ -477,6 +482,18 @@ impl GpuNativeExecutorContext {
         evidence.route_output_bytes = expert_scratch.layout.route_outputs_bytes();
         Ok(evidence)
     }
+}
+
+fn validate_route_parallel_scratch_identity(
+    context_id: u64,
+    geometry: GpuNativeQ4ExpertGeometry,
+    scratch_context_id: u64,
+    scratch_geometry: GpuNativeQ4ExpertGeometry,
+) -> Result<(), GpuNativeBootstrapError> {
+    if scratch_context_id != context_id || scratch_geometry != geometry {
+        return Err(GpuNativeBootstrapError::ForeignTokenState);
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -538,6 +555,35 @@ mod tests {
         assert!(RouteParallelGeometry::try_new(g, &limits).is_ok());
         limits.max_compute_workgroups_per_dimension = 0;
         assert!(RouteParallelGeometry::try_new(g, &limits).is_err());
+        for (d_model, d_ff) in [(32, 576), (576, 32)] {
+            let g = GpuNativeQ4ExpertGeometry::try_new(d_model, d_ff, 128, 8).unwrap();
+            limits.max_compute_workgroups_per_dimension = 8;
+            assert!(matches!(
+                RouteParallelGeometry::try_new(g, &limits),
+                Err(GpuNativeBootstrapError::DispatchGeometryUnsupported {
+                    workgroups: 9,
+                    maximum: 8
+                })
+            ));
+        }
+    }
+    #[test]
+    fn q4_route_parallel_foreign_and_mismatched_scratch_fail_closed() {
+        let g = GpuNativeQ4ExpertGeometry::try_new(2048, 768, 128, 8).unwrap();
+        assert!(validate_route_parallel_scratch_identity(1, g, 1, g).is_ok());
+        assert!(matches!(
+            validate_route_parallel_scratch_identity(1, g, 2, g),
+            Err(GpuNativeBootstrapError::ForeignTokenState)
+        ));
+        for other in [
+            GpuNativeQ4ExpertGeometry::try_new(2048, 768, 128, 1).unwrap(),
+            GpuNativeQ4ExpertGeometry::try_new(2048, 800, 128, 8).unwrap(),
+        ] {
+            assert!(matches!(
+                validate_route_parallel_scratch_identity(1, g, 1, other),
+                Err(GpuNativeBootstrapError::ForeignTokenState)
+            ));
+        }
     }
     #[test]
     fn q4_route_parallel_shader_parses_and_validates_without_a_device() {
@@ -606,18 +652,30 @@ mod tests {
     fn q4_route_parallel_keeps_control_path_and_gpu_boundary_contract() {
         let runtime = include_str!("../../gpu_native_token_loop.rs");
         let encoded = function(runtime, "encode_expert_layer_unified");
-        assert!(encoded.contains("Q4QualificationArm::Control =>"));
+        assert!(encoded.contains("if q4_uses_frozen_serial_control(observation.map(|o| o.arm))"));
         assert!(encoded.contains("encode_q4_expert_serial_qualification"));
-        assert!(encoded.contains("encode_q4_expert_route_parallel_qualification"));
-        assert!(
-            encoded.contains("else {\n        self.executor.encode_q4_expert_arena_combine(")
-                || encoded
-                    .contains("else {\n            self.executor.encode_q4_expert_arena_combine(")
+        assert_eq!(
+            encoded.matches(".encode_q4_expert_route_parallel(").count(),
+            1
         );
+        assert!(!encoded.contains("encode_q4_expert_arena_combine"));
+        assert!(!encoded.contains("Q4QualificationArm::Treatment"));
+        let require = encoded.find("require_q4_route_parallel_scratch(").unwrap();
+        assert!(require < encoded.find(".encode_q4_expert_route_parallel(").unwrap());
+        let allocation = function(runtime, "create_request_state_inner");
+        assert!(allocation.contains("if q4_uses_frozen_serial_control("));
+        assert!(allocation.contains("create_q4_route_parallel_scratch(expert_geom)?"));
+        assert!(!allocation.contains("Q4QualificationArm::Treatment"));
         let source = include_str!("q4_route_parallel.rs");
         assert!(function(source, "encode_q4_expert_serial_qualification")
             .contains("self.encode_q4_expert_arena_combine("));
-        let treatment = function(source, "encode_q4_expert_route_parallel_qualification");
+        let treatment = function(source, "encode_q4_expert_route_parallel");
+        assert!(
+            treatment
+                .find("validate_route_parallel_scratch_identity(")
+                .unwrap()
+                < treatment.find("encoder.begin_compute_pass(").unwrap()
+        );
         for forbidden in [
             ".submit(",
             ".poll(",

--- a/rust-engine/src/backend/gpu_native/q4_route_parallel.rs
+++ b/rust-engine/src/backend/gpu_native/q4_route_parallel.rs
@@ -1,0 +1,1003 @@
+//! Isolated PR2-C route scheduling. Production serial encoding stays in the parent.
+use super::*;
+
+// Compile treatment as the exact unchanged production shader plus isolated
+// entrypoints. The production shader hash and all historical pins stay intact.
+const ROUTE_PARALLEL_SHADER: &str = concat!(
+    include_str!("../wgpu_shaders/gpu_native_q4_expert.wgsl"),
+    include_str!("../wgpu_shaders/gpu_native_q4_expert_route_parallel.wgsl"),
+);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct RouteParallelGeometry {
+    pub(crate) gate_up_workgroups: u32,
+    pub(crate) down_workgroups: u32,
+    pub(crate) route_width: u32,
+    pub(crate) activation_elements: usize,
+}
+impl RouteParallelGeometry {
+    pub(crate) fn try_new(
+        g: GpuNativeQ4ExpertGeometry,
+        limits: &wgpu::Limits,
+    ) -> Result<Self, GpuNativeBootstrapError> {
+        let overflow = || GpuNativeBootstrapError::ExpertGeometryOverflow {
+            d_model: g.d_model,
+            d_ff: g.d_ff,
+            num_experts: g.num_experts,
+            top_k: g.top_k,
+        };
+        let activation_elements = g.top_k.checked_mul(g.d_ff).ok_or_else(overflow)?;
+        u32::try_from(activation_elements).map_err(|_| overflow())?;
+        let result = Self {
+            gate_up_workgroups: u32::try_from(g.d_ff.div_ceil(64)).map_err(|_| overflow())?,
+            down_workgroups: u32::try_from(g.d_model.div_ceil(64)).map_err(|_| overflow())?,
+            route_width: u32::try_from(g.top_k).map_err(|_| overflow())?,
+            activation_elements,
+        };
+        for workgroups in [
+            result.gate_up_workgroups,
+            result.down_workgroups,
+            result.route_width,
+        ] {
+            if workgroups > limits.max_compute_workgroups_per_dimension {
+                return Err(GpuNativeBootstrapError::DispatchGeometryUnsupported {
+                    workgroups: u64::from(workgroups),
+                    maximum: limits.max_compute_workgroups_per_dimension,
+                });
+            }
+        }
+        let layout = GpuNativeScratchLayout::try_new(activation_elements)?;
+        super::super::validate_startup_buffer(
+            "pr2c_activation",
+            layout.bytes,
+            wgpu::BufferUsages::STORAGE,
+            limits,
+        )?;
+        Ok(result)
+    }
+}
+
+/// Only the treatment owns this storage-only top_k*d_ff activation and its
+/// two pipelines. Locations, outputs, status and combined remain shared scratch.
+pub(crate) struct GpuNativeQ4RouteParallelScratch {
+    context_id: u64,
+    geometry: GpuNativeQ4ExpertGeometry,
+    activation: GpuNativeScratch,
+    gate_up: wgpu::ComputePipeline,
+    down: wgpu::ComputePipeline,
+}
+
+#[derive(Clone, Copy, Debug, Default, serde::Serialize)]
+pub(crate) struct DispatchEvidence {
+    pub(crate) layer_executions: u64,
+    pub(crate) accounting_mismatch: bool,
+    pub(crate) selected_routes: u64,
+    pub(crate) top_k: u64,
+    pub(crate) serial_gate_up_dispatches: u64,
+    pub(crate) serial_down_dispatches: u64,
+    pub(crate) parallel_gate_up_dispatches: u64,
+    pub(crate) parallel_down_dispatches: u64,
+    pub(crate) routes_covered: u64,
+    pub(crate) max_route_width: u64,
+    pub(crate) activation_bytes: u64,
+    pub(crate) route_output_bytes: u64,
+    pub(crate) gate_up_rows: u64,
+    pub(crate) down_rows: u64,
+    pub(crate) validation_dispatches: u64,
+    pub(crate) combine_dispatches: u64,
+    pub(crate) contain_dispatches: u64,
+}
+
+// Identical, bounded observation cost in both qualifier arms. Ordinary
+// serving does not call this helper or take qualification snapshots.
+#[derive(Clone, Copy)]
+struct Q4DispatchCounters {
+    resolve: u64,
+    gate_up: u64,
+    down: u64,
+    combine: u64,
+}
+impl Q4DispatchCounters {
+    fn capture(executor: &GpuNativeExecutorContext) -> Self {
+        Self {
+            resolve: executor
+                .counters
+                .expert_route_resolve_dispatches
+                .load(Ordering::Relaxed),
+            gate_up: executor
+                .counters
+                .q4_expert_gate_up_dispatches
+                .load(Ordering::Relaxed),
+            down: executor
+                .counters
+                .q4_expert_down_dispatches
+                .load(Ordering::Relaxed),
+            combine: executor
+                .counters
+                .expert_combine_dispatches
+                .load(Ordering::Relaxed),
+        }
+    }
+    fn delta(self, before: Self) -> Self {
+        let delta = |after: u64, before: u64| after.checked_sub(before).unwrap_or(u64::MAX);
+        Self {
+            resolve: delta(self.resolve, before.resolve),
+            gate_up: delta(self.gate_up, before.gate_up),
+            down: delta(self.down, before.down),
+            combine: delta(self.combine, before.combine),
+        }
+    }
+}
+
+impl GpuNativeExecutorContext {
+    pub(crate) fn create_q4_route_parallel_qualification_scratch(
+        &self,
+        geometry: GpuNativeQ4ExpertGeometry,
+    ) -> Result<GpuNativeQ4RouteParallelScratch, GpuNativeBootstrapError> {
+        let gpu = self.authoritative_gpu()?;
+        let plan = RouteParallelGeometry::try_new(geometry, &gpu.device.limits())?;
+        let activation = self.create_scratch(plan.activation_elements)?;
+        let module = gpu
+            .device
+            .create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some("pr2c_q4_route_parallel_shader"),
+                source: wgpu::ShaderSource::Wgsl(ROUTE_PARALLEL_SHADER.into()),
+            });
+        let layout = gpu
+            .device
+            .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("pr2c_q4_route_parallel_layout"),
+                bind_group_layouts: &[&self.q4_expert_pipelines.expert_bind_group_layout],
+                push_constant_ranges: &[wgpu::PushConstantRange {
+                    stages: wgpu::ShaderStages::COMPUTE,
+                    range: 0..GPU_NATIVE_EXPERT_PUSH_CONSTANT_BYTES,
+                }],
+            });
+        let pipeline = |entry_point| {
+            gpu.device
+                .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                    label: Some(entry_point),
+                    layout: Some(&layout),
+                    module: &module,
+                    entry_point,
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
+                })
+        };
+        Ok(GpuNativeQ4RouteParallelScratch {
+            context_id: self.context_id,
+            geometry,
+            activation,
+            gate_up: pipeline("q4_expert_gate_up_route_parallel_main"),
+            down: pipeline("q4_expert_down_route_parallel_main"),
+        })
+    }
+
+    /// Qualification observes the existing production counters surrounding the
+    /// exact ordinary serial encoder. No synthetic serial implementation.
+    pub(crate) fn encode_q4_expert_serial_qualification(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        router_plan: &GpuNativeRouterPlan,
+        router_scratch: &GpuNativeRouterScratch,
+        arena: &GpuNativeQ4ExpertArena,
+        state: &GpuNativeTokenState,
+        expert_scratch: &GpuNativeQ4ExpertScratch,
+    ) -> Result<DispatchEvidence, GpuNativeBootstrapError> {
+        let before = Q4DispatchCounters::capture(self);
+        self.encode_q4_expert_arena_combine(
+            encoder,
+            router_plan,
+            router_scratch,
+            arena,
+            state,
+            expert_scratch,
+        )?;
+        let delta = Q4DispatchCounters::capture(self).delta(before);
+        let k = arena.geometry.top_k as u64;
+        Ok(DispatchEvidence {
+            layer_executions: delta.resolve,
+            selected_routes: k,
+            top_k: k,
+            serial_gate_up_dispatches: delta.gate_up,
+            serial_down_dispatches: delta.down,
+            activation_bytes: expert_scratch.layout.activation_bytes(),
+            route_output_bytes: expert_scratch.layout.route_outputs_bytes(),
+            gate_up_rows: k * arena.geometry.d_ff as u64,
+            down_rows: k * arena.geometry.d_model as u64,
+            validation_dispatches: 1,
+            combine_dispatches: delta.combine,
+            contain_dispatches: 1,
+            ..DispatchEvidence::default()
+        })
+    }
+
+    pub(crate) fn encode_q4_expert_route_parallel_qualification(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        router_plan: &GpuNativeRouterPlan,
+        router_scratch: &GpuNativeRouterScratch,
+        arena: &GpuNativeQ4ExpertArena,
+        state: &GpuNativeTokenState,
+        expert_scratch: &GpuNativeQ4ExpertScratch,
+        parallel: &GpuNativeQ4RouteParallelScratch,
+    ) -> Result<DispatchEvidence, GpuNativeBootstrapError> {
+        let before = Q4DispatchCounters::capture(self);
+        let gpu = self.authoritative_gpu()?;
+        let limits = gpu.device.limits();
+        let geometry = RouteParallelGeometry::try_new(arena.geometry, &limits)?;
+        if parallel.context_id != self.context_id || parallel.geometry != arena.geometry {
+            return Err(GpuNativeBootstrapError::ForeignTokenState);
+        }
+        let mut evidence = DispatchEvidence::default();
+        validate_token_state_owner(self.context_id, state.context_id)?;
+        let _gate = validate_router_plan_with_registry(
+            self.context_id,
+            self.layout.d_model,
+            &self.dense_weights.lock(),
+            router_plan,
+        )?;
+        validate_router_scratch(self.context_id, router_plan.geometry, router_scratch)?;
+        validate_q4_expert_arena(self.context_id, arena, &limits)?;
+        validate_q4_expert_scratch(self.context_id, arena.geometry, expert_scratch, &limits)?;
+        validate_router_expert_geometry(router_plan, arena)?;
+        if state.layout.d_model != arena.geometry.d_model {
+            return Err(GpuNativeBootstrapError::ExpertDModelMismatch {
+                expected: arena.geometry.d_model,
+                actual: state.layout.d_model,
+            });
+        }
+        validate_q4_expert_pipeline_limits(&limits)?;
+        router_scratch.layout.validate_for_limits(&limits)?;
+        state.layout.validate_for_limits(&limits)?;
+        let route_workgroups = self.checked_workgroups(arena.geometry.top_k, &limits)?;
+        let gate_up_workgroups = self.checked_workgroups(arena.geometry.d_ff, &limits)?;
+        let down_workgroups = self.checked_workgroups(arena.geometry.d_model, &limits)?;
+        let combine_workgroups = down_workgroups;
+        let residual_workgroups = down_workgroups;
+        let bank_slots =
+            arena.plan.layout.banks.map(|bank| {
+                u32::try_from(bank.slot_capacity).expect("validated bank slot capacity")
+            });
+        let resolve_pc = GpuNativeExpertResolvePushConstants {
+            num_experts: arena.geometry.num_experts as u32,
+            top_k: arena.geometry.top_k as u32,
+            active_banks: arena.plan.layout.active_banks as u32,
+            _reserved: 0,
+            bank_slots,
+        };
+        let combine_pc = GpuNativeExpertCombinePushConstants {
+            d_model: arena.geometry.d_model as u32,
+            top_k: arena.geometry.top_k as u32,
+            _reserved_0: 0,
+            _reserved_1: 0,
+        };
+
+        // All fallible host-side validation and dispatch planning above is
+        // complete before this first expert command is recorded.
+        let route_bind_group = gpu.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("gpu_native_expert_route_resolve_bind_group"),
+            layout: &self.q4_expert_pipelines.route_bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: router_scratch.selected_ids.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: arena.mapping.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: expert_scratch.resolved_locations.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 3,
+                    resource: state.status.as_entire_binding(),
+                },
+            ],
+        });
+        {
+            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                label: Some("gpu_native_expert_route_resolve_pass"),
+                timestamp_writes: None,
+            });
+            pass.set_pipeline(&self.q4_expert_pipelines.route_resolve);
+            pass.set_bind_group(0, &route_bind_group, &[]);
+            pass.set_push_constants(0, bytemuck::bytes_of(&resolve_pc));
+            pass.dispatch_workgroups(route_workgroups, 1, 1);
+        }
+
+        let expert_bind_group =
+            |label: &'static str, input: &wgpu::Buffer, output: &wgpu::Buffer| {
+                gpu.device.create_bind_group(&wgpu::BindGroupDescriptor {
+                    label: Some(label),
+                    layout: &self.q4_expert_pipelines.expert_bind_group_layout,
+                    entries: &[
+                        wgpu::BindGroupEntry {
+                            binding: 0,
+                            resource: arena.banks[0].as_entire_binding(),
+                        },
+                        wgpu::BindGroupEntry {
+                            binding: 1,
+                            resource: arena.banks[1].as_entire_binding(),
+                        },
+                        wgpu::BindGroupEntry {
+                            binding: 2,
+                            resource: arena.banks[2].as_entire_binding(),
+                        },
+                        wgpu::BindGroupEntry {
+                            binding: 3,
+                            resource: arena.banks[3].as_entire_binding(),
+                        },
+                        wgpu::BindGroupEntry {
+                            binding: 4,
+                            resource: input.as_entire_binding(),
+                        },
+                        wgpu::BindGroupEntry {
+                            binding: 5,
+                            resource: expert_scratch.resolved_locations.as_entire_binding(),
+                        },
+                        wgpu::BindGroupEntry {
+                            binding: 6,
+                            resource: output.as_entire_binding(),
+                        },
+                        wgpu::BindGroupEntry {
+                            binding: 7,
+                            resource: state.status.as_entire_binding(),
+                        },
+                    ],
+                })
+            };
+        let gate_up_bind_group = expert_bind_group(
+            "gpu_native_q4_expert_gate_up_bind_group",
+            &state.hidden,
+            &parallel.activation.buffer,
+        );
+        let down_bind_group = expert_bind_group(
+            "gpu_native_q4_expert_down_bind_group",
+            &parallel.activation.buffer,
+            &expert_scratch.route_outputs.buffer,
+        );
+        {
+            let pc = GpuNativeQ4ExpertPushConstants {
+                d_model: arena.geometry.d_model as u32,
+                d_ff: arena.geometry.d_ff as u32,
+                blocks_per_projection: arena.geometry.blocks_per_projection as u32,
+                slot_stride_bytes: arena.geometry.slot_stride_bytes as u32,
+                route_slot: 0,
+                top_k: arena.geometry.top_k as u32,
+                swiglu_limit: crate::inference::swiglu_limit().unwrap_or(f32::INFINITY),
+                _reserved: 0,
+            };
+            {
+                let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                    label: Some("gpu_native_q4_expert_gate_up_pass"),
+                    timestamp_writes: None,
+                });
+                pass.set_pipeline(&parallel.gate_up);
+                pass.set_bind_group(0, &gate_up_bind_group, &[]);
+                pass.set_push_constants(0, bytemuck::bytes_of(&pc));
+                pass.dispatch_workgroups(gate_up_workgroups, geometry.route_width, 1);
+                evidence.parallel_gate_up_dispatches += 1;
+                evidence.gate_up_rows += (arena.geometry.d_ff * arena.geometry.top_k) as u64;
+            }
+            {
+                let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                    label: Some("gpu_native_q4_expert_down_pass"),
+                    timestamp_writes: None,
+                });
+                pass.set_pipeline(&parallel.down);
+                pass.set_bind_group(0, &down_bind_group, &[]);
+                pass.set_push_constants(0, bytemuck::bytes_of(&pc));
+                pass.dispatch_workgroups(down_workgroups, geometry.route_width, 1);
+                evidence.parallel_down_dispatches += 1;
+                evidence.down_rows += (arena.geometry.d_model * arena.geometry.top_k) as u64;
+                evidence.routes_covered += u64::from(geometry.route_width);
+                evidence.max_route_width = u64::from(geometry.route_width);
+            }
+        }
+
+        let combine_bind_group = gpu.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("gpu_native_expert_combine_bind_group"),
+            layout: &self.q4_expert_pipelines.combine_bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: router_scratch.selected_weights.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: expert_scratch.resolved_locations.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: expert_scratch.route_outputs.buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 3,
+                    resource: expert_scratch.combined.buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 4,
+                    resource: state.status.as_entire_binding(),
+                },
+            ],
+        });
+        let mut control_pass = |label, pipeline: &wgpu::ComputePipeline, workgroups| {
+            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                label: Some(label),
+                timestamp_writes: None,
+            });
+            pass.set_pipeline(pipeline);
+            // Control resources intentionally occupy @group(1), but WGPU still
+            // requires the pipeline's explicit empty group-0 layout to be bound.
+            pass.set_bind_group(0, &self.q4_expert_pipelines.control_empty_bind_group, &[]);
+            pass.set_bind_group(1, &combine_bind_group, &[]);
+            pass.set_push_constants(0, bytemuck::bytes_of(&combine_pc));
+            pass.dispatch_workgroups(workgroups, 1, 1);
+        };
+        control_pass(
+            "gpu_native_expert_validate_pass",
+            &self.q4_expert_pipelines.validate,
+            1,
+        );
+        control_pass(
+            "gpu_native_expert_combine_pass",
+            &self.q4_expert_pipelines.combine,
+            combine_workgroups,
+        );
+        control_pass(
+            "gpu_native_expert_contain_pass",
+            &self.q4_expert_pipelines.contain,
+            combine_workgroups,
+        );
+        drop(control_pass);
+        evidence.validation_dispatches += 1;
+        evidence.combine_dispatches += 1;
+        evidence.contain_dispatches += 1;
+        self.encode_residual_add_pass(
+            gpu,
+            encoder,
+            state,
+            &expert_scratch.combined,
+            residual_workgroups,
+        );
+        self.counters.record_expert_dispatches(1);
+        let delta = Q4DispatchCounters::capture(self).delta(before);
+        // Fail mechanism accounting closed if the ordinary counters disagree
+        // with the dispatches actually recorded at the treatment seam.
+        evidence.accounting_mismatch = delta.gate_up != evidence.parallel_gate_up_dispatches
+            || delta.down != evidence.parallel_down_dispatches
+            || delta.resolve != 1
+            || delta.combine != evidence.combine_dispatches;
+        evidence.layer_executions = delta.resolve;
+        evidence.selected_routes = arena.geometry.top_k as u64;
+        evidence.top_k = arena.geometry.top_k as u64;
+        evidence.activation_bytes = parallel.activation.layout.bytes;
+        evidence.route_output_bytes = expert_scratch.layout.route_outputs_bytes();
+        Ok(evidence)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn function(source: &str, name: &str) -> String {
+        let start = source.find(&format!("fn {name}(")).unwrap();
+        let body = start + source[start..].find('{').unwrap();
+        let mut depth = 0;
+        for (i, ch) in source[body..].char_indices() {
+            match ch {
+                '{' => depth += 1,
+                '}' => depth -= 1,
+                _ => {}
+            }
+            if depth == 0 {
+                return source[start..=body + i].into();
+            }
+        }
+        panic!("unterminated function {name}");
+    }
+    #[test]
+    fn q4_route_parallel_geometry_covers_each_route_row_once_topk_one_through_max() {
+        for k in 1..=MAX_GPU_NATIVE_ROUTER_TOP_K {
+            for (d_model, d_ff) in [(32, 32), (96, 160), (2048, 768)] {
+                let g = GpuNativeQ4ExpertGeometry::try_new(d_model, d_ff, 128, k).unwrap();
+                let p = RouteParallelGeometry::try_new(g, &wgpu::Limits::default()).unwrap();
+                for (rows, x) in [(d_ff, p.gate_up_workgroups), (d_model, p.down_workgroups)] {
+                    let mut visits = vec![0; k * rows];
+                    for route in 0..p.route_width as usize {
+                        for row in 0..x as usize * 64 {
+                            if row < rows {
+                                visits[route * rows + row] += 1;
+                            }
+                        }
+                    }
+                    assert!(visits.iter().all(|&n| n == 1));
+                }
+                assert_eq!(p.activation_elements, k * d_ff);
+                let production = GpuNativeQ4ExpertScratchLayout::try_new(g).unwrap();
+                assert_eq!(production.activation_bytes(), (d_ff * 4) as u64);
+                assert_eq!(production.route_outputs_bytes(), (k * d_model * 4) as u64);
+            }
+        }
+    }
+    #[test]
+    fn q4_route_parallel_y_and_x_dispatch_limits_are_validated_before_encoding() {
+        let mut limits = wgpu::Limits::default();
+        let g = GpuNativeQ4ExpertGeometry::try_new(32, 32, 128, 8).unwrap();
+        limits.max_compute_workgroups_per_dimension = 7;
+        assert!(matches!(
+            RouteParallelGeometry::try_new(g, &limits),
+            Err(GpuNativeBootstrapError::DispatchGeometryUnsupported {
+                workgroups: 8,
+                maximum: 7
+            })
+        ));
+        limits.max_compute_workgroups_per_dimension = 8;
+        assert!(RouteParallelGeometry::try_new(g, &limits).is_ok());
+        limits.max_compute_workgroups_per_dimension = 0;
+        assert!(RouteParallelGeometry::try_new(g, &limits).is_err());
+    }
+    #[test]
+    fn q4_route_parallel_shader_parses_and_validates_without_a_device() {
+        let m = naga::front::wgsl::parse_str(ROUTE_PARALLEL_SHADER).unwrap();
+        naga::valid::Validator::new(
+            naga::valid::ValidationFlags::all(),
+            naga::valid::Capabilities::all(),
+        )
+        .validate(&m)
+        .unwrap();
+        for name in [
+            "q4_expert_gate_up_route_parallel_main",
+            "q4_expert_down_route_parallel_main",
+        ] {
+            let e = m.entry_points.iter().find(|e| e.name == name).unwrap();
+            assert_eq!(e.workgroup_size, [64, 1, 1]);
+        }
+    }
+    #[test]
+    fn q4_route_parallel_pins_production_arithmetic_and_swiglu_exactly() {
+        use sha2::Digest;
+        assert_eq!(
+            format!(
+                "{:x}",
+                sha2::Sha256::digest(GPU_NATIVE_Q4_EXPERT_SHADER.as_bytes())
+            ),
+            "54bae352aad7f25920212f596c00b8e3bac2c0a14281b9664d219d1eea212306"
+        );
+        assert_eq!(ROUTE_PARALLEL_SHADER.matches("fn q4_dot(").count(), 1);
+        assert_eq!(
+            function(ROUTE_PARALLEL_SHADER, "q4_dot"),
+            function(GPU_NATIVE_Q4_EXPERT_SHADER, "q4_dot")
+        );
+        for stage in ["gate_up", "down"] {
+            let name = format!("q4_expert_{stage}_main");
+            let parallel_name = format!("q4_expert_{stage}_route_parallel_main");
+            let actual = function(ROUTE_PARALLEL_SHADER, &parallel_name);
+            let expected = function(GPU_NATIVE_Q4_EXPERT_SHADER, &name)
+                .replace(&name, &parallel_name)
+                .replace(
+                    "let row = gid.x;",
+                    "let row = gid.x;\n    let route_slot = gid.y;",
+                )
+                .replace(
+                    "if (row >= pc.d_ff)",
+                    "if (row >= pc.d_ff || route_slot >= pc.top_k)",
+                )
+                .replace(
+                    "if (row >= pc.d_model)",
+                    "if (row >= pc.d_model || route_slot >= pc.top_k)",
+                )
+                .replace("resolved_route()", "resolved_route_parallel(route_slot)")
+                .replace("pc.route_slot", "route_slot")
+                .replace("OUTPUT[row]", "OUTPUT[route_slot * pc.d_ff + row]")
+                .replace(
+                    "first_block, blocks_per_row, 0u)",
+                    "first_block, blocks_per_row, route_slot * pc.d_ff)",
+                );
+            assert_eq!(
+                actual, expected,
+                "only route addressing and bounds may change"
+            );
+        }
+    }
+    #[test]
+    fn q4_route_parallel_keeps_control_path_and_gpu_boundary_contract() {
+        let runtime = include_str!("../../gpu_native_token_loop.rs");
+        let encoded = function(runtime, "encode_expert_layer_unified");
+        assert!(encoded.contains("Q4QualificationArm::Control =>"));
+        assert!(encoded.contains("encode_q4_expert_serial_qualification"));
+        assert!(encoded.contains("encode_q4_expert_route_parallel_qualification"));
+        assert!(
+            encoded.contains("else {\n        self.executor.encode_q4_expert_arena_combine(")
+                || encoded
+                    .contains("else {\n            self.executor.encode_q4_expert_arena_combine(")
+        );
+        let source = include_str!("q4_route_parallel.rs");
+        assert!(function(source, "encode_q4_expert_serial_qualification")
+            .contains("self.encode_q4_expert_arena_combine("));
+        let treatment = function(source, "encode_q4_expert_route_parallel_qualification");
+        for forbidden in [
+            ".submit(",
+            ".poll(",
+            "map_async",
+            "copy_buffer_to_buffer",
+            "create_command_encoder",
+            "rayon",
+            "spawn",
+        ] {
+            assert!(!treatment.contains(forbidden), "{forbidden}");
+        }
+        assert!(!treatment.contains("for route_slot in"));
+        assert!(treatment
+            .contains("pass.dispatch_workgroups(gate_up_workgroups, geometry.route_width, 1)"));
+        assert!(treatment
+            .contains("pass.dispatch_workgroups(down_workgroups, geometry.route_width, 1)"));
+        let serial = function(
+            include_str!("../gpu_native.rs"),
+            "encode_q4_expert_arena_combine",
+        );
+        assert!(serial.contains("for route_slot in 0..arena.geometry.top_k"));
+        let combine = function(GPU_NATIVE_EXPERT_CONTROL_SHADER, "expert_combine_main");
+        assert!(combine.contains("for (var route = 0u; route < pc.top_k; route += 1u)"));
+        assert!(combine.contains("value += SELECTED_WEIGHTS[route]"));
+        for method in [&serial, &treatment] {
+            let mut prev = 0;
+            for pass in [
+                "gpu_native_expert_route_resolve_pass",
+                "gpu_native_q4_expert_gate_up_pass",
+                "gpu_native_q4_expert_down_pass",
+                "gpu_native_expert_validate_pass",
+                "gpu_native_expert_combine_pass",
+                "gpu_native_expert_contain_pass",
+                "self.encode_residual_add_pass",
+            ] {
+                let next = method.find(pass).unwrap();
+                assert!(next > prev);
+                prev = next;
+            }
+        }
+    }
+
+    // This test uses ONLY a CPU Vulkan adapter (lavapipe), never a hardware
+    // GPU. It is explicit because portable installations need not ship Mesa.
+    #[test]
+    #[ignore = "requires a CPU Vulkan software adapter; never runs hardware"]
+    fn q4_route_parallel_software_vulkan_bit_identity_and_failure_containment() {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+            backends: wgpu::Backends::VULKAN,
+            ..Default::default()
+        });
+        let adapter = instance
+            .enumerate_adapters(wgpu::Backends::VULKAN)
+            .into_iter()
+            .find(|a| a.get_info().device_type == wgpu::DeviceType::Cpu)
+            .expect("CPU Vulkan adapter required; hardware execution prohibited");
+        assert_eq!(adapter.get_info().device_type, wgpu::DeviceType::Cpu);
+        eprintln!("PR2-C software adapter: {:?}", adapter.get_info());
+        let (device, queue) = pollster::block_on(adapter.request_device(
+            &wgpu::DeviceDescriptor {
+                label: Some("PR2-C software only"),
+                required_features: wgpu::Features::PUSH_CONSTANTS,
+                required_limits: adapter.limits(),
+            },
+            None,
+        ))
+        .unwrap();
+        for k in 1..=8 {
+            let c = software_case(&device, &queue, false, k, 0, false, false, false);
+            let t = software_case(&device, &queue, true, k, 0, false, false, false);
+            assert_eq!(c, t, "same-device f32 bits must match at top_k={k}");
+            assert_eq!(c.0, 0);
+            assert!(c.2.iter().any(|&v| v != 0));
+        }
+        for (initial_status, stale_epoch, bad_numerical, private_output) in [
+            (4, false, false, false),
+            (0, true, false, false),
+            (0, false, true, false),
+            (8, false, false, true),
+        ] {
+            for parallel in [false, true] {
+                let result = software_case(
+                    &device,
+                    &queue,
+                    parallel,
+                    8,
+                    initial_status,
+                    stale_epoch,
+                    bad_numerical,
+                    private_output,
+                );
+                assert_ne!(result.0, 0);
+                assert!(
+                    result.2.iter().all(|&bits| bits == 0),
+                    "all mixture bytes must be contained"
+                );
+                if stale_epoch {
+                    assert_eq!(result.0, 4);
+                }
+                if bad_numerical {
+                    assert_eq!(result.0, 8);
+                }
+                if private_output {
+                    assert!(result.1.iter().any(|&bits| bits != 0));
+                }
+            }
+        }
+    }
+
+    fn software_case(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        parallel: bool,
+        k: usize,
+        initial_status: u32,
+        stale_epoch: bool,
+        numerical: bool,
+        private_output: bool,
+    ) -> (u32, Vec<u32>, Vec<u32>) {
+        use wgpu::util::DeviceExt;
+        let g = GpuNativeQ4ExpertGeometry::try_new(96, 160, 128, k).unwrap();
+        let buffer = |label, bytes: &[u8]| {
+            device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some(label),
+                contents: bytes,
+                usage: wgpu::BufferUsages::STORAGE
+                    | wgpu::BufferUsages::COPY_SRC
+                    | wgpu::BufferUsages::COPY_DST,
+            })
+        };
+        let mut bank_bytes: [Vec<u8>; 4] =
+            std::array::from_fn(|_| vec![0; g.slot_stride_bytes * k.div_ceil(4)]);
+        let mut routes = Vec::<u32>::new();
+        for route in 0..k {
+            let bank = route % 4;
+            let slot = route / 4;
+            let start = slot * g.slot_stride_bytes;
+            bank_bytes[bank][start..start + 4].copy_from_slice(&1u32.to_le_bytes());
+            let mut payload = super::super::tests::q4_uniform_expert(
+                g,
+                0.015625 * (route + 1) as f32,
+                -0.03125 * (route + 1) as f32,
+                0.0078125 * (route + 1) as f32,
+            );
+            if numerical && route == k - 1 {
+                payload[0..2].copy_from_slice(&half::f16::NAN.to_bits().to_le_bytes());
+            }
+            bank_bytes[bank][start + 4..start + 4 + payload.len()].copy_from_slice(&payload);
+            routes.push(((bank as u32) << 30) | slot as u32);
+            routes.push(if stale_epoch && route == k - 1 { 2 } else { 1 });
+        }
+        let banks: Vec<_> = bank_bytes.iter().map(|b| buffer("banks", b)).collect();
+        let hidden: Vec<f32> = (0..g.d_model)
+            .map(|i| ((i % 11) as f32 - 4.0) * 0.03125)
+            .collect();
+        let input = buffer("input", bytemuck::cast_slice(&hidden));
+        let resolved = buffer("resolved", bytemuck::cast_slice(&routes));
+        let activation = buffer(
+            "activation",
+            &vec![0; g.d_ff * if parallel { k } else { 1 } * 4],
+        );
+        let outputs = buffer(
+            "outputs",
+            bytemuck::cast_slice(&vec![
+                if private_output { 3.0f32 } else { 0.0 };
+                k * g.d_model
+            ]),
+        );
+        let combined = buffer("combined", bytemuck::cast_slice(&vec![7.0f32; g.d_model]));
+        let status = buffer("status", &initial_status.to_le_bytes());
+        let weights: Vec<f32> = (0..k)
+            .map(|i| (i + 1) as f32 / (k * (k + 1) / 2) as f32)
+            .collect();
+        let weights = buffer("weights", bytemuck::cast_slice(&weights));
+        let binding_layout = |read_only: &[bool]| {
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: None,
+                entries: &read_only
+                    .iter()
+                    .enumerate()
+                    .map(|(i, &read_only)| wgpu::BindGroupLayoutEntry {
+                        binding: i as u32,
+                        visibility: wgpu::ShaderStages::COMPUTE,
+                        ty: wgpu::BindingType::Buffer {
+                            ty: wgpu::BufferBindingType::Storage { read_only },
+                            has_dynamic_offset: false,
+                            min_binding_size: None,
+                        },
+                        count: None,
+                    })
+                    .collect::<Vec<_>>(),
+            })
+        };
+        let expert_layout = binding_layout(&[true, true, true, true, true, true, false, false]);
+        let combine_layout = binding_layout(&[true, true, true, false, false]);
+        let empty_layout = binding_layout(&[]);
+        let empty_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: None,
+            layout: &empty_layout,
+            entries: &[],
+        });
+        let group = |layout: &wgpu::BindGroupLayout, buffers: &[&wgpu::Buffer]| {
+            device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: None,
+                layout,
+                entries: &buffers
+                    .iter()
+                    .enumerate()
+                    .map(|(i, b)| wgpu::BindGroupEntry {
+                        binding: i as u32,
+                        resource: b.as_entire_binding(),
+                    })
+                    .collect::<Vec<_>>(),
+            })
+        };
+        let gate_group = group(
+            &expert_layout,
+            &[
+                &banks[0],
+                &banks[1],
+                &banks[2],
+                &banks[3],
+                &input,
+                &resolved,
+                &activation,
+                &status,
+            ],
+        );
+        let down_group = group(
+            &expert_layout,
+            &[
+                &banks[0],
+                &banks[1],
+                &banks[2],
+                &banks[3],
+                &activation,
+                &resolved,
+                &outputs,
+                &status,
+            ],
+        );
+        let combine_group = group(
+            &combine_layout,
+            &[&weights, &resolved, &outputs, &combined, &status],
+        );
+        let expert_module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: None,
+            source: wgpu::ShaderSource::Wgsl(
+                if parallel {
+                    ROUTE_PARALLEL_SHADER
+                } else {
+                    GPU_NATIVE_Q4_EXPERT_SHADER
+                }
+                .into(),
+            ),
+        });
+        let control_module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: None,
+            source: wgpu::ShaderSource::Wgsl(GPU_NATIVE_EXPERT_CONTROL_SHADER.into()),
+        });
+        let pipeline =
+            |module: &wgpu::ShaderModule, entry_point, layouts: &[&wgpu::BindGroupLayout]| {
+                let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                    label: None,
+                    bind_group_layouts: layouts,
+                    push_constant_ranges: &[wgpu::PushConstantRange {
+                        stages: wgpu::ShaderStages::COMPUTE,
+                        range: 0..32,
+                    }],
+                });
+                device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                    label: None,
+                    layout: Some(&layout),
+                    module,
+                    entry_point,
+                    compilation_options: Default::default(),
+                })
+            };
+        let gate = pipeline(
+            &expert_module,
+            if parallel {
+                "q4_expert_gate_up_route_parallel_main"
+            } else {
+                "q4_expert_gate_up_main"
+            },
+            &[&expert_layout],
+        );
+        let down = pipeline(
+            &expert_module,
+            if parallel {
+                "q4_expert_down_route_parallel_main"
+            } else {
+                "q4_expert_down_main"
+            },
+            &[&expert_layout],
+        );
+        let validate = pipeline(
+            &control_module,
+            "expert_validate_main",
+            &[&empty_layout, &combine_layout],
+        );
+        let combine = pipeline(
+            &control_module,
+            "expert_combine_main",
+            &[&empty_layout, &combine_layout],
+        );
+        let contain = pipeline(
+            &control_module,
+            "expert_contain_main",
+            &[&empty_layout, &combine_layout],
+        );
+        let mut encoder = device.create_command_encoder(&Default::default());
+        if !private_output {
+            for route in 0..if parallel { 1 } else { k } {
+                let pc = GpuNativeQ4ExpertPushConstants {
+                    d_model: g.d_model as u32,
+                    d_ff: g.d_ff as u32,
+                    blocks_per_projection: g.blocks_per_projection as u32,
+                    slot_stride_bytes: g.slot_stride_bytes as u32,
+                    route_slot: route as u32,
+                    top_k: k as u32,
+                    swiglu_limit: 3.0,
+                    _reserved: 0,
+                };
+                for (pipeline, group, rows) in [
+                    (&gate, &gate_group, g.d_ff),
+                    (&down, &down_group, g.d_model),
+                ] {
+                    let mut pass = encoder.begin_compute_pass(&Default::default());
+                    pass.set_pipeline(pipeline);
+                    pass.set_bind_group(0, group, &[]);
+                    pass.set_push_constants(0, bytemuck::bytes_of(&pc));
+                    pass.dispatch_workgroups(
+                        rows.div_ceil(64) as u32,
+                        if parallel { k as u32 } else { 1 },
+                        1,
+                    );
+                }
+            }
+        }
+        let pc: [u32; 8] = [g.d_model as u32, k as u32, 0, 0, 0, 0, 0, 0];
+        for (pipeline, x) in [
+            (&validate, 1),
+            (&combine, g.d_model.div_ceil(64) as u32),
+            (&contain, g.d_model.div_ceil(64) as u32),
+        ] {
+            let mut pass = encoder.begin_compute_pass(&Default::default());
+            pass.set_pipeline(pipeline);
+            pass.set_bind_group(0, &empty_group, &[]);
+            pass.set_bind_group(1, &combine_group, &[]);
+            pass.set_push_constants(0, bytemuck::cast_slice(&pc));
+            pass.dispatch_workgroups(x, 1, 1);
+        }
+        let output_bytes = (k * g.d_model * 4) as u64;
+        let combined_bytes = (g.d_model * 4) as u64;
+        let staging = device.create_buffer(&wgpu::BufferDescriptor {
+            label: None,
+            size: 4 + output_bytes + combined_bytes,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+            mapped_at_creation: false,
+        });
+        encoder.copy_buffer_to_buffer(&status, 0, &staging, 0, 4);
+        encoder.copy_buffer_to_buffer(&outputs, 0, &staging, 4, output_bytes);
+        encoder.copy_buffer_to_buffer(&combined, 0, &staging, 4 + output_bytes, combined_bytes);
+        queue.submit(Some(encoder.finish()));
+        let (tx, rx) = std::sync::mpsc::channel();
+        staging
+            .slice(..)
+            .map_async(wgpu::MapMode::Read, move |r| tx.send(r).unwrap());
+        device.poll(wgpu::Maintain::Wait);
+        rx.recv().unwrap().unwrap();
+        let mapped = staging.slice(..).get_mapped_range();
+        let words: Vec<u32> = mapped
+            .chunks_exact(4)
+            .map(|b| u32::from_le_bytes(b.try_into().unwrap()))
+            .collect();
+        (
+            words[0],
+            words[1..1 + k * g.d_model].to_vec(),
+            words[1 + k * g.d_model..].to_vec(),
+        )
+    }
+}

--- a/rust-engine/src/backend/gpu_native/q4_route_parallel.rs
+++ b/rust-engine/src/backend/gpu_native/q4_route_parallel.rs
@@ -64,8 +64,46 @@ pub(crate) struct GpuNativeQ4RouteParallelScratch {
     context_id: u64,
     geometry: GpuNativeQ4ExpertGeometry,
     activation: GpuNativeScratch,
+}
+
+/// Executor-owned route-parallel pipelines. These are invariant across
+/// requests and are created once with the other GPU-native pipelines.
+pub(super) struct GpuNativeQ4RouteParallelPipelines {
     gate_up: wgpu::ComputePipeline,
     down: wgpu::ComputePipeline,
+}
+
+impl GpuNativeQ4RouteParallelPipelines {
+    pub(super) fn create_for_executor(
+        device: &wgpu::Device,
+        q4_expert_pipelines: &GpuNativeQ4ExpertPipelines,
+    ) -> Self {
+        let module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("pr2c_q4_route_parallel_shader"),
+            source: wgpu::ShaderSource::Wgsl(ROUTE_PARALLEL_SHADER.into()),
+        });
+        let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("pr2c_q4_route_parallel_layout"),
+            bind_group_layouts: &[&q4_expert_pipelines.expert_bind_group_layout],
+            push_constant_ranges: &[wgpu::PushConstantRange {
+                stages: wgpu::ShaderStages::COMPUTE,
+                range: 0..GPU_NATIVE_EXPERT_PUSH_CONSTANT_BYTES,
+            }],
+        });
+        let pipeline = |entry_point| {
+            device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                label: Some(entry_point),
+                layout: Some(&layout),
+                module: &module,
+                entry_point,
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            })
+        };
+        Self {
+            gate_up: pipeline("q4_expert_gate_up_route_parallel_main"),
+            down: pipeline("q4_expert_down_route_parallel_main"),
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default, serde::Serialize)]
@@ -138,38 +176,10 @@ impl GpuNativeExecutorContext {
         let gpu = self.authoritative_gpu()?;
         let plan = RouteParallelGeometry::try_new(geometry, &gpu.device.limits())?;
         let activation = self.create_scratch(plan.activation_elements)?;
-        let module = gpu
-            .device
-            .create_shader_module(wgpu::ShaderModuleDescriptor {
-                label: Some("pr2c_q4_route_parallel_shader"),
-                source: wgpu::ShaderSource::Wgsl(ROUTE_PARALLEL_SHADER.into()),
-            });
-        let layout = gpu
-            .device
-            .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-                label: Some("pr2c_q4_route_parallel_layout"),
-                bind_group_layouts: &[&self.q4_expert_pipelines.expert_bind_group_layout],
-                push_constant_ranges: &[wgpu::PushConstantRange {
-                    stages: wgpu::ShaderStages::COMPUTE,
-                    range: 0..GPU_NATIVE_EXPERT_PUSH_CONSTANT_BYTES,
-                }],
-            });
-        let pipeline = |entry_point| {
-            gpu.device
-                .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
-                    label: Some(entry_point),
-                    layout: Some(&layout),
-                    module: &module,
-                    entry_point,
-                    compilation_options: wgpu::PipelineCompilationOptions::default(),
-                })
-        };
         Ok(GpuNativeQ4RouteParallelScratch {
             context_id: self.context_id,
             geometry,
             activation,
-            gate_up: pipeline("q4_expert_gate_up_route_parallel_main"),
-            down: pipeline("q4_expert_down_route_parallel_main"),
         })
     }
 
@@ -379,7 +389,7 @@ impl GpuNativeExecutorContext {
                     label: Some("gpu_native_q4_expert_gate_up_pass"),
                     timestamp_writes: None,
                 });
-                pass.set_pipeline(&parallel.gate_up);
+                pass.set_pipeline(&self.q4_route_parallel_pipelines.gate_up);
                 pass.set_bind_group(0, &gate_up_bind_group, &[]);
                 pass.set_push_constants(0, bytemuck::bytes_of(&pc));
                 pass.dispatch_workgroups(gate_up_workgroups, geometry.route_width, 1);
@@ -391,7 +401,7 @@ impl GpuNativeExecutorContext {
                     label: Some("gpu_native_q4_expert_down_pass"),
                     timestamp_writes: None,
                 });
-                pass.set_pipeline(&parallel.down);
+                pass.set_pipeline(&self.q4_route_parallel_pipelines.down);
                 pass.set_bind_group(0, &down_bind_group, &[]);
                 pass.set_push_constants(0, bytemuck::bytes_of(&pc));
                 pass.dispatch_workgroups(down_workgroups, geometry.route_width, 1);
@@ -584,6 +594,53 @@ mod tests {
                 Err(GpuNativeBootstrapError::ForeignTokenState)
             ));
         }
+    }
+    #[test]
+    fn q4_route_parallel_pipelines_are_executor_owned_not_request_local() {
+        let source = include_str!("q4_route_parallel.rs");
+        let scratch = function(source, "create_q4_route_parallel_scratch");
+        let request = function(
+            include_str!("../../gpu_native_token_loop.rs"),
+            "create_request_state_inner",
+        );
+        for request_local in [&scratch, &request] {
+            for forbidden in [
+                "create_shader_module",
+                "create_pipeline_layout",
+                "create_compute_pipeline",
+            ] {
+                assert!(!request_local.contains(forbidden), "{forbidden}");
+            }
+        }
+        assert!(scratch.contains("self.create_scratch(plan.activation_elements)?"));
+
+        let pipelines = function(source, "create_for_executor");
+        assert_eq!(pipelines.matches("create_shader_module").count(), 1);
+        assert_eq!(pipelines.matches("create_pipeline_layout").count(), 1);
+        assert_eq!(pipelines.matches("create_compute_pipeline").count(), 1);
+        for entry_point in [
+            "q4_expert_gate_up_route_parallel_main",
+            "q4_expert_down_route_parallel_main",
+        ] {
+            assert!(pipelines.contains(entry_point));
+        }
+
+        let executor = include_str!("../gpu_native.rs");
+        let context = executor.find("impl GpuNativeExecutorContext").unwrap();
+        let initialize = function(&executor[context..], "try_new");
+        let q4 = initialize
+            .find("GpuNativeQ4ExpertPipelines::try_new")
+            .unwrap();
+        let parallel = initialize
+            .find("GpuNativeQ4RouteParallelPipelines::create_for_executor")
+            .unwrap();
+        assert!(q4 < parallel);
+        assert_eq!(
+            initialize
+                .matches("GpuNativeQ4RouteParallelPipelines::create_for_executor")
+                .count(),
+            1
+        );
     }
     #[test]
     fn q4_route_parallel_shader_parses_and_validates_without_a_device() {

--- a/rust-engine/src/backend/wgpu_shaders/gpu_native_q4_expert_route_parallel.wgsl
+++ b/rust-engine/src/backend/wgpu_shaders/gpu_native_q4_expert_route_parallel.wgsl
@@ -1,0 +1,91 @@
+
+// PR2-C qualification only. The serial entrypoints above remain unchanged.
+fn resolved_route_parallel(route_slot: u32) -> ExpertRoute {
+    if (route_slot >= pc.top_k || atomicLoad(&STATUS.bits) != 0u) {
+        return ExpertRoute(UNMAPPED, 0u);
+    }
+    return RESOLVED_LOCATIONS[route_slot];
+}
+
+@compute @workgroup_size(64, 1, 1)
+fn q4_expert_gate_up_route_parallel_main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let row = gid.x;
+    let route_slot = gid.y;
+    if (row >= pc.d_ff || route_slot >= pc.top_k) {
+        return;
+    }
+    let route = resolved_route_parallel(route_slot);
+    let location = route.location;
+    if (location == UNMAPPED) {
+        OUTPUT[route_slot * pc.d_ff + row] = 0.0;
+        return;
+    }
+    let bank = location >> LOCATION_BANK_SHIFT;
+    let slot = location & LOCATION_SLOT_MASK;
+    let slot_base = slot * pc.slot_stride_bytes;
+    let current_slot_epoch = read_bank_word(bank, slot_base >> 2u);
+    if (current_slot_epoch == 0u || current_slot_epoch != route.slot_epoch) {
+        atomicOr(&STATUS.bits, EXPERT_RESIDENCY_MISS);
+        OUTPUT[route_slot * pc.d_ff + row] = 0.0;
+        return;
+    }
+    let payload_base = slot_base + 4u;
+    let blocks_per_row = pc.d_model / BLOCK_ELEMS;
+    let row_block = row * blocks_per_row;
+    let gate = q4_dot(bank, payload_base, row_block, blocks_per_row, 0u);
+    let up = q4_dot(
+        bank,
+        payload_base,
+        pc.blocks_per_projection + row_block,
+        blocks_per_row,
+        0u,
+    );
+    if (!is_finite(gate) || !is_finite(up)) {
+        atomicOr(&STATUS.bits, EXPERT_NUMERICAL_FAILURE);
+        OUTPUT[route_slot * pc.d_ff + row] = 0.0;
+        return;
+    }
+    let clamped_gate = clamp(gate, -pc.swiglu_limit, pc.swiglu_limit);
+    let activation = (clamped_gate / (1.0 + exp(-clamped_gate))) * up;
+    if (!is_finite(activation)) {
+        atomicOr(&STATUS.bits, EXPERT_NUMERICAL_FAILURE);
+        OUTPUT[route_slot * pc.d_ff + row] = 0.0;
+        return;
+    }
+    OUTPUT[route_slot * pc.d_ff + row] = activation;
+}
+
+@compute @workgroup_size(64, 1, 1)
+fn q4_expert_down_route_parallel_main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let row = gid.x;
+    let route_slot = gid.y;
+    if (row >= pc.d_model || route_slot >= pc.top_k) {
+        return;
+    }
+    let route_output = route_slot * pc.d_model + row;
+    let route = resolved_route_parallel(route_slot);
+    let location = route.location;
+    if (location == UNMAPPED) {
+        OUTPUT[route_output] = 0.0;
+        return;
+    }
+    let bank = location >> LOCATION_BANK_SHIFT;
+    let slot = location & LOCATION_SLOT_MASK;
+    let slot_base = slot * pc.slot_stride_bytes;
+    let current_slot_epoch = read_bank_word(bank, slot_base >> 2u);
+    if (current_slot_epoch == 0u || current_slot_epoch != route.slot_epoch) {
+        atomicOr(&STATUS.bits, EXPERT_RESIDENCY_MISS);
+        OUTPUT[route_output] = 0.0;
+        return;
+    }
+    let payload_base = slot_base + 4u;
+    let blocks_per_row = pc.d_ff / BLOCK_ELEMS;
+    let first_block = 2u * pc.blocks_per_projection + row * blocks_per_row;
+    let value = q4_dot(bank, payload_base, first_block, blocks_per_row, route_slot * pc.d_ff);
+    if (!is_finite(value)) {
+        atomicOr(&STATUS.bits, EXPERT_NUMERICAL_FAILURE);
+        OUTPUT[route_output] = 0.0;
+        return;
+    }
+    OUTPUT[route_output] = value;
+}

--- a/rust-engine/src/gpu_native_physical_install_staging.rs
+++ b/rust-engine/src/gpu_native_physical_install_staging.rs
@@ -2,6 +2,9 @@
 //! staging. Control explicitly forces the legacy Vec writer; treatment uses
 //! the ordinary production demand-install path in a fresh runtime.
 
+#[path = "gpu_native_q4_route_parallel.rs"]
+pub(crate) mod q4_route_parallel;
+
 use crate::backend::gpu_native::GpuNativeProductionPhysicalInstallSnapshot;
 use crate::backend::{GpuExpertIoSnapshot, GpuExpertMemorySnapshot};
 use crate::engine::{

--- a/rust-engine/src/gpu_native_q4_route_parallel.rs
+++ b/rust-engine/src/gpu_native_q4_route_parallel.rs
@@ -1,0 +1,1138 @@
+//! PR2-C qualification-only Q4 route scheduling. No production config knob.
+use super::*;
+use crate::backend::gpu_native::q4_route_parallel::DispatchEvidence;
+use parking_lot::Mutex;
+
+pub(crate) const SCHEMA: &str = "mer.gpu-native-q4-route-parallel.v1";
+pub(crate) const MODE: &str = "qualify-gpu-native-q4-route-parallel";
+const BASE_SHA: &str = "e379ae3a11c9b9b5c4d80a6b02fc3414f9a38fe1";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum Arm {
+    Control,
+    Treatment,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub(crate) struct Mechanism {
+    expert_layer_executions: u64,
+    selected_routes_total: u64,
+    top_k_min: u64,
+    top_k_max: u64,
+    control_serial_gate_up_dispatches: u64,
+    control_serial_down_dispatches: u64,
+    treatment_route_parallel_gate_up_dispatches: u64,
+    treatment_route_parallel_down_dispatches: u64,
+    treatment_route_parallel_routes_covered: u64,
+    treatment_max_route_width: u64,
+    activation_scratch_bytes: u64,
+    route_output_bytes: u64,
+    q4_gate_up_rows_covered: u64,
+    q4_down_rows_covered: u64,
+    expert_validation_dispatches: u64,
+    expert_combine_dispatches: u64,
+    expert_contain_dispatches: u64,
+    unexpected_status_bits: u32,
+    accounting_mismatch: bool,
+}
+
+pub(crate) struct Observation {
+    pub(crate) arm: Arm,
+    evidence: Mutex<Mechanism>,
+}
+impl Observation {
+    fn new(arm: Arm) -> Self {
+        Self {
+            arm,
+            evidence: Mutex::new(Mechanism::default()),
+        }
+    }
+    pub(crate) fn record(&self, d: DispatchEvidence) {
+        let mut m = self.evidence.lock();
+        m.accounting_mismatch |= d.accounting_mismatch;
+        macro_rules! add {
+            ($field:ident, $value:expr) => {
+                match m.$field.checked_add($value) {
+                    Some(value) => m.$field = value,
+                    None => m.accounting_mismatch = true,
+                }
+            };
+        }
+        add!(expert_layer_executions, d.layer_executions);
+        add!(selected_routes_total, d.selected_routes);
+        add!(
+            control_serial_gate_up_dispatches,
+            d.serial_gate_up_dispatches
+        );
+        add!(control_serial_down_dispatches, d.serial_down_dispatches);
+        add!(
+            treatment_route_parallel_gate_up_dispatches,
+            d.parallel_gate_up_dispatches
+        );
+        add!(
+            treatment_route_parallel_down_dispatches,
+            d.parallel_down_dispatches
+        );
+        add!(treatment_route_parallel_routes_covered, d.routes_covered);
+        add!(q4_gate_up_rows_covered, d.gate_up_rows);
+        add!(q4_down_rows_covered, d.down_rows);
+        add!(expert_validation_dispatches, d.validation_dispatches);
+        add!(expert_combine_dispatches, d.combine_dispatches);
+        add!(expert_contain_dispatches, d.contain_dispatches);
+        m.top_k_min = if m.top_k_min == 0 {
+            d.top_k
+        } else {
+            m.top_k_min.min(d.top_k)
+        };
+        m.top_k_max = m.top_k_max.max(d.top_k);
+        m.treatment_max_route_width = m.treatment_max_route_width.max(d.max_route_width);
+        if m.activation_scratch_bytes != 0 && m.activation_scratch_bytes != d.activation_bytes
+            || m.route_output_bytes != 0 && m.route_output_bytes != d.route_output_bytes
+        {
+            m.accounting_mismatch = true;
+        }
+        m.activation_scratch_bytes = d.activation_bytes;
+        m.route_output_bytes = d.route_output_bytes;
+    }
+    pub(crate) fn record_status(&self, statuses: &[u32], final_status: u32) {
+        self.evidence.lock().unexpected_status_bits |=
+            statuses.iter().fold(final_status, |a, b| a | b) & !4;
+    }
+    fn take(&self) -> Mechanism {
+        std::mem::take(&mut *self.evidence.lock())
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct Q4ArmReport {
+    q4_arm: Arm,
+    common: ArmReport,
+    warmup_mechanism: Mechanism,
+    mechanism: Mechanism,
+    final_ram_cache_state_sha256: Option<String>,
+    warmup_baseline_physical_install_observer:
+        Option<crate::engine::GpuNativePhysicalInstallConcurrencyQualificationSnapshot>,
+    baseline_physical_install_observer:
+        Option<crate::engine::GpuNativePhysicalInstallConcurrencyQualificationSnapshot>,
+}
+
+fn q4_source_snapshot(
+    source: &crate::engine::GpuNativePhysicalInstallConcurrencyQualificationSnapshot,
+) -> GpuNativePhysicalInstallStagingQualificationSnapshot {
+    let mut snapshot = concurrency_common_snapshot(source);
+    snapshot.production_physical_install_changed = false;
+    snapshot
+}
+
+async fn run_q4_arm(
+    prepared: &Prepared,
+    args: &CommandArgs,
+    q4_arm: Arm,
+) -> Result<Q4ArmReport, BenchmarkFailure> {
+    // Both PR2-C arms use the ordinary production source and physical-install
+    // path. This existing treatment observer changes only qualification tracing.
+    let (arm_name, arm) = match q4_arm {
+        Arm::Control => (
+            "control",
+            GpuNativePhysicalInstallStagingQualificationArm::Control,
+        ),
+        Arm::Treatment => (
+            "treatment",
+            GpuNativePhysicalInstallStagingQualificationArm::Treatment,
+        ),
+    };
+    let mode_name = MODE;
+    let observation = Arc::new(Observation::new(q4_arm));
+    let mut benchmark = benchmark_report(prepared);
+    let runtime = crate::gpu_native_real_benchmark::construct_runtime(
+        &prepared.spec,
+        prepared.tokenizer.clone(),
+        arm_name,
+        None,
+        &mut benchmark,
+    )
+    .await?;
+    let enable_result = runtime
+        .engine
+        .enable_gpu_native_physical_install_concurrency_qualification(
+            crate::engine::GpuNativePhysicalInstallConcurrencyQualificationArm::Treatment,
+        );
+    let enable_result = enable_result.and_then(|()| {
+        runtime
+            .gpu_native_token_loop
+            .as_ref()
+            .ok_or_else(|| "missing GPU-native token loop".to_string())?
+            .enable_q4_route_parallel_qualification(observation.clone())
+    });
+    if let Err(error) = enable_result {
+        let failure = BenchmarkFailure::new("startup", "qualification-arm-enable-failed", error);
+        let _ = crate::gpu_native_real_benchmark::shutdown_runtime(
+            runtime,
+            arm_name,
+            None,
+            &mut benchmark,
+        )
+        .await;
+        return Err(failure);
+    }
+    if let Err(validation_error) = crate::gpu_native_real_benchmark::validate_and_record_runtime(
+        &runtime,
+        &prepared.resolved_config_sha256,
+        &args.expected_adapter_name,
+        &mut benchmark,
+    ) {
+        let shutdown = crate::gpu_native_real_benchmark::shutdown_runtime(
+            runtime,
+            arm_name,
+            None,
+            &mut benchmark,
+        )
+        .await;
+        return match shutdown {
+            Ok(()) => Err(validation_error),
+            Err(shutdown_error) => Err(BenchmarkFailure::new(
+                "postcondition",
+                "runtime-validation-and-shutdown-failed",
+                format!("{validation_error}; {shutdown_error}"),
+            )),
+        };
+    }
+
+    let mut warmup_results = Vec::with_capacity(FROZEN_WARMUP_RUNS);
+    let mut execution_failure = None;
+    let mut warmup_start = match ArmStart::capture(&runtime) {
+        Ok(captured) => Some(captured),
+        Err(error) => {
+            execution_failure = Some(error);
+            None
+        }
+    };
+    if execution_failure.is_none() {
+        for index in 0..FROZEN_WARMUP_RUNS {
+            let result = crate::with_progress_timeout(
+                format!("{mode_name} {arm_name} warmup {index}"),
+                args.progress_watchdog,
+                crate::gpu_native_real_benchmark::execute_request(
+                    &runtime,
+                    &prepared.prompt_ids,
+                    FROZEN_OUTPUT_TOKENS,
+                    index,
+                ),
+            )
+            .await;
+            match result {
+                Ok(run) => {
+                    warmup_results.push(WarmupEvidence {
+                        run_index: index,
+                        generated_tokens: run.generated_tokens,
+                        generated_token_ids_sha256: run.generated_token_ids_sha256,
+                        generated_text_sha256: run.generated_text_sha256,
+                    });
+                    benchmark.warmup_runs_completed += 1;
+                }
+                Err(error) => {
+                    execution_failure = Some(BenchmarkFailure::new(
+                        "inference",
+                        "warmup-request-failed",
+                        error.to_string(),
+                    ));
+                    break;
+                }
+            }
+        }
+    }
+
+    let mut warmup_source = None;
+    let mut warmup_concurrency = None;
+    let mut warmup_production_physical_install = None;
+    let mut warmup_production = None;
+    let mut warmup_ram_cache_state_sha256 = None;
+    let mut warmup_work = None;
+    if execution_failure.is_none() {
+        warmup_concurrency = runtime
+            .engine
+            .gpu_native_physical_install_concurrency_qualification_snapshot();
+        warmup_source = warmup_concurrency.as_ref().map(q4_source_snapshot);
+        if warmup_source.is_none() {
+            execution_failure = Some(BenchmarkFailure::new(
+                "postcondition",
+                "missing-warmup-source-snapshot",
+                "PR2-C qualification source counters disappeared after warmup",
+            ));
+        }
+    }
+    if execution_failure.is_none() {
+        warmup_production = Some(runtime.engine.production_demand_source_snapshot());
+    }
+    if execution_failure.is_none() {
+        warmup_production_physical_install = runtime.engine.production_physical_install_snapshot();
+        if warmup_production_physical_install.is_none() {
+            execution_failure = Some(BenchmarkFailure::new(
+                "postcondition",
+                "missing-warmup-production-physical-install-snapshot",
+                "PR2-C production physical-install counters disappeared after warmup",
+            ));
+        }
+    }
+    if execution_failure.is_none() {
+        warmup_ram_cache_state_sha256 = runtime
+            .engine
+            .gpu_native_demand_source_qualification_ram_cache_state_sha256();
+        if warmup_ram_cache_state_sha256.is_none() {
+            execution_failure = Some(BenchmarkFailure::new(
+                "postcondition",
+                "missing-warmup-ram-cache-state",
+                "PR2-C RAM-cache state could not be hashed before the warmup counter reset",
+            ));
+        }
+    }
+    if execution_failure.is_none() {
+        match warmup_start
+            .take()
+            .expect("warmup start captured")
+            .finish(&runtime)
+        {
+            Ok(work) => warmup_work = Some(work),
+            Err(error) => execution_failure = Some(error),
+        }
+    }
+
+    let warmup_mechanism = observation.take();
+    let mut start = None;
+    if execution_failure.is_none() {
+        if let Err(error) = runtime
+            .engine
+            .reset_gpu_native_demand_source_qualification()
+        {
+            execution_failure = Some(BenchmarkFailure::new(
+                "postcondition",
+                "qualification-counter-reset-failed",
+                error,
+            ));
+        } else {
+            match ArmStart::capture(&runtime) {
+                Ok(captured) => start = Some(captured),
+                Err(error) => execution_failure = Some(error),
+            }
+        }
+    }
+
+    if execution_failure.is_none() {
+        for index in 0..FROZEN_MEASURED_RUNS {
+            let result = crate::with_progress_timeout(
+                format!("{mode_name} {arm_name} measured {index}"),
+                args.progress_watchdog,
+                crate::gpu_native_real_benchmark::execute_request(
+                    &runtime,
+                    &prepared.prompt_ids,
+                    FROZEN_OUTPUT_TOKENS,
+                    index,
+                ),
+            )
+            .await;
+            match result {
+                Ok(run) => benchmark.per_run_results.push(run),
+                Err(error) => {
+                    execution_failure = Some(BenchmarkFailure::new(
+                        "inference",
+                        "measured-request-failed",
+                        error.to_string(),
+                    ));
+                    break;
+                }
+            }
+        }
+    }
+
+    let concurrency = runtime
+        .engine
+        .gpu_native_physical_install_concurrency_qualification_snapshot();
+    let source = concurrency.as_ref().map(q4_source_snapshot);
+    let production_physical_install = runtime.engine.production_physical_install_snapshot();
+    if execution_failure.is_none() && production_physical_install.is_none() {
+        execution_failure = Some(BenchmarkFailure::new(
+            "postcondition",
+            "missing-production-physical-install-snapshot",
+            "PR2-C production physical-install counters disappeared after measurement",
+        ));
+    }
+    let production = Some(runtime.engine.production_demand_source_snapshot());
+    let work = if execution_failure.is_none() {
+        match start.expect("measurement start captured").finish(&runtime) {
+            Ok(work) => Some(work),
+            Err(error) => {
+                execution_failure = Some(error);
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    let mechanism = observation.take();
+    let final_ram_cache_state_sha256 = runtime
+        .engine
+        .gpu_native_demand_source_qualification_ram_cache_state_sha256();
+    if final_ram_cache_state_sha256.is_none() && execution_failure.is_none() {
+        execution_failure = Some(BenchmarkFailure::new(
+            "postcondition",
+            "missing-final-cache-state",
+            "PR2-C requires final RAM cache identity",
+        ));
+    }
+    let shutdown =
+        crate::gpu_native_real_benchmark::shutdown_runtime(runtime, arm_name, None, &mut benchmark)
+            .await;
+    if let Err(error) = shutdown {
+        execution_failure = Some(match execution_failure {
+            Some(previous) => BenchmarkFailure::new(
+                "postcondition",
+                "execution-and-shutdown-failed",
+                format!("{previous}; {error}"),
+            ),
+            None => error,
+        });
+    }
+
+    if execution_failure.is_none() {
+        if let Err(error) = benchmark.finish() {
+            execution_failure = Some(error);
+        }
+    }
+    if let Some(failure) = execution_failure.clone() {
+        benchmark.fail(failure.clone());
+    }
+    Ok(Q4ArmReport {
+        q4_arm,
+        warmup_mechanism,
+        mechanism,
+        final_ram_cache_state_sha256,
+        common: ArmReport {
+            arm,
+            complete: execution_failure.is_none(),
+            failure: execution_failure,
+            isolated_runtime: true,
+            warmup_results,
+            warmup_source,
+            warmup_production_physical_install,
+            warmup_production,
+            warmup_ram_cache_state_sha256,
+            warmup_work,
+            source,
+            production_physical_install,
+            production,
+            work,
+            benchmark,
+        },
+        warmup_baseline_physical_install_observer: warmup_concurrency,
+        baseline_physical_install_observer: concurrency,
+    })
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct Contract {
+    qualification_only: bool,
+    production_q4_route_parallel_changed: bool,
+    control_uses_ordinary_serial_production_path: bool,
+    treatment_uses_route_parallel_qualification_path: bool,
+    source_acquisition_changed: bool,
+    ram_cache_policy_changed: bool,
+    physical_residency_changed: bool,
+    victim_policy_changed: bool,
+    mapping_semantics_changed: bool,
+    expert_q4_arithmetic_changed: bool,
+    expert_combine_order_changed: bool,
+    expert_failure_semantics_changed: bool,
+    queue_submission_contract_changed: bool,
+    wgpu_version_changed: bool,
+}
+impl Default for Contract {
+    fn default() -> Self {
+        Self {
+            qualification_only: true,
+            production_q4_route_parallel_changed: false,
+            control_uses_ordinary_serial_production_path: true,
+            treatment_uses_route_parallel_qualification_path: true,
+            source_acquisition_changed: false,
+            ram_cache_policy_changed: false,
+            physical_residency_changed: false,
+            victim_policy_changed: false,
+            mapping_semantics_changed: false,
+            expert_q4_arithmetic_changed: false,
+            expert_combine_order_changed: false,
+            expert_failure_semantics_changed: false,
+            queue_submission_contract_changed: false,
+            wgpu_version_changed: false,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+struct MechanismGate {
+    ordinary_serial_production_path_exercised: bool,
+    qualification_route_parallel_path_exercised: bool,
+    control_dispatch_accounting_exact: bool,
+    treatment_dispatch_accounting_exact: bool,
+    treatment_route_width_gt_one: bool,
+    expert_layer_execution_count_exact: bool,
+    selected_route_count_exact: bool,
+    gate_up_row_coverage_exact: bool,
+    down_row_coverage_exact: bool,
+    route_output_logical_shape_exact: bool,
+    validation_dispatch_count_exact: bool,
+    combine_dispatch_count_exact: bool,
+    contain_dispatch_count_exact: bool,
+    activation_scratch_geometry_exact: bool,
+    unexpected_status_bits_zero: bool,
+    mechanism_accounting_mismatch_zero: bool,
+    passed: bool,
+}
+
+fn mechanism_gate(c: &Mechanism, t: &Mechanism, d_model: u64, d_ff: u64, k: u64) -> MechanismGate {
+    let expected = c.expert_layer_executions.checked_mul(k);
+    let gate_rows = expected.and_then(|v| v.checked_mul(d_ff));
+    let down_rows = expected.and_then(|v| v.checked_mul(d_model));
+    let serial = c.expert_layer_executions > 0
+        && expected == Some(c.selected_routes_total)
+        && expected == Some(c.control_serial_gate_up_dispatches)
+        && expected == Some(c.control_serial_down_dispatches)
+        && c.treatment_route_parallel_gate_up_dispatches == 0
+        && c.treatment_route_parallel_down_dispatches == 0
+        && c.treatment_route_parallel_routes_covered == 0
+        && c.treatment_max_route_width == 0;
+    let parallel = t.expert_layer_executions > 0
+        && t.control_serial_gate_up_dispatches == 0
+        && t.control_serial_down_dispatches == 0
+        && t.treatment_route_parallel_gate_up_dispatches == t.expert_layer_executions
+        && t.treatment_route_parallel_down_dispatches == t.expert_layer_executions
+        && expected == Some(t.treatment_route_parallel_routes_covered)
+        && t.treatment_max_route_width == k;
+    let mut gate = MechanismGate {
+        ordinary_serial_production_path_exercised: serial,
+        qualification_route_parallel_path_exercised: parallel,
+        control_dispatch_accounting_exact: serial,
+        treatment_dispatch_accounting_exact: parallel,
+        treatment_route_width_gt_one: t.treatment_max_route_width >= 2,
+        expert_layer_execution_count_exact: c.expert_layer_executions == t.expert_layer_executions,
+        selected_route_count_exact: c.selected_routes_total == t.selected_routes_total
+            && c.top_k_min == k
+            && c.top_k_max == k
+            && t.top_k_min == k
+            && t.top_k_max == k,
+        gate_up_row_coverage_exact: gate_rows == Some(c.q4_gate_up_rows_covered)
+            && gate_rows == Some(t.q4_gate_up_rows_covered),
+        down_row_coverage_exact: down_rows == Some(c.q4_down_rows_covered)
+            && down_rows == Some(t.q4_down_rows_covered),
+        route_output_logical_shape_exact: k.checked_mul(d_model).and_then(|v| v.checked_mul(4))
+            == Some(c.route_output_bytes)
+            && c.route_output_bytes == t.route_output_bytes,
+        validation_dispatch_count_exact: c.expert_validation_dispatches
+            == c.expert_layer_executions
+            && t.expert_validation_dispatches == c.expert_validation_dispatches,
+        combine_dispatch_count_exact: c.expert_combine_dispatches == c.expert_layer_executions
+            && t.expert_combine_dispatches == c.expert_combine_dispatches,
+        contain_dispatch_count_exact: c.expert_contain_dispatches == c.expert_layer_executions
+            && t.expert_contain_dispatches == c.expert_contain_dispatches,
+        activation_scratch_geometry_exact: d_ff.checked_mul(4) == Some(c.activation_scratch_bytes)
+            && k.checked_mul(d_ff).and_then(|v| v.checked_mul(4))
+                == Some(t.activation_scratch_bytes),
+        unexpected_status_bits_zero: c.unexpected_status_bits == 0 && t.unexpected_status_bits == 0,
+        mechanism_accounting_mismatch_zero: !c.accounting_mismatch && !t.accounting_mismatch,
+        passed: false,
+    };
+    gate.passed = gate.ordinary_serial_production_path_exercised
+        && gate.qualification_route_parallel_path_exercised
+        && gate.control_dispatch_accounting_exact
+        && gate.treatment_dispatch_accounting_exact
+        && gate.treatment_route_width_gt_one
+        && gate.expert_layer_execution_count_exact
+        && gate.selected_route_count_exact
+        && gate.gate_up_row_coverage_exact
+        && gate.down_row_coverage_exact
+        && gate.route_output_logical_shape_exact
+        && gate.validation_dispatch_count_exact
+        && gate.combine_dispatch_count_exact
+        && gate.contain_dispatch_count_exact
+        && gate.activation_scratch_geometry_exact
+        && gate.unexpected_status_bits_zero
+        && gate.mechanism_accounting_mismatch_zero;
+    gate
+}
+
+// Only these already-defined wall-time fields are excluded from exact work
+// comparison. Every other field, including any future counter, must match.
+const CONTEXT_TIMINGS: &[&str] = &[
+    "physical_probe_us",
+    "ssd_stall_us",
+    "residency_service_us",
+    "boundary_wait_us",
+    "source_acquisition_wall_us",
+    "logical_demand_admission_us",
+    "physical_demand_install_us",
+    "total_residency_service_us",
+    "physical_slot_prepare_us",
+    "physical_queue_staging_us",
+    "mapping_publication_us",
+    "physical_install_total_us",
+];
+fn work_projection(mut value: serde_json::Value) -> serde_json::Value {
+    fn visit(v: &mut serde_json::Value) {
+        match v {
+            serde_json::Value::Object(fields) => {
+                fields.retain(|key, _| !CONTEXT_TIMINGS.contains(&key.as_str()));
+                for v in fields.values_mut() {
+                    visit(v);
+                }
+            }
+            serde_json::Value::Array(items) => {
+                for v in items {
+                    visit(v);
+                }
+            }
+            _ => {}
+        }
+    }
+    visit(&mut value);
+    value
+}
+fn exact_work<T: Serialize>(c: &T, t: &T) -> bool {
+    match (serde_json::to_value(c), serde_json::to_value(t)) {
+        (Ok(c), Ok(t)) => !c.is_null() && !t.is_null() && work_projection(c) == work_projection(t),
+        _ => false,
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct Q4Reconciliation {
+    production_and_work: ProductionReconciliation,
+    warmup_all_source_counters_and_order_exact: bool,
+    measured_all_source_counters_and_order_exact: bool,
+    warmup_all_residency_recovery_and_boundary_work_exact: bool,
+    measured_all_residency_recovery_and_boundary_work_exact: bool,
+    generated_token_ids_exact: bool,
+    generated_text_hashes_exact: bool,
+    warmup_generated_text_hashes_exact: bool,
+    final_ram_cache_state_exact: bool,
+    all_invariants_pass: bool,
+}
+
+fn reconcile_q4(c: &Q4ArmReport, t: &Q4ArmReport) -> Q4Reconciliation {
+    let production_and_work =
+        production_reconciliation(reconcile(&c.common, &t.common), &c.common, &t.common);
+    let generated_token_ids_exact = generated_results(&c.common)
+        .iter()
+        .map(|r| &r.generated_token_ids)
+        .eq(generated_results(&t.common)
+            .iter()
+            .map(|r| &r.generated_token_ids));
+    let generated_text_hashes_exact = generated_results(&c.common)
+        .iter()
+        .map(|r| &r.generated_text_sha256)
+        .eq(generated_results(&t.common)
+            .iter()
+            .map(|r| &r.generated_text_sha256));
+    let warmup_generated_text_hashes_exact = c
+        .common
+        .warmup_results
+        .iter()
+        .map(|r| &r.generated_text_sha256)
+        .eq(t
+            .common
+            .warmup_results
+            .iter()
+            .map(|r| &r.generated_text_sha256));
+    let mut r = Q4Reconciliation {
+        production_and_work,
+        warmup_all_source_counters_and_order_exact: exact_work(
+            &c.common.warmup_source,
+            &t.common.warmup_source,
+        ),
+        measured_all_source_counters_and_order_exact: exact_work(
+            &c.common.source,
+            &t.common.source,
+        ),
+        warmup_all_residency_recovery_and_boundary_work_exact: exact_work(
+            &c.common.warmup_work,
+            &t.common.warmup_work,
+        ),
+        measured_all_residency_recovery_and_boundary_work_exact: exact_work(
+            &c.common.work,
+            &t.common.work,
+        ),
+        generated_token_ids_exact,
+        generated_text_hashes_exact,
+        warmup_generated_text_hashes_exact,
+        final_ram_cache_state_exact: c.final_ram_cache_state_sha256.is_some()
+            && c.final_ram_cache_state_sha256 == t.final_ram_cache_state_sha256,
+        all_invariants_pass: false,
+    };
+    r.all_invariants_pass = r.production_and_work.all_invariants_pass
+        && r.warmup_all_source_counters_and_order_exact
+        && r.measured_all_source_counters_and_order_exact
+        && r.warmup_all_residency_recovery_and_boundary_work_exact
+        && r.measured_all_residency_recovery_and_boundary_work_exact
+        && r.generated_token_ids_exact
+        && r.generated_text_hashes_exact
+        && r.warmup_generated_text_hashes_exact
+        && r.final_ram_cache_state_exact;
+    r
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct Gates {
+    behavioral: BehavioralGate,
+    work_equivalence: WorkEquivalenceGate,
+    warmup_mechanism: MechanismGate,
+    measured_mechanism: MechanismGate,
+    selected_route_weights_equality_supported_by_existing_boundary: bool,
+    selected_route_weights_contract: &'static str,
+    all_invariants_pass: bool,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct Performance {
+    measurements: ProductionPerformanceComparison,
+    control_ttft_seconds: f64,
+    treatment_ttft_seconds: f64,
+    control_activation_scratch_bytes: u64,
+    treatment_activation_scratch_bytes: u64,
+    control_route_compute_dispatches_per_expert_layer: f64,
+    treatment_route_compute_dispatches_per_expert_layer: f64,
+    route_compute_dispatch_reduction_percent: f64,
+    structural_metric_name: &'static str,
+    classification_metric: &'static str,
+    timing_claim: &'static str,
+}
+fn classify_performance(control_decode: f64, treatment_decode: f64) -> &'static str {
+    if treatment_decode > control_decode {
+        "improved"
+    } else if treatment_decode < control_decode {
+        "regressed"
+    } else {
+        "neutral"
+    }
+}
+fn performance_q4(c: &Q4ArmReport, t: &Q4ArmReport) -> Result<Performance, BenchmarkFailure> {
+    let mut measurements = production_performance(&c.common, &t.common)?;
+    measurements.performance_result = classify_performance(
+        measurements.control.decode_tps,
+        measurements.treatment.decode_tps,
+    );
+    let dispatches = |m: &Mechanism| {
+        (m.control_serial_gate_up_dispatches
+            + m.control_serial_down_dispatches
+            + m.treatment_route_parallel_gate_up_dispatches
+            + m.treatment_route_parallel_down_dispatches) as f64
+            / m.expert_layer_executions as f64
+    };
+    let control = dispatches(&c.mechanism);
+    let treatment = dispatches(&t.mechanism);
+    let ttft = |a: &ArmReport| {
+        generated_results(a)
+            .iter()
+            .map(|r| r.timing.time_to_first_token_seconds)
+            .sum::<f64>()
+            / generated_results(a).len() as f64
+    };
+    Ok(Performance {
+        measurements, control_ttft_seconds: ttft(&c.common), treatment_ttft_seconds: ttft(&t.common),
+        control_activation_scratch_bytes: c.mechanism.activation_scratch_bytes,
+        treatment_activation_scratch_bytes: t.mechanism.activation_scratch_bytes,
+        control_route_compute_dispatches_per_expert_layer: control,
+        treatment_route_compute_dispatches_per_expert_layer: treatment,
+        route_compute_dispatch_reduction_percent: if control > 0.0 { (control - treatment) / control * 100.0 } else { 0.0 },
+        structural_metric_name: "ROUTE-COMPUTE DISPATCH REDUCTION",
+        classification_metric: "measured mean decode TPS; formal gates are independent of performance",
+        timing_claim: "2D dispatch exposes routes to GPU scheduling; dispatch counts do not measure simultaneous execution or GPU kernel time",
+    })
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct Report {
+    schema: &'static str,
+    mode: &'static str,
+    base_sha: &'static str,
+    #[serde(flatten)]
+    contract: Contract,
+    frozen_workload: FrozenWorkload,
+    d_model: usize,
+    d_ff: usize,
+    layers: usize,
+    experts_per_layer: usize,
+    top_k: usize,
+    replacement: &'static str,
+    dispatch_accounting_definition: &'static str,
+    baseline_observer_contract: &'static str,
+    benchmark_complete: bool,
+    qualification_pass: bool,
+    performance_result: &'static str,
+    failure: Option<BenchmarkFailure>,
+    provenance: Option<BenchmarkProvenance>,
+    control: Option<Q4ArmReport>,
+    treatment: Option<Q4ArmReport>,
+    reconciliation: Option<Q4Reconciliation>,
+    gates: Option<Gates>,
+    performance: Option<Performance>,
+}
+impl Report {
+    fn pending(adapter: String) -> Self {
+        Self {
+            schema: SCHEMA, mode: MODE, base_sha: BASE_SHA, contract: Contract::default(),
+            frozen_workload: frozen_workload(adapter), d_model: 2048, d_ff: 768, layers: 48,
+            experts_per_layer: 128, top_k: 8, replacement: "physical-lru-prediction-protected",
+            baseline_observer_contract: "both PR2-C arms enable the existing PR2-B-B treatment observer and use ordinary source/install behavior; nested baseline observer production-change flags describe PR2-B versus its historical baseline, not changes made by PR2-C",
+            dispatch_accounting_definition: "host-encoded expert layer executions, including invalid tails and recovery segments; selected_routes_total counts encoded route lanes; accepted selected-route counts and ordered IDs are independently recorded by the existing boundary contract",
+            benchmark_complete: false, qualification_pass: false, performance_result: "not_measured",
+            failure: None, provenance: None, control: None, treatment: None,
+            reconciliation: None, gates: None, performance: None,
+        }
+    }
+}
+fn write_report(report: &Report, path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)?;
+    use std::io::Write;
+    file.write_all(serde_json::to_string_pretty(report)?.as_bytes())?;
+    file.write_all(b"\n")?;
+    Ok(())
+}
+
+pub(crate) async fn run_command(args: CommandArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let mut report = Report::pending(args.expected_adapter_name.clone());
+    let result = run_qualification(&args, &mut report).await;
+    if let Err(error) = &result {
+        report.qualification_pass = false;
+        if report.failure.is_none() {
+            report.failure = Some(BenchmarkFailure::new(
+                "qualification",
+                "pr2c-failed",
+                error.to_string(),
+            ));
+        }
+    }
+    write_report(&report, &args.report_out)?;
+    result
+}
+async fn run_qualification(
+    args: &CommandArgs,
+    report: &mut Report,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if args.report_out.exists() {
+        return Err("PR2-C requires a new report path".into());
+    }
+    if args.expected_adapter_name != "NVIDIA L4" {
+        return Err("frozen PR2-C adapter must be NVIDIA L4".into());
+    }
+    let prepared = prepare(args)?;
+    report.provenance = Some(prepared.provenance.clone());
+    for arm in [Arm::Control, Arm::Treatment] {
+        let result = run_q4_arm(&prepared, args, arm).await?;
+        let failure = result.common.failure.clone();
+        match arm {
+            Arm::Control => report.control = Some(result),
+            Arm::Treatment => report.treatment = Some(result),
+        }
+        if let Some(failure) = failure {
+            report.failure = Some(failure.clone());
+            return Err(failure.into());
+        }
+    }
+    let c = report.control.as_ref().expect("control stored");
+    let t = report.treatment.as_ref().expect("treatment stored");
+    let reconciliation = reconcile_q4(c, t);
+    let (mut behavioral, mut work_equivalence) =
+        common_gates(&reconciliation.production_and_work.common);
+    behavioral.passed &= reconciliation.generated_token_ids_exact
+        && reconciliation.generated_text_hashes_exact
+        && reconciliation.warmup_generated_text_hashes_exact;
+    work_equivalence.passed &= reconciliation.all_invariants_pass;
+    let warmup_mechanism = mechanism_gate(&c.warmup_mechanism, &t.warmup_mechanism, 2048, 768, 8);
+    let measured_mechanism = mechanism_gate(&c.mechanism, &t.mechanism, 2048, 768, 8);
+    let all_invariants_pass = reconciliation.all_invariants_pass
+        && behavioral.passed
+        && work_equivalence.passed
+        && warmup_mechanism.passed
+        && measured_mechanism.passed;
+    // Performance is calculated and reported even when formal parity fails.
+    let performance = performance_q4(c, t)?;
+    report.performance_result = performance.measurements.performance_result;
+    report.benchmark_complete = c.common.complete && t.common.complete;
+    report.qualification_pass = report.benchmark_complete && all_invariants_pass;
+    report.reconciliation = Some(reconciliation);
+    report.gates = Some(Gates {
+        behavioral, work_equivalence, warmup_mechanism, measured_mechanism,
+        selected_route_weights_equality_supported_by_existing_boundary: false,
+        selected_route_weights_contract: "existing ordinary boundary exposes ordered selected IDs, not f32 selected weights; no additional readback is introduced; focused same-device tests compare route and combined f32 bits",
+        all_invariants_pass,
+    });
+    report.performance = Some(performance);
+    if !report.qualification_pass {
+        return Err(BenchmarkFailure::new(
+            "postcondition",
+            "formal-gate-failed",
+            "PR2-C correctness, work or mechanism reconciliation failed",
+        )
+        .into());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn evidence(arm: Arm, k: u64) -> DispatchEvidence {
+        DispatchEvidence {
+            layer_executions: 1,
+            accounting_mismatch: false,
+            selected_routes: k,
+            top_k: k,
+            serial_gate_up_dispatches: if arm == Arm::Control { k } else { 0 },
+            serial_down_dispatches: if arm == Arm::Control { k } else { 0 },
+            parallel_gate_up_dispatches: u64::from(arm == Arm::Treatment),
+            parallel_down_dispatches: u64::from(arm == Arm::Treatment),
+            routes_covered: if arm == Arm::Treatment { k } else { 0 },
+            max_route_width: if arm == Arm::Treatment { k } else { 0 },
+            activation_bytes: 768 * 4 * if arm == Arm::Treatment { k } else { 1 },
+            route_output_bytes: k * 2048 * 4,
+            gate_up_rows: k * 768,
+            down_rows: k * 2048,
+            validation_dispatches: 1,
+            combine_dispatches: 1,
+            contain_dispatches: 1,
+        }
+    }
+    fn pair(k: u64) -> (Mechanism, Mechanism) {
+        let c = Observation::new(Arm::Control);
+        let t = Observation::new(Arm::Treatment);
+        for _ in 0..3 {
+            c.record(evidence(Arm::Control, k));
+            t.record(evidence(Arm::Treatment, k));
+        }
+        (c.take(), t.take())
+    }
+    #[test]
+    fn q4_route_parallel_accounting_reconciles_control_and_treatment() {
+        for k in 2..=8 {
+            let (c, t) = pair(k);
+            assert!(mechanism_gate(&c, &t, 2048, 768, k).passed);
+            assert_eq!(
+                c.control_serial_gate_up_dispatches + c.control_serial_down_dispatches,
+                6 * k
+            );
+            assert_eq!(
+                t.treatment_route_parallel_gate_up_dispatches
+                    + t.treatment_route_parallel_down_dispatches,
+                6
+            );
+        }
+    }
+    #[test]
+    fn q4_route_parallel_width_one_is_valid_math_but_not_mechanism_pass() {
+        let (c, t) = pair(1);
+        let g = mechanism_gate(&c, &t, 2048, 768, 1);
+        assert!(g.control_dispatch_accounting_exact && g.treatment_dispatch_accounting_exact);
+        assert!(!g.treatment_route_width_gt_one && !g.passed);
+    }
+    #[test]
+    fn q4_route_parallel_mechanism_rejects_serial_fallback_and_empty_work() {
+        let (c, mut t) = pair(8);
+        t.control_serial_gate_up_dispatches = 24;
+        t.control_serial_down_dispatches = 24;
+        t.treatment_route_parallel_gate_up_dispatches = 0;
+        t.treatment_route_parallel_down_dispatches = 0;
+        assert!(!mechanism_gate(&c, &t, 2048, 768, 8).passed);
+        assert!(!mechanism_gate(&Mechanism::default(), &Mechanism::default(), 2048, 768, 8).passed);
+    }
+    #[test]
+    fn q4_route_parallel_mechanism_rejects_each_accounting_difference() {
+        let (c, t) = pair(8);
+        macro_rules! corrupt { ($($f:ident),+) => { $(let mut bad = t.clone(); bad.$f += 1; assert!(!mechanism_gate(&c, &bad, 2048, 768, 8).passed, stringify!($f));)+ }; }
+        corrupt!(
+            expert_layer_executions,
+            selected_routes_total,
+            top_k_min,
+            top_k_max,
+            control_serial_gate_up_dispatches,
+            control_serial_down_dispatches,
+            treatment_route_parallel_gate_up_dispatches,
+            treatment_route_parallel_down_dispatches,
+            treatment_route_parallel_routes_covered,
+            treatment_max_route_width,
+            activation_scratch_bytes,
+            route_output_bytes,
+            q4_gate_up_rows_covered,
+            q4_down_rows_covered,
+            expert_validation_dispatches,
+            expert_combine_dispatches,
+            expert_contain_dispatches,
+            unexpected_status_bits
+        );
+    }
+    #[test]
+    fn q4_route_parallel_observation_reset_overflow_and_status_fail_closed() {
+        let o = Observation::new(Arm::Treatment);
+        o.record(evidence(Arm::Treatment, 8));
+        o.record_status(&[0, 4, 4], 4);
+        assert_eq!(o.take().unexpected_status_bits, 0);
+        assert_eq!(o.take().expert_layer_executions, 0);
+        o.record_status(&[4, 8, 1 << 20], 0);
+        assert_ne!(o.take().unexpected_status_bits, 0);
+        let mut e = evidence(Arm::Treatment, 8);
+        e.layer_executions = u64::MAX;
+        o.record(e);
+        o.record(evidence(Arm::Treatment, 8));
+        assert!(o.take().accounting_mismatch);
+    }
+    #[test]
+    fn q4_route_parallel_work_gate_rejects_every_non_timing_field_and_absent_evidence() {
+        let fields = [
+            "demand_source_requests",
+            "source_ram_hits",
+            "source_ram_misses",
+            "source_nvme_reads",
+            "source_nvme_bytes",
+            "ram_cache_inserts",
+            "ram_cache_evictions",
+            "logical_admissions",
+            "ram_to_vram_installs",
+            "expert_weight_upload_bytes",
+            "physical_install_completions",
+            "physical_evictions",
+            "physical_victim_ids_sha256",
+            "physical_residency_identity_sha256",
+            "mapping_publications",
+            "mapping_unpublications",
+            "physical_reinstalls",
+            "residency_miss_attempts",
+            "residency_services",
+            "recovery_segments",
+            "queue_submissions",
+            "boundary_maps",
+            "boundary_readbacks",
+            "speculative_requests",
+            "demand_ram_insert_ids_sha256",
+            "demand_ram_eviction_ids_sha256",
+            "future_counter",
+        ];
+        let mut c = serde_json::json!({"source_acquisition_wall_us":1});
+        for key in fields {
+            c[key] = 1.into();
+        }
+        let mut timing = c.clone();
+        for key in CONTEXT_TIMINGS {
+            timing[*key] = 123.into();
+        }
+        assert!(exact_work(&c, &timing));
+        for key in fields {
+            let mut t = c.clone();
+            t[key] = 2.into();
+            assert!(!exact_work(&c, &t), "{key}");
+        }
+        assert!(!exact_work(&Option::<u64>::None, &None));
+    }
+    #[test]
+    fn q4_route_parallel_contract_is_explicit_and_performance_independent() {
+        let report = Report::pending("NVIDIA L4".into());
+        let json = serde_json::to_value(report).unwrap();
+        for field in [
+            "qualification_only",
+            "control_uses_ordinary_serial_production_path",
+            "treatment_uses_route_parallel_qualification_path",
+        ] {
+            assert_eq!(json[field], true);
+        }
+        for field in [
+            "production_q4_route_parallel_changed",
+            "source_acquisition_changed",
+            "ram_cache_policy_changed",
+            "physical_residency_changed",
+            "victim_policy_changed",
+            "mapping_semantics_changed",
+            "expert_q4_arithmetic_changed",
+            "expert_combine_order_changed",
+            "expert_failure_semantics_changed",
+            "queue_submission_contract_changed",
+            "wgpu_version_changed",
+            "benchmark_complete",
+            "qualification_pass",
+        ] {
+            assert_eq!(json[field], false);
+        }
+        let (c, t) = pair(8);
+        for (a, b, expected) in [
+            (1.0, 2.0, "improved"),
+            (2.0, 2.0, "neutral"),
+            (3.0, 2.0, "regressed"),
+        ] {
+            assert_eq!(classify_performance(a, b), expected);
+            assert!(mechanism_gate(&c, &t, 2048, 768, 8).passed);
+        }
+    }
+    #[test]
+    fn q4_route_parallel_cli_is_explicit_and_has_no_workload_overrides() {
+        use clap::Parser;
+        let arguments = [
+            "micro-expert-router",
+            MODE,
+            "--config",
+            FROZEN_CONFIG_PATH,
+            "--expected-adapter-name",
+            "NVIDIA L4",
+            "--report-out",
+            "/tmp/pr2c-new.json",
+        ];
+        let cli = crate::Cli::try_parse_from(arguments).unwrap();
+        assert!(matches!(
+            cli.cmd,
+            crate::Cmd::QualifyGpuNativeQ4RouteParallel { .. }
+        ));
+        for override_flag in [
+            "--top-k",
+            "--output-tokens",
+            "--warmup-runs",
+            "--parallel",
+            "--prompt",
+        ] {
+            let mut invalid = arguments.to_vec();
+            invalid.extend([override_flag, "1"]);
+            assert!(crate::Cli::try_parse_from(invalid).is_err());
+        }
+    }
+    #[tokio::test]
+    async fn q4_route_parallel_preflight_failure_emits_typed_report_without_runtime() {
+        let dir = std::env::temp_dir().join(format!(
+            "mer-pr2c-preflight-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir(&dir).unwrap();
+        let path = dir.join("failure.json");
+        let result = run_command(CommandArgs {
+            config: PathBuf::from(FROZEN_CONFIG_PATH),
+            expected_adapter_name: "software-only-invalid-for-frozen-workload".into(),
+            report_out: path.clone(),
+            progress_watchdog: crate::rayon_autotune::ProgressWatchdogConfig::disabled(),
+        })
+        .await;
+        assert!(result.is_err());
+        let original = std::fs::read(&path).unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&original).unwrap();
+        assert_eq!(json["schema"], SCHEMA);
+        assert_eq!(json["qualification_pass"], false);
+        assert_eq!(json["benchmark_complete"], false);
+        assert!(json["failure"].is_object());
+        assert!(json["control"].is_null() && json["treatment"].is_null());
+        assert!(write_report(&Report::pending("NVIDIA L4".into()), &path).is_err());
+        assert_eq!(std::fs::read(path).unwrap(), original);
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+}

--- a/rust-engine/src/gpu_native_q4_route_parallel.rs
+++ b/rust-engine/src/gpu_native_q4_route_parallel.rs
@@ -1,11 +1,11 @@
-//! PR2-C qualification-only Q4 route scheduling. No production config knob.
+//! PR2-C.1 production qualification of the ordinary Q4 route-parallel encoder. No production config knob.
 use super::*;
 use crate::backend::gpu_native::q4_route_parallel::DispatchEvidence;
 use parking_lot::Mutex;
 
-pub(crate) const SCHEMA: &str = "mer.gpu-native-q4-route-parallel.v1";
-pub(crate) const MODE: &str = "qualify-gpu-native-q4-route-parallel";
-const BASE_SHA: &str = "e379ae3a11c9b9b5c4d80a6b02fc3414f9a38fe1";
+pub(crate) const SCHEMA: &str = "mer.gpu-native-q4-route-parallel-production.v1";
+pub(crate) const MODE: &str = "qualify-gpu-native-q4-route-parallel-production";
+const BASE_SHA: &str = "6be8881fbae7b2b8a4a8df0a612bf90923a7ef61";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -130,7 +130,7 @@ async fn run_q4_arm(
     args: &CommandArgs,
     q4_arm: Arm,
 ) -> Result<Q4ArmReport, BenchmarkFailure> {
-    // Both PR2-C arms use the ordinary production source and physical-install
+    // Both PR2-C.1 arms use the ordinary production source and physical-install
     // path. This existing treatment observer changes only qualification tracing.
     let (arm_name, arm) = match q4_arm {
         Arm::Control => (
@@ -378,7 +378,7 @@ async fn run_q4_arm(
         execution_failure = Some(BenchmarkFailure::new(
             "postcondition",
             "missing-final-cache-state",
-            "PR2-C requires final RAM cache identity",
+            "PR2-C.1 requires final RAM cache identity",
         ));
     }
     let shutdown =
@@ -434,13 +434,18 @@ async fn run_q4_arm(
 struct Contract {
     qualification_only: bool,
     production_q4_route_parallel_changed: bool,
-    control_uses_ordinary_serial_production_path: bool,
-    treatment_uses_route_parallel_qualification_path: bool,
+    control_uses_frozen_serial_reference_path: bool,
+    treatment_uses_ordinary_production_route_parallel_path: bool,
     source_acquisition_changed: bool,
     ram_cache_policy_changed: bool,
     physical_residency_changed: bool,
     victim_policy_changed: bool,
     mapping_semantics_changed: bool,
+    logical_admission_changed: bool,
+    prefetch_or_speculation_changed: bool,
+    recovery_semantics_changed: bool,
+    routing_semantics_changed: bool,
+    model_or_workload_changed: bool,
     expert_q4_arithmetic_changed: bool,
     expert_combine_order_changed: bool,
     expert_failure_semantics_changed: bool,
@@ -450,15 +455,20 @@ struct Contract {
 impl Default for Contract {
     fn default() -> Self {
         Self {
-            qualification_only: true,
-            production_q4_route_parallel_changed: false,
-            control_uses_ordinary_serial_production_path: true,
-            treatment_uses_route_parallel_qualification_path: true,
+            qualification_only: false,
+            production_q4_route_parallel_changed: true,
+            control_uses_frozen_serial_reference_path: true,
+            treatment_uses_ordinary_production_route_parallel_path: true,
             source_acquisition_changed: false,
             ram_cache_policy_changed: false,
             physical_residency_changed: false,
             victim_policy_changed: false,
             mapping_semantics_changed: false,
+            logical_admission_changed: false,
+            prefetch_or_speculation_changed: false,
+            recovery_semantics_changed: false,
+            routing_semantics_changed: false,
+            model_or_workload_changed: false,
             expert_q4_arithmetic_changed: false,
             expert_combine_order_changed: false,
             expert_failure_semantics_changed: false,
@@ -470,8 +480,8 @@ impl Default for Contract {
 
 #[derive(Clone, Debug, Default, Serialize)]
 struct MechanismGate {
-    ordinary_serial_production_path_exercised: bool,
-    qualification_route_parallel_path_exercised: bool,
+    control_frozen_serial_path_exercised: bool,
+    treatment_ordinary_production_route_parallel_path_exercised: bool,
     control_dispatch_accounting_exact: bool,
     treatment_dispatch_accounting_exact: bool,
     treatment_route_width_gt_one: bool,
@@ -509,8 +519,8 @@ fn mechanism_gate(c: &Mechanism, t: &Mechanism, d_model: u64, d_ff: u64, k: u64)
         && expected == Some(t.treatment_route_parallel_routes_covered)
         && t.treatment_max_route_width == k;
     let mut gate = MechanismGate {
-        ordinary_serial_production_path_exercised: serial,
-        qualification_route_parallel_path_exercised: parallel,
+        control_frozen_serial_path_exercised: serial,
+        treatment_ordinary_production_route_parallel_path_exercised: parallel,
         control_dispatch_accounting_exact: serial,
         treatment_dispatch_accounting_exact: parallel,
         treatment_route_width_gt_one: t.treatment_max_route_width >= 2,
@@ -541,8 +551,8 @@ fn mechanism_gate(c: &Mechanism, t: &Mechanism, d_model: u64, d_ff: u64, k: u64)
         mechanism_accounting_mismatch_zero: !c.accounting_mismatch && !t.accounting_mismatch,
         passed: false,
     };
-    gate.passed = gate.ordinary_serial_production_path_exercised
-        && gate.qualification_route_parallel_path_exercised
+    gate.passed = gate.control_frozen_serial_path_exercised
+        && gate.treatment_ordinary_production_route_parallel_path_exercised
         && gate.control_dispatch_accounting_exact
         && gate.treatment_dispatch_accounting_exact
         && gate.treatment_route_width_gt_one
@@ -781,7 +791,7 @@ impl Report {
             schema: SCHEMA, mode: MODE, base_sha: BASE_SHA, contract: Contract::default(),
             frozen_workload: frozen_workload(adapter), d_model: 2048, d_ff: 768, layers: 48,
             experts_per_layer: 128, top_k: 8, replacement: "physical-lru-prediction-protected",
-            baseline_observer_contract: "both PR2-C arms enable the existing PR2-B-B treatment observer and use ordinary source/install behavior; nested baseline observer production-change flags describe PR2-B versus its historical baseline, not changes made by PR2-C",
+            baseline_observer_contract: "both PR2-C.1 arms enable the existing PR2-B-B treatment observer and use ordinary source/install behavior; nested baseline observer production-change flags describe PR2-B versus its historical baseline, not changes made by PR2-C.1",
             dispatch_accounting_definition: "host-encoded expert layer executions, including invalid tails and recovery segments; selected_routes_total counts encoded route lanes; accepted selected-route counts and ordered IDs are independently recorded by the existing boundary contract",
             benchmark_complete: false, qualification_pass: false, performance_result: "not_measured",
             failure: None, provenance: None, control: None, treatment: None,
@@ -811,7 +821,7 @@ pub(crate) async fn run_command(args: CommandArgs) -> Result<(), Box<dyn std::er
         if report.failure.is_none() {
             report.failure = Some(BenchmarkFailure::new(
                 "qualification",
-                "pr2c-failed",
+                "pr2c1-failed",
                 error.to_string(),
             ));
         }
@@ -824,10 +834,10 @@ async fn run_qualification(
     report: &mut Report,
 ) -> Result<(), Box<dyn std::error::Error>> {
     if args.report_out.exists() {
-        return Err("PR2-C requires a new report path".into());
+        return Err("PR2-C.1 requires a new report path".into());
     }
     if args.expected_adapter_name != "NVIDIA L4" {
-        return Err("frozen PR2-C adapter must be NVIDIA L4".into());
+        return Err("frozen PR2-C.1 adapter must be NVIDIA L4".into());
     }
     let prepared = prepare(args)?;
     report.provenance = Some(prepared.provenance.clone());
@@ -876,7 +886,7 @@ async fn run_qualification(
         return Err(BenchmarkFailure::new(
             "postcondition",
             "formal-gate-failed",
-            "PR2-C correctness, work or mechanism reconciliation failed",
+            "PR2-C.1 correctness, work or mechanism reconciliation failed",
         )
         .into());
     }
@@ -1040,20 +1050,30 @@ mod tests {
     fn q4_route_parallel_contract_is_explicit_and_performance_independent() {
         let report = Report::pending("NVIDIA L4".into());
         let json = serde_json::to_value(report).unwrap();
+        assert_eq!(
+            json["schema"],
+            "mer.gpu-native-q4-route-parallel-production.v1"
+        );
+        assert_eq!(json["base_sha"], "6be8881fbae7b2b8a4a8df0a612bf90923a7ef61");
         for field in [
-            "qualification_only",
-            "control_uses_ordinary_serial_production_path",
-            "treatment_uses_route_parallel_qualification_path",
+            "production_q4_route_parallel_changed",
+            "control_uses_frozen_serial_reference_path",
+            "treatment_uses_ordinary_production_route_parallel_path",
         ] {
             assert_eq!(json[field], true);
         }
         for field in [
-            "production_q4_route_parallel_changed",
+            "qualification_only",
             "source_acquisition_changed",
             "ram_cache_policy_changed",
             "physical_residency_changed",
             "victim_policy_changed",
             "mapping_semantics_changed",
+            "logical_admission_changed",
+            "prefetch_or_speculation_changed",
+            "recovery_semantics_changed",
+            "routing_semantics_changed",
+            "model_or_workload_changed",
             "expert_q4_arithmetic_changed",
             "expert_combine_order_changed",
             "expert_failure_semantics_changed",
@@ -1075,6 +1095,33 @@ mod tests {
         }
     }
     #[test]
+    fn q4_route_parallel_source_residency_and_configuration_remain_frozen() {
+        use sha2::Digest;
+        for (source, expected) in [
+            (
+                include_str!("engine.rs"),
+                "842f1ff0027b66292a8c429379710ee81d703ae3c455c725275647231ddc4409",
+            ),
+            (
+                include_str!("gpu_native_residency.rs"),
+                "2cb1d408f795b76a48298f47a56393d12b7228e8b8ca9d03172baaa81371f30e",
+            ),
+            (
+                include_str!("config.rs"),
+                "811463154e63bc5fce36e291e3c06df2de9ac289426c3bf8de60e60b7e531de4",
+            ),
+            (
+                include_str!("gpu_native_physical_install_staging.rs"),
+                "bd74830366047f26ab43e1be4a53bad225c7db3331857e2c56b83a5fde06f0bb",
+            ),
+        ] {
+            assert_eq!(
+                format!("{:x}", sha2::Sha256::digest(source.as_bytes())),
+                expected
+            );
+        }
+    }
+    #[test]
     fn q4_route_parallel_cli_is_explicit_and_has_no_workload_overrides() {
         use clap::Parser;
         let arguments = [
@@ -1090,12 +1137,15 @@ mod tests {
         let cli = crate::Cli::try_parse_from(arguments).unwrap();
         assert!(matches!(
             cli.cmd,
-            crate::Cmd::QualifyGpuNativeQ4RouteParallel { .. }
+            crate::Cmd::QualifyGpuNativeQ4RouteParallelProduction { .. }
         ));
         for override_flag in [
             "--top-k",
             "--output-tokens",
             "--warmup-runs",
+            "--measured-runs",
+            "--request-json",
+            "--cache-reset",
             "--parallel",
             "--prompt",
         ] {

--- a/rust-engine/src/gpu_native_token_loop.rs
+++ b/rust-engine/src/gpu_native_token_loop.rs
@@ -3,6 +3,10 @@
 //! Owns the execution of the entire forward transformer pass on GPU:
 //! Embedding lookup -> Layer (Attention RMSNorm -> QKV/RoPE/KV -> Causal Attention/O -> MoE RMSNorm -> Router -> Q4 Expert Combine) -> Final RMSNorm -> LM Head -> GPU Greedy Argmax.
 
+use crate::backend::gpu_native::q4_route_parallel::GpuNativeQ4RouteParallelScratch;
+use crate::gpu_native_physical_install_staging::q4_route_parallel::{
+    Arm as Q4QualificationArm, Observation as Q4QualificationObservation,
+};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::fmt;
@@ -978,9 +982,24 @@ pub struct GpuNativeTokenLoop {
     counters: GpuNativeTokenLoopCounters,
     recovery_counters: GpuNativeRecoveryCounters,
     execution_guard: TokioMutex<()>,
+    q4_qualification: std::sync::OnceLock<Arc<Q4QualificationObservation>>,
 }
 
 impl GpuNativeTokenLoop {
+    /// Only the explicit PR2-C qualifier may install this one-shot observer
+    /// before the first request in an isolated runtime.
+    pub(crate) fn enable_q4_route_parallel_qualification(
+        &self,
+        observation: Arc<Q4QualificationObservation>,
+    ) -> Result<(), String> {
+        if self.snapshot().token_attempts != 0 {
+            return Err("PR2-C must be enabled before any request".into());
+        }
+        self.q4_qualification
+            .set(observation)
+            .map_err(|_| "PR2-C already enabled".into())
+    }
+
     /// Validate that `model` conforms strictly to the supported Qwen3Moe GPU-native contract.
     pub fn validate_model_compatibility(
         model: &RealModel,
@@ -1299,6 +1318,7 @@ impl GpuNativeTokenLoop {
             report_layout,
             counters: GpuNativeTokenLoopCounters::default(),
             recovery_counters: GpuNativeRecoveryCounters::default(),
+            q4_qualification: std::sync::OnceLock::new(),
             execution_guard: TokioMutex::new(()),
         }))
     }
@@ -1407,6 +1427,13 @@ impl GpuNativeTokenLoop {
             self.executor.create_q4_expert_scratch(expert_geom)?
         };
 
+        let q4_parallel_scratch = match self.q4_qualification.get().map(|o| o.arm) {
+            Some(Q4QualificationArm::Treatment) => Some(
+                self.executor
+                    .create_q4_route_parallel_qualification_scratch(expert_geom)?,
+            ),
+            _ => None,
+        };
         let logits_scratch = self
             .executor
             .create_scratch(self.model_geometry.vocab_size)?;
@@ -1434,6 +1461,7 @@ impl GpuNativeTokenLoop {
             attn_scratch,
             router_scratch,
             expert_scratch,
+            q4_parallel_scratch,
             logits_scratch,
             sampled_token_buf,
             pre_expert_checkpoints,
@@ -2196,6 +2224,9 @@ impl GpuNativeTokenLoop {
             };
             attempts += 1;
             let report = &output.boundary_report;
+            if let Some(observation) = self.q4_qualification.get() {
+                observation.record_status(&report.layer_statuses, report.final_status);
+            }
 
             if let Some(fail_layer) =
                 report.first_failure_layer_in(segment.attempted_layers.clone())?
@@ -2465,14 +2496,46 @@ impl GpuNativeTokenLoop {
                 );
             }
         }
-        self.executor.encode_q4_expert_arena_combine(
-            encoder,
-            &layer_plan.router_plan,
-            &request.router_scratch,
-            arena,
-            &request.token_state,
-            &request.expert_scratch,
-        )?;
+        if let Some(observation) = self.q4_qualification.get() {
+            let evidence = match observation.arm {
+                Q4QualificationArm::Control => self.executor.encode_q4_expert_serial_qualification(
+                    encoder,
+                    &layer_plan.router_plan,
+                    &request.router_scratch,
+                    arena,
+                    &request.token_state,
+                    &request.expert_scratch,
+                )?,
+                Q4QualificationArm::Treatment => {
+                    let scratch = request.q4_parallel_scratch.as_ref().ok_or_else(|| {
+                        GpuNativeTokenLoopError::InvalidBoundaryReport {
+                            detail: "PR2-C treatment scratch missing; serial fallback prohibited"
+                                .into(),
+                        }
+                    })?;
+                    self.executor
+                        .encode_q4_expert_route_parallel_qualification(
+                            encoder,
+                            &layer_plan.router_plan,
+                            &request.router_scratch,
+                            arena,
+                            &request.token_state,
+                            &request.expert_scratch,
+                            scratch,
+                        )?
+                }
+            };
+            observation.record(evidence);
+        } else {
+            self.executor.encode_q4_expert_arena_combine(
+                encoder,
+                &layer_plan.router_plan,
+                &request.router_scratch,
+                arena,
+                &request.token_state,
+                &request.expert_scratch,
+            )?;
+        }
 
         if let Some(sink) = semantic_sink {
             if let Some(layout) = sink.target_layout_for_layer(layer_idx) {
@@ -3193,6 +3256,7 @@ pub struct GpuNativeRequestState {
     pub attn_scratch: GpuNativeAttentionScratch,
     pub router_scratch: GpuNativeRouterScratch,
     pub expert_scratch: GpuNativeQ4ExpertScratch,
+    q4_parallel_scratch: Option<GpuNativeQ4RouteParallelScratch>,
     pub logits_scratch: GpuNativeScratch,
     pub sampled_token_buf: GpuNativeScratch,
     pub pre_expert_checkpoints: GpuNativePreExpertCheckpoints,

--- a/rust-engine/src/gpu_native_token_loop.rs
+++ b/rust-engine/src/gpu_native_token_loop.rs
@@ -33,6 +33,19 @@ use crate::gpu_native_residency::GpuNativeTieredResidencyManager;
 use crate::model::RealModel;
 use crate::sampling::SamplingParams;
 
+// Only explicit qualification control may select the frozen serial encoder.
+fn q4_uses_frozen_serial_control(arm: Option<Q4QualificationArm>) -> bool {
+    matches!(arm, Some(Q4QualificationArm::Control))
+}
+
+fn require_q4_route_parallel_scratch(
+    scratch: Option<&GpuNativeQ4RouteParallelScratch>,
+) -> Result<&GpuNativeQ4RouteParallelScratch, GpuNativeTokenLoopError> {
+    scratch.ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
+        detail: "production Q4 route-parallel scratch missing; serial fallback prohibited".into(),
+    })
+}
+
 /// Structured summary of runtime counters across the GPU-native token loop.
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct GpuNativeTokenLoopSnapshot {
@@ -1427,13 +1440,15 @@ impl GpuNativeTokenLoop {
             self.executor.create_q4_expert_scratch(expert_geom)?
         };
 
-        let q4_parallel_scratch = match self.q4_qualification.get().map(|o| o.arm) {
-            Some(Q4QualificationArm::Treatment) => Some(
-                self.executor
-                    .create_q4_route_parallel_qualification_scratch(expert_geom)?,
-            ),
-            _ => None,
-        };
+        let q4_parallel_scratch =
+            if q4_uses_frozen_serial_control(self.q4_qualification.get().map(|o| o.arm)) {
+                None
+            } else {
+                Some(
+                    self.executor
+                        .create_q4_route_parallel_scratch(expert_geom)?,
+                )
+            };
         let logits_scratch = self
             .executor
             .create_scratch(self.model_geometry.vocab_size)?;
@@ -2496,45 +2511,31 @@ impl GpuNativeTokenLoop {
                 );
             }
         }
-        if let Some(observation) = self.q4_qualification.get() {
-            let evidence = match observation.arm {
-                Q4QualificationArm::Control => self.executor.encode_q4_expert_serial_qualification(
-                    encoder,
-                    &layer_plan.router_plan,
-                    &request.router_scratch,
-                    arena,
-                    &request.token_state,
-                    &request.expert_scratch,
-                )?,
-                Q4QualificationArm::Treatment => {
-                    let scratch = request.q4_parallel_scratch.as_ref().ok_or_else(|| {
-                        GpuNativeTokenLoopError::InvalidBoundaryReport {
-                            detail: "PR2-C treatment scratch missing; serial fallback prohibited"
-                                .into(),
-                        }
-                    })?;
-                    self.executor
-                        .encode_q4_expert_route_parallel_qualification(
-                            encoder,
-                            &layer_plan.router_plan,
-                            &request.router_scratch,
-                            arena,
-                            &request.token_state,
-                            &request.expert_scratch,
-                            scratch,
-                        )?
-                }
-            };
-            observation.record(evidence);
-        } else {
-            self.executor.encode_q4_expert_arena_combine(
+        let observation = self.q4_qualification.get();
+        let evidence = if q4_uses_frozen_serial_control(observation.map(|o| o.arm)) {
+            self.executor.encode_q4_expert_serial_qualification(
                 encoder,
                 &layer_plan.router_plan,
                 &request.router_scratch,
                 arena,
                 &request.token_state,
                 &request.expert_scratch,
-            )?;
+            )?
+        } else {
+            // Ordinary serving and treatment enter this same production call.
+            let scratch = require_q4_route_parallel_scratch(request.q4_parallel_scratch.as_ref())?;
+            self.executor.encode_q4_expert_route_parallel(
+                encoder,
+                &layer_plan.router_plan,
+                &request.router_scratch,
+                arena,
+                &request.token_state,
+                &request.expert_scratch,
+                scratch,
+            )?
+        };
+        if let Some(observation) = observation {
+            observation.record(evidence);
         }
 
         if let Some(sink) = semantic_sink {
@@ -3284,6 +3285,26 @@ pub(crate) mod tests {
     use crate::gating::{LinearGate, ScoringFunc};
     use crate::model::RealModelConfig;
     use crate::transformer::{LMHead, MultiHeadSelfAttention, RmsNorm, TransformerLayer};
+
+    #[test]
+    fn q4_route_parallel_production_and_treatment_never_select_serial() {
+        assert!(!q4_uses_frozen_serial_control(None));
+        assert!(!q4_uses_frozen_serial_control(Some(
+            Q4QualificationArm::Treatment
+        )));
+        assert!(q4_uses_frozen_serial_control(Some(
+            Q4QualificationArm::Control
+        )));
+    }
+
+    #[test]
+    fn q4_route_parallel_missing_production_scratch_fails_closed() {
+        assert!(matches!(
+            require_q4_route_parallel_scratch(None),
+            Err(GpuNativeTokenLoopError::InvalidBoundaryReport { detail })
+                if detail == "production Q4 route-parallel scratch missing; serial fallback prohibited"
+        ));
+    }
 
     pub(crate) fn make_test_qwen3_moe_config() -> RealModelConfig {
         RealModelConfig {

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -940,9 +940,10 @@ enum Cmd {
         report_out: PathBuf,
     },
 
-    /// PR2-C qualification only: ordinary production remains serial.
-    #[command(name = "qualify-gpu-native-q4-route-parallel")]
-    QualifyGpuNativeQ4RouteParallel {
+    /// PR2-C.1 production qualification: frozen serial control versus the
+    /// ordinary production route-parallel encoder used by treatment.
+    #[command(name = "qualify-gpu-native-q4-route-parallel-production")]
+    QualifyGpuNativeQ4RouteParallelProduction {
         #[arg(long)]
         config: PathBuf,
         #[arg(long)]
@@ -1918,7 +1919,7 @@ fn startup_config_path(cmd: &Cmd) -> Option<&Path> {
         | Cmd::BenchReal { config, .. }
         | Cmd::BenchGpuNativeReal { config, .. }
         | Cmd::QualifyGpuNativeDemandSourceConcurrencyProduction { config, .. }
-        | Cmd::QualifyGpuNativeQ4RouteParallel { config, .. }
+        | Cmd::QualifyGpuNativeQ4RouteParallelProduction { config, .. }
         | Cmd::QualifyGpuNativePhysicalInstallStagingProduction { config, .. }
         | Cmd::QualifyGpuNativePhysicalInstallConcurrencyProduction { config, .. }
         | Cmd::QualifyHybridQ4 { config, .. }
@@ -2366,7 +2367,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 ),
             )
         }
-        Cmd::QualifyGpuNativeQ4RouteParallel {
+        Cmd::QualifyGpuNativeQ4RouteParallelProduction {
             config,
             expected_adapter_name,
             report_out,

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -940,6 +940,17 @@ enum Cmd {
         report_out: PathBuf,
     },
 
+    /// PR2-C qualification only: ordinary production remains serial.
+    #[command(name = "qualify-gpu-native-q4-route-parallel")]
+    QualifyGpuNativeQ4RouteParallel {
+        #[arg(long)]
+        config: PathBuf,
+        #[arg(long)]
+        expected_adapter_name: String,
+        #[arg(long)]
+        report_out: PathBuf,
+    },
+
     /// PR2-B-B.1 production-path qualification. Control forces the frozen
     /// sequential direct-staging implementation; treatment exercises ordinary
     /// production concurrent staging and deterministic ordered commit.
@@ -1907,6 +1918,7 @@ fn startup_config_path(cmd: &Cmd) -> Option<&Path> {
         | Cmd::BenchReal { config, .. }
         | Cmd::BenchGpuNativeReal { config, .. }
         | Cmd::QualifyGpuNativeDemandSourceConcurrencyProduction { config, .. }
+        | Cmd::QualifyGpuNativeQ4RouteParallel { config, .. }
         | Cmd::QualifyGpuNativePhysicalInstallStagingProduction { config, .. }
         | Cmd::QualifyGpuNativePhysicalInstallConcurrencyProduction { config, .. }
         | Cmd::QualifyHybridQ4 { config, .. }
@@ -2353,6 +2365,23 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     },
                 ),
             )
+        }
+        Cmd::QualifyGpuNativeQ4RouteParallel {
+            config,
+            expected_adapter_name,
+            report_out,
+        } => {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()?;
+            rt.block_on(crate::gpu_native_physical_install_staging::q4_route_parallel::run_command(
+                crate::gpu_native_physical_install_staging::CommandArgs {
+                    config,
+                    expected_adapter_name,
+                    report_out,
+                    progress_watchdog,
+                },
+            ))
         }
         Cmd::QualifyGpuNativePhysicalInstallStagingProduction {
             config,


### PR DESCRIPTION
## Summary

Productionizes the hardware-qualified PR2-C route-parallel Q4 expert compute path and makes it the ordinary production encoder while retaining the frozen serial path exclusively as the qualification control.

This PR intentionally preserves the exact qualified ancestry from `main` without rebase or squash:

- `0ae9db908a32549be52fdae45c3f0047aed81301` — PR2-C route-parallel qualification implementation
- `6be8881fbae7b2b8a4a8df0a612bf90923a7ef61` — frozen PR2-C hardware-qualified evidence checkpoint
- `e86375ae9a232c3a71d1541fd260a57b5c19c3c5` — C.1 productionization / original mechanism-qualified head
- `b66d91e2f72e819ead2711cb49de9485c587b669` — P1 pipeline-ownership fix and final hardware-qualified production head

Base: `main` at `e379ae3a11c9b9b5c4d80a6b02fc3414f9a38fe1`.

## Production behavior

- Ordinary serving uses the single production `encode_q4_expert_route_parallel` path.
- Qualification treatment uses that same ordinary production path.
- Qualification control alone uses the frozen pre-C serial encoder.
- Missing/invalid production route-parallel state fails closed; there is no silent serial fallback.
- Route-parallel WGSL module/layout/pipelines are executor-owned and created once during GPU-native executor initialization.
- Request-local route-parallel scratch contains only context/geometry identity plus the `top_k * d_ff` activation buffer.
- Existing Q4 arithmetic, routing, combine order, recovery semantics, source acquisition, RAM/NVMe cache behavior, physical residency, victim policy, mapping, queue submission contract, WGPU version, model, and workload remain unchanged.
- Executable route-parallel WGSL is unchanged by the P1 fix.

## Final authoritative NVIDIA L4 qualification

Exact head:
`b66d91e2f72e819ead2711cb49de9485c587b669`

Result:
- `benchmark_complete=true`
- `qualification_pass=true`
- `performance_result=improved`
- `failure=null`
- all behavioral, work-equivalence, warmup-mechanism, measured-mechanism, and reconciliation invariants passed

Measured performance:
- decode TPS: `1.0240053510 -> 1.0994160432` (**+7.3643%**)
- end-to-end generated TPS: `0.9232540867 -> 0.9908567490` (**+7.3222%**)
- mean request wall: `138.640581397s -> 129.181750970s` (**-6.8226%**)
- TTFT: `14.617393954s -> 13.665419000s`

Structural proof:
- route-compute dispatches / expert layer: **16 -> 2**
- dispatch reduction: **87.5%**
- activation scratch: `3,072 -> 24,576` bytes
- expert layer executions: `58,437` in both arms
- selected routes: `467,496` in both arms
- route width: `8`
- accounting mismatch: `false`
- unexpected status bits: `0`

Exact work/behavior reconciliation includes generated token IDs and text hashes, route identity, source requests, RAM hits/misses, NVMe reads/bytes, logical admissions, H2D installs/bytes, eviction/victim order, residency identity stream, mapping publication/unpublication, recovery boundaries, final RAM cache state, zero speculative work, zero full-token replay, zero reservation leaks, zero batch-commit violations, and zero stale singleflight entries.

Storage/residency timing did not create the win: treatment source acquisition was **+18.978%** slower and total residency service **+12.156%** slower, while decode still improved **+7.364%** and mean request wall fell **6.823%**.

## P1 review finding and resolution

Review found that `e86375ae...` created the route-parallel shader module/layout/two compute pipelines from request-state construction, while benchmark timing began after request-state creation. That made the original C.1 request/E2E timing incomplete for production setup cost.

`b66d91e...` fixes this narrowly by hoisting invariant route-parallel pipelines into `GpuNativeExecutorContext` initialization and leaving only the activation buffer request-local. The compute encoder, dispatch geometry, bindings, push constants, WGSL, validation/combine/contain ordering, residual addition, accounting, and failure semantics are unchanged. A structural regression test prohibits request-local shader/layout/pipeline creation.

A fresh authoritative L4 qualification was run on `b66d91e...`; the result above supersedes `e86375ae...` as the merge gate. The earlier result remains historical mechanism evidence only.

## Final authoritative artifacts

- report SHA-256: `9babaceb23bb13b705715247b524e11d55ebe1c239d199a9cf08812edca0c31b`
- log SHA-256: `70716a433103038f1934d16750e388aa076ffac1293462f5f013cc03646a210b`
- exit SHA-256: `9a271f2a916b0b6ee6cecb2426f0b3206ef074578be55d9bc94f6f3fe3ab86aa`
- runner SHA-256: `606dda42b3bff0f0a28572c299a37df813415265bb176f213c5e7734aa640e96`

Software validation on the P1 fix:
- `cargo check --features tokenizer`: PASS
- focused PR2-C/C.1 suite: 19 passed, 0 failed, 1 ignored
- full suite: 1,397 passed, 0 failed, 15 ignored
- release build with tokenizer: PASS
- changed-file formatting: PASS
- `git diff --check`: PASS
- clean worktree

L4 preflight:
- canonical release build: PASS
- `validate-data`: PASS (`6144` experts, `2658304` bytes/expert, `4096` alignment, `q4_0`, `mixed_experts=0`)
- exact clean head `b66d91e2f72e819ead2711cb49de9485c587b669`

## Claim boundary

This proves that 2D route dispatch reduces route-compute dispatch count and improves measured inference on the NVIDIA L4 qualification workload. It does **not** claim that all eight experts execute simultaneously or that GPU kernel time decreased.

## Merge requirement

Merge with a normal merge commit to preserve the exact hardware-qualified ancestry. **Do not squash or rebase.**

Next milestone after merge: PR3-DIFF0 true constrained-host-RAM / NVMe-authoritative out-of-core proof.