### PR TITLE
Productionize physical slot zero-fill elision

### DIFF
--- a/rust-engine/src/backend/gpu_native.rs
+++ b/rust-engine/src/backend/gpu_native.rs
@@ -2274,6 +2274,26 @@ pub(crate) struct GpuNativePhysicalInstallEvidence {
     pub(crate) individual_physical_stage_us: u64,
 }
 
+impl GpuNativePhysicalInstallEvidence {
+    fn direct_stage<const NO_ZERO_FILL: bool>(
+        geometry: GpuNativeQ4ExpertGeometry,
+        prepare_us: u64,
+        queue_staging_us: u64,
+    ) -> Self {
+        let upload_bytes = geometry.slot_stride_bytes as u64;
+        Self {
+            direct_staging_writes: 1,
+            physical_slot_bytes_staged: upload_bytes,
+            physical_slot_zero_fill_bytes: if NO_ZERO_FILL { 0 } else { upload_bytes },
+            physical_slot_epoch_write_bytes: GPU_NATIVE_EXPERT_SLOT_EPOCH_BYTES as u64,
+            physical_slot_payload_copy_bytes: geometry.logical_expert_bytes as u64,
+            physical_slot_prepare_us: prepare_us,
+            physical_queue_staging_us: queue_staging_us,
+            ..Self::default()
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub(crate) enum GpuNativePhysicalSlotFillPolicy {
@@ -2292,8 +2312,8 @@ pub(crate) struct GpuNativeQ4ExpertPreparedInstall<'a, B = wgpu::Buffer> {
 }
 
 /// Compact cumulative telemetry for the ordinary production demand-install
-/// implementation. Setup uploads, the explicit qualifier control, and the
-/// unchanged speculative Vec path do not contribute to these counters.
+/// implementation and the concurrent full-zero control. Setup uploads, the
+/// legacy/sequential controls, and speculation do not contribute to these counters.
 #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub(crate) struct GpuNativeProductionPhysicalInstallSnapshot {
     pub(crate) physical_install_sets: u64,
@@ -2652,7 +2672,7 @@ fn physical_q4_expert_slot(
 }
 
 /// The single checked physical-slot byte-layout contract shared by setup,
-/// legacy Vec staging, and ordinary production direct WGPU staging.
+/// legacy Vec staging, and the explicit full-zero direct-staging control.
 fn fill_physical_q4_expert_slot(
     geometry: GpuNativeQ4ExpertGeometry,
     logical_id: u32,
@@ -2710,10 +2730,10 @@ impl<'a> CheckedPhysicalQ4ExpertSlot<'a> {
         Ok(())
     }
 
-    /// ORACLE qualification only. The ordinary full-zero fill above is kept
-    /// unchanged. Reuse its validated payload/epoch and require complete
-    /// destination coverage before writing even the first epoch byte.
-    fn fill_qualification_no_zero_fill(
+    /// Shared production/qualification complete overwrite. Reuse the validated
+    /// payload/epoch and require complete destination coverage before writing
+    /// even the first epoch byte. Future padded slots must use full-zero fill.
+    fn fill_complete_overwrite_no_zero(
         self,
         destination: &mut [u8],
     ) -> Result<(), GpuNativeBootstrapError> {
@@ -7600,11 +7620,27 @@ impl GpuNativeExecutorContext {
         permit: GpuNativeQ4ExpertInstallPermit<'a>,
         payload: &[u8],
     ) -> Result<GpuNativeQ4ExpertPreparedInstall<'a>, GpuNativeBootstrapError> {
-        self.stage_q4_expert_residency_inner::<false, true, false>(permit, payload)
+        self.stage_q4_expert_residency_inner::<false, true, true>(permit, payload)
             .map(|(prepared, _)| prepared)
     }
 
     pub(crate) fn stage_q4_expert_residency_production_observed<'a>(
+        &self,
+        permit: GpuNativeQ4ExpertInstallPermit<'a>,
+        payload: &[u8],
+    ) -> Result<
+        (
+            GpuNativeQ4ExpertPreparedInstall<'a>,
+            GpuNativePhysicalInstallEvidence,
+        ),
+        GpuNativeBootstrapError,
+    > {
+        self.stage_q4_expert_residency_inner::<true, true, true>(permit, payload)
+    }
+
+    /// Concurrent full-zero qualification control. It shares production's
+    /// staging transaction, counters, and ordered commit; only host fill differs.
+    pub(crate) fn stage_q4_expert_residency_full_zero_control_observed<'a>(
         &self,
         permit: GpuNativeQ4ExpertInstallPermit<'a>,
         payload: &[u8],
@@ -7649,8 +7685,8 @@ impl GpuNativeExecutorContext {
         self.stage_q4_expert_residency_inner::<true, true, true>(permit, payload)
     }
 
-    /// `MEASURE=false` removes subphase timers from normal serving. Only the
-    /// explicit ORACLE qualification wrapper selects `NO_ZERO_FILL=true`.
+    /// `MEASURE=false` removes subphase timers from normal serving. Both
+    /// production and historical ORACLE treatment use `NO_ZERO_FILL=true`.
     fn stage_q4_expert_residency_inner<
         'a,
         const MEASURE: bool,
@@ -7699,7 +7735,7 @@ impl GpuNativeExecutorContext {
             }
             let fill_started = MEASURE.then(Instant::now);
             if NO_ZERO_FILL {
-                checked.fill_qualification_no_zero_fill(view.as_mut())?;
+                checked.fill_complete_overwrite_no_zero(view.as_mut())?;
             } else {
                 checked.fill(view.as_mut())?;
             }
@@ -7720,19 +7756,11 @@ impl GpuNativeExecutorContext {
                 }
                 Ok((
                     prepared,
-                    GpuNativePhysicalInstallEvidence {
-                        full_slot_vec_materializations: 0,
-                        direct_staging_writes: 1,
-                        physical_slot_bytes_staged: upload_bytes,
-                        physical_slot_zero_fill_bytes: if NO_ZERO_FILL { 0 } else { upload_bytes },
-                        physical_slot_epoch_write_bytes: GPU_NATIVE_EXPERT_SLOT_EPOCH_BYTES as u64,
-                        physical_slot_payload_copy_bytes: arena.geometry.logical_expert_bytes
-                            as u64,
-                        physical_slot_prepare_us: prepare_us.get(),
-                        physical_queue_staging_us: queue_staging_us.get(),
-                        mapping_publication_us: 0,
-                        individual_physical_stage_us: 0,
-                    },
+                    GpuNativePhysicalInstallEvidence::direct_stage::<NO_ZERO_FILL>(
+                        arena.geometry,
+                        prepare_us.get(),
+                        queue_staging_us.get(),
+                    ),
                 ))
             }
             Err(error) => {
@@ -11296,6 +11324,29 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn production_no_zero_and_full_zero_control_evidence_preserve_staged_bytes() {
+        let geometry = GpuNativeQ4ExpertGeometry::try_new(2048, 768, 128, 8).unwrap();
+        let production = GpuNativePhysicalInstallEvidence::direct_stage::<true>(geometry, 7, 11);
+        let control = GpuNativePhysicalInstallEvidence::direct_stage::<false>(geometry, 7, 11);
+        assert_eq!(production.physical_slot_zero_fill_bytes, 0);
+        assert_eq!(control.physical_slot_zero_fill_bytes, 2_654_212);
+        for evidence in [production, control] {
+            assert_eq!(evidence.direct_staging_writes, 1);
+            assert_eq!(evidence.full_slot_vec_materializations, 0);
+            assert_eq!(evidence.physical_slot_epoch_write_bytes, 4);
+            assert_eq!(evidence.physical_slot_payload_copy_bytes, 2_654_208);
+            assert_eq!(evidence.physical_slot_bytes_staged, 2_654_212);
+        }
+        assert_eq!(
+            production,
+            GpuNativePhysicalInstallEvidence {
+                physical_slot_zero_fill_bytes: 0,
+                ..control
+            }
+        );
+    }
+
+    #[test]
     fn qualification_no_zero_fill_frozen_geometry_overwrites_every_sentinel_byte() {
         let geometry = GpuNativeQ4ExpertGeometry::try_new(2048, 768, 128, 8).unwrap();
         assert_eq!(geometry.payload_offset_bytes(), 4);
@@ -11318,7 +11369,7 @@ pub(crate) mod tests {
             let mut treatment = vec![0xa5; geometry.slot_stride_bytes()];
             CheckedPhysicalQ4ExpertSlot::new(geometry, 7, epoch, &payload)
                 .unwrap()
-                .fill_qualification_no_zero_fill(&mut treatment)
+                .fill_complete_overwrite_no_zero(&mut treatment)
                 .unwrap();
             assert_eq!(treatment.len(), payload_end);
             assert_eq!(&treatment[..4], &epoch.to_le_bytes());
@@ -11339,7 +11390,7 @@ pub(crate) mod tests {
             let mut destination = vec![0xa5; destination_bytes];
             let checked = CheckedPhysicalQ4ExpertSlot::new(geometry, 7, 1, &payload).unwrap();
             assert!(matches!(
-                checked.fill_qualification_no_zero_fill(&mut destination),
+                checked.fill_complete_overwrite_no_zero(&mut destination),
                 Err(GpuNativeBootstrapError::ExpertPhysicalSlotDestinationLength { .. })
             ));
             assert!(destination.iter().all(|&byte| byte == 0xa5));
@@ -11353,7 +11404,7 @@ pub(crate) mod tests {
         let mut destination = vec![0xa5; padded.slot_stride_bytes()];
         let checked = CheckedPhysicalQ4ExpertSlot::new(padded, 7, 1, &payload).unwrap();
         assert!(matches!(
-            checked.fill_qualification_no_zero_fill(&mut destination),
+            checked.fill_complete_overwrite_no_zero(&mut destination),
             Err(GpuNativeBootstrapError::ExpertPhysicalSlotDestinationLength { .. })
         ));
         assert!(destination.iter().all(|&byte| byte == 0xa5));
@@ -11388,7 +11439,7 @@ pub(crate) mod tests {
                                         vec![0xa5; arena.geometry().slot_stride_bytes()];
                                     if no_zero_fill {
                                         checked
-                                            .fill_qualification_no_zero_fill(&mut destination)?;
+                                            .fill_complete_overwrite_no_zero(&mut destination)?;
                                     } else {
                                         checked.fill(&mut destination)?;
                                     }

--- a/rust-engine/src/backend/gpu_native.rs
+++ b/rust-engine/src/backend/gpu_native.rs
@@ -2263,9 +2263,22 @@ pub(crate) struct GpuNativePhysicalInstallEvidence {
     pub(crate) full_slot_vec_materializations: u64,
     pub(crate) direct_staging_writes: u64,
     pub(crate) physical_slot_bytes_staged: u64,
+    /// Explicit host writes; these do not measure or reduce H2D bytes.
+    pub(crate) physical_slot_zero_fill_bytes: u64,
+    pub(crate) physical_slot_epoch_write_bytes: u64,
+    pub(crate) physical_slot_payload_copy_bytes: u64,
     pub(crate) physical_slot_prepare_us: u64,
     pub(crate) physical_queue_staging_us: u64,
     pub(crate) mapping_publication_us: u64,
+    /// Existing residency stage timer, carried to the completion observer.
+    pub(crate) individual_physical_stage_us: u64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum GpuNativePhysicalSlotFillPolicy {
+    FullSlotZero,
+    QualificationNoZeroFill,
 }
 
 /// Unpublished half-transaction produced after an exact physical slot has
@@ -2692,6 +2705,40 @@ impl<'a> CheckedPhysicalQ4ExpertSlot<'a> {
         let payload_end = payload_start
             .checked_add(self.geometry.logical_expert_bytes)
             .ok_or(GpuNativeBootstrapError::ExpertArenaBudgetOverflow)?;
+        destination[payload_start..payload_end]
+            .copy_from_slice(&self.payload[..self.geometry.logical_expert_bytes]);
+        Ok(())
+    }
+
+    /// ORACLE qualification only. The ordinary full-zero fill above is kept
+    /// unchanged. Reuse its validated payload/epoch and require complete
+    /// destination coverage before writing even the first epoch byte.
+    fn fill_qualification_no_zero_fill(
+        self,
+        destination: &mut [u8],
+    ) -> Result<(), GpuNativeBootstrapError> {
+        if destination.len() != self.geometry.slot_stride_bytes {
+            return Err(
+                GpuNativeBootstrapError::ExpertPhysicalSlotDestinationLength {
+                    expected: self.geometry.slot_stride_bytes,
+                    actual: destination.len(),
+                },
+            );
+        }
+        let payload_start = self.geometry.payload_offset_bytes();
+        let payload_end = payload_start
+            .checked_add(self.geometry.logical_expert_bytes)
+            .ok_or(GpuNativeBootstrapError::ExpertArenaBudgetOverflow)?;
+        if payload_end != destination.len() {
+            return Err(
+                GpuNativeBootstrapError::ExpertPhysicalSlotDestinationLength {
+                    expected: payload_end,
+                    actual: destination.len(),
+                },
+            );
+        }
+        destination[..GPU_NATIVE_EXPERT_SLOT_EPOCH_BYTES]
+            .copy_from_slice(&self.slot_epoch.to_le_bytes());
         destination[payload_start..payload_end]
             .copy_from_slice(&self.payload[..self.geometry.logical_expert_bytes]);
         Ok(())
@@ -7537,9 +7584,13 @@ impl GpuNativeExecutorContext {
                 full_slot_vec_materializations: 0,
                 direct_staging_writes: 1,
                 physical_slot_bytes_staged: upload_bytes,
+                physical_slot_zero_fill_bytes: upload_bytes,
+                physical_slot_epoch_write_bytes: GPU_NATIVE_EXPERT_SLOT_EPOCH_BYTES as u64,
+                physical_slot_payload_copy_bytes: arena.geometry.logical_expert_bytes as u64,
                 physical_slot_prepare_us: prepare_us.get(),
                 physical_queue_staging_us: queue_staging_us.get(),
                 mapping_publication_us: mapping_us.get(),
+                individual_physical_stage_us: 0,
             },
         ))
     }
@@ -7549,7 +7600,7 @@ impl GpuNativeExecutorContext {
         permit: GpuNativeQ4ExpertInstallPermit<'a>,
         payload: &[u8],
     ) -> Result<GpuNativeQ4ExpertPreparedInstall<'a>, GpuNativeBootstrapError> {
-        self.stage_q4_expert_residency_inner::<false, true>(permit, payload)
+        self.stage_q4_expert_residency_inner::<false, true, false>(permit, payload)
             .map(|(prepared, _)| prepared)
     }
 
@@ -7564,7 +7615,7 @@ impl GpuNativeExecutorContext {
         ),
         GpuNativeBootstrapError,
     > {
-        self.stage_q4_expert_residency_inner::<true, true>(permit, payload)
+        self.stage_q4_expert_residency_inner::<true, true, false>(permit, payload)
     }
 
     /// Historical qualification wrapper retained for focused PR2-B-B tests.
@@ -7579,11 +7630,33 @@ impl GpuNativeExecutorContext {
         ),
         GpuNativeBootstrapError,
     > {
-        self.stage_q4_expert_residency_inner::<true, false>(permit, payload)
+        self.stage_q4_expert_residency_inner::<true, false, false>(permit, payload)
     }
 
-    /// `MEASURE=false` removes subphase timers from normal serving.
-    fn stage_q4_expert_residency_inner<'a, const MEASURE: bool, const RECORD_PRODUCTION: bool>(
+    /// ORACLE v5's only staging difference: omit the redundant host zero
+    /// writes after proving epoch + payload cover the complete destination.
+    pub(crate) fn stage_q4_expert_residency_qualification_no_zero_fill<'a>(
+        &self,
+        permit: GpuNativeQ4ExpertInstallPermit<'a>,
+        payload: &[u8],
+    ) -> Result<
+        (
+            GpuNativeQ4ExpertPreparedInstall<'a>,
+            GpuNativePhysicalInstallEvidence,
+        ),
+        GpuNativeBootstrapError,
+    > {
+        self.stage_q4_expert_residency_inner::<true, true, true>(permit, payload)
+    }
+
+    /// `MEASURE=false` removes subphase timers from normal serving. Only the
+    /// explicit ORACLE qualification wrapper selects `NO_ZERO_FILL=true`.
+    fn stage_q4_expert_residency_inner<
+        'a,
+        const MEASURE: bool,
+        const RECORD_PRODUCTION: bool,
+        const NO_ZERO_FILL: bool,
+    >(
         &self,
         permit: GpuNativeQ4ExpertInstallPermit<'a>,
         payload: &[u8],
@@ -7625,7 +7698,11 @@ impl GpuNativeExecutorContext {
                 queue_staging_us.set(elapsed_us(started));
             }
             let fill_started = MEASURE.then(Instant::now);
-            checked.fill(view.as_mut())?;
+            if NO_ZERO_FILL {
+                checked.fill_qualification_no_zero_fill(view.as_mut())?;
+            } else {
+                checked.fill(view.as_mut())?;
+            }
             if let Some(started) = fill_started {
                 prepare_us.set(prepare_us.get().saturating_add(elapsed_us(started)));
             }
@@ -7647,9 +7724,14 @@ impl GpuNativeExecutorContext {
                         full_slot_vec_materializations: 0,
                         direct_staging_writes: 1,
                         physical_slot_bytes_staged: upload_bytes,
+                        physical_slot_zero_fill_bytes: if NO_ZERO_FILL { 0 } else { upload_bytes },
+                        physical_slot_epoch_write_bytes: GPU_NATIVE_EXPERT_SLOT_EPOCH_BYTES as u64,
+                        physical_slot_payload_copy_bytes: arena.geometry.logical_expert_bytes
+                            as u64,
                         physical_slot_prepare_us: prepare_us.get(),
                         physical_queue_staging_us: queue_staging_us.get(),
                         mapping_publication_us: 0,
+                        individual_physical_stage_us: 0,
                     },
                 ))
             }
@@ -7835,9 +7917,13 @@ impl GpuNativeExecutorContext {
                 full_slot_vec_materializations: 1,
                 direct_staging_writes: 0,
                 physical_slot_bytes_staged: upload_bytes,
+                physical_slot_zero_fill_bytes: upload_bytes,
+                physical_slot_epoch_write_bytes: GPU_NATIVE_EXPERT_SLOT_EPOCH_BYTES as u64,
+                physical_slot_payload_copy_bytes: arena.geometry.logical_expert_bytes as u64,
                 physical_slot_prepare_us: prepare_us,
                 physical_queue_staging_us: queue_staging_us.get(),
                 mapping_publication_us: mapping_us.get(),
+                individual_physical_stage_us: 0,
             },
         ))
     }
@@ -11207,6 +11293,125 @@ pub(crate) mod tests {
                 }
             )
         );
+    }
+
+    #[test]
+    fn qualification_no_zero_fill_frozen_geometry_overwrites_every_sentinel_byte() {
+        let geometry = GpuNativeQ4ExpertGeometry::try_new(2048, 768, 128, 8).unwrap();
+        assert_eq!(geometry.payload_offset_bytes(), 4);
+        assert_eq!(geometry.logical_expert_bytes(), 2_654_208);
+        assert_eq!(geometry.slot_stride_bytes(), 2_654_212);
+        let payload_end = geometry.payload_offset_bytes() + geometry.logical_expert_bytes();
+        assert_eq!(payload_end, geometry.slot_stride_bytes());
+        assert_eq!(geometry.slot_stride_bytes() - payload_end, 0);
+        // No legitimate output byte equals the sentinel, so absence of A5
+        // proves complete overwrite in addition to equality with the control.
+        let payload = (0..geometry.logical_expert_bytes())
+            .map(|index| (index % 0xa5) as u8)
+            .collect::<Vec<_>>();
+        for epoch in [1, 0x04030201, u32::MAX] {
+            let mut control = vec![0xa5; geometry.slot_stride_bytes()];
+            CheckedPhysicalQ4ExpertSlot::new(geometry, 7, epoch, &payload)
+                .unwrap()
+                .fill(&mut control)
+                .unwrap();
+            let mut treatment = vec![0xa5; geometry.slot_stride_bytes()];
+            CheckedPhysicalQ4ExpertSlot::new(geometry, 7, epoch, &payload)
+                .unwrap()
+                .fill_qualification_no_zero_fill(&mut treatment)
+                .unwrap();
+            assert_eq!(treatment.len(), payload_end);
+            assert_eq!(&treatment[..4], &epoch.to_le_bytes());
+            assert_eq!(&treatment[4..], payload.as_slice());
+            assert!(!treatment.contains(&0xa5));
+            assert_eq!(treatment, control);
+        }
+    }
+
+    #[test]
+    fn qualification_no_zero_fill_rejects_incomplete_coverage_before_any_write() {
+        let geometry = GpuNativeQ4ExpertGeometry::try_new(32, 32, 128, 8).unwrap();
+        let payload = vec![0x31; geometry.logical_expert_bytes()];
+        for destination_bytes in [
+            geometry.slot_stride_bytes() - 4,
+            geometry.slot_stride_bytes() + 4,
+        ] {
+            let mut destination = vec![0xa5; destination_bytes];
+            let checked = CheckedPhysicalQ4ExpertSlot::new(geometry, 7, 1, &payload).unwrap();
+            assert!(matches!(
+                checked.fill_qualification_no_zero_fill(&mut destination),
+                Err(GpuNativeBootstrapError::ExpertPhysicalSlotDestinationLength { .. })
+            ));
+            assert!(destination.iter().all(|&byte| byte == 0xa5));
+        }
+        // Synthetic future geometry: length equals stride, but a tail exists.
+        // This does not change the production geometry constructor.
+        let padded = GpuNativeQ4ExpertGeometry {
+            slot_stride_bytes: geometry.slot_stride_bytes() + 4,
+            ..geometry
+        };
+        let mut destination = vec![0xa5; padded.slot_stride_bytes()];
+        let checked = CheckedPhysicalQ4ExpertSlot::new(padded, 7, 1, &payload).unwrap();
+        assert!(matches!(
+            checked.fill_qualification_no_zero_fill(&mut destination),
+            Err(GpuNativeBootstrapError::ExpertPhysicalSlotDestinationLength { .. })
+        ));
+        assert!(destination.iter().all(|&byte| byte == 0xa5));
+        CheckedPhysicalQ4ExpertSlot::new(padded, 7, 1, &payload)
+            .unwrap()
+            .fill(&mut destination)
+            .unwrap();
+        assert_eq!(&destination[geometry.slot_stride_bytes()..], &[0; 4]);
+    }
+
+    #[test]
+    fn qualification_no_zero_fill_preserves_split_transaction_slots_and_publication() {
+        for width in 1..=8 {
+            let control = test_mutable_expert_arena(width);
+            let treatment = test_mutable_expert_arena(width);
+            let payload = q4_uniform_expert(control.geometry(), 0.01, -0.02, 0.005);
+            let mut outputs = Vec::new();
+            for (arena, no_zero_fill) in [(&control, false), (&treatment, true)] {
+                let mut pending = Vec::new();
+                let mut bytes = Vec::new();
+                for id in 0..width as u32 {
+                    let key = GpuNativeQ4ExpertKey::new(3, id, 10 + id as u64);
+                    let permit = expect_expert_install(
+                        arena.acquire_with_unpublish(key, |_, _| {}).unwrap(),
+                    );
+                    pending.push(
+                        permit
+                            .stage_with_checked_physical_writer(
+                                &payload,
+                                |bank, offset, checked| {
+                                    let mut destination =
+                                        vec![0xa5; arena.geometry().slot_stride_bytes()];
+                                    if no_zero_fill {
+                                        checked
+                                            .fill_qualification_no_zero_fill(&mut destination)?;
+                                    } else {
+                                        checked.fill(&mut destination)?;
+                                    }
+                                    bytes.push((bank, offset, destination));
+                                    Ok(())
+                                },
+                            )
+                            .unwrap(),
+                    );
+                }
+                assert_eq!(arena.residency_snapshot().resident_slots, 0);
+                assert_eq!(arena.residency_snapshot().expert_mapping_publications, 0);
+                let mut mappings = Vec::new();
+                for prepared in pending {
+                    prepared
+                        .commit_with_mapping_writer(|offset, entry| mappings.push((offset, entry)))
+                        .unwrap();
+                }
+                assert_eq!(arena.residency_snapshot().resident_slots, width);
+                outputs.push((bytes, mappings));
+            }
+            assert_eq!(outputs[0], outputs[1]);
+        }
     }
 
     #[test]

--- a/rust-engine/src/buffer_pool.rs
+++ b/rust-engine/src/buffer_pool.rs
@@ -31,8 +31,9 @@ use tokio::sync::Notify;
 
 static EXPERT_BUFFER_POOL_PRIMARY_BYTES: AtomicU64 = AtomicU64::new(0);
 static EXPERT_BUFFER_POOL_SHADOW_BYTES: AtomicU64 = AtomicU64::new(0);
+static EXPERT_BUFFER_POOL_QUALIFICATION_ORACLE_BYTES: AtomicU64 = AtomicU64::new(0);
 
-/// Bytes allocated by the primary slots of all live expert buffer pools.
+/// Bytes allocated by production-primary slots of all live expert buffer pools.
 pub fn expert_buffer_pool_primary_bytes() -> u64 {
     EXPERT_BUFFER_POOL_PRIMARY_BYTES.load(Ordering::Relaxed)
 }
@@ -42,9 +43,23 @@ pub fn expert_buffer_pool_shadow_bytes() -> u64 {
     EXPERT_BUFFER_POOL_SHADOW_BYTES.load(Ordering::Relaxed)
 }
 
-/// Bytes allocated by every slot of all live expert buffer pools.
+/// Bytes allocated by qualification-only ORACLE future-source pools.
+pub fn expert_buffer_pool_qualification_oracle_bytes() -> u64 {
+    EXPERT_BUFFER_POOL_QUALIFICATION_ORACLE_BYTES.load(Ordering::Relaxed)
+}
+
+/// Bytes allocated by every production and qualification expert-buffer slot.
 pub fn expert_buffer_pool_allocated_bytes() -> u64 {
-    expert_buffer_pool_primary_bytes().saturating_add(expert_buffer_pool_shadow_bytes())
+    expert_buffer_pool_primary_bytes()
+        .saturating_add(expert_buffer_pool_shadow_bytes())
+        .saturating_add(expert_buffer_pool_qualification_oracle_bytes())
+}
+
+/// Source-plane classification carried by every pooled buffer.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum BufferPoolOrigin {
+    Production,
+    QualificationOracleFutureSource,
 }
 
 struct Inner {
@@ -63,14 +78,23 @@ struct Inner {
     shadow_slots: usize,
     buffer_size: usize,
     align: usize,
+    origin: BufferPoolOrigin,
 }
 
 impl Drop for Inner {
     fn drop(&mut self) {
         let primary = (self.primary_slots as u64).saturating_mul(self.buffer_size as u64);
         let shadow = (self.shadow_slots as u64).saturating_mul(self.buffer_size as u64);
-        EXPERT_BUFFER_POOL_PRIMARY_BYTES.fetch_sub(primary, Ordering::Relaxed);
-        EXPERT_BUFFER_POOL_SHADOW_BYTES.fetch_sub(shadow, Ordering::Relaxed);
+        match self.origin {
+            BufferPoolOrigin::Production => {
+                EXPERT_BUFFER_POOL_PRIMARY_BYTES.fetch_sub(primary, Ordering::Relaxed);
+                EXPERT_BUFFER_POOL_SHADOW_BYTES.fetch_sub(shadow, Ordering::Relaxed);
+            }
+            BufferPoolOrigin::QualificationOracleFutureSource => {
+                debug_assert_eq!(self.shadow_slots, 0);
+                EXPERT_BUFFER_POOL_QUALIFICATION_ORACLE_BYTES.fetch_sub(primary, Ordering::Relaxed);
+            }
+        }
     }
 }
 
@@ -99,7 +123,47 @@ impl BufferPool {
         buffer_size: usize,
         align: usize,
     ) -> Self {
-        assert!(primary_slots > 0, "primary pool must have at least one slot");
+        Self::new_with_origin(
+            primary_slots,
+            shadow_slots,
+            buffer_size,
+            align,
+            BufferPoolOrigin::Production,
+        )
+    }
+
+    /// Pre-allocate a bounded qualification-only future-source plane.
+    /// Buffers from this pool are structurally distinguishable from the
+    /// production PRIMARY/shadow allocation and are never promoted.
+    pub(crate) fn new_qualification_oracle_future_source(
+        slots: usize,
+        buffer_size: usize,
+        align: usize,
+    ) -> Self {
+        Self::new_with_origin(
+            slots,
+            0,
+            buffer_size,
+            align,
+            BufferPoolOrigin::QualificationOracleFutureSource,
+        )
+    }
+
+    fn new_with_origin(
+        primary_slots: usize,
+        shadow_slots: usize,
+        buffer_size: usize,
+        align: usize,
+        origin: BufferPoolOrigin,
+    ) -> Self {
+        assert!(
+            primary_slots > 0,
+            "primary pool must have at least one slot"
+        );
+        assert!(
+            origin == BufferPoolOrigin::Production || shadow_slots == 0,
+            "qualification ORACLE pools cannot have shadow slots"
+        );
         let mut free = Vec::with_capacity(primary_slots);
         for _ in 0..primary_slots {
             free.push(AlignedBuffer::new(buffer_size, align));
@@ -115,8 +179,16 @@ impl BufferPool {
         };
         let primary_bytes = (primary_slots as u64).saturating_mul(buffer_size as u64);
         let shadow_bytes = (shadow_slots as u64).saturating_mul(buffer_size as u64);
-        EXPERT_BUFFER_POOL_PRIMARY_BYTES.fetch_add(primary_bytes, Ordering::Relaxed);
-        EXPERT_BUFFER_POOL_SHADOW_BYTES.fetch_add(shadow_bytes, Ordering::Relaxed);
+        match origin {
+            BufferPoolOrigin::Production => {
+                EXPERT_BUFFER_POOL_PRIMARY_BYTES.fetch_add(primary_bytes, Ordering::Relaxed);
+                EXPERT_BUFFER_POOL_SHADOW_BYTES.fetch_add(shadow_bytes, Ordering::Relaxed);
+            }
+            BufferPoolOrigin::QualificationOracleFutureSource => {
+                EXPERT_BUFFER_POOL_QUALIFICATION_ORACLE_BYTES
+                    .fetch_add(primary_bytes, Ordering::Relaxed);
+            }
+        }
         Self {
             inner: Arc::new(Inner {
                 free: Mutex::new(free),
@@ -127,6 +199,7 @@ impl BufferPool {
                 shadow_slots,
                 buffer_size,
                 align,
+                origin,
             }),
         }
     }
@@ -183,11 +256,17 @@ impl BufferPool {
         let mut out = Vec::with_capacity(self.inner.primary_slots + self.inner.shadow_slots);
         {
             let mut g = self.inner.free.lock();
-            out.extend(g.iter_mut().map(|b| (b.as_mut_slice().as_mut_ptr(), b.len())));
+            out.extend(
+                g.iter_mut()
+                    .map(|b| (b.as_mut_slice().as_mut_ptr(), b.len())),
+            );
         }
         if let Some(s) = &self.inner.shadow {
             let mut g = s.lock();
-            out.extend(g.iter_mut().map(|b| (b.as_mut_slice().as_mut_ptr(), b.len())));
+            out.extend(
+                g.iter_mut()
+                    .map(|b| (b.as_mut_slice().as_mut_ptr(), b.len())),
+            );
         }
         out
     }
@@ -203,9 +282,18 @@ impl BufferPool {
         })
     }
 
-    #[cfg(test)]
     pub(crate) fn primary_available(&self) -> usize {
         self.inner.free.lock().len()
+    }
+
+    /// Source-plane classification shared by every buffer in this pool.
+    pub(crate) fn origin(&self) -> BufferPoolOrigin {
+        self.inner.origin
+    }
+
+    #[cfg(test)]
+    pub(crate) fn same_allocation(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.inner, &other.inner)
     }
 
     /// Try to pop a free **shadow** buffer immediately. Returns `None`
@@ -302,17 +390,26 @@ pub struct PooledBuffer {
 impl PooledBuffer {
     #[inline]
     pub fn as_slice(&self) -> &[u8] {
-        self.buffer.as_ref().expect("PooledBuffer must hold a buffer until Drop").as_slice()
+        self.buffer
+            .as_ref()
+            .expect("PooledBuffer must hold a buffer until Drop")
+            .as_slice()
     }
 
     #[inline]
     pub fn as_mut_slice(&mut self) -> &mut [u8] {
-        self.buffer.as_mut().expect("PooledBuffer must hold a buffer until Drop").as_mut_slice()
+        self.buffer
+            .as_mut()
+            .expect("PooledBuffer must hold a buffer until Drop")
+            .as_mut_slice()
     }
 
     #[inline]
     pub fn len(&self) -> usize {
-        self.buffer.as_ref().expect("PooledBuffer must hold a buffer until Drop").len()
+        self.buffer
+            .as_ref()
+            .expect("PooledBuffer must hold a buffer until Drop")
+            .len()
     }
 
     /// Whether this buffer was acquired from the shadow (speculative)
@@ -323,6 +420,12 @@ impl PooledBuffer {
     #[inline]
     pub fn is_shadow(&self) -> bool {
         self.slot == Slot::Shadow
+    }
+
+    /// Source-plane classification of the pool that owns this buffer.
+    #[inline]
+    pub(crate) fn pool_origin(&self) -> BufferPoolOrigin {
+        self.pool.origin
     }
 }
 
@@ -454,7 +557,9 @@ mod tests {
         // not shadow, so the shadow slot is now exhausted.
         drop(promoted);
         // Primary now has one free buffer (the just-dropped, promoted one).
-        let _p = pool.try_acquire().expect("primary should have the promoted buffer");
+        let _p = pool
+            .try_acquire()
+            .expect("primary should have the promoted buffer");
         // Shadow remains empty because we promoted its only slot.
         assert!(pool.try_acquire_shadow().is_none());
     }
@@ -475,5 +580,30 @@ mod tests {
         let _primary = pool.try_acquire().unwrap();
         let _shadow = pool.try_acquire_shadow().unwrap();
         assert_eq!(pool.allocated_bytes(), 5 * 8192);
+    }
+
+    #[test]
+    fn qualification_oracle_pool_is_structurally_distinct_and_recyclable() {
+        let pool = BufferPool::new_qualification_oracle_future_source(2, 8192, 4096);
+        let clone = pool.clone();
+        assert_eq!(
+            pool.origin(),
+            BufferPoolOrigin::QualificationOracleFutureSource
+        );
+        assert!(pool.same_allocation(&clone));
+        assert_eq!(pool.capacity(), 2);
+        assert_eq!(pool.shadow_capacity(), 0);
+        assert_eq!(pool.allocated_bytes(), 2 * 8192);
+        let first = pool.try_acquire().unwrap();
+        let second = pool.try_acquire().unwrap();
+        assert_eq!(
+            first.pool_origin(),
+            BufferPoolOrigin::QualificationOracleFutureSource
+        );
+        assert_eq!(pool.primary_available(), 0);
+        assert!(pool.try_acquire().is_none());
+        drop(first);
+        drop(second);
+        assert_eq!(pool.primary_available(), pool.capacity());
     }
 }

--- a/rust-engine/src/engine.rs
+++ b/rust-engine/src/engine.rs
@@ -518,6 +518,10 @@ pub(crate) enum GpuNativePhysicalInstallStagingQualificationArm {
 pub(crate) enum GpuNativePhysicalInstallConcurrencyQualificationArm {
     Control,
     Treatment,
+    /// Zero-fill production qualifier: concurrent direct staging with full zero.
+    ConcurrentFullZeroControl,
+    /// Zero-fill qualifier: observe ordinary production, with no zero fill.
+    ProductionNoZeroFillTreatment,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -617,6 +621,13 @@ pub(crate) struct GpuNativePhysicalInstallConcurrencyQualificationSnapshot {
     pub(crate) direct_staging_writes: u64,
     pub(crate) direct_staging_failures: u64,
     pub(crate) physical_slot_bytes_staged: u64,
+    pub(crate) physical_slot_zero_fill_bytes: u64,
+    pub(crate) physical_slot_epoch_write_bytes: u64,
+    pub(crate) physical_slot_payload_copy_bytes: u64,
+    pub(crate) evidence_accounting_errors: u64,
+    pub(crate) timing_accounting_errors: u64,
+    pub(crate) active_physical_staging: u64,
+    pub(crate) ordered_install_set_behavior_sha256: String,
     pub(crate) mapping_publications: u64,
     pub(crate) mapping_unpublications: u64,
     pub(crate) physical_slot_prepare_us: u64,
@@ -1019,6 +1030,12 @@ struct GpuNativeDemandSourceQualification {
     direct_staging_writes: AtomicU64,
     direct_staging_failures: AtomicU64,
     physical_slot_bytes_staged: AtomicU64,
+    physical_slot_zero_fill_bytes: AtomicU64,
+    physical_slot_epoch_write_bytes: AtomicU64,
+    physical_slot_payload_copy_bytes: AtomicU64,
+    evidence_accounting_errors: AtomicU64,
+    timing_accounting_errors: AtomicU64,
+    ordered_install_set_behavior: parking_lot::Mutex<QualificationOrderedHasher>,
     mapping_publications: AtomicU64,
     mapping_unpublications: AtomicU64,
     physical_slot_prepare_us: AtomicU64,
@@ -1112,6 +1129,14 @@ impl GpuNativeDemandSourceQualification {
             direct_staging_writes: AtomicU64::new(0),
             direct_staging_failures: AtomicU64::new(0),
             physical_slot_bytes_staged: AtomicU64::new(0),
+            physical_slot_zero_fill_bytes: AtomicU64::new(0),
+            physical_slot_epoch_write_bytes: AtomicU64::new(0),
+            physical_slot_payload_copy_bytes: AtomicU64::new(0),
+            evidence_accounting_errors: AtomicU64::new(0),
+            timing_accounting_errors: AtomicU64::new(0),
+            ordered_install_set_behavior: parking_lot::Mutex::new(
+                QualificationOrderedHasher::default(),
+            ),
             mapping_publications: AtomicU64::new(0),
             mapping_unpublications: AtomicU64::new(0),
             physical_slot_prepare_us: AtomicU64::new(0),
@@ -1352,7 +1377,11 @@ impl GpuNativeDemandSourceQualification {
         let width_min = self.install_set_width_min.load(Ordering::Relaxed);
         GpuNativePhysicalInstallConcurrencyQualificationSnapshot {
             arm,
-            production_physical_install_concurrency_changed: true,
+            production_physical_install_concurrency_changed: matches!(
+                arm,
+                GpuNativePhysicalInstallConcurrencyQualificationArm::Control
+                    | GpuNativePhysicalInstallConcurrencyQualificationArm::Treatment
+            ),
             normal_production_uses_concurrent_physical_staging: true,
             control_forces_sequential_direct_staging: matches!(
                 arm,
@@ -1361,6 +1390,7 @@ impl GpuNativeDemandSourceQualification {
             treatment_uses_ordinary_production_path: matches!(
                 arm,
                 GpuNativePhysicalInstallConcurrencyQualificationArm::Treatment
+                    | GpuNativePhysicalInstallConcurrencyQualificationArm::ProductionNoZeroFillTreatment
             ),
             single_request_stream: self.overlapping_demand_sets.load(Ordering::Relaxed) == 0,
             overlapping_demand_sets: self.overlapping_demand_sets.load(Ordering::Relaxed),
@@ -1398,6 +1428,19 @@ impl GpuNativeDemandSourceQualification {
             direct_staging_writes: self.direct_staging_writes.load(Ordering::Relaxed),
             direct_staging_failures: self.direct_staging_failures.load(Ordering::Relaxed),
             physical_slot_bytes_staged: self.physical_slot_bytes_staged.load(Ordering::Relaxed),
+            physical_slot_zero_fill_bytes: self
+                .physical_slot_zero_fill_bytes
+                .load(Ordering::Relaxed),
+            physical_slot_epoch_write_bytes: self
+                .physical_slot_epoch_write_bytes
+                .load(Ordering::Relaxed),
+            physical_slot_payload_copy_bytes: self
+                .physical_slot_payload_copy_bytes
+                .load(Ordering::Relaxed),
+            evidence_accounting_errors: self.evidence_accounting_errors.load(Ordering::Relaxed),
+            timing_accounting_errors: self.timing_accounting_errors.load(Ordering::Relaxed),
+            active_physical_staging: self.active_physical_staging.load(Ordering::Relaxed),
+            ordered_install_set_behavior_sha256: self.ordered_install_set_behavior.lock().hex(),
             mapping_publications: self.mapping_publications.load(Ordering::Relaxed),
             mapping_unpublications: self.mapping_unpublications.load(Ordering::Relaxed),
             physical_slot_prepare_us: self.physical_slot_prepare_us.load(Ordering::Relaxed),
@@ -1458,6 +1501,14 @@ impl GpuNativeDemandSourceQualification {
     }
 }
 
+#[cfg(test)]
+pub(crate) fn empty_physical_zero_fill_test_snapshot(
+    arm: GpuNativePhysicalInstallConcurrencyQualificationArm,
+) -> GpuNativePhysicalInstallConcurrencyQualificationSnapshot {
+    GpuNativeDemandSourceQualification::new_physical_install_concurrency(arm, 385, 0)
+        .physical_install_concurrency_snapshot()
+}
+
 impl GpuNativePhysicalInstallObserver for GpuNativeDemandSourceQualification {
     fn record_physical_victim(&self, global_id: u32) {
         self.physical_victim_ids.lock().record_id(global_id);
@@ -1507,6 +1558,30 @@ impl GpuNativePhysicalInstallObserver for GpuNativeDemandSourceQualification {
             .fetch_add(evidence.direct_staging_writes, Ordering::Relaxed);
         self.physical_slot_bytes_staged
             .fetch_add(evidence.physical_slot_bytes_staged, Ordering::Relaxed);
+        for (counter, bytes) in [
+            (
+                &self.physical_slot_zero_fill_bytes,
+                evidence.physical_slot_zero_fill_bytes,
+            ),
+            (
+                &self.physical_slot_epoch_write_bytes,
+                evidence.physical_slot_epoch_write_bytes,
+            ),
+            (
+                &self.physical_slot_payload_copy_bytes,
+                evidence.physical_slot_payload_copy_bytes,
+            ),
+        ] {
+            if counter
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |total| {
+                    total.checked_add(bytes)
+                })
+                .is_err()
+            {
+                self.evidence_accounting_errors
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+        }
         self.mapping_publications.fetch_add(1, Ordering::Relaxed);
         self.physical_slot_prepare_us
             .fetch_add(evidence.physical_slot_prepare_us, Ordering::Relaxed);
@@ -1557,6 +1632,13 @@ impl GpuNativePhysicalInstallObserver for GpuNativeDemandSourceQualification {
         ) {
             return;
         }
+        // Record in reservation/request order before Rayon work starts.
+        self.ordered_install_set_behavior.lock().record_set(&[
+            width as u32,
+            u32::from(parallel),
+            u32::from(caller_in_rayon_worker),
+            rayon_threads as u32,
+        ]);
         let width = width as u64;
         self.physical_install_sets.fetch_add(1, Ordering::Relaxed);
         self.physical_install_experts
@@ -1627,6 +1709,8 @@ impl GpuNativePhysicalInstallObserver for GpuNativeDemandSourceQualification {
             self.purpose,
             GpuNativeQualificationPurpose::PhysicalInstallConcurrency(
                 GpuNativePhysicalInstallConcurrencyQualificationArm::Treatment
+                    | GpuNativePhysicalInstallConcurrencyQualificationArm::ConcurrentFullZeroControl
+                    | GpuNativePhysicalInstallConcurrencyQualificationArm::ProductionNoZeroFillTreatment
             )
         ) {
             return;
@@ -1649,9 +1733,30 @@ impl GpuNativePhysicalInstallObserver for GpuNativeDemandSourceQualification {
             self.purpose,
             GpuNativeQualificationPurpose::PhysicalInstallConcurrency(
                 GpuNativePhysicalInstallConcurrencyQualificationArm::Treatment
+                    | GpuNativePhysicalInstallConcurrencyQualificationArm::ConcurrentFullZeroControl
+                    | GpuNativePhysicalInstallConcurrencyQualificationArm::ProductionNoZeroFillTreatment
             )
         ) {
             return;
+        }
+        if evidence
+            .physical_slot_epoch_write_bytes
+            .checked_add(evidence.physical_slot_payload_copy_bytes)
+            != Some(evidence.physical_slot_bytes_staged)
+            || evidence.direct_staging_writes != 1
+            || evidence.full_slot_vec_materializations != 0
+        {
+            self.evidence_accounting_errors
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        if evidence
+            .physical_slot_prepare_us
+            .checked_add(evidence.physical_queue_staging_us)
+            .is_none_or(|subphases| subphases > individual_stage_us)
+            || evidence.individual_physical_stage_us != individual_stage_us
+        {
+            self.timing_accounting_errors
+                .fetch_add(1, Ordering::Relaxed);
         }
         self.physical_stage_completions
             .fetch_add(1, Ordering::Relaxed);
@@ -1667,6 +1772,8 @@ impl GpuNativePhysicalInstallObserver for GpuNativeDemandSourceQualification {
             self.purpose,
             GpuNativeQualificationPurpose::PhysicalInstallConcurrency(
                 GpuNativePhysicalInstallConcurrencyQualificationArm::Treatment
+                    | GpuNativePhysicalInstallConcurrencyQualificationArm::ConcurrentFullZeroControl
+                    | GpuNativePhysicalInstallConcurrencyQualificationArm::ProductionNoZeroFillTreatment
             )
         ) {
             self.physical_stage_failures.fetch_add(1, Ordering::Relaxed);
@@ -1679,6 +1786,8 @@ impl GpuNativePhysicalInstallObserver for GpuNativeDemandSourceQualification {
             self.purpose,
             GpuNativeQualificationPurpose::PhysicalInstallConcurrency(
                 GpuNativePhysicalInstallConcurrencyQualificationArm::Treatment
+                    | GpuNativePhysicalInstallConcurrencyQualificationArm::ConcurrentFullZeroControl
+                    | GpuNativePhysicalInstallConcurrencyQualificationArm::ProductionNoZeroFillTreatment
             )
         ) {
             self.physical_parallel_stage_wall_us
@@ -1691,6 +1800,8 @@ impl GpuNativePhysicalInstallObserver for GpuNativeDemandSourceQualification {
             self.purpose,
             GpuNativeQualificationPurpose::PhysicalInstallConcurrency(
                 GpuNativePhysicalInstallConcurrencyQualificationArm::Treatment
+                    | GpuNativePhysicalInstallConcurrencyQualificationArm::ConcurrentFullZeroControl
+                    | GpuNativePhysicalInstallConcurrencyQualificationArm::ProductionNoZeroFillTreatment
             )
         ) {
             self.ordered_commit_attempts.fetch_add(1, Ordering::Relaxed);
@@ -1702,6 +1813,8 @@ impl GpuNativePhysicalInstallObserver for GpuNativeDemandSourceQualification {
             self.purpose,
             GpuNativeQualificationPurpose::PhysicalInstallConcurrency(
                 GpuNativePhysicalInstallConcurrencyQualificationArm::Treatment
+                    | GpuNativePhysicalInstallConcurrencyQualificationArm::ConcurrentFullZeroControl
+                    | GpuNativePhysicalInstallConcurrencyQualificationArm::ProductionNoZeroFillTreatment
             )
         ) {
             self.ordered_commit_completions
@@ -6373,7 +6486,15 @@ impl Engine {
                                 &demands,
                                 state.as_ref(),
                             ),
-                        GpuNativePhysicalInstallConcurrencyQualificationArm::Treatment => manager
+                        GpuNativePhysicalInstallConcurrencyQualificationArm::ConcurrentFullZeroControl => manager
+                            .ensure_demand_set_full_zero_control_observed(
+                                GpuNativeResidencyPriority::Demand,
+                                layer_index,
+                                &demands,
+                                state.as_ref(),
+                            ),
+                        GpuNativePhysicalInstallConcurrencyQualificationArm::Treatment
+                        | GpuNativePhysicalInstallConcurrencyQualificationArm::ProductionNoZeroFillTreatment => manager
                             .ensure_demand_set_production_observed(
                                 GpuNativeResidencyPriority::Demand,
                                 layer_index,
@@ -9132,6 +9253,58 @@ mod tests {
     impl Drop for TempDir {
         fn drop(&mut self) {
             let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+
+    #[test]
+    fn physical_zero_fill_observer_records_both_concurrent_arms_and_detects_errors() {
+        use GpuNativePhysicalInstallConcurrencyQualificationArm as Arm;
+        for arm in [
+            Arm::ConcurrentFullZeroControl,
+            Arm::ProductionNoZeroFillTreatment,
+        ] {
+            let state =
+                GpuNativeDemandSourceQualification::new_physical_install_concurrency(arm, 385, 0);
+            state.record_physical_install_set(2, true, false, 4);
+            state.record_physical_stage_started();
+            state.record_physical_stage_started();
+            let evidence = GpuNativePhysicalInstallEvidence {
+                direct_staging_writes: 1,
+                physical_slot_bytes_staged: 2_654_212,
+                physical_slot_zero_fill_bytes: match arm {
+                    Arm::ProductionNoZeroFillTreatment => 0,
+                    Arm::ConcurrentFullZeroControl => 2_654_212,
+                    _ => unreachable!("test includes only zero-fill production qualification arms"),
+                },
+                physical_slot_epoch_write_bytes: 4,
+                physical_slot_payload_copy_bytes: 2_654_208,
+                physical_slot_prepare_us: 5,
+                physical_queue_staging_us: 3,
+                individual_physical_stage_us: 10,
+                ..GpuNativePhysicalInstallEvidence::default()
+            };
+            state.record_physical_stage_completed(evidence, 10);
+            state.record_physical_stage_completed(evidence, 10);
+            let snapshot = state.physical_install_concurrency_snapshot();
+            assert_eq!(snapshot.physical_stage_completions, 2);
+            assert_eq!(snapshot.active_physical_staging, 0);
+            assert_eq!(snapshot.max_in_flight_physical_staging, 2);
+            assert_eq!(snapshot.parallel_staging_sets, 1);
+            assert_eq!(snapshot.sum_individual_physical_stage_us, 20);
+            assert_eq!(snapshot.evidence_accounting_errors, 0);
+            assert_eq!(snapshot.timing_accounting_errors, 0);
+            state.record_physical_stage_started();
+            state.record_physical_stage_completed(
+                GpuNativePhysicalInstallEvidence {
+                    physical_slot_payload_copy_bytes: 1,
+                    physical_slot_prepare_us: 50,
+                    ..evidence
+                },
+                10,
+            );
+            let invalid = state.physical_install_concurrency_snapshot();
+            assert_eq!(invalid.evidence_accounting_errors, 1);
+            assert_eq!(invalid.timing_accounting_errors, 1);
         }
     }
 

--- a/rust-engine/src/engine.rs
+++ b/rust-engine/src/engine.rs
@@ -27,9 +27,9 @@ use crate::expert_cache::{
 use crate::gating::Router;
 use crate::gpu_native_residency::{
     global_to_layer_local as gpu_native_global_to_layer_local, GpuNativeDemandExpert,
-    GpuNativePhysicalInstallObserver, GpuNativeResidencyPriority, GpuNativeSpeculativeInstall,
-    GpuNativeSpeculativeProbe, GpuNativeTieredResidencyError, GpuNativeTieredResidencyManager,
-    GpuNativeTieredResidencySnapshot,
+    GpuNativeModelExpertVramPlan, GpuNativePhysicalInstallObserver, GpuNativeResidencyPriority,
+    GpuNativeSpeculativeInstall, GpuNativeSpeculativeProbe, GpuNativeTieredResidencyError,
+    GpuNativeTieredResidencyManager, GpuNativeTieredResidencySnapshot,
 };
 use crate::inference::{
     combine_outputs, run_inference_bf16, run_inference_f16, run_inference_int8,
@@ -924,6 +924,16 @@ impl QualificationOrderedHasher {
     fn hex(&self) -> String {
         format!("{:x}", self.inner.clone().finalize())
     }
+}
+
+/// Reproduce the historical `selected_route_ids_sha256` framing exactly for
+/// an ordered sequence of already-global expert-id sets.
+pub(crate) fn qualification_ordered_sets_sha256(ordered_sets: &[Vec<u32>]) -> String {
+    let mut hasher = QualificationOrderedHasher::default();
+    for ids in ordered_sets {
+        hasher.record_set(ids);
+    }
+    hasher.hex()
 }
 
 /// Normalize completed source reads into original request order before any
@@ -3233,11 +3243,21 @@ pub struct Engine {
     diagnostic_cpu_q4_boundary_emulated_dispatches: AtomicU64,
     diagnostic_route_capture_armed: std::sync::atomic::AtomicBool,
     diagnostic_route_capture: parking_lot::Mutex<Option<DiagnosticRouteCaptureArm>>,
+    gpu_native_actual_route_observer_armed: AtomicBool,
+    gpu_native_actual_route_observer:
+        parking_lot::RwLock<Option<Arc<dyn GpuNativeActualRouteObserver>>>,
     gpu_native_demand_source_qualification:
         parking_lot::RwLock<Option<Arc<GpuNativeDemandSourceQualification>>>,
     production_demand_source: Arc<ProductionDemandSourceTelemetry>,
     #[cfg(test)]
     production_batch_test_hooks: parking_lot::Mutex<ProductionBatchTestHooks>,
+}
+
+/// Diagnostic-only consumer for route IDs already present in the ordinary
+/// GPU-native token-loop boundary report. Implementations must observe only;
+/// normal serving and benchmarks never install one.
+pub(crate) trait GpuNativeActualRouteObserver: Send + Sync {
+    fn record_position(&self, position: usize, selected_ids_by_layer: &[Vec<u32>]);
 }
 
 #[cfg(test)]
@@ -3606,6 +3626,8 @@ impl Engine {
             diagnostic_cpu_q4_boundary_emulated_dispatches: AtomicU64::new(0),
             diagnostic_route_capture_armed: std::sync::atomic::AtomicBool::new(false),
             diagnostic_route_capture: parking_lot::Mutex::new(None),
+            gpu_native_actual_route_observer_armed: AtomicBool::new(false),
+            gpu_native_actual_route_observer: parking_lot::RwLock::new(None),
             gpu_native_demand_source_qualification: parking_lot::RwLock::new(None),
             production_demand_source,
             #[cfg(test)]
@@ -4431,6 +4453,44 @@ impl Engine {
             .map(|manager| manager.snapshot())
     }
 
+    pub(crate) fn gpu_native_model_expert_vram_plan_for_budget(
+        &self,
+        total_expert_budget_bytes: u64,
+    ) -> Result<GpuNativeModelExpertVramPlan, GpuNativeDemandResidencyError> {
+        let manager = self
+            .core
+            .gpu_native_residency
+            .as_ref()
+            .ok_or(GpuNativeDemandResidencyError::ManagerNotInstalled)?;
+        manager
+            .plan_for_budget(total_expert_budget_bytes)
+            .map_err(Into::into)
+    }
+
+    pub(crate) fn install_gpu_native_actual_route_observer(
+        &self,
+        observer: Arc<dyn GpuNativeActualRouteObserver>,
+    ) -> Result<(), String> {
+        let mut slot = self.gpu_native_actual_route_observer.write();
+        if slot.is_some() {
+            return Err("GPU-native actual-route observer is already installed".into());
+        }
+        *slot = Some(observer);
+        self.gpu_native_actual_route_observer_armed
+            .store(true, Ordering::Release);
+        Ok(())
+    }
+
+    pub(crate) fn clear_gpu_native_actual_route_observer(&self) -> Result<(), String> {
+        self.gpu_native_actual_route_observer_armed
+            .store(false, Ordering::Release);
+        let removed = self.gpu_native_actual_route_observer.write().take();
+        if removed.is_none() {
+            return Err("GPU-native actual-route observer was not installed".into());
+        }
+        Ok(())
+    }
+
     /// Install v2 evidence. Control explicitly forces the legacy sequential
     /// helper; treatment exercises the same ordinary production path used
     /// when no qualifier is active. The dedicated command calls this only on a
@@ -4653,10 +4713,25 @@ impl Engine {
     /// route observation and prefetch infrastructure without requiring CPU hidden state.
     pub(crate) fn record_gpu_native_actual_routes(
         self: &Arc<Self>,
+        position: usize,
         selected_ids_by_layer: &[Vec<u32>],
     ) {
         self.core.governor.refresh();
         let per_layer_opt = self.core.storage.config().num_experts_per_layer;
+
+        if self
+            .gpu_native_actual_route_observer_armed
+            .load(Ordering::Acquire)
+        {
+            if let Some(observer) = self
+                .gpu_native_actual_route_observer
+                .read()
+                .as_ref()
+                .cloned()
+            {
+                observer.record_position(position, selected_ids_by_layer);
+            }
+        }
 
         if let Some(qualification) = self.gpu_native_demand_source_qualification() {
             let per_layer = per_layer_opt.unwrap_or(0);

--- a/rust-engine/src/expert_cache.rs
+++ b/rust-engine/src/expert_cache.rs
@@ -665,17 +665,23 @@ impl ExpertCache {
 // Phase 2 — logical GPU expert admission: Segmented Hybrid Policy.
 // =====================================================================
 
-/// One host-side logical GPU admission. The payload remains a `Vec<u8>` in
-/// process memory; physical routed-expert device buffers are owned and
-/// accounted by `GpuBackend`'s physical registry.
+/// Host bytes are optional only for the private ORACLE qualification path.
+/// The logical-only variant owns a byte charge and a small access audit; it
+/// cannot retain expert bytes, an ExpertResident, or a source-pool lease.
+enum GpuResidentHostPayload {
+    Materialized(Vec<u8>),
+    QualificationLogicalOnly {
+        charged_bytes: usize,
+        data_accesses: Arc<AtomicU64>,
+    },
+}
+
+/// One host-side logical GPU admission. Production constructors retain the
+/// supplied Vec unchanged; physical device buffers are owned by the backend.
 pub struct GpuResident {
     pub id: u32,
-    /// Host payload retained by the logical admission policy.
-    bytes: Vec<u8>,
-    /// On-disk encoding of `bytes`. `F32` residents feed the dense
-    /// matmul pipeline; `Q4_0` residents stay in native GGUF blocks
-    /// and feed the inline-dequant pipeline (`matmul_q4_0.wgsl`) —
-    /// see `GpuBackend::expert_matmul`.
+    payload: GpuResidentHostPayload,
+    /// Native on-disk encoding, preserved even for a logical-only admission.
     dtype: crate::inference::WeightDtype,
 }
 
@@ -683,7 +689,7 @@ impl GpuResident {
     pub fn new(id: u32, bytes: Vec<u8>) -> Self {
         Self {
             id,
-            bytes,
+            payload: GpuResidentHostPayload::Materialized(bytes),
             dtype: crate::inference::WeightDtype::F32,
         }
     }
@@ -693,31 +699,69 @@ impl GpuResident {
     /// matmul pipeline (e.g. Q4_0 inline dequant) without guessing
     /// from the byte length.
     pub fn new_with_dtype(id: u32, bytes: Vec<u8>, dtype: crate::inference::WeightDtype) -> Self {
-        Self { id, bytes, dtype }
+        Self {
+            id,
+            payload: GpuResidentHostPayload::Materialized(bytes),
+            dtype,
+        }
+    }
+
+    /// ORACLE qualification only: charge the ordinary logical cache without
+    /// copying or retaining source bytes. The run-owned audit survives cache
+    /// eviction and spans warmup and measured requests. It owns no source data.
+    pub(crate) fn new_qualification_logical_only(
+        id: u32,
+        charged_bytes: usize,
+        dtype: crate::inference::WeightDtype,
+        data_accesses: Arc<AtomicU64>,
+    ) -> Self {
+        assert!(
+            charged_bytes > 0,
+            "qualification logical-only admission requires a positive byte charge"
+        );
+        Self {
+            id,
+            payload: GpuResidentHostPayload::QualificationLogicalOnly {
+                charged_bytes,
+                data_accesses,
+            },
+            dtype,
+        }
     }
 
     /// Bare weight bytes ready for `run_inference_*`.
+    /// Logical-only qualification admissions are never a physical byte source.
     #[inline]
     pub fn data(&self) -> &[u8] {
-        &self.bytes
+        match &self.payload {
+            GpuResidentHostPayload::Materialized(bytes) => bytes,
+            GpuResidentHostPayload::QualificationLogicalOnly { data_accesses, .. } => {
+                data_accesses.fetch_add(1, Ordering::Relaxed);
+                panic!("qualification logical-only GpuResident has no payload bytes; physical staging must use ExpertResident::data()");
+            }
+        }
     }
 
-    /// Native encoding of [`GpuResident::data`].
     #[inline]
     pub fn dtype(&self) -> crate::inference::WeightDtype {
         self.dtype
     }
 
-    /// Size of the logical host payload admitted for future GPU upload.
+    /// Logical capacity charge, independent of host payload materialization.
     #[inline]
     pub fn byte_len(&self) -> usize {
-        self.bytes.len()
+        match &self.payload {
+            GpuResidentHostPayload::Materialized(bytes) => bytes.len(),
+            GpuResidentHostPayload::QualificationLogicalOnly { charged_bytes, .. } => {
+                *charged_bytes
+            }
+        }
     }
 }
 
 impl crate::backend::GpuStorage for GpuResident {
     fn byte_len(&self) -> usize {
-        self.bytes.len()
+        self.byte_len()
     }
     fn as_wgpu_buffer(&self) -> Option<&wgpu::Buffer> {
         None // GpuResident is host-side only; VRAM lives in VramExpertEntry
@@ -2162,6 +2206,187 @@ mod tests {
                 panic!("unexpected missing demand payloads: {missing:?}")
             }
         }
+    }
+
+    #[test]
+    fn production_gpu_resident_constructors_preserve_materialized_vec_ownership() {
+        use crate::inference::WeightDtype;
+        for dtype in [None, Some(WeightDtype::Q4_0)] {
+            let mut bytes = Vec::with_capacity(32);
+            bytes.extend_from_slice(&[3, 1, 4, 1, 5]);
+            let pointer = bytes.as_ptr();
+            let capacity = bytes.capacity();
+            let resident = match dtype {
+                None => GpuResident::new(17, bytes),
+                Some(dtype) => GpuResident::new_with_dtype(17, bytes, dtype),
+            };
+            assert_eq!(resident.id, 17);
+            assert_eq!(resident.dtype(), dtype.unwrap_or(WeightDtype::F32));
+            assert_eq!(resident.data(), &[3, 1, 4, 1, 5]);
+            assert_eq!(resident.data().as_ptr(), pointer);
+            assert_eq!(resident.byte_len(), 5);
+            assert_eq!(crate::backend::GpuStorage::byte_len(&resident), 5);
+            match &resident.payload {
+                GpuResidentHostPayload::Materialized(bytes) => {
+                    assert_eq!(bytes.capacity(), capacity)
+                }
+                _ => panic!("production constructor changed payload representation"),
+            }
+        }
+        assert!(GpuResident::new(0, Vec::new()).data().is_empty());
+    }
+
+    #[test]
+    fn qualification_logical_only_has_no_payload_allocation_and_data_access_fails_closed() {
+        let audit = Arc::new(AtomicU64::new(0));
+        let resident = GpuResident::new_qualification_logical_only(
+            17,
+            usize::MAX,
+            crate::inference::WeightDtype::Q4_0,
+            audit.clone(),
+        );
+        // Even an impossible allocation size is only metadata. This variant
+        // contains no Vec, ExpertResident, PooledBuffer, or source-owning Arc.
+        assert!(matches!(
+            &resident.payload,
+            GpuResidentHostPayload::QualificationLogicalOnly {
+                charged_bytes: usize::MAX,
+                ..
+            }
+        ));
+        assert!(std::mem::size_of::<GpuResident>() <= 64);
+        assert_eq!(resident.byte_len(), usize::MAX);
+        assert_eq!(crate::backend::GpuStorage::byte_len(&resident), usize::MAX);
+        assert_eq!(resident.id, 17);
+        assert_eq!(resident.dtype(), crate::inference::WeightDtype::Q4_0);
+        let failure = std::panic::catch_unwind(|| resident.data()).unwrap_err();
+        let message = failure.downcast_ref::<&str>().copied().unwrap();
+        assert!(message.contains("qualification logical-only GpuResident has no payload bytes"));
+        assert_eq!(audit.load(Ordering::Relaxed), 1);
+        drop(resident);
+        assert_eq!(
+            audit.load(Ordering::Relaxed),
+            1,
+            "audit survives eviction/drop"
+        );
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "qualification logical-only admission requires a positive byte charge"
+    )]
+    fn qualification_logical_only_rejects_zero_charge() {
+        GpuResident::new_qualification_logical_only(
+            1,
+            0,
+            crate::inference::WeightDtype::F32,
+            Arc::new(AtomicU64::new(0)),
+        );
+    }
+
+    #[test]
+    fn qualification_logical_only_cache_charge_generation_lru_and_protection_match_materialized() {
+        let caches = [
+            Arc::new(GpuExpertCache::new(16, 0.0, 0)),
+            Arc::new(GpuExpertCache::new(16, 0.0, 0)),
+        ];
+        let audit = Arc::new(AtomicU64::new(0));
+        let source = |id, only| {
+            Arc::new(if only {
+                GpuResident::new_qualification_logical_only(
+                    id,
+                    8,
+                    crate::inference::WeightDtype::F32,
+                    audit.clone(),
+                )
+            } else {
+                GpuResident::new(id, vec![id as u8; 8])
+            })
+        };
+        let mut observations = Vec::new();
+        for (only, cache) in caches.iter().enumerate() {
+            let mut history = Vec::new();
+            for ids in [vec![2, 1], vec![1], vec![3], vec![2]] {
+                let sources = ids.iter().map(|&id| (id, source(id, only == 1))).collect();
+                let (admissions, newly) =
+                    ready_demand_set(cache.demand_admit_set(&ids, &sources).unwrap());
+                assert_eq!(
+                    admissions
+                        .iter()
+                        .map(|a| a.resident().id)
+                        .collect::<Vec<_>>(),
+                    ids
+                );
+                assert!(admissions.iter().all(|a| a.byte_len() == 8
+                    && cache.contains_generation(a.resident().id, a.generation())));
+                history.push((
+                    newly,
+                    cache.used_bytes(),
+                    admissions
+                        .iter()
+                        .map(|a| a.generation())
+                        .collect::<Vec<_>>(),
+                    cache
+                        .inner
+                        .lock()
+                        .lru
+                        .iter()
+                        .map(|(id, a)| (*id, a.generation()))
+                        .collect::<Vec<_>>(),
+                ));
+                if ids == [1] {
+                    assert!(cache.get(1).is_hit());
+                }
+            }
+            // ID 1 was most recently touched, so 3 first evicted 2. Readmission
+            // of 2 gets a fresh ordinary generation and then evicts 1.
+            assert_eq!(history[0].2, vec![1, 2]);
+            assert_eq!(history[1].2, vec![2]);
+            assert_eq!(
+                history[2].3.iter().map(|x| x.0).collect::<Vec<_>>(),
+                vec![3, 1]
+            );
+            assert_eq!(history[3].2, vec![4]);
+            let _protection = cache.protect_demand_set(&[3, 2]).unwrap();
+            let before = cache.used_bytes();
+            assert!(matches!(
+                cache.demand_admit_set(&[4], &HashMap::from([(4, source(4, only == 1))])),
+                Err(GpuDemandAdmissionError::ProtectedDemandCapacity { .. })
+            ));
+            assert_eq!(cache.used_bytes(), before);
+            observations.push(history);
+        }
+        assert_eq!(observations[0], observations[1]);
+        assert_eq!(audit.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn qualification_logical_only_generation_exhaustion_and_capacity_fail_closed() {
+        let cache = GpuExpertCache::new(8, 0.0, 0);
+        let audit = Arc::new(AtomicU64::new(0));
+        let make = |id, bytes| {
+            Arc::new(GpuResident::new_qualification_logical_only(
+                id,
+                bytes,
+                crate::inference::WeightDtype::Q4_0,
+                audit.clone(),
+            ))
+        };
+        assert!(matches!(
+            cache.demand_admit_set(&[1], &HashMap::from([(1, make(1, 9))])),
+            Err(GpuDemandAdmissionError::PayloadExceedsLruCapacity {
+                bytes: 9,
+                capacity: 8
+            })
+        ));
+        cache.inner.lock().next_generation = u64::MAX;
+        assert!(matches!(
+            cache.demand_admit_set(&[1], &HashMap::from([(1, make(1, 8))])),
+            Err(GpuDemandAdmissionError::GenerationExhausted)
+        ));
+        assert_eq!(cache.used_bytes(), 0);
+        assert!(!cache.contains(1));
+        assert_eq!(audit.load(Ordering::Relaxed), 0);
     }
 
     #[test]

--- a/rust-engine/src/expert_cache.rs
+++ b/rust-engine/src/expert_cache.rs
@@ -193,6 +193,14 @@ impl ExpertResident {
         self.buffer.is_shadow()
     }
 
+    /// Source-plane classification of the aligned buffer backing this
+    /// resident. Qualification code uses this to fail closed if a future
+    /// position accidentally retains a production PRIMARY resident.
+    #[inline]
+    pub(crate) fn buffer_pool_origin(&self) -> crate::buffer_pool::BufferPoolOrigin {
+        self.buffer.pool_origin()
+    }
+
     /// Bare weight bytes — i.e. the buffer with any leading Unified
     /// Tensor Header stripped. The vast majority of callers want this.
     ///
@@ -234,7 +242,9 @@ impl ExpertResident {
         bool,
     )
     where
-        F: FnOnce(&[u8]) -> Result<
+        F: FnOnce(
+            &[u8],
+        ) -> Result<
             crate::inference::PreparedQ8_0Expert,
             crate::inference::ExpertWeightsError,
         >,
@@ -254,10 +264,8 @@ impl ExpertResident {
 
 impl Drop for ExpertResident {
     fn drop(&mut self) {
-        RESIDENT_EXPERT_BUFFER_BYTES.fetch_sub(
-            self.buffer.as_slice().len() as u64,
-            Ordering::Relaxed,
-        );
+        RESIDENT_EXPERT_BUFFER_BYTES
+            .fetch_sub(self.buffer.as_slice().len() as u64, Ordering::Relaxed);
     }
 }
 
@@ -468,7 +476,8 @@ impl ExpertCache {
             0
         };
         let mut pre_evicted = None;
-        let effective_len = guard.len()
+        let effective_len = guard
+            .len()
             .saturating_add(self.reserved_slots.load(Ordering::Relaxed));
         if effective_len >= self.capacity && guard.peek(&id).is_none() {
             // Pick the victim under the active policy: strict LRU by
@@ -1128,10 +1137,7 @@ impl GpuExpertCache {
     /// telemetry/recency lookup.
     pub fn current_admission(&self, id: u32) -> Option<GpuAdmission> {
         let g = self.inner.lock();
-        g.anchor
-            .get(&id)
-            .or_else(|| g.lru.peek(&id))
-            .cloned()
+        g.anchor.get(&id).or_else(|| g.lru.peek(&id)).cloned()
     }
 
     /// Check whether an expert is currently resident in either the
@@ -1261,7 +1267,10 @@ impl GpuExpertCache {
             g.promotion_rearm.remove(&id);
             return GpuHotPromotionOutcome::GenerationExhausted;
         };
-        let admission = GpuAdmission { resident, generation };
+        let admission = GpuAdmission {
+            resident,
+            generation,
+        };
         g.promotion_pending.remove(&id);
         g.promotion_rearm.remove(&id);
 
@@ -1411,7 +1420,10 @@ impl GpuExpertCache {
         let Some(generation) = g.allocate_generation() else {
             return false;
         };
-        let admission = GpuAdmission { resident, generation };
+        let admission = GpuAdmission {
+            resident,
+            generation,
+        };
         if use_anchor {
             g.anchor.insert(admission.resident.id, admission);
             g.anchor_used_bytes = g
@@ -1489,8 +1501,7 @@ impl GpuExpertCache {
         }
         // Strictly non-evicting: must fit in whatever LRU budget is
         // currently free.
-        if g
-            .lru_used_bytes
+        if g.lru_used_bytes
             .checked_add(bytes)
             .is_none_or(|used| used > self.lru_capacity_bytes)
         {
@@ -1499,7 +1510,10 @@ impl GpuExpertCache {
         let Some(generation) = g.allocate_generation() else {
             return false;
         };
-        let admission = GpuAdmission { resident, generation };
+        let admission = GpuAdmission {
+            resident,
+            generation,
+        };
         g.promotion_pending.remove(&admission.resident.id);
         g.promotion_rearm.remove(&admission.resident.id);
         g.lru.put(admission.resident.id, admission);
@@ -2381,7 +2395,10 @@ mod tests {
         let cache = GpuExpertCache::new(20, 0.0, 3);
         assert!(cache.promote_sync(gpu_res(1, 8)));
         assert!(cache.promote_sync(gpu_res(2, 20)));
-        assert!(!cache.contains(1), "id 1 must be rearmed by logical eviction");
+        assert!(
+            !cache.contains(1),
+            "id 1 must be rearmed by logical eviction"
+        );
 
         assert!(!cache.try_promote_lru_no_evict(gpu_res(1, 8)));
         assert!(
@@ -2442,7 +2459,10 @@ mod tests {
 
         assert!(cache.current_admission(1).is_some());
         assert!(cache.promote_sync(gpu_res(3, 10)));
-        assert!(!cache.contains(1), "non-mutating lookup must leave id 1 LRU");
+        assert!(
+            !cache.contains(1),
+            "non-mutating lookup must leave id 1 LRU"
+        );
         assert!(cache.contains(2));
         assert!(cache.contains(3));
     }
@@ -2609,7 +2629,10 @@ mod tests {
         assert_eq!(cache.lru_len(), 2);
 
         assert_eq!(cache.demand_admit_lru(gpu_res(9, 40)), Ok(true));
-        assert!(!cache.contains(7), "existing demand lookup must not touch LRU");
+        assert!(
+            !cache.contains(7),
+            "existing demand lookup must not touch LRU"
+        );
         assert!(cache.contains(8));
         assert!(cache.contains(9));
     }
@@ -2668,7 +2691,10 @@ mod tests {
         );
         assert_eq!(cache.demand_admit_lru(gpu_res(4, 40)), Ok(true));
 
-        assert!(!cache.contains(1), "oldest unrelated LRU entry must remain victim");
+        assert!(
+            !cache.contains(1),
+            "oldest unrelated LRU entry must remain victim"
+        );
         assert!(cache.contains(2));
         assert!(cache.contains(3));
         assert!(cache.contains(4));
@@ -2710,7 +2736,10 @@ mod tests {
         assert!(!cache.claim_promotion(7, 99));
 
         assert_eq!(cache.demand_admit_lru(gpu_res(9, 25)), Ok(true));
-        assert!(!cache.contains(7), "Anchor-full attempt must not touch LRU recency");
+        assert!(
+            !cache.contains(7),
+            "Anchor-full attempt must not touch LRU recency"
+        );
         assert!(cache.contains(8));
         assert!(cache.contains(9));
     }
@@ -2865,7 +2894,9 @@ mod tests {
     fn logical_admission_generation_changes_only_after_eviction_and_readmission() {
         let cache = GpuExpertCache::new(16, 0.0, 0);
         assert!(cache.promote_sync(gpu_res(7, 8)));
-        let g1 = cache.current_generation(7).expect("first admission generation");
+        let g1 = cache
+            .current_generation(7)
+            .expect("first admission generation");
         let hit_generation = match cache.get(7) {
             GpuLookup::LruHit(admission) => admission.generation(),
             _ => panic!("expected logical LRU hit"),
@@ -2883,7 +2914,10 @@ mod tests {
     fn promotion_claim_rearms_after_logical_eviction_above_hit_threshold() {
         let cache = GpuExpertCache::new(16, 0.0, 3);
         assert!(cache.promote_sync(gpu_res(7, 8)));
-        assert!(!cache.claim_promotion(7, 99), "admitted id needs no request");
+        assert!(
+            !cache.claim_promotion(7, 99),
+            "admitted id needs no request"
+        );
         assert!(cache.promote_sync(gpu_res(8, 16)));
         assert!(!cache.contains(7));
 
@@ -2891,7 +2925,10 @@ mod tests {
             cache.claim_promotion(7, 99),
             "evicted id can claim again without a fresh RAM-hit edge"
         );
-        assert!(!cache.claim_promotion(7, 100), "only one request may be pending");
+        assert!(
+            !cache.claim_promotion(7, 100),
+            "only one request may be pending"
+        );
         assert!(cache.promote_sync(gpu_res(7, 8)));
         assert!(cache.contains(7));
     }

--- a/rust-engine/src/gpu_native_oracle_routes.rs
+++ b/rust-engine/src/gpu_native_oracle_routes.rs
@@ -381,15 +381,47 @@ struct PolicyCounts {
     compulsory_cold_installs: u64,
 }
 
+impl PolicyCounts {
+    fn checked_accumulate(&mut self, other: Self) -> Result<(), OracleTraceError> {
+        self.route_references = self
+            .route_references
+            .checked_add(other.route_references)
+            .ok_or_else(|| OracleTraceError::new("analysis-overflow", "route count overflow"))?;
+        self.cache_hits = self
+            .cache_hits
+            .checked_add(other.cache_hits)
+            .ok_or_else(|| OracleTraceError::new("analysis-overflow", "hit count overflow"))?;
+        self.missing_installs = self
+            .missing_installs
+            .checked_add(other.missing_installs)
+            .ok_or_else(|| OracleTraceError::new("analysis-overflow", "miss count overflow"))?;
+        self.miss_boundaries = self
+            .miss_boundaries
+            .checked_add(other.miss_boundaries)
+            .ok_or_else(|| {
+                OracleTraceError::new("analysis-overflow", "miss-boundary count overflow")
+            })?;
+        self.compulsory_cold_installs = self
+            .compulsory_cold_installs
+            .checked_add(other.compulsory_cold_installs)
+            .ok_or_else(|| {
+                OracleTraceError::new("analysis-overflow", "compulsory miss count overflow")
+            })?;
+        Ok(())
+    }
+}
+
 fn validate_accesses(
     capacity: usize,
     experts: usize,
     accesses: &[Vec<u32>],
 ) -> Result<(), OracleTraceError> {
-    if capacity == 0 {
+    if capacity == 0 || experts == 0 || capacity > experts {
         return Err(OracleTraceError::new(
-            "zero-slot-capacity",
-            "offline residency analysis requires at least one physical slot",
+            "invalid-simulation-capacity",
+            format!(
+                "offline residency analysis requires 1 <= capacity <= experts; observed capacity={capacity} experts={experts}"
+            ),
         ));
     }
     for (position, ids) in accesses.iter().enumerate() {
@@ -415,130 +447,312 @@ fn validate_accesses(
     Ok(())
 }
 
-/// Exact empty-start LRU simulation of production demand-set semantics: hits
-/// are touched in ordered top-k order, the whole set is protected while enough
-/// oldest unprotected residents are evicted, then misses install in route order.
+struct ProductionLruSimulation {
+    capacity: usize,
+    experts: usize,
+    lru: VecDeque<u32>,
+    ever_seen: HashSet<u32>,
+}
+
+impl ProductionLruSimulation {
+    fn try_new(capacity: usize, experts: usize) -> Result<Self, OracleTraceError> {
+        validate_accesses(capacity, experts, &[])?;
+        Ok(Self {
+            capacity,
+            experts,
+            lru: VecDeque::with_capacity(capacity),
+            ever_seen: HashSet::with_capacity(experts),
+        })
+    }
+
+    /// Run one counter scope while preserving physical residency, LRU order,
+    /// and compulsory-use history from every earlier scope.
+    fn run(&mut self, accesses: &[Vec<u32>]) -> Result<PolicyCounts, OracleTraceError> {
+        validate_accesses(self.capacity, self.experts, accesses)?;
+        let mut counts = PolicyCounts::default();
+        for ids in accesses {
+            counts.route_references = counts
+                .route_references
+                .checked_add(ids.len() as u64)
+                .ok_or_else(|| {
+                    OracleTraceError::new("analysis-overflow", "route count overflow")
+                })?;
+            let protected = ids.iter().copied().collect::<HashSet<_>>();
+            let mut misses = Vec::new();
+            for &id in ids {
+                if let Some(index) = self.lru.iter().position(|&resident| resident == id) {
+                    let resident = self.lru.remove(index).expect("located LRU resident");
+                    self.lru.push_back(resident);
+                    counts.cache_hits += 1;
+                } else {
+                    misses.push(id);
+                    counts.missing_installs += 1;
+                    if self.ever_seen.insert(id) {
+                        counts.compulsory_cold_installs += 1;
+                    }
+                }
+            }
+            if !misses.is_empty() {
+                counts.miss_boundaries += 1;
+            }
+            while self.lru.len().saturating_add(misses.len()) > self.capacity {
+                let victim = self
+                    .lru
+                    .iter()
+                    .position(|id| !protected.contains(id))
+                    .ok_or_else(|| {
+                        OracleTraceError::new(
+                            "no-unprotected-lru-victim",
+                            "validated simultaneous set left no legal LRU victim",
+                        )
+                    })?;
+                self.lru.remove(victim);
+            }
+            for id in misses {
+                self.lru.push_back(id);
+            }
+        }
+        Ok(counts)
+    }
+}
+
+struct BeladyMinSimulation {
+    capacity: usize,
+    experts: usize,
+    residents: HashSet<u32>,
+    ever_seen: HashSet<u32>,
+    future: Vec<VecDeque<usize>>,
+    planned_accesses: Vec<Vec<u32>>,
+    next_position: usize,
+}
+
+impl BeladyMinSimulation {
+    fn try_new(
+        capacity: usize,
+        experts: usize,
+        complete_accesses: &[Vec<u32>],
+    ) -> Result<Self, OracleTraceError> {
+        validate_accesses(capacity, experts, complete_accesses)?;
+        let mut future = vec![VecDeque::<usize>::new(); experts];
+        for (position, ids) in complete_accesses.iter().enumerate() {
+            for &id in ids {
+                future[id as usize].push_back(position);
+            }
+        }
+        Ok(Self {
+            capacity,
+            experts,
+            residents: HashSet::with_capacity(capacity),
+            ever_seen: HashSet::with_capacity(experts),
+            future,
+            planned_accesses: complete_accesses.to_vec(),
+            next_position: 0,
+        })
+    }
+
+    /// Run one counter scope without resetting residency or the complete
+    /// future-use index assembled for the whole warmup/measurement lifecycle.
+    fn run(&mut self, accesses: &[Vec<u32>]) -> Result<PolicyCounts, OracleTraceError> {
+        validate_accesses(self.capacity, self.experts, accesses)?;
+        let end = self
+            .next_position
+            .checked_add(accesses.len())
+            .ok_or_else(|| OracleTraceError::new("analysis-overflow", "position overflow"))?;
+        if end > self.planned_accesses.len() {
+            return Err(OracleTraceError::new(
+                "min-sequence-overrun",
+                "MIN counter scope exceeds the complete future-use sequence",
+            ));
+        }
+
+        let mut counts = PolicyCounts::default();
+        for ids in accesses {
+            let position = self.next_position;
+            if self.planned_accesses[position] != *ids {
+                return Err(OracleTraceError::new(
+                    "min-sequence-drift",
+                    format!("MIN scope access differs from planned position {position}"),
+                ));
+            }
+            for &id in ids {
+                let observed = self.future[id as usize].pop_front();
+                if observed != Some(position) {
+                    return Err(OracleTraceError::new(
+                        "future-index-corrupt",
+                        "next-use index did not match the current position",
+                    ));
+                }
+            }
+            counts.route_references = counts
+                .route_references
+                .checked_add(ids.len() as u64)
+                .ok_or_else(|| {
+                    OracleTraceError::new("analysis-overflow", "route count overflow")
+                })?;
+            let protected = ids.iter().copied().collect::<HashSet<_>>();
+            let mut misses = Vec::new();
+            for &id in ids {
+                if self.residents.contains(&id) {
+                    counts.cache_hits += 1;
+                } else {
+                    misses.push(id);
+                    counts.missing_installs += 1;
+                    if self.ever_seen.insert(id) {
+                        counts.compulsory_cold_installs += 1;
+                    }
+                }
+            }
+            if !misses.is_empty() {
+                counts.miss_boundaries += 1;
+            }
+            while self.residents.len().saturating_add(misses.len()) > self.capacity {
+                let victim = self
+                    .residents
+                    .iter()
+                    .copied()
+                    .filter(|id| !protected.contains(id))
+                    .max_by_key(|id| {
+                        (
+                            self.future[*id as usize]
+                                .front()
+                                .copied()
+                                .unwrap_or(usize::MAX),
+                            *id,
+                        )
+                    })
+                    .ok_or_else(|| {
+                        OracleTraceError::new(
+                            "no-unprotected-min-victim",
+                            "validated simultaneous set left no legal MIN victim",
+                        )
+                    })?;
+                self.residents.remove(&victim);
+            }
+            self.residents.extend(misses);
+            self.next_position += 1;
+        }
+        Ok(counts)
+    }
+
+    fn finish(&self) -> Result<(), OracleTraceError> {
+        if self.next_position != self.planned_accesses.len()
+            || self.future.iter().any(|uses| !uses.is_empty())
+        {
+            return Err(OracleTraceError::new(
+                "min-sequence-incomplete",
+                "MIN simulation did not consume its complete future-use sequence",
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct WindowPolicyCounts {
+    uncounted_warmup: PolicyCounts,
+    counted_measurement: PolicyCounts,
+}
+
+fn complete_window_accesses(
+    warmup: &[Vec<u32>],
+    measured: &[Vec<u32>],
+    measured_runs: usize,
+) -> Result<Vec<Vec<u32>>, OracleTraceError> {
+    if measured_runs == 0 {
+        return Err(OracleTraceError::new(
+            "zero-measured-runs",
+            "stateful analysis requires at least one measured route pass",
+        ));
+    }
+    let measured_records = measured
+        .len()
+        .checked_mul(measured_runs)
+        .ok_or_else(|| OracleTraceError::new("analysis-overflow", "route count overflow"))?;
+    let total = warmup
+        .len()
+        .checked_add(measured_records)
+        .ok_or_else(|| OracleTraceError::new("analysis-overflow", "route count overflow"))?;
+    let mut complete = Vec::with_capacity(total);
+    complete.extend_from_slice(warmup);
+    for _ in 0..measured_runs {
+        complete.extend_from_slice(measured);
+    }
+    Ok(complete)
+}
+
+fn simulate_production_lru_window(
+    capacity: usize,
+    experts: usize,
+    warmup: &[Vec<u32>],
+    measured: &[Vec<u32>],
+    measured_runs: usize,
+) -> Result<WindowPolicyCounts, OracleTraceError> {
+    if measured_runs == 0 {
+        return Err(OracleTraceError::new(
+            "zero-measured-runs",
+            "stateful analysis requires at least one measured route pass",
+        ));
+    }
+    let mut state = ProductionLruSimulation::try_new(capacity, experts)?;
+    let uncounted_warmup = state.run(warmup)?;
+    let mut counted_measurement = PolicyCounts::default();
+    for _ in 0..measured_runs {
+        counted_measurement.checked_accumulate(state.run(measured)?)?;
+    }
+    Ok(WindowPolicyCounts {
+        uncounted_warmup,
+        counted_measurement,
+    })
+}
+
+fn simulate_belady_min_window(
+    capacity: usize,
+    experts: usize,
+    warmup: &[Vec<u32>],
+    measured: &[Vec<u32>],
+    measured_runs: usize,
+) -> Result<WindowPolicyCounts, OracleTraceError> {
+    let complete = complete_window_accesses(warmup, measured, measured_runs)?;
+    let mut state = BeladyMinSimulation::try_new(capacity, experts, &complete)?;
+    let uncounted_warmup = state.run(warmup)?;
+    let mut counted_measurement = PolicyCounts::default();
+    for _ in 0..measured_runs {
+        counted_measurement.checked_accumulate(state.run(measured)?)?;
+    }
+    state.finish()?;
+    Ok(WindowPolicyCounts {
+        uncounted_warmup,
+        counted_measurement,
+    })
+}
+
+/// Exact empty-start LRU simulation of one production demand-set pass.
 fn simulate_production_lru(
     capacity: usize,
     experts: usize,
     accesses: &[Vec<u32>],
 ) -> Result<PolicyCounts, OracleTraceError> {
-    validate_accesses(capacity, experts, accesses)?;
-    let mut lru = VecDeque::<u32>::with_capacity(capacity);
-    let mut ever_seen = HashSet::new();
-    let mut counts = PolicyCounts::default();
-    for ids in accesses {
-        counts.route_references = counts
-            .route_references
-            .checked_add(ids.len() as u64)
-            .ok_or_else(|| OracleTraceError::new("analysis-overflow", "route count overflow"))?;
-        let protected = ids.iter().copied().collect::<HashSet<_>>();
-        let mut misses = Vec::new();
-        for &id in ids {
-            if let Some(index) = lru.iter().position(|&resident| resident == id) {
-                let resident = lru.remove(index).expect("located LRU resident");
-                lru.push_back(resident);
-                counts.cache_hits += 1;
-            } else {
-                misses.push(id);
-                counts.missing_installs += 1;
-                if ever_seen.insert(id) {
-                    counts.compulsory_cold_installs += 1;
-                }
-            }
-        }
-        if !misses.is_empty() {
-            counts.miss_boundaries += 1;
-        }
-        while lru.len().saturating_add(misses.len()) > capacity {
-            let victim = lru
-                .iter()
-                .position(|id| !protected.contains(id))
-                .ok_or_else(|| {
-                    OracleTraceError::new(
-                        "no-unprotected-lru-victim",
-                        "validated simultaneous set left no legal LRU victim",
-                    )
-                })?;
-            lru.remove(victim);
-        }
-        for id in misses {
-            lru.push_back(id);
-        }
-    }
-    Ok(counts)
+    Ok(simulate_production_lru_window(capacity, experts, &[], accesses, 1)?.counted_measurement)
 }
 
-/// Belady/MIN-style empty-start simulation for simultaneous top-k accesses.
-/// Every current route is protected; among other residents, the expert whose
-/// next route-set use is farthest away (or absent) is evicted.
+/// Empty-start Belady/MIN simulation of one simultaneous-set pass.
 fn simulate_belady_min(
     capacity: usize,
     experts: usize,
     accesses: &[Vec<u32>],
 ) -> Result<PolicyCounts, OracleTraceError> {
-    validate_accesses(capacity, experts, accesses)?;
-    let mut future = vec![VecDeque::<usize>::new(); experts];
-    for (position, ids) in accesses.iter().enumerate() {
-        for &id in ids {
-            future[id as usize].push_back(position);
-        }
-    }
-    let mut residents = HashSet::<u32>::with_capacity(capacity);
-    let mut ever_seen = HashSet::new();
-    let mut counts = PolicyCounts::default();
-    for (position, ids) in accesses.iter().enumerate() {
-        for &id in ids {
-            let observed = future[id as usize].pop_front();
-            if observed != Some(position) {
-                return Err(OracleTraceError::new(
-                    "future-index-corrupt",
-                    "next-use index did not match the current position",
-                ));
-            }
-        }
-        counts.route_references = counts
-            .route_references
-            .checked_add(ids.len() as u64)
-            .ok_or_else(|| OracleTraceError::new("analysis-overflow", "route count overflow"))?;
-        let protected = ids.iter().copied().collect::<HashSet<_>>();
-        let mut misses = Vec::new();
-        for &id in ids {
-            if residents.contains(&id) {
-                counts.cache_hits += 1;
-            } else {
-                misses.push(id);
-                counts.missing_installs += 1;
-                if ever_seen.insert(id) {
-                    counts.compulsory_cold_installs += 1;
-                }
-            }
-        }
-        if !misses.is_empty() {
-            counts.miss_boundaries += 1;
-        }
-        while residents.len().saturating_add(misses.len()) > capacity {
-            let victim = residents
-                .iter()
-                .copied()
-                .filter(|id| !protected.contains(id))
-                .max_by_key(|id| {
-                    (
-                        future[*id as usize].front().copied().unwrap_or(usize::MAX),
-                        *id,
-                    )
-                })
-                .ok_or_else(|| {
-                    OracleTraceError::new(
-                        "no-unprotected-min-victim",
-                        "validated simultaneous set left no legal MIN victim",
-                    )
-                })?;
-            residents.remove(&victim);
-        }
-        residents.extend(misses);
-    }
-    Ok(counts)
+    Ok(simulate_belady_min_window(capacity, experts, &[], accesses, 1)?.counted_measurement)
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+pub(crate) struct PolicyOracleAnalysis {
+    pub(crate) cache_hits: u64,
+    pub(crate) missing_expert_installs: u64,
+    pub(crate) layer_miss_boundaries: u64,
+    pub(crate) bytes_to_move: u64,
+    pub(crate) compulsory_first_observation_installs: u64,
+    pub(crate) capacity_replacement_installs: u64,
+    pub(crate) resident_route_fraction: f64,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -547,39 +761,31 @@ pub(crate) struct LayerOracleAnalysis {
     pub(crate) physical_expert_slots: usize,
     pub(crate) route_references: u64,
     pub(crate) unique_experts_touched: usize,
-    pub(crate) lru_cache_hits: u64,
-    pub(crate) lru_missing_expert_installs: u64,
-    pub(crate) lru_layer_miss_boundaries: u64,
-    pub(crate) lru_bytes_to_move: u64,
-    pub(crate) minimum_cache_hits: u64,
-    pub(crate) minimum_missing_expert_installs: u64,
-    pub(crate) minimum_layer_miss_boundaries: u64,
-    pub(crate) minimum_bytes_to_move: u64,
-    pub(crate) compulsory_cold_installs: u64,
-    pub(crate) lru_capacity_replacement_installs: u64,
-    pub(crate) minimum_capacity_replacement_installs: u64,
-    pub(crate) lru_resident_route_fraction: f64,
-    pub(crate) maximum_potentially_resident_route_fraction: f64,
+    pub(crate) lru: PolicyOracleAnalysis,
+    pub(crate) minimum: PolicyOracleAnalysis,
 }
 
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub(crate) struct AggregateOracleAnalysis {
     pub(crate) physical_expert_slots: usize,
     pub(crate) route_references: u64,
     pub(crate) unique_experts_touched: usize,
-    pub(crate) lru_cache_hits: u64,
-    pub(crate) lru_missing_expert_installs: u64,
-    pub(crate) lru_layer_miss_boundaries: u64,
-    pub(crate) lru_bytes_to_move: u64,
-    pub(crate) minimum_cache_hits: u64,
-    pub(crate) minimum_missing_expert_installs: u64,
-    pub(crate) minimum_layer_miss_boundaries: u64,
-    pub(crate) minimum_bytes_to_move: u64,
-    pub(crate) compulsory_cold_installs: u64,
-    pub(crate) lru_capacity_replacement_installs: u64,
-    pub(crate) minimum_capacity_replacement_installs: u64,
-    pub(crate) lru_resident_route_fraction: f64,
-    pub(crate) maximum_potentially_resident_route_fraction: f64,
+    pub(crate) lru: PolicyOracleAnalysis,
+    pub(crate) minimum: PolicyOracleAnalysis,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct PhaseOracleAnalysis {
+    pub(crate) per_layer: Vec<LayerOracleAnalysis>,
+    pub(crate) aggregate: AggregateOracleAnalysis,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct StatefulWindowOracleAnalysis {
+    pub(crate) warmup_runs: usize,
+    pub(crate) measured_runs: usize,
+    pub(crate) uncounted_warmup: PhaseOracleAnalysis,
+    pub(crate) counted_measurement: PhaseOracleAnalysis,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -592,8 +798,9 @@ pub(crate) struct BudgetOracleAnalysis {
     pub(crate) physical_slot_stride_bytes: u64,
     pub(crate) physical_expert_slots: usize,
     pub(crate) per_layer_physical_expert_slots: Vec<usize>,
-    pub(crate) per_layer: Vec<LayerOracleAnalysis>,
-    pub(crate) aggregate: AggregateOracleAnalysis,
+    pub(crate) cold_start: PhaseOracleAnalysis,
+    pub(crate) first_measured_after_warmup: StatefulWindowOracleAnalysis,
+    pub(crate) frozen_perf_shape: StatefulWindowOracleAnalysis,
 }
 
 fn checked_transfer_bytes(installs: u64, bytes: u64) -> Result<u64, OracleTraceError> {
@@ -610,18 +817,196 @@ fn resident_fraction(hits: u64, references: u64) -> f64 {
     }
 }
 
+fn checked_add_u64(left: u64, right: u64) -> Result<u64, OracleTraceError> {
+    left.checked_add(right)
+        .ok_or_else(|| OracleTraceError::new("analysis-overflow", "counter overflow"))
+}
+
+fn checked_add_usize(left: usize, right: usize) -> Result<usize, OracleTraceError> {
+    left.checked_add(right)
+        .ok_or_else(|| OracleTraceError::new("analysis-overflow", "counter overflow"))
+}
+
+fn analyze_policy(
+    counts: PolicyCounts,
+    slot_stride_bytes: u64,
+    layer_boundaries: usize,
+) -> Result<PolicyOracleAnalysis, OracleTraceError> {
+    if checked_add_u64(counts.cache_hits, counts.missing_installs)? != counts.route_references {
+        return Err(OracleTraceError::new(
+            "analysis-reconciliation",
+            "cache hits plus missing installs do not equal route references",
+        ));
+    }
+    if counts.miss_boundaries > layer_boundaries as u64 {
+        return Err(OracleTraceError::new(
+            "analysis-reconciliation",
+            "layer miss boundaries exceed analyzed layer records",
+        ));
+    }
+    let capacity_replacement_installs = counts
+        .missing_installs
+        .checked_sub(counts.compulsory_cold_installs)
+        .ok_or_else(|| {
+            OracleTraceError::new(
+                "analysis-reconciliation",
+                "compulsory installs exceed total missing installs",
+            )
+        })?;
+    Ok(PolicyOracleAnalysis {
+        cache_hits: counts.cache_hits,
+        missing_expert_installs: counts.missing_installs,
+        layer_miss_boundaries: counts.miss_boundaries,
+        bytes_to_move: checked_transfer_bytes(counts.missing_installs, slot_stride_bytes)?,
+        compulsory_first_observation_installs: counts.compulsory_cold_installs,
+        capacity_replacement_installs,
+        resident_route_fraction: resident_fraction(counts.cache_hits, counts.route_references),
+    })
+}
+
+fn analyze_layer_phase(
+    layer_index: usize,
+    physical_expert_slots: usize,
+    accesses: &[Vec<u32>],
+    lru: PolicyCounts,
+    minimum: PolicyCounts,
+    slot_stride_bytes: u64,
+) -> Result<LayerOracleAnalysis, OracleTraceError> {
+    let expected_references = accesses
+        .iter()
+        .try_fold(0u64, |total, ids| checked_add_u64(total, ids.len() as u64))?;
+    if lru.route_references != expected_references
+        || minimum.route_references != expected_references
+        || lru.compulsory_cold_installs != minimum.compulsory_cold_installs
+        || minimum.missing_installs > lru.missing_installs
+    {
+        return Err(OracleTraceError::new(
+            "analysis-reconciliation",
+            format!("layer {layer_index} LRU/MIN counters disagree with the phase route evidence"),
+        ));
+    }
+    Ok(LayerOracleAnalysis {
+        layer_index,
+        physical_expert_slots,
+        route_references: expected_references,
+        unique_experts_touched: accesses
+            .iter()
+            .flatten()
+            .copied()
+            .collect::<HashSet<_>>()
+            .len(),
+        lru: analyze_policy(lru, slot_stride_bytes, accesses.len())?,
+        minimum: analyze_policy(minimum, slot_stride_bytes, accesses.len())?,
+    })
+}
+
+fn accumulate_policy(
+    aggregate: &mut PolicyOracleAnalysis,
+    layer: PolicyOracleAnalysis,
+) -> Result<(), OracleTraceError> {
+    aggregate.cache_hits = checked_add_u64(aggregate.cache_hits, layer.cache_hits)?;
+    aggregate.missing_expert_installs = checked_add_u64(
+        aggregate.missing_expert_installs,
+        layer.missing_expert_installs,
+    )?;
+    aggregate.layer_miss_boundaries =
+        checked_add_u64(aggregate.layer_miss_boundaries, layer.layer_miss_boundaries)?;
+    aggregate.bytes_to_move = checked_add_u64(aggregate.bytes_to_move, layer.bytes_to_move)?;
+    aggregate.compulsory_first_observation_installs = checked_add_u64(
+        aggregate.compulsory_first_observation_installs,
+        layer.compulsory_first_observation_installs,
+    )?;
+    aggregate.capacity_replacement_installs = checked_add_u64(
+        aggregate.capacity_replacement_installs,
+        layer.capacity_replacement_installs,
+    )?;
+    Ok(())
+}
+
+fn empty_policy_analysis() -> PolicyOracleAnalysis {
+    PolicyOracleAnalysis {
+        cache_hits: 0,
+        missing_expert_installs: 0,
+        layer_miss_boundaries: 0,
+        bytes_to_move: 0,
+        compulsory_first_observation_installs: 0,
+        capacity_replacement_installs: 0,
+        resident_route_fraction: 1.0,
+    }
+}
+
+fn analyze_phase(
+    per_layer: Vec<LayerOracleAnalysis>,
+    expected_route_references: u64,
+    expected_physical_slots: usize,
+) -> Result<PhaseOracleAnalysis, OracleTraceError> {
+    let mut aggregate = AggregateOracleAnalysis {
+        physical_expert_slots: 0,
+        route_references: 0,
+        unique_experts_touched: 0,
+        lru: empty_policy_analysis(),
+        minimum: empty_policy_analysis(),
+    };
+    for layer in &per_layer {
+        aggregate.physical_expert_slots =
+            checked_add_usize(aggregate.physical_expert_slots, layer.physical_expert_slots)?;
+        aggregate.route_references =
+            checked_add_u64(aggregate.route_references, layer.route_references)?;
+        aggregate.unique_experts_touched = checked_add_usize(
+            aggregate.unique_experts_touched,
+            layer.unique_experts_touched,
+        )?;
+        accumulate_policy(&mut aggregate.lru, layer.lru)?;
+        accumulate_policy(&mut aggregate.minimum, layer.minimum)?;
+    }
+    aggregate.lru.resident_route_fraction =
+        resident_fraction(aggregate.lru.cache_hits, aggregate.route_references);
+    aggregate.minimum.resident_route_fraction =
+        resident_fraction(aggregate.minimum.cache_hits, aggregate.route_references);
+    if aggregate.route_references != expected_route_references
+        || aggregate.physical_expert_slots != expected_physical_slots
+        || aggregate.minimum.missing_expert_installs > aggregate.lru.missing_expert_installs
+    {
+        return Err(OracleTraceError::new(
+            "analysis-reconciliation",
+            "aggregate phase counters disagree with source route or slot evidence",
+        ));
+    }
+    Ok(PhaseOracleAnalysis {
+        per_layer,
+        aggregate,
+    })
+}
+
+fn layer_accesses(trace: &OracleRouteTrace) -> Vec<Vec<Vec<u32>>> {
+    let mut accesses = vec![Vec::<Vec<u32>>::new(); trace.geometry.layers];
+    for record in &trace.records {
+        accesses[record.layer_index].push(record.ordered_selected_expert_ids.clone());
+    }
+    accesses
+}
+
 fn analyze_trace_with_plan(
-    trace: &OracleRouteTrace,
+    warmup_trace: &OracleRouteTrace,
+    measured_trace: &OracleRouteTrace,
     requested_budget_mib: u64,
     plan: &GpuNativeModelExpertVramPlan,
 ) -> Result<BudgetOracleAnalysis, OracleTraceError> {
-    trace.validate()?;
+    warmup_trace.validate()?;
+    measured_trace.validate()?;
+    if warmup_trace.geometry != measured_trace.geometry {
+        return Err(OracleTraceError::new(
+            "warmup-measured-geometry-mismatch",
+            "captured warmup and measured traces use different model geometry",
+        ));
+    }
+    let geometry = measured_trace.geometry;
     let plan_geometry = plan.geometry();
-    if plan.num_layers() != trace.geometry.layers
-        || plan_geometry.num_experts() != trace.geometry.experts
-        || plan_geometry.top_k() != trace.geometry.top_k
-        || plan_geometry.d_model() != trace.geometry.d_model
-        || plan_geometry.d_ff() != trace.geometry.d_ff
+    if plan.num_layers() != geometry.layers
+        || plan_geometry.num_experts() != geometry.experts
+        || plan_geometry.top_k() != geometry.top_k
+        || plan_geometry.d_model() != geometry.d_model
+        || plan_geometry.d_ff() != geometry.d_ff
     {
         return Err(OracleTraceError::new(
             "slot-plan-geometry-mismatch",
@@ -634,102 +1019,111 @@ fn analyze_trace_with_plan(
         .map(|layer| layer.slot_capacity())
         .collect::<Vec<_>>();
     let slot_stride_bytes = plan_geometry.slot_stride_bytes() as u64;
-    let mut accesses = vec![Vec::<Vec<u32>>::new(); trace.geometry.layers];
-    for record in &trace.records {
-        accesses[record.layer_index].push(record.ordered_selected_expert_ids.clone());
+    let warmup_accesses = layer_accesses(warmup_trace);
+    let measured_accesses = layer_accesses(measured_trace);
+    let frozen_measured_references = (measured_trace.total_selected_expert_ids as u64)
+        .checked_mul(3)
+        .ok_or_else(|| OracleTraceError::new("analysis-overflow", "route count overflow"))?;
+
+    let mut cold_layers = Vec::with_capacity(geometry.layers);
+    let mut first_warmup_layers = Vec::with_capacity(geometry.layers);
+    let mut first_measured_layers = Vec::with_capacity(geometry.layers);
+    let mut frozen_warmup_layers = Vec::with_capacity(geometry.layers);
+    let mut frozen_measured_layers = Vec::with_capacity(geometry.layers);
+    for layer_index in 0..geometry.layers {
+        let capacity = capacities[layer_index];
+        let warmup = &warmup_accesses[layer_index];
+        let measured = &measured_accesses[layer_index];
+
+        let cold_lru = simulate_production_lru(capacity, geometry.experts, measured)?;
+        let cold_minimum = simulate_belady_min(capacity, geometry.experts, measured)?;
+        cold_layers.push(analyze_layer_phase(
+            layer_index,
+            capacity,
+            measured,
+            cold_lru,
+            cold_minimum,
+            slot_stride_bytes,
+        )?);
+
+        let first_lru =
+            simulate_production_lru_window(capacity, geometry.experts, warmup, measured, 1)?;
+        let first_minimum =
+            simulate_belady_min_window(capacity, geometry.experts, warmup, measured, 1)?;
+        first_warmup_layers.push(analyze_layer_phase(
+            layer_index,
+            capacity,
+            warmup,
+            first_lru.uncounted_warmup,
+            first_minimum.uncounted_warmup,
+            slot_stride_bytes,
+        )?);
+        first_measured_layers.push(analyze_layer_phase(
+            layer_index,
+            capacity,
+            measured,
+            first_lru.counted_measurement,
+            first_minimum.counted_measurement,
+            slot_stride_bytes,
+        )?);
+
+        let frozen_lru =
+            simulate_production_lru_window(capacity, geometry.experts, warmup, measured, 3)?;
+        let frozen_minimum =
+            simulate_belady_min_window(capacity, geometry.experts, warmup, measured, 3)?;
+        frozen_warmup_layers.push(analyze_layer_phase(
+            layer_index,
+            capacity,
+            warmup,
+            frozen_lru.uncounted_warmup,
+            frozen_minimum.uncounted_warmup,
+            slot_stride_bytes,
+        )?);
+        let frozen_accesses = complete_window_accesses(&[], measured, 3)?;
+        frozen_measured_layers.push(analyze_layer_phase(
+            layer_index,
+            capacity,
+            &frozen_accesses,
+            frozen_lru.counted_measurement,
+            frozen_minimum.counted_measurement,
+            slot_stride_bytes,
+        )?);
     }
 
-    let mut aggregate = AggregateOracleAnalysis::default();
-    let mut per_layer = Vec::with_capacity(trace.geometry.layers);
-    for layer_index in 0..trace.geometry.layers {
-        let capacity = capacities[layer_index];
-        let layer_accesses = &accesses[layer_index];
-        let unique_experts_touched = layer_accesses
-            .iter()
-            .flatten()
-            .copied()
-            .collect::<HashSet<_>>()
-            .len();
-        let lru = simulate_production_lru(capacity, trace.geometry.experts, layer_accesses)?;
-        let minimum = simulate_belady_min(capacity, trace.geometry.experts, layer_accesses)?;
-        if lru.route_references != minimum.route_references
-            || lru.compulsory_cold_installs != minimum.compulsory_cold_installs
-        {
-            return Err(OracleTraceError::new(
-                "analysis-reconciliation",
-                "LRU and MIN simulations disagree on route references or compulsory misses",
-            ));
-        }
-        let layer = LayerOracleAnalysis {
-            layer_index,
-            physical_expert_slots: capacity,
-            route_references: lru.route_references,
-            unique_experts_touched,
-            lru_cache_hits: lru.cache_hits,
-            lru_missing_expert_installs: lru.missing_installs,
-            lru_layer_miss_boundaries: lru.miss_boundaries,
-            lru_bytes_to_move: checked_transfer_bytes(lru.missing_installs, slot_stride_bytes)?,
-            minimum_cache_hits: minimum.cache_hits,
-            minimum_missing_expert_installs: minimum.missing_installs,
-            minimum_layer_miss_boundaries: minimum.miss_boundaries,
-            minimum_bytes_to_move: checked_transfer_bytes(
-                minimum.missing_installs,
-                slot_stride_bytes,
-            )?,
-            compulsory_cold_installs: minimum.compulsory_cold_installs,
-            lru_capacity_replacement_installs: lru
-                .missing_installs
-                .checked_sub(lru.compulsory_cold_installs)
-                .ok_or_else(|| {
-                    OracleTraceError::new(
-                        "analysis-reconciliation",
-                        "LRU compulsory misses exceed total misses",
-                    )
-                })?,
-            minimum_capacity_replacement_installs: minimum
-                .missing_installs
-                .checked_sub(minimum.compulsory_cold_installs)
-                .ok_or_else(|| {
-                    OracleTraceError::new(
-                        "analysis-reconciliation",
-                        "MIN compulsory misses exceed total misses",
-                    )
-                })?,
-            lru_resident_route_fraction: resident_fraction(lru.cache_hits, lru.route_references),
-            maximum_potentially_resident_route_fraction: resident_fraction(
-                minimum.cache_hits,
-                minimum.route_references,
-            ),
-        };
-        aggregate.physical_expert_slots += layer.physical_expert_slots;
-        aggregate.route_references += layer.route_references;
-        aggregate.unique_experts_touched += layer.unique_experts_touched;
-        aggregate.lru_cache_hits += layer.lru_cache_hits;
-        aggregate.lru_missing_expert_installs += layer.lru_missing_expert_installs;
-        aggregate.lru_layer_miss_boundaries += layer.lru_layer_miss_boundaries;
-        aggregate.lru_bytes_to_move += layer.lru_bytes_to_move;
-        aggregate.minimum_cache_hits += layer.minimum_cache_hits;
-        aggregate.minimum_missing_expert_installs += layer.minimum_missing_expert_installs;
-        aggregate.minimum_layer_miss_boundaries += layer.minimum_layer_miss_boundaries;
-        aggregate.minimum_bytes_to_move += layer.minimum_bytes_to_move;
-        aggregate.compulsory_cold_installs += layer.compulsory_cold_installs;
-        aggregate.lru_capacity_replacement_installs += layer.lru_capacity_replacement_installs;
-        aggregate.minimum_capacity_replacement_installs +=
-            layer.minimum_capacity_replacement_installs;
-        per_layer.push(layer);
-    }
-    aggregate.lru_resident_route_fraction =
-        resident_fraction(aggregate.lru_cache_hits, aggregate.route_references);
-    aggregate.maximum_potentially_resident_route_fraction =
-        resident_fraction(aggregate.minimum_cache_hits, aggregate.route_references);
-    if aggregate.route_references != trace.total_selected_expert_ids as u64
-        || aggregate.physical_expert_slots != plan.model_slot_capacity()
-    {
-        return Err(OracleTraceError::new(
-            "analysis-reconciliation",
-            "aggregate route references or slot capacity disagree with source evidence",
-        ));
-    }
+    let expected_slots = plan.model_slot_capacity();
+    let cold_start = analyze_phase(
+        cold_layers,
+        measured_trace.total_selected_expert_ids as u64,
+        expected_slots,
+    )?;
+    let first_measured_after_warmup = StatefulWindowOracleAnalysis {
+        warmup_runs: 1,
+        measured_runs: 1,
+        uncounted_warmup: analyze_phase(
+            first_warmup_layers,
+            warmup_trace.total_selected_expert_ids as u64,
+            expected_slots,
+        )?,
+        counted_measurement: analyze_phase(
+            first_measured_layers,
+            measured_trace.total_selected_expert_ids as u64,
+            expected_slots,
+        )?,
+    };
+    let frozen_perf_shape = StatefulWindowOracleAnalysis {
+        warmup_runs: 1,
+        measured_runs: 3,
+        uncounted_warmup: analyze_phase(
+            frozen_warmup_layers,
+            warmup_trace.total_selected_expert_ids as u64,
+            expected_slots,
+        )?,
+        counted_measurement: analyze_phase(
+            frozen_measured_layers,
+            frozen_measured_references,
+            expected_slots,
+        )?,
+    };
 
     Ok(BudgetOracleAnalysis {
         requested_expert_budget_mib: requested_budget_mib,
@@ -740,8 +1134,9 @@ fn analyze_trace_with_plan(
         physical_slot_stride_bytes: slot_stride_bytes,
         physical_expert_slots: plan.model_slot_capacity(),
         per_layer_physical_expert_slots: capacities,
-        per_layer,
-        aggregate,
+        cold_start,
+        first_measured_after_warmup,
+        frozen_perf_shape,
     })
 }
 
@@ -1306,9 +1701,9 @@ pub(crate) async fn run_command(args: CommandArgs) -> Result<(), Box<dyn std::er
                         "slot-plan-failed",
                         error.to_string(),
                     )
-                })?;
+            })?;
             analysis.push(
-                analyze_trace_with_plan(&measured.trace, budget_mib, &plan)
+                analyze_trace_with_plan(&warmup.trace, &measured.trace, budget_mib, &plan)
                     .map_err(counter_failure)?,
             );
         }
@@ -1382,8 +1777,8 @@ pub(crate) async fn run_command(args: CommandArgs) -> Result<(), Box<dyn std::er
             additional_gpu_readback_introduced: false,
             performance_claim_from_trace_run: false,
             production_slot_planner: "GpuNativeModelExpertVramPlan::try_new with authoritative GpuNativeExecutorContext::device_limits",
-            analyzer_initial_residency: "empty per-layer physical arenas",
-            minimum_policy: "simultaneous-set Belady/MIN; current route protected, farthest next-use unprotected resident evicted",
+            analyzer_initial_residency: "cold_start begins empty; first_measured_after_warmup and frozen_perf_shape each begin empty before one uncounted captured warmup and preserve per-policy state through their counted measurements",
+            minimum_policy: "stateful simultaneous-set Belady/MIN; the future-use index spans each complete warmup-plus-measurement window without reset; current route protected, farthest next-use unprotected resident evicted",
         },
         warmup: warmup.evidence,
         measured: measured.evidence,
@@ -1555,16 +1950,149 @@ mod tests {
     }
 
     #[test]
-    fn production_model_slot_planner_reuse_matches_qwen_geometry() {
-        let qwen = GpuNativeQ4ExpertGeometry::try_new(2048, 768, 128, 8).unwrap();
-        let budget = 15_576 * MIB;
-        let limits = wgpu::Limits {
+    fn warmup_is_uncounted_and_state_persists_through_frozen_repetitions() {
+        let warmup = vec![vec![0], vec![1]];
+        let measured = vec![vec![0], vec![1], vec![2], vec![0], vec![1], vec![2]];
+        let cold_lru = simulate_production_lru(2, 3, &measured).unwrap();
+        let first_lru = simulate_production_lru_window(2, 3, &warmup, &measured, 1).unwrap();
+        let first_minimum = simulate_belady_min_window(2, 3, &warmup, &measured, 1).unwrap();
+        let frozen_lru = simulate_production_lru_window(2, 3, &warmup, &measured, 3).unwrap();
+        let frozen_minimum = simulate_belady_min_window(2, 3, &warmup, &measured, 3).unwrap();
+
+        assert_eq!(first_lru.uncounted_warmup.route_references, 2);
+        assert_eq!(first_lru.counted_measurement.route_references, 6);
+        assert_eq!(first_lru.uncounted_warmup.compulsory_cold_installs, 2);
+        assert_eq!(first_lru.counted_measurement.compulsory_cold_installs, 1);
+        assert!(first_lru.counted_measurement.missing_installs < cold_lru.missing_installs);
+        assert!(
+            first_minimum.counted_measurement.missing_installs
+                <= first_lru.counted_measurement.missing_installs
+        );
+        assert_eq!(first_minimum.counted_measurement.missing_installs, 2);
+
+        assert_eq!(frozen_lru.uncounted_warmup.route_references, 2);
+        assert_eq!(frozen_lru.counted_measurement.route_references, 18);
+        assert_eq!(frozen_lru.counted_measurement.missing_installs, 16);
+        assert!(frozen_lru.counted_measurement.missing_installs < 3 * cold_lru.missing_installs);
+        assert_eq!(frozen_lru.counted_measurement.compulsory_cold_installs, 1);
+        assert!(
+            frozen_minimum.counted_measurement.missing_installs
+                <= frozen_lru.counted_measurement.missing_installs
+        );
+        assert_eq!(frozen_minimum.counted_measurement.missing_installs, 8);
+        assert!(frozen_lru.counted_measurement.miss_boundaries <= 18);
+        assert!(frozen_minimum.counted_measurement.miss_boundaries <= 18);
+
+        // With one future index spanning all three passes, MIN retains expert
+        // 1 at the first pass's final miss because it sees the next pass. A
+        // per-pass future reset would tie-break it away and report 3 misses.
+        let cross_repetition_min =
+            simulate_belady_min_window(2, 3, &[vec![0]], &[vec![1], vec![2]], 3).unwrap();
+        assert_eq!(cross_repetition_min.counted_measurement.missing_installs, 2);
+    }
+
+    fn qwen_limits() -> wgpu::Limits {
+        wgpu::Limits {
             max_push_constant_size: 32,
             max_storage_buffers_per_shader_stage: 8,
             max_compute_workgroup_size_x: 64,
             max_compute_invocations_per_workgroup: 64,
             ..wgpu::Limits::default()
-        };
+        }
+    }
+
+    fn qwen_trace() -> OracleRouteTrace {
+        let mut records = Vec::new();
+        for position in 0..2 {
+            for layer_index in 0..48 {
+                let first_expert = (position * 8) as u32;
+                records.push(OracleRouteRecord {
+                    position,
+                    layer_index,
+                    ordered_selected_expert_ids: (first_expert..first_expert + 8).collect(),
+                });
+            }
+        }
+        OracleRouteTrace::try_new(
+            OracleGeometry {
+                layers: 48,
+                experts: 128,
+                top_k: 8,
+                d_model: 2048,
+                d_ff: 768,
+            },
+            records,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn full_capacity_postwarm_phases_have_zero_measured_misses_and_boundaries() {
+        let qwen = GpuNativeQ4ExpertGeometry::try_new(2048, 768, 128, 8).unwrap();
+        let plan =
+            GpuNativeModelExpertVramPlan::try_new(48, qwen, 15_576 * MIB, &qwen_limits()).unwrap();
+        let trace = qwen_trace();
+        let analysis = analyze_trace_with_plan(&trace, &trace, 15_576, &plan).unwrap();
+
+        assert!(analysis.cold_start.aggregate.lru.missing_expert_installs > 0);
+        assert_eq!(analysis.first_measured_after_warmup.warmup_runs, 1);
+        assert_eq!(analysis.first_measured_after_warmup.measured_runs, 1);
+        assert_eq!(analysis.frozen_perf_shape.warmup_runs, 1);
+        assert_eq!(analysis.frozen_perf_shape.measured_runs, 3);
+        for phase in [
+            &analysis.first_measured_after_warmup.counted_measurement,
+            &analysis.frozen_perf_shape.counted_measurement,
+        ] {
+            assert_eq!(phase.aggregate.lru.missing_expert_installs, 0);
+            assert_eq!(phase.aggregate.lru.layer_miss_boundaries, 0);
+            assert_eq!(phase.aggregate.minimum.missing_expert_installs, 0);
+            assert_eq!(phase.aggregate.minimum.layer_miss_boundaries, 0);
+            assert!(phase.per_layer.iter().all(|layer| {
+                layer.lru.missing_expert_installs == 0
+                    && layer.lru.layer_miss_boundaries == 0
+                    && layer.minimum.missing_expert_installs == 0
+                    && layer.minimum.layer_miss_boundaries == 0
+            }));
+        }
+        assert_eq!(
+            analysis
+                .first_measured_after_warmup
+                .counted_measurement
+                .aggregate
+                .route_references,
+            trace.total_selected_expert_ids as u64
+        );
+        assert_eq!(
+            analysis
+                .frozen_perf_shape
+                .counted_measurement
+                .aggregate
+                .route_references,
+            3 * trace.total_selected_expert_ids as u64
+        );
+        assert_eq!(
+            analysis
+                .frozen_perf_shape
+                .counted_measurement
+                .aggregate
+                .lru
+                .compulsory_first_observation_installs,
+            0
+        );
+
+        let json = serde_json::to_value(&analysis).unwrap();
+        assert!(json.get("cold_start").is_some());
+        assert!(json.get("first_measured_after_warmup").is_some());
+        assert!(json.get("frozen_perf_shape").is_some());
+        assert!(json.get("per_layer").is_none());
+        assert!(json.get("aggregate").is_none());
+    }
+
+    #[test]
+    fn production_model_slot_planner_reuse_matches_qwen_geometry() {
+        let qwen = GpuNativeQ4ExpertGeometry::try_new(2048, 768, 128, 8).unwrap();
+        let budget = 15_576 * MIB;
+        let limits = qwen_limits();
         let plan = GpuNativeModelExpertVramPlan::try_new(48, qwen, budget, &limits).unwrap();
         assert_eq!(plan.num_layers(), 48);
         assert_eq!(plan.model_slot_capacity(), 48 * 128);

--- a/rust-engine/src/gpu_native_oracle_routes.rs
+++ b/rust-engine/src/gpu_native_oracle_routes.rs
@@ -1,0 +1,1578 @@
+//! Qualification-only capture of the ordered routes already selected by the
+//! ordinary production GPU-native token loop, plus pure offline residency
+//! lower-bound analysis.
+//!
+//! The command in this module calls only `GpuNativeTokenLoop::step_token`.
+//! Route IDs are observed at `Engine::record_gpu_native_actual_routes`, after
+//! the compact boundary report has already been read for normal recovery and
+//! completion accounting. No diagnostic GPU copy or readback is added.
+
+#[cfg(test)]
+use crate::backend::gpu_native::GpuNativeQ4ExpertGeometry;
+use crate::backend::GpuDeviceIdentity;
+use crate::engine::{GpuNativeActualRouteObserver, RoutedExpertExecutionSnapshot};
+use crate::gpu_native_real_benchmark::{
+    BenchmarkFailure, BenchmarkProvenance, ProductionConfiguration, RequestEvidence,
+    RuntimeContractEvidence, RuntimeContractInput,
+};
+use crate::gpu_native_residency::GpuNativeModelExpertVramPlan;
+use crate::gpu_native_token_loop::{
+    GpuNativeModelGeometry, GpuNativeRecoverySnapshot, GpuNativeTokenLoopSnapshot,
+};
+use crate::greedy_parity::{BackgroundShutdownEvidence, ModelIdentityEvidence, ModelLoadEvidence};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::{HashSet, VecDeque};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+pub(crate) const SCHEMA: &str = "mer.gpu-native-oracle-route-trace.v1";
+pub(crate) const MODE: &str = "gpu-native-oracle-route-trace";
+pub(crate) const BASE_GIT_SHA: &str = "7ab35f10d2798faf3d997e0d90f51f3e6519529e";
+const CANONICAL_SERIALIZATION: &str = "domain mer.gpu-native-oracle-route-sequence.v1 NUL; record_count u64-le; repeated position u64-le, layer_index u32-le, selected_count u32-le, ordered local expert ids u32-le";
+const LEGACY_SERIALIZATION: &str = "historical QualificationOrderedHasher sets: 0x53, set_len u64-le, ordered global expert ids u32-le; one set per position/layer";
+const MIB: u64 = 1024 * 1024;
+const EXPECTED_ADAPTER_NAME: &str = "NVIDIA L4";
+const EXPECTED_EXPERT_FILE_BYTES: usize = 2_658_304;
+const EXPECTED_ROUTED_EXPERT_FOOTPRINT_BYTES: u64 = 16_332_619_776;
+const REQUESTED_BUDGETS_MIB: [u64; 7] = [2_048, 4_096, 8_192, 10_240, 12_288, 14_336, 15_576];
+
+#[derive(Clone, Debug)]
+pub(crate) struct CommandArgs {
+    pub(crate) config: PathBuf,
+    pub(crate) request_json: PathBuf,
+    pub(crate) report_out: PathBuf,
+    pub(crate) progress_watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct OracleGeometry {
+    pub(crate) layers: usize,
+    pub(crate) experts: usize,
+    pub(crate) top_k: usize,
+    pub(crate) d_model: usize,
+    pub(crate) d_ff: usize,
+}
+
+impl From<GpuNativeModelGeometry> for OracleGeometry {
+    fn from(value: GpuNativeModelGeometry) -> Self {
+        Self {
+            layers: value.num_layers,
+            experts: value.num_experts,
+            top_k: value.top_k,
+            d_model: value.d_model,
+            d_ff: value.d_ff,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct OracleRouteRecord {
+    pub(crate) position: usize,
+    pub(crate) layer_index: usize,
+    pub(crate) ordered_selected_expert_ids: Vec<u32>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct OracleRouteTrace {
+    pub(crate) schema: String,
+    pub(crate) geometry: OracleGeometry,
+    pub(crate) total_positions: usize,
+    pub(crate) total_layer_records: usize,
+    pub(crate) total_selected_expert_ids: usize,
+    pub(crate) canonical_serialization: String,
+    pub(crate) ordered_route_sequence_sha256: String,
+    pub(crate) legacy_serialization: String,
+    pub(crate) legacy_selected_route_ids_sha256: String,
+    pub(crate) records: Vec<OracleRouteRecord>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct OracleTraceError {
+    pub(crate) code: &'static str,
+    pub(crate) detail: String,
+}
+
+impl OracleTraceError {
+    fn new(code: &'static str, detail: impl Into<String>) -> Self {
+        Self {
+            code,
+            detail: detail.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for OracleTraceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.code, self.detail)
+    }
+}
+
+impl std::error::Error for OracleTraceError {}
+
+fn validate_route_records(
+    geometry: OracleGeometry,
+    records: &[OracleRouteRecord],
+) -> Result<(usize, usize), OracleTraceError> {
+    if geometry.layers == 0
+        || geometry.experts == 0
+        || geometry.top_k == 0
+        || geometry.top_k > geometry.experts
+    {
+        return Err(OracleTraceError::new(
+            "invalid-geometry",
+            format!("invalid oracle route geometry {geometry:?}"),
+        ));
+    }
+    if records.is_empty() || !records.len().is_multiple_of(geometry.layers) {
+        return Err(OracleTraceError::new(
+            "wrong-layer-count",
+            format!(
+                "{} route records cannot form nonempty positions of exactly {} layers",
+                records.len(),
+                geometry.layers
+            ),
+        ));
+    }
+
+    let total_positions = records.len() / geometry.layers;
+    let mut total_selected = 0usize;
+    for position in 0..total_positions {
+        for layer_index in 0..geometry.layers {
+            let record_index = position
+                .checked_mul(geometry.layers)
+                .and_then(|base| base.checked_add(layer_index))
+                .ok_or_else(|| {
+                    OracleTraceError::new("route-count-overflow", "route index overflow")
+                })?;
+            let record = &records[record_index];
+            if record.position != position || record.layer_index != layer_index {
+                return Err(OracleTraceError::new(
+                    "route-order",
+                    format!(
+                        "record {record_index} expected position={position} layer={layer_index}, observed position={} layer={}",
+                        record.position, record.layer_index
+                    ),
+                ));
+            }
+            if record.ordered_selected_expert_ids.len() != geometry.top_k {
+                return Err(OracleTraceError::new(
+                    "wrong-top-k-count",
+                    format!(
+                        "position {position} layer {layer_index} has {} selected IDs, expected {}",
+                        record.ordered_selected_expert_ids.len(),
+                        geometry.top_k
+                    ),
+                ));
+            }
+            let mut unique = HashSet::with_capacity(geometry.top_k);
+            for &expert_id in &record.ordered_selected_expert_ids {
+                if expert_id as usize >= geometry.experts {
+                    return Err(OracleTraceError::new(
+                        "invalid-expert-id",
+                        format!(
+                            "position {position} layer {layer_index} selected expert {expert_id}, maximum is {}",
+                            geometry.experts - 1
+                        ),
+                    ));
+                }
+                if !unique.insert(expert_id) {
+                    return Err(OracleTraceError::new(
+                        "duplicate-top-k-id",
+                        format!(
+                            "position {position} layer {layer_index} repeats expert {expert_id}"
+                        ),
+                    ));
+                }
+            }
+            total_selected = total_selected
+                .checked_add(record.ordered_selected_expert_ids.len())
+                .ok_or_else(|| {
+                    OracleTraceError::new("route-count-overflow", "selected expert count overflow")
+                })?;
+        }
+    }
+    Ok((total_positions, total_selected))
+}
+
+fn canonical_route_bytes(records: &[OracleRouteRecord]) -> Result<Vec<u8>, OracleTraceError> {
+    let mut bytes = b"mer.gpu-native-oracle-route-sequence.v1\0".to_vec();
+    let record_count = u64::try_from(records.len()).map_err(|_| {
+        OracleTraceError::new("route-count-overflow", "record count does not fit u64")
+    })?;
+    bytes.extend_from_slice(&record_count.to_le_bytes());
+    for record in records {
+        let position = u64::try_from(record.position).map_err(|_| {
+            OracleTraceError::new("route-count-overflow", "position does not fit u64")
+        })?;
+        let layer = u32::try_from(record.layer_index).map_err(|_| {
+            OracleTraceError::new("route-count-overflow", "layer index does not fit u32")
+        })?;
+        let selected_count =
+            u32::try_from(record.ordered_selected_expert_ids.len()).map_err(|_| {
+                OracleTraceError::new("route-count-overflow", "top-k count does not fit u32")
+            })?;
+        bytes.extend_from_slice(&position.to_le_bytes());
+        bytes.extend_from_slice(&layer.to_le_bytes());
+        bytes.extend_from_slice(&selected_count.to_le_bytes());
+        for &expert_id in &record.ordered_selected_expert_ids {
+            bytes.extend_from_slice(&expert_id.to_le_bytes());
+        }
+    }
+    Ok(bytes)
+}
+
+fn ordered_route_sequence_sha256(
+    records: &[OracleRouteRecord],
+) -> Result<String, OracleTraceError> {
+    Ok(format!(
+        "{:x}",
+        Sha256::digest(canonical_route_bytes(records)?)
+    ))
+}
+
+fn legacy_route_sequence_sha256(
+    geometry: OracleGeometry,
+    records: &[OracleRouteRecord],
+) -> Result<String, OracleTraceError> {
+    let mut global_sets = Vec::with_capacity(records.len());
+    for record in records {
+        let layer_base = record
+            .layer_index
+            .checked_mul(geometry.experts)
+            .ok_or_else(|| {
+                OracleTraceError::new("route-count-overflow", "global layer offset overflow")
+            })?;
+        let ids = record
+            .ordered_selected_expert_ids
+            .iter()
+            .map(|&local_id| {
+                layer_base
+                    .checked_add(local_id as usize)
+                    .and_then(|global_id| u32::try_from(global_id).ok())
+                    .ok_or_else(|| {
+                        OracleTraceError::new("route-count-overflow", "global expert ID overflow")
+                    })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        global_sets.push(ids);
+    }
+    Ok(crate::engine::qualification_ordered_sets_sha256(
+        &global_sets,
+    ))
+}
+
+impl OracleRouteTrace {
+    pub(crate) fn try_new(
+        geometry: OracleGeometry,
+        records: Vec<OracleRouteRecord>,
+    ) -> Result<Self, OracleTraceError> {
+        let (total_positions, total_selected_expert_ids) =
+            validate_route_records(geometry, &records)?;
+        let total_layer_records = records.len();
+        let ordered_route_sequence_sha256 = ordered_route_sequence_sha256(&records)?;
+        let legacy_selected_route_ids_sha256 = legacy_route_sequence_sha256(geometry, &records)?;
+        Ok(Self {
+            schema: SCHEMA.to_string(),
+            geometry,
+            total_positions,
+            total_layer_records,
+            total_selected_expert_ids,
+            canonical_serialization: CANONICAL_SERIALIZATION.to_string(),
+            ordered_route_sequence_sha256,
+            legacy_serialization: LEGACY_SERIALIZATION.to_string(),
+            legacy_selected_route_ids_sha256,
+            records,
+        })
+    }
+
+    pub(crate) fn validate(&self) -> Result<(), OracleTraceError> {
+        if self.schema != SCHEMA {
+            return Err(OracleTraceError::new(
+                "wrong-schema",
+                format!("expected {SCHEMA}, observed {}", self.schema),
+            ));
+        }
+        if self.canonical_serialization != CANONICAL_SERIALIZATION
+            || self.legacy_serialization != LEGACY_SERIALIZATION
+        {
+            return Err(OracleTraceError::new(
+                "serialization-contract-drift",
+                "route hash serialization description does not match schema v1",
+            ));
+        }
+        let (positions, selected) = validate_route_records(self.geometry, &self.records)?;
+        if self.total_positions != positions
+            || self.total_layer_records != self.records.len()
+            || self.total_selected_expert_ids != selected
+        {
+            return Err(OracleTraceError::new(
+                "trace-total-mismatch",
+                "stored trace totals disagree with validated records",
+            ));
+        }
+        let canonical = ordered_route_sequence_sha256(&self.records)?;
+        if self.ordered_route_sequence_sha256 != canonical {
+            return Err(OracleTraceError::new(
+                "canonical-route-hash-mismatch",
+                format!(
+                    "stored {} differs from recomputed {canonical}",
+                    self.ordered_route_sequence_sha256
+                ),
+            ));
+        }
+        let legacy = legacy_route_sequence_sha256(self.geometry, &self.records)?;
+        if self.legacy_selected_route_ids_sha256 != legacy {
+            return Err(OracleTraceError::new(
+                "legacy-route-hash-mismatch",
+                format!(
+                    "stored {} differs from recomputed {legacy}",
+                    self.legacy_selected_route_ids_sha256
+                ),
+            ));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn parse(bytes: &[u8]) -> Result<Self, OracleTraceError> {
+        let trace: Self = serde_json::from_slice(bytes)
+            .map_err(|error| OracleTraceError::new("trace-parse-failed", error.to_string()))?;
+        trace.validate()?;
+        Ok(trace)
+    }
+}
+
+#[derive(Default)]
+struct RouteCollector {
+    records: parking_lot::Mutex<Vec<OracleRouteRecord>>,
+}
+
+impl GpuNativeActualRouteObserver for RouteCollector {
+    fn record_position(&self, position: usize, selected_ids_by_layer: &[Vec<u32>]) {
+        let mut records = self.records.lock();
+        records.extend(
+            selected_ids_by_layer
+                .iter()
+                .enumerate()
+                .map(|(layer_index, ids)| OracleRouteRecord {
+                    position,
+                    layer_index,
+                    ordered_selected_expert_ids: ids.clone(),
+                }),
+        );
+    }
+}
+
+impl RouteCollector {
+    fn take(&self) -> Vec<OracleRouteRecord> {
+        std::mem::take(&mut *self.records.lock())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct PolicyCounts {
+    route_references: u64,
+    cache_hits: u64,
+    missing_installs: u64,
+    miss_boundaries: u64,
+    compulsory_cold_installs: u64,
+}
+
+fn validate_accesses(
+    capacity: usize,
+    experts: usize,
+    accesses: &[Vec<u32>],
+) -> Result<(), OracleTraceError> {
+    if capacity == 0 {
+        return Err(OracleTraceError::new(
+            "zero-slot-capacity",
+            "offline residency analysis requires at least one physical slot",
+        ));
+    }
+    for (position, ids) in accesses.iter().enumerate() {
+        if ids.len() > capacity {
+            return Err(OracleTraceError::new(
+                "route-set-exceeds-capacity",
+                format!(
+                    "position {position} needs {} simultaneous experts but capacity is {capacity}",
+                    ids.len()
+                ),
+            ));
+        }
+        let mut unique = HashSet::with_capacity(ids.len());
+        for &id in ids {
+            if id as usize >= experts || !unique.insert(id) {
+                return Err(OracleTraceError::new(
+                    "invalid-analysis-route",
+                    format!("position {position} contains invalid or duplicate expert {id}"),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Exact empty-start LRU simulation of production demand-set semantics: hits
+/// are touched in ordered top-k order, the whole set is protected while enough
+/// oldest unprotected residents are evicted, then misses install in route order.
+fn simulate_production_lru(
+    capacity: usize,
+    experts: usize,
+    accesses: &[Vec<u32>],
+) -> Result<PolicyCounts, OracleTraceError> {
+    validate_accesses(capacity, experts, accesses)?;
+    let mut lru = VecDeque::<u32>::with_capacity(capacity);
+    let mut ever_seen = HashSet::new();
+    let mut counts = PolicyCounts::default();
+    for ids in accesses {
+        counts.route_references = counts
+            .route_references
+            .checked_add(ids.len() as u64)
+            .ok_or_else(|| OracleTraceError::new("analysis-overflow", "route count overflow"))?;
+        let protected = ids.iter().copied().collect::<HashSet<_>>();
+        let mut misses = Vec::new();
+        for &id in ids {
+            if let Some(index) = lru.iter().position(|&resident| resident == id) {
+                let resident = lru.remove(index).expect("located LRU resident");
+                lru.push_back(resident);
+                counts.cache_hits += 1;
+            } else {
+                misses.push(id);
+                counts.missing_installs += 1;
+                if ever_seen.insert(id) {
+                    counts.compulsory_cold_installs += 1;
+                }
+            }
+        }
+        if !misses.is_empty() {
+            counts.miss_boundaries += 1;
+        }
+        while lru.len().saturating_add(misses.len()) > capacity {
+            let victim = lru
+                .iter()
+                .position(|id| !protected.contains(id))
+                .ok_or_else(|| {
+                    OracleTraceError::new(
+                        "no-unprotected-lru-victim",
+                        "validated simultaneous set left no legal LRU victim",
+                    )
+                })?;
+            lru.remove(victim);
+        }
+        for id in misses {
+            lru.push_back(id);
+        }
+    }
+    Ok(counts)
+}
+
+/// Belady/MIN-style empty-start simulation for simultaneous top-k accesses.
+/// Every current route is protected; among other residents, the expert whose
+/// next route-set use is farthest away (or absent) is evicted.
+fn simulate_belady_min(
+    capacity: usize,
+    experts: usize,
+    accesses: &[Vec<u32>],
+) -> Result<PolicyCounts, OracleTraceError> {
+    validate_accesses(capacity, experts, accesses)?;
+    let mut future = vec![VecDeque::<usize>::new(); experts];
+    for (position, ids) in accesses.iter().enumerate() {
+        for &id in ids {
+            future[id as usize].push_back(position);
+        }
+    }
+    let mut residents = HashSet::<u32>::with_capacity(capacity);
+    let mut ever_seen = HashSet::new();
+    let mut counts = PolicyCounts::default();
+    for (position, ids) in accesses.iter().enumerate() {
+        for &id in ids {
+            let observed = future[id as usize].pop_front();
+            if observed != Some(position) {
+                return Err(OracleTraceError::new(
+                    "future-index-corrupt",
+                    "next-use index did not match the current position",
+                ));
+            }
+        }
+        counts.route_references = counts
+            .route_references
+            .checked_add(ids.len() as u64)
+            .ok_or_else(|| OracleTraceError::new("analysis-overflow", "route count overflow"))?;
+        let protected = ids.iter().copied().collect::<HashSet<_>>();
+        let mut misses = Vec::new();
+        for &id in ids {
+            if residents.contains(&id) {
+                counts.cache_hits += 1;
+            } else {
+                misses.push(id);
+                counts.missing_installs += 1;
+                if ever_seen.insert(id) {
+                    counts.compulsory_cold_installs += 1;
+                }
+            }
+        }
+        if !misses.is_empty() {
+            counts.miss_boundaries += 1;
+        }
+        while residents.len().saturating_add(misses.len()) > capacity {
+            let victim = residents
+                .iter()
+                .copied()
+                .filter(|id| !protected.contains(id))
+                .max_by_key(|id| {
+                    (
+                        future[*id as usize].front().copied().unwrap_or(usize::MAX),
+                        *id,
+                    )
+                })
+                .ok_or_else(|| {
+                    OracleTraceError::new(
+                        "no-unprotected-min-victim",
+                        "validated simultaneous set left no legal MIN victim",
+                    )
+                })?;
+            residents.remove(&victim);
+        }
+        residents.extend(misses);
+    }
+    Ok(counts)
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct LayerOracleAnalysis {
+    pub(crate) layer_index: usize,
+    pub(crate) physical_expert_slots: usize,
+    pub(crate) route_references: u64,
+    pub(crate) unique_experts_touched: usize,
+    pub(crate) lru_cache_hits: u64,
+    pub(crate) lru_missing_expert_installs: u64,
+    pub(crate) lru_layer_miss_boundaries: u64,
+    pub(crate) lru_bytes_to_move: u64,
+    pub(crate) minimum_cache_hits: u64,
+    pub(crate) minimum_missing_expert_installs: u64,
+    pub(crate) minimum_layer_miss_boundaries: u64,
+    pub(crate) minimum_bytes_to_move: u64,
+    pub(crate) compulsory_cold_installs: u64,
+    pub(crate) lru_capacity_replacement_installs: u64,
+    pub(crate) minimum_capacity_replacement_installs: u64,
+    pub(crate) lru_resident_route_fraction: f64,
+    pub(crate) maximum_potentially_resident_route_fraction: f64,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub(crate) struct AggregateOracleAnalysis {
+    pub(crate) physical_expert_slots: usize,
+    pub(crate) route_references: u64,
+    pub(crate) unique_experts_touched: usize,
+    pub(crate) lru_cache_hits: u64,
+    pub(crate) lru_missing_expert_installs: u64,
+    pub(crate) lru_layer_miss_boundaries: u64,
+    pub(crate) lru_bytes_to_move: u64,
+    pub(crate) minimum_cache_hits: u64,
+    pub(crate) minimum_missing_expert_installs: u64,
+    pub(crate) minimum_layer_miss_boundaries: u64,
+    pub(crate) minimum_bytes_to_move: u64,
+    pub(crate) compulsory_cold_installs: u64,
+    pub(crate) lru_capacity_replacement_installs: u64,
+    pub(crate) minimum_capacity_replacement_installs: u64,
+    pub(crate) lru_resident_route_fraction: f64,
+    pub(crate) maximum_potentially_resident_route_fraction: f64,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct BudgetOracleAnalysis {
+    pub(crate) requested_expert_budget_mib: u64,
+    pub(crate) requested_expert_budget_bytes: u64,
+    pub(crate) minimum_executable_budget_bytes: u64,
+    pub(crate) arena_allocation_bytes: u64,
+    pub(crate) unused_budget_bytes: u64,
+    pub(crate) physical_slot_stride_bytes: u64,
+    pub(crate) physical_expert_slots: usize,
+    pub(crate) per_layer_physical_expert_slots: Vec<usize>,
+    pub(crate) per_layer: Vec<LayerOracleAnalysis>,
+    pub(crate) aggregate: AggregateOracleAnalysis,
+}
+
+fn checked_transfer_bytes(installs: u64, bytes: u64) -> Result<u64, OracleTraceError> {
+    installs
+        .checked_mul(bytes)
+        .ok_or_else(|| OracleTraceError::new("analysis-overflow", "transfer byte count overflow"))
+}
+
+fn resident_fraction(hits: u64, references: u64) -> f64 {
+    if references == 0 {
+        1.0
+    } else {
+        hits as f64 / references as f64
+    }
+}
+
+fn analyze_trace_with_plan(
+    trace: &OracleRouteTrace,
+    requested_budget_mib: u64,
+    plan: &GpuNativeModelExpertVramPlan,
+) -> Result<BudgetOracleAnalysis, OracleTraceError> {
+    trace.validate()?;
+    let plan_geometry = plan.geometry();
+    if plan.num_layers() != trace.geometry.layers
+        || plan_geometry.num_experts() != trace.geometry.experts
+        || plan_geometry.top_k() != trace.geometry.top_k
+        || plan_geometry.d_model() != trace.geometry.d_model
+        || plan_geometry.d_ff() != trace.geometry.d_ff
+    {
+        return Err(OracleTraceError::new(
+            "slot-plan-geometry-mismatch",
+            "production slot-plan geometry differs from the validated route trace",
+        ));
+    }
+    let capacities = plan
+        .layer_plans()
+        .iter()
+        .map(|layer| layer.slot_capacity())
+        .collect::<Vec<_>>();
+    let slot_stride_bytes = plan_geometry.slot_stride_bytes() as u64;
+    let mut accesses = vec![Vec::<Vec<u32>>::new(); trace.geometry.layers];
+    for record in &trace.records {
+        accesses[record.layer_index].push(record.ordered_selected_expert_ids.clone());
+    }
+
+    let mut aggregate = AggregateOracleAnalysis::default();
+    let mut per_layer = Vec::with_capacity(trace.geometry.layers);
+    for layer_index in 0..trace.geometry.layers {
+        let capacity = capacities[layer_index];
+        let layer_accesses = &accesses[layer_index];
+        let unique_experts_touched = layer_accesses
+            .iter()
+            .flatten()
+            .copied()
+            .collect::<HashSet<_>>()
+            .len();
+        let lru = simulate_production_lru(capacity, trace.geometry.experts, layer_accesses)?;
+        let minimum = simulate_belady_min(capacity, trace.geometry.experts, layer_accesses)?;
+        if lru.route_references != minimum.route_references
+            || lru.compulsory_cold_installs != minimum.compulsory_cold_installs
+        {
+            return Err(OracleTraceError::new(
+                "analysis-reconciliation",
+                "LRU and MIN simulations disagree on route references or compulsory misses",
+            ));
+        }
+        let layer = LayerOracleAnalysis {
+            layer_index,
+            physical_expert_slots: capacity,
+            route_references: lru.route_references,
+            unique_experts_touched,
+            lru_cache_hits: lru.cache_hits,
+            lru_missing_expert_installs: lru.missing_installs,
+            lru_layer_miss_boundaries: lru.miss_boundaries,
+            lru_bytes_to_move: checked_transfer_bytes(lru.missing_installs, slot_stride_bytes)?,
+            minimum_cache_hits: minimum.cache_hits,
+            minimum_missing_expert_installs: minimum.missing_installs,
+            minimum_layer_miss_boundaries: minimum.miss_boundaries,
+            minimum_bytes_to_move: checked_transfer_bytes(
+                minimum.missing_installs,
+                slot_stride_bytes,
+            )?,
+            compulsory_cold_installs: minimum.compulsory_cold_installs,
+            lru_capacity_replacement_installs: lru
+                .missing_installs
+                .checked_sub(lru.compulsory_cold_installs)
+                .ok_or_else(|| {
+                    OracleTraceError::new(
+                        "analysis-reconciliation",
+                        "LRU compulsory misses exceed total misses",
+                    )
+                })?,
+            minimum_capacity_replacement_installs: minimum
+                .missing_installs
+                .checked_sub(minimum.compulsory_cold_installs)
+                .ok_or_else(|| {
+                    OracleTraceError::new(
+                        "analysis-reconciliation",
+                        "MIN compulsory misses exceed total misses",
+                    )
+                })?,
+            lru_resident_route_fraction: resident_fraction(lru.cache_hits, lru.route_references),
+            maximum_potentially_resident_route_fraction: resident_fraction(
+                minimum.cache_hits,
+                minimum.route_references,
+            ),
+        };
+        aggregate.physical_expert_slots += layer.physical_expert_slots;
+        aggregate.route_references += layer.route_references;
+        aggregate.unique_experts_touched += layer.unique_experts_touched;
+        aggregate.lru_cache_hits += layer.lru_cache_hits;
+        aggregate.lru_missing_expert_installs += layer.lru_missing_expert_installs;
+        aggregate.lru_layer_miss_boundaries += layer.lru_layer_miss_boundaries;
+        aggregate.lru_bytes_to_move += layer.lru_bytes_to_move;
+        aggregate.minimum_cache_hits += layer.minimum_cache_hits;
+        aggregate.minimum_missing_expert_installs += layer.minimum_missing_expert_installs;
+        aggregate.minimum_layer_miss_boundaries += layer.minimum_layer_miss_boundaries;
+        aggregate.minimum_bytes_to_move += layer.minimum_bytes_to_move;
+        aggregate.compulsory_cold_installs += layer.compulsory_cold_installs;
+        aggregate.lru_capacity_replacement_installs += layer.lru_capacity_replacement_installs;
+        aggregate.minimum_capacity_replacement_installs +=
+            layer.minimum_capacity_replacement_installs;
+        per_layer.push(layer);
+    }
+    aggregate.lru_resident_route_fraction =
+        resident_fraction(aggregate.lru_cache_hits, aggregate.route_references);
+    aggregate.maximum_potentially_resident_route_fraction =
+        resident_fraction(aggregate.minimum_cache_hits, aggregate.route_references);
+    if aggregate.route_references != trace.total_selected_expert_ids as u64
+        || aggregate.physical_expert_slots != plan.model_slot_capacity()
+    {
+        return Err(OracleTraceError::new(
+            "analysis-reconciliation",
+            "aggregate route references or slot capacity disagree with source evidence",
+        ));
+    }
+
+    Ok(BudgetOracleAnalysis {
+        requested_expert_budget_mib: requested_budget_mib,
+        requested_expert_budget_bytes: plan.total_expert_budget_bytes(),
+        minimum_executable_budget_bytes: plan.minimum_executable_budget_bytes(),
+        arena_allocation_bytes: plan.total_arena_allocation_bytes(),
+        unused_budget_bytes: plan.unused_remainder_bytes(),
+        physical_slot_stride_bytes: slot_stride_bytes,
+        physical_expert_slots: plan.model_slot_capacity(),
+        per_layer_physical_expert_slots: capacities,
+        per_layer,
+        aggregate,
+    })
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct TraceRunEvidence {
+    pub(crate) generated_token_ids: Vec<u32>,
+    pub(crate) generated_token_ids_sha256: String,
+    pub(crate) generated_text_sha256: String,
+    pub(crate) route_sequence_sha256: String,
+    pub(crate) legacy_selected_route_ids_sha256: String,
+    pub(crate) token_loop: GpuNativeTokenLoopSnapshot,
+    pub(crate) recovery: GpuNativeRecoverySnapshot,
+    pub(crate) routed_execution: RoutedExpertExecutionSnapshot,
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+pub(crate) struct DeterminismEvidence {
+    pub(crate) identical_input: bool,
+    pub(crate) greedy: bool,
+    pub(crate) generated_token_ids_match: bool,
+    pub(crate) generated_text_hashes_match: bool,
+    pub(crate) ordered_route_sequence_hashes_match: bool,
+    pub(crate) legacy_route_hashes_match: bool,
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+pub(crate) struct ObservationEvidence {
+    pub(crate) ordinary_step_token_only: bool,
+    pub(crate) seam: &'static str,
+    pub(crate) additional_gpu_readback_introduced: bool,
+    pub(crate) performance_claim_from_trace_run: bool,
+    pub(crate) production_slot_planner: &'static str,
+    pub(crate) analyzer_initial_residency: &'static str,
+    pub(crate) minimum_policy: &'static str,
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+pub(crate) struct ExpertStorageEvidence {
+    pub(crate) routed_expert_count: u64,
+    pub(crate) expert_file_bytes: u64,
+    pub(crate) routed_expert_footprint_bytes: u64,
+    pub(crate) physical_slot_stride_bytes: u64,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct OracleRouteTraceReport {
+    pub(crate) schema: &'static str,
+    pub(crate) mode: &'static str,
+    pub(crate) complete: bool,
+    pub(crate) diagnostic_only: bool,
+    pub(crate) base_git_sha: &'static str,
+    pub(crate) provenance: BenchmarkProvenance,
+    pub(crate) model_identity: ModelIdentityEvidence,
+    pub(crate) model_load: ModelLoadEvidence,
+    pub(crate) adapter_identity: GpuDeviceIdentity,
+    pub(crate) runtime_contract: RuntimeContractEvidence,
+    pub(crate) request: RequestEvidence,
+    pub(crate) production_configuration: ProductionConfiguration,
+    pub(crate) expert_storage: ExpertStorageEvidence,
+    pub(crate) observation: ObservationEvidence,
+    pub(crate) warmup: TraceRunEvidence,
+    pub(crate) measured: TraceRunEvidence,
+    pub(crate) determinism: DeterminismEvidence,
+    pub(crate) trace: OracleRouteTrace,
+    pub(crate) offline_oracle_analysis: Vec<BudgetOracleAnalysis>,
+    pub(crate) shutdown: BackgroundShutdownEvidence,
+}
+
+struct CapturedRun {
+    evidence: TraceRunEvidence,
+    trace: OracleRouteTrace,
+}
+
+fn counter_failure(error: impl std::fmt::Display) -> BenchmarkFailure {
+    BenchmarkFailure::new(
+        "postcondition",
+        "trace-accounting-invalid",
+        error.to_string(),
+    )
+}
+
+async fn execute_trace_request(
+    runtime: &crate::BenchRealRuntime,
+    prompt_ids: &[u32],
+    requested_output_tokens: usize,
+    label: &str,
+    watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+) -> Result<CapturedRun, BenchmarkFailure> {
+    let token_loop = runtime.gpu_native_token_loop.as_ref().ok_or_else(|| {
+        BenchmarkFailure::new(
+            "startup",
+            "missing-gpu-native-token-loop",
+            "oracle route trace runtime has no GPU-native token loop",
+        )
+    })?;
+    let token_before = token_loop.snapshot();
+    let recovery_before = token_loop.recovery_snapshot();
+    let routed_before = runtime.engine.routed_expert_execution_snapshot();
+    let collector = Arc::new(RouteCollector::default());
+    runtime
+        .engine
+        .install_gpu_native_actual_route_observer(collector.clone())
+        .map_err(|error| {
+            BenchmarkFailure::new("startup", "route-observer-install-failed", error)
+        })?;
+
+    let execution = crate::with_progress_timeout(label.to_string(), watchdog, async {
+        let mut request = token_loop.create_request_state()?;
+        let mut generated_ids = Vec::with_capacity(requested_output_tokens);
+        let mut completed_positions = 0usize;
+        for (prompt_index, &token_id) in prompt_ids.iter().enumerate() {
+            let sample = prompt_index + 1 == prompt_ids.len();
+            let sampled = token_loop
+                .step_token(
+                    &runtime.engine,
+                    &mut request,
+                    token_id,
+                    completed_positions,
+                    sample,
+                )
+                .await?;
+            completed_positions += 1;
+            if sample {
+                generated_ids.push(sampled.ok_or_else(|| {
+                    BenchmarkFailure::new(
+                        "inference",
+                        "missing-first-generated-token",
+                        "final prompt position produced no sampled token",
+                    )
+                })?);
+            } else if sampled.is_some() {
+                return Err(BenchmarkFailure::new(
+                    "inference",
+                    "unexpected-prefix-sample",
+                    "prompt prefix position unexpectedly produced a sampled token",
+                )
+                .into());
+            }
+        }
+        while generated_ids.len() < requested_output_tokens {
+            let token_id = *generated_ids.last().ok_or_else(|| {
+                BenchmarkFailure::new(
+                    "inference",
+                    "missing-generated-seed",
+                    "decode has no preceding generated token",
+                )
+            })?;
+            let sampled = token_loop
+                .step_token(
+                    &runtime.engine,
+                    &mut request,
+                    token_id,
+                    completed_positions,
+                    true,
+                )
+                .await?
+                .ok_or_else(|| {
+                    BenchmarkFailure::new(
+                        "inference",
+                        "missing-decode-token",
+                        format!("position {completed_positions} produced no sampled token"),
+                    )
+                })?;
+            generated_ids.push(sampled);
+            completed_positions += 1;
+        }
+        Ok::<Vec<u32>, Box<dyn std::error::Error>>(generated_ids)
+    })
+    .await
+    .map_err(|error| {
+        BenchmarkFailure::new("inference", "route-trace-request-failed", error.to_string())
+    });
+    let clear = runtime.engine.clear_gpu_native_actual_route_observer();
+    let generated_ids = match (execution, clear) {
+        (Ok(ids), Ok(())) => ids,
+        (Err(error), Ok(())) => return Err(error),
+        (Ok(_), Err(clear_error)) => {
+            return Err(BenchmarkFailure::new(
+                "postcondition",
+                "route-observer-clear-failed",
+                clear_error,
+            ))
+        }
+        (Err(error), Err(clear_error)) => {
+            return Err(BenchmarkFailure::new(
+                "postcondition",
+                "route-request-and-observer-clear-failed",
+                format!("{error}; {clear_error}"),
+            ))
+        }
+    };
+
+    let token_delta =
+        crate::gpu_native_real_benchmark::token_loop_delta(token_before, token_loop.snapshot())?;
+    let recovery_delta = crate::gpu_native_real_benchmark::recovery_delta(
+        recovery_before,
+        token_loop.recovery_snapshot(),
+    )?;
+    let routed_delta = crate::gpu_native_real_benchmark::routed_delta(
+        routed_before,
+        runtime.engine.routed_expert_execution_snapshot(),
+    )?;
+    crate::gpu_native_real_benchmark::validate_request_postconditions(
+        prompt_ids.len(),
+        requested_output_tokens,
+        generated_ids.len(),
+        token_delta,
+        recovery_delta,
+        routed_delta,
+    )?;
+
+    let trace = OracleRouteTrace::try_new(token_loop.model_geometry().into(), collector.take())
+        .map_err(counter_failure)?;
+    let trace_bytes = serde_json::to_vec(&trace).map_err(|error| {
+        BenchmarkFailure::new(
+            "postcondition",
+            "trace-serialization-failed",
+            error.to_string(),
+        )
+    })?;
+    let trace = OracleRouteTrace::parse(&trace_bytes).map_err(counter_failure)?;
+    if trace.total_positions as u64 != token_delta.tokens_completed
+        || trace.total_selected_expert_ids as u64 != routed_delta.selected_routed_experts
+    {
+        return Err(BenchmarkFailure::new(
+            "postcondition",
+            "trace-route-accounting-mismatch",
+            format!(
+                "trace positions={} selected_ids={} token_loop_completed={} routed_selected={}",
+                trace.total_positions,
+                trace.total_selected_expert_ids,
+                token_delta.tokens_completed,
+                routed_delta.selected_routed_experts
+            ),
+        ));
+    }
+    let output_text = runtime.tokenizer.decode(&generated_ids).map_err(|error| {
+        BenchmarkFailure::new("postcondition", "output-decode-failed", error.to_string())
+    })?;
+    let evidence = TraceRunEvidence {
+        generated_token_ids_sha256: crate::greedy_parity::token_ids_sha256(&generated_ids),
+        generated_text_sha256: crate::greedy_parity::sha256_hex(output_text.as_bytes()),
+        route_sequence_sha256: trace.ordered_route_sequence_sha256.clone(),
+        legacy_selected_route_ids_sha256: trace.legacy_selected_route_ids_sha256.clone(),
+        generated_token_ids: generated_ids,
+        token_loop: token_delta,
+        recovery: recovery_delta,
+        routed_execution: routed_delta,
+    };
+    Ok(CapturedRun { evidence, trace })
+}
+
+struct ValidatedRuntime {
+    model_load: ModelLoadEvidence,
+    adapter_identity: GpuDeviceIdentity,
+    runtime_contract: RuntimeContractEvidence,
+}
+
+fn validate_runtime(
+    runtime: &crate::BenchRealRuntime,
+    expected_config_sha256: &str,
+    expected_adapter_name: &str,
+) -> Result<ValidatedRuntime, BenchmarkFailure> {
+    let observed_config_sha256 = crate::resolved_real_runtime_identity_sha256(
+        &runtime.cfg,
+        runtime.model.config.architecture,
+        runtime.model.config.first_k_dense_replace,
+        &runtime.model.config.advanced,
+    )
+    .map_err(|error| {
+        BenchmarkFailure::new(
+            "startup",
+            "runtime-config-identity-unavailable",
+            error.to_string(),
+        )
+    })?;
+    if observed_config_sha256 != expected_config_sha256 {
+        return Err(BenchmarkFailure::new(
+            "startup",
+            "runtime-config-identity-drift",
+            format!(
+                "runtime identity {observed_config_sha256} differs from preflight identity {expected_config_sha256}"
+            ),
+        ));
+    }
+    if runtime.cfg.storage.predict_fanout != 0 {
+        return Err(BenchmarkFailure::new(
+            "startup",
+            "prefetch-enabled",
+            "ORACLE-0A requires storage.predict_fanout=0 at runtime",
+        ));
+    }
+    let token_loop = runtime.gpu_native_token_loop.as_ref().ok_or_else(|| {
+        BenchmarkFailure::new(
+            "startup",
+            "missing-gpu-native-token-loop",
+            "oracle route trace runtime has no GPU-native token loop",
+        )
+    })?;
+    if token_loop.snapshot() != GpuNativeTokenLoopSnapshot::default()
+        || token_loop.recovery_snapshot() != GpuNativeRecoverySnapshot::default()
+        || runtime.engine.routed_expert_execution_snapshot()
+            != RoutedExpertExecutionSnapshot::default()
+    {
+        return Err(BenchmarkFailure::new(
+            "startup",
+            "nonzero-initial-runtime-counters",
+            "fresh oracle route runtime did not begin with zero token/recovery/routed counters",
+        ));
+    }
+    let model_load = crate::greedy_parity_model_load(runtime);
+    let contract_input = RuntimeContractInput {
+        real_transformer_enabled: runtime.cfg.real_transformer.enabled,
+        real_transformer_gpu_native: runtime.cfg.real_transformer.gpu_native,
+        compute_offload: runtime.cfg.real_transformer.compute_offload,
+        legacy_execution_plan: runtime.engine.execution_context().plan().into(),
+        token_loop_geometry: Some(token_loop.model_geometry()),
+        authoritative_device: runtime.engine.gpu_device_identity(),
+        model_load: model_load.clone(),
+        routed_failure_policy: runtime.engine.routed_expert_gpu_failure_policy(),
+    };
+    let (runtime_contract, adapter_identity) =
+        crate::gpu_native_real_benchmark::validate_runtime_contract(
+            &contract_input,
+            expected_adapter_name,
+        )?;
+    Ok(ValidatedRuntime {
+        model_load,
+        adapter_identity,
+        runtime_contract,
+    })
+}
+
+fn emit_report(
+    report: &OracleRouteTraceReport,
+    report_out: &std::path::Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut bytes = serde_json::to_vec_pretty(report)?;
+    bytes.push(b'\n');
+    if let Some(parent) = report_out
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(report_out, bytes)?;
+    eprintln!(
+        "GPU-native ORACLE-0A route trace written to {}",
+        report_out.display()
+    );
+    Ok(())
+}
+
+pub(crate) async fn run_command(args: CommandArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let input = crate::load_real_cli_request_input(
+        "trace-gpu-native-oracle-routes",
+        None,
+        Some(&args.request_json),
+        None,
+    )?;
+    if input.output_tokens == 0 {
+        return Err(BenchmarkFailure::new(
+            "preflight",
+            "output-token-required",
+            "ORACLE-0A requires at least one generated token",
+        )
+        .into());
+    }
+
+    let build = crate::qualification::BuildProvenance::embedded();
+    crate::gpu_native_real_benchmark::validate_preflight_provenance(&build)?;
+    let cfg = crate::config::Config::from_file(&args.config)?;
+    crate::gpu_native_real_benchmark::validate_source_config(&cfg)?;
+    if cfg.storage.predict_fanout != 0 {
+        return Err(BenchmarkFailure::new(
+            "preflight",
+            "prefetch-enabled",
+            "ORACLE-0A requires frozen storage.predict_fanout=0",
+        )
+        .into());
+    }
+    let (artifacts, artifact_errors) = crate::qualification_artifacts(&args.config, &cfg);
+    crate::gpu_native_real_benchmark::validate_artifacts(&artifacts, &artifact_errors)?;
+    let expert_metadata =
+        crate::qualification::read_expert_metadata(&cfg.model.data_dir.join("metadata.json"))
+            .map_err(|error| {
+                BenchmarkFailure::new("preflight", "expert-metadata-unavailable", error)
+            })?;
+    crate::gpu_native_real_benchmark::validate_expert_metadata(&expert_metadata)?;
+    let spec = crate::resolve_real_cli_spec_from_config(
+        cfg,
+        crate::RealCliRuntimeMode::IsolatedGpuNativeBenchmark,
+    )?;
+    let model_identity = crate::greedy_parity_model_identity(&spec);
+    if !model_identity.is_qwen3_coder_30b_a3b_q4_0() {
+        return Err(BenchmarkFailure::new(
+            "preflight",
+            "wrong-model-identity",
+            format!(
+                "requires exact Qwen3-Coder 30B-A3B Q4_0 identity; observed {model_identity:?}"
+            ),
+        )
+        .into());
+    }
+    let routed_expert_count = u64::try_from(spec.cfg.model.num_layers)
+        .map_err(|_| {
+            BenchmarkFailure::new(
+                "preflight",
+                "expert-footprint-overflow",
+                "model.num_layers does not fit u64",
+            )
+        })?
+        .checked_mul(u64::from(spec.cfg.model.num_experts))
+        .ok_or_else(|| {
+            BenchmarkFailure::new(
+                "preflight",
+                "expert-footprint-overflow",
+                "num_layers * num_experts overflowed",
+            )
+        })?;
+    let expert_file_bytes = u64::try_from(spec.cfg.model.expert_size).map_err(|_| {
+        BenchmarkFailure::new(
+            "preflight",
+            "expert-footprint-overflow",
+            "model.expert_size does not fit u64",
+        )
+    })?;
+    let routed_expert_footprint_bytes = routed_expert_count
+        .checked_mul(expert_file_bytes)
+        .ok_or_else(|| {
+            BenchmarkFailure::new(
+                "preflight",
+                "expert-footprint-overflow",
+                "routed expert count * model.expert_size overflowed",
+            )
+        })?;
+    if spec.cfg.model.expert_size != EXPECTED_EXPERT_FILE_BYTES
+        || routed_expert_footprint_bytes != EXPECTED_ROUTED_EXPERT_FOOTPRINT_BYTES
+    {
+        return Err(BenchmarkFailure::new(
+            "preflight",
+            "wrong-expert-footprint",
+            format!(
+                "requires {} routed experts of {EXPECTED_EXPERT_FILE_BYTES} bytes for an exact {EXPECTED_ROUTED_EXPERT_FOOTPRINT_BYTES}-byte footprint; observed {routed_expert_count} experts of {} bytes for {routed_expert_footprint_bytes} bytes",
+                48 * 128,
+                spec.cfg.model.expert_size,
+            ),
+        )
+        .into());
+    }
+    let resolved_config_sha256 = crate::resolved_real_cli_spec_sha256(&spec)?;
+    let tokenizer = crate::load_real_cli_tokenizer(
+        &spec.cfg,
+        crate::RealCliRuntimeMode::IsolatedGpuNativeBenchmark,
+    )?;
+    let prompt_ids = tokenizer.encode(&input.prompt)?;
+    if prompt_ids.is_empty() {
+        return Err(BenchmarkFailure::new(
+            "preflight",
+            "empty-prompt-tokenization",
+            "prompt encoded to zero tokens",
+        )
+        .into());
+    }
+    let (executable, executable_sha256) = crate::current_executable_identity()?;
+    let executable_canonical_path = std::fs::canonicalize(&executable)?.display().to_string();
+    if !crate::gpu_native_real_benchmark::is_hex(&executable_sha256, 64)
+        || !crate::gpu_native_real_benchmark::is_hex(&resolved_config_sha256, 64)
+    {
+        return Err(BenchmarkFailure::new(
+            "preflight",
+            "provenance-unavailable",
+            "executable or resolved-config SHA256 was unavailable",
+        )
+        .into());
+    }
+    let production_configuration =
+        ProductionConfiguration::from_config(&spec.cfg, &expert_metadata);
+    let provenance = BenchmarkProvenance {
+        build,
+        executable_canonical_path,
+        executable_sha256,
+        resolved_config_sha256: resolved_config_sha256.clone(),
+        artifacts,
+        expert_metadata,
+    };
+    let request = RequestEvidence {
+        prompt_sha256: crate::greedy_parity::sha256_hex(input.prompt.as_bytes()),
+        prompt_token_ids_sha256: crate::greedy_parity::token_ids_sha256(&prompt_ids),
+        prompt_token_count: prompt_ids.len(),
+        requested_output_tokens: input.output_tokens,
+        greedy: true,
+    };
+
+    let runtime = crate::build_isolated_greedy_runtime(
+        &spec,
+        crate::RealCliRuntimeMode::IsolatedGpuNativeBenchmark,
+        tokenizer,
+    )
+    .await?;
+    let execution = async {
+        let validated = validate_runtime(
+            &runtime,
+            &resolved_config_sha256,
+            EXPECTED_ADAPTER_NAME,
+        )?;
+        let warmup = execute_trace_request(
+            &runtime,
+            &prompt_ids,
+            input.output_tokens,
+            "trace-gpu-native-oracle-routes warmup",
+            args.progress_watchdog,
+        )
+        .await?;
+        let measured = execute_trace_request(
+            &runtime,
+            &prompt_ids,
+            input.output_tokens,
+            "trace-gpu-native-oracle-routes measured",
+            args.progress_watchdog,
+        )
+        .await?;
+        let determinism = DeterminismEvidence {
+            identical_input: true,
+            greedy: true,
+            generated_token_ids_match: warmup.evidence.generated_token_ids
+                == measured.evidence.generated_token_ids,
+            generated_text_hashes_match: warmup.evidence.generated_text_sha256
+                == measured.evidence.generated_text_sha256,
+            ordered_route_sequence_hashes_match: warmup.trace.ordered_route_sequence_sha256
+                == measured.trace.ordered_route_sequence_sha256,
+            legacy_route_hashes_match: warmup.trace.legacy_selected_route_ids_sha256
+                == measured.trace.legacy_selected_route_ids_sha256,
+        };
+        if !determinism.generated_token_ids_match
+            || !determinism.generated_text_hashes_match
+            || !determinism.ordered_route_sequence_hashes_match
+            || !determinism.legacy_route_hashes_match
+        {
+            return Err(BenchmarkFailure::new(
+                "postcondition",
+                "nondeterministic-route-trace",
+                "identical greedy warmup/measured requests produced different tokens, text, or routes",
+            ));
+        }
+
+        let mut analysis = Vec::with_capacity(REQUESTED_BUDGETS_MIB.len());
+        for budget_mib in REQUESTED_BUDGETS_MIB {
+            let budget_bytes = budget_mib.checked_mul(MIB).ok_or_else(|| {
+                BenchmarkFailure::new(
+                    "postcondition",
+                    "budget-overflow",
+                    "requested analysis budget overflowed bytes",
+                )
+            })?;
+            let plan = runtime
+                .engine
+                .gpu_native_model_expert_vram_plan_for_budget(budget_bytes)
+                .map_err(|error| {
+                    BenchmarkFailure::new(
+                        "postcondition",
+                        "slot-plan-failed",
+                        error.to_string(),
+                    )
+                })?;
+            analysis.push(
+                analyze_trace_with_plan(&measured.trace, budget_mib, &plan)
+                    .map_err(counter_failure)?,
+            );
+        }
+        Ok::<_, BenchmarkFailure>((validated, warmup, measured, determinism, analysis))
+    }
+    .await;
+    let shutdown = runtime.shutdown_isolated().await;
+    let (validated, warmup, measured, determinism, analysis, shutdown) = match (execution, shutdown)
+    {
+        (Ok(values), Ok(shutdown)) => {
+            if !shutdown.controlled_shutdown_requested || !shutdown.all_runtime_resources_released {
+                return Err(BenchmarkFailure::new(
+                    "postcondition",
+                    "runtime-shutdown-incomplete",
+                    format!("controlled isolated runtime shutdown was incomplete: {shutdown:?}"),
+                )
+                .into());
+            }
+            (values.0, values.1, values.2, values.3, values.4, shutdown)
+        }
+        (Err(error), Ok(_)) => return Err(error.into()),
+        (Ok(_), Err(error)) => {
+            return Err(BenchmarkFailure::new(
+                "postcondition",
+                "runtime-shutdown-failed",
+                error.to_string(),
+            )
+            .into())
+        }
+        (Err(execution_error), Err(shutdown_error)) => {
+            return Err(BenchmarkFailure::new(
+                "postcondition",
+                "execution-and-shutdown-failed",
+                format!("{execution_error}; {shutdown_error}"),
+            )
+            .into())
+        }
+    };
+
+    let report = OracleRouteTraceReport {
+        schema: SCHEMA,
+        mode: MODE,
+        complete: true,
+        diagnostic_only: true,
+        base_git_sha: BASE_GIT_SHA,
+        provenance,
+        model_identity,
+        model_load: validated.model_load,
+        adapter_identity: validated.adapter_identity,
+        runtime_contract: validated.runtime_contract,
+        request,
+        production_configuration,
+        expert_storage: ExpertStorageEvidence {
+            routed_expert_count,
+            expert_file_bytes,
+            routed_expert_footprint_bytes,
+            physical_slot_stride_bytes: analysis
+                .first()
+                .ok_or_else(|| {
+                    BenchmarkFailure::new(
+                        "postcondition",
+                        "missing-offline-analysis",
+                        "no requested VRAM budget analysis was produced",
+                    )
+                })?
+                .physical_slot_stride_bytes,
+        },
+        observation: ObservationEvidence {
+            ordinary_step_token_only: true,
+            seam: "GpuNativeTokenLoop::step_token -> step_token_unified_inner completion -> Engine::record_gpu_native_actual_routes(position, boundary_report.selected_ids)",
+            additional_gpu_readback_introduced: false,
+            performance_claim_from_trace_run: false,
+            production_slot_planner: "GpuNativeModelExpertVramPlan::try_new with authoritative GpuNativeExecutorContext::device_limits",
+            analyzer_initial_residency: "empty per-layer physical arenas",
+            minimum_policy: "simultaneous-set Belady/MIN; current route protected, farthest next-use unprotected resident evicted",
+        },
+        warmup: warmup.evidence,
+        measured: measured.evidence,
+        determinism,
+        trace: measured.trace,
+        offline_oracle_analysis: analysis,
+        shutdown,
+    };
+    emit_report(&report, &args.report_out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn geometry(layers: usize, experts: usize, top_k: usize) -> OracleGeometry {
+        OracleGeometry {
+            layers,
+            experts,
+            top_k,
+            d_model: 32,
+            d_ff: 32,
+        }
+    }
+
+    fn small_trace() -> OracleRouteTrace {
+        OracleRouteTrace::try_new(
+            geometry(2, 4, 2),
+            vec![
+                OracleRouteRecord {
+                    position: 0,
+                    layer_index: 0,
+                    ordered_selected_expert_ids: vec![2, 1],
+                },
+                OracleRouteRecord {
+                    position: 0,
+                    layer_index: 1,
+                    ordered_selected_expert_ids: vec![0, 3],
+                },
+                OracleRouteRecord {
+                    position: 1,
+                    layer_index: 0,
+                    ordered_selected_expert_ids: vec![1, 3],
+                },
+                OracleRouteRecord {
+                    position: 1,
+                    layer_index: 1,
+                    ordered_selected_expert_ids: vec![2, 0],
+                },
+            ],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn canonical_route_serialization_and_hashing_are_order_sensitive() {
+        let trace = small_trace();
+        let bytes = canonical_route_bytes(&trace.records).unwrap();
+        assert!(bytes.starts_with(b"mer.gpu-native-oracle-route-sequence.v1\0"));
+        assert_eq!(
+            trace.ordered_route_sequence_sha256,
+            ordered_route_sequence_sha256(&trace.records).unwrap()
+        );
+        let mut reordered = trace.records.clone();
+        reordered[0].ordered_selected_expert_ids.swap(0, 1);
+        assert_ne!(
+            trace.ordered_route_sequence_sha256,
+            ordered_route_sequence_sha256(&reordered).unwrap()
+        );
+    }
+
+    #[test]
+    fn valid_trace_reconciles_counts_and_hashes() {
+        let trace = small_trace();
+        trace.validate().unwrap();
+        assert_eq!(trace.total_positions, 2);
+        assert_eq!(trace.total_layer_records, 4);
+        assert_eq!(trace.total_selected_expert_ids, 8);
+        assert_ne!(
+            trace.ordered_route_sequence_sha256,
+            trace.legacy_selected_route_ids_sha256
+        );
+    }
+
+    #[test]
+    fn invalid_expert_id_is_rejected() {
+        let mut trace = small_trace();
+        trace.records[0].ordered_selected_expert_ids[0] = 4;
+        assert_eq!(trace.validate().unwrap_err().code, "invalid-expert-id");
+    }
+
+    #[test]
+    fn duplicate_top_k_id_is_rejected() {
+        let mut trace = small_trace();
+        trace.records[0].ordered_selected_expert_ids = vec![1, 1];
+        assert_eq!(trace.validate().unwrap_err().code, "duplicate-top-k-id");
+    }
+
+    #[test]
+    fn wrong_layer_count_is_rejected() {
+        let mut trace = small_trace();
+        trace.records.pop();
+        assert_eq!(trace.validate().unwrap_err().code, "wrong-layer-count");
+    }
+
+    #[test]
+    fn wrong_top_k_count_is_rejected() {
+        let mut trace = small_trace();
+        trace.records[0].ordered_selected_expert_ids.pop();
+        assert_eq!(trace.validate().unwrap_err().code, "wrong-top-k-count");
+    }
+
+    #[test]
+    fn trace_json_parsing_is_deterministic_and_validated() {
+        let trace = small_trace();
+        let bytes = serde_json::to_vec(&trace).unwrap();
+        let first = OracleRouteTrace::parse(&bytes).unwrap();
+        let second = OracleRouteTrace::parse(&bytes).unwrap();
+        assert_eq!(first, second);
+        let mut corrupt = serde_json::to_value(&trace).unwrap();
+        corrupt["records"][0]["ordered_selected_expert_ids"][0] = serde_json::json!(99);
+        assert_eq!(
+            OracleRouteTrace::parse(&serde_json::to_vec(&corrupt).unwrap())
+                .unwrap_err()
+                .code,
+            "invalid-expert-id"
+        );
+    }
+
+    #[test]
+    fn belady_min_is_optimal_on_small_single_access_sequence() {
+        let accesses = vec![vec![0], vec![1], vec![2], vec![0], vec![1], vec![2]];
+        let lru = simulate_production_lru(2, 3, &accesses).unwrap();
+        let min = simulate_belady_min(2, 3, &accesses).unwrap();
+        assert_eq!(lru.missing_installs, 6);
+        assert_eq!(min.missing_installs, 4);
+        assert_eq!(min.compulsory_cold_installs, 3);
+        assert_eq!(min.miss_boundaries, 4);
+    }
+
+    #[test]
+    fn simultaneous_top_k_access_protects_the_entire_current_set() {
+        let accesses = vec![vec![0, 1], vec![1, 2], vec![0, 2]];
+        let min = simulate_belady_min(2, 3, &accesses).unwrap();
+        assert_eq!(min.route_references, 6);
+        assert_eq!(min.cache_hits, 2);
+        assert_eq!(min.missing_installs, 4);
+        assert_eq!(min.miss_boundaries, 3);
+    }
+
+    #[test]
+    fn full_capacity_has_only_compulsory_cold_installs() {
+        let accesses = vec![vec![0, 1], vec![2, 3], vec![0, 3], vec![1, 2]];
+        let lru = simulate_production_lru(4, 4, &accesses).unwrap();
+        let min = simulate_belady_min(4, 4, &accesses).unwrap();
+        assert_eq!(lru.missing_installs, 4);
+        assert_eq!(min.missing_installs, 4);
+        assert_eq!(min.compulsory_cold_installs, 4);
+        assert_eq!(min.missing_installs - min.compulsory_cold_installs, 0);
+    }
+
+    #[test]
+    fn capacity_constrained_set_sequence_reports_replacement_misses() {
+        let accesses = vec![vec![0, 1], vec![2, 3], vec![0, 1], vec![2, 3]];
+        let min = simulate_belady_min(2, 4, &accesses).unwrap();
+        assert_eq!(min.compulsory_cold_installs, 4);
+        assert_eq!(min.missing_installs, 8);
+        assert_eq!(min.miss_boundaries, 4);
+    }
+
+    #[test]
+    fn production_model_slot_planner_reuse_matches_qwen_geometry() {
+        let qwen = GpuNativeQ4ExpertGeometry::try_new(2048, 768, 128, 8).unwrap();
+        let budget = 15_576 * MIB;
+        let limits = wgpu::Limits {
+            max_push_constant_size: 32,
+            max_storage_buffers_per_shader_stage: 8,
+            max_compute_workgroup_size_x: 64,
+            max_compute_invocations_per_workgroup: 64,
+            ..wgpu::Limits::default()
+        };
+        let plan = GpuNativeModelExpertVramPlan::try_new(48, qwen, budget, &limits).unwrap();
+        assert_eq!(plan.num_layers(), 48);
+        assert_eq!(plan.model_slot_capacity(), 48 * 128);
+        assert!(plan
+            .layer_plans()
+            .iter()
+            .all(|layer| layer.slot_capacity() == 128));
+        assert!(plan.total_arena_allocation_bytes() <= budget);
+        assert_eq!(qwen.slot_stride_bytes(), 2_654_212);
+    }
+}

--- a/rust-engine/src/gpu_native_oracle_scheduled_residency.rs
+++ b/rust-engine/src/gpu_native_oracle_scheduled_residency.rs
@@ -10,7 +10,8 @@
 //! overlap and never uses the production predictor/speculative path.
 
 use crate::backend::gpu_native::{
-    GpuNativePhysicalInstallEvidence, GpuNativeQ4ExpertKey, GpuNativeQ4ExpertResidency,
+    GpuNativePhysicalInstallEvidence, GpuNativePhysicalSlotFillPolicy, GpuNativeQ4ExpertGeometry,
+    GpuNativeQ4ExpertKey, GpuNativeQ4ExpertResidency,
 };
 use crate::backend::GpuDeviceIdentity;
 use crate::buffer_pool::{BufferPool, BufferPoolOrigin};
@@ -43,7 +44,7 @@ use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 
-pub(crate) const SCHEMA: &str = "mer.gpu-native-oracle-scheduled-residency.v4";
+pub(crate) const SCHEMA: &str = "mer.gpu-native-oracle-scheduled-residency.v5";
 pub(crate) const MODE: &str = "qualify-gpu-native-oracle-scheduled-residency";
 const FROZEN_PAYLOAD_CONTROL_SHA: &str = "4eb143b34b00826e2031b313f3734bace18a7ecc";
 const FROZEN_PAYLOAD_CONTROL_TREE: &str = "37600e48e6dc3552f4a5b33e643351d4243280f5";
@@ -86,6 +87,7 @@ pub(crate) enum OracleScheduledResidencyMode {
     SourceOnly,
     TokenBoundaryDirect,
     TokenBoundaryDirectLogicalOnly,
+    TokenBoundaryDirectLogicalOnlyNoZeroFill,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
@@ -97,10 +99,22 @@ enum LogicalPayloadMode {
 
 const fn logical_payload_mode(mode: OracleScheduledResidencyMode) -> LogicalPayloadMode {
     match mode {
-        OracleScheduledResidencyMode::TokenBoundaryDirectLogicalOnly => {
+        OracleScheduledResidencyMode::TokenBoundaryDirectLogicalOnly
+        | OracleScheduledResidencyMode::TokenBoundaryDirectLogicalOnlyNoZeroFill => {
             LogicalPayloadMode::QualificationLogicalOnly
         }
         _ => LogicalPayloadMode::Materialized,
+    }
+}
+
+const fn physical_fill_policy(
+    mode: OracleScheduledResidencyMode,
+) -> GpuNativePhysicalSlotFillPolicy {
+    match mode {
+        OracleScheduledResidencyMode::TokenBoundaryDirectLogicalOnlyNoZeroFill => {
+            GpuNativePhysicalSlotFillPolicy::QualificationNoZeroFill
+        }
+        _ => GpuNativePhysicalSlotFillPolicy::FullSlotZero,
     }
 }
 
@@ -115,7 +129,8 @@ const fn late_source_policy(mode: OracleScheduledResidencyMode) -> LateSourcePol
     match mode {
         OracleScheduledResidencyMode::SourceOnly => LateSourcePolicy::NonblockingDemandFallback,
         OracleScheduledResidencyMode::TokenBoundaryDirect
-        | OracleScheduledResidencyMode::TokenBoundaryDirectLogicalOnly => {
+        | OracleScheduledResidencyMode::TokenBoundaryDirectLogicalOnly
+        | OracleScheduledResidencyMode::TokenBoundaryDirectLogicalOnlyNoZeroFill => {
             LateSourcePolicy::AwaitResidualAtSafeBoundary
         }
     }
@@ -454,6 +469,17 @@ struct OracleCounters {
     boundary_physical_install_order_checks: u64,
     boundary_physical_install_order_errors: u64,
     boundary_physical_install_bytes: u64,
+    physical_slot_zero_fill_bytes: u64,
+    physical_slot_epoch_write_bytes: u64,
+    physical_slot_payload_copy_bytes: u64,
+    physical_slot_prepare_us: u64,
+    physical_queue_staging_us: u64,
+    mapping_publication_us: u64,
+    individual_physical_stage_us: u64,
+    physical_install_total_us: u64,
+    physical_install_evidence_errors: u64,
+    physical_install_timing_errors: u64,
+
     boundary_physical_evictions: u64,
     boundary_physical_reinstalls: u64,
     boundary_stale_generation: u64,
@@ -743,7 +769,8 @@ fn validate_retained_source_origins(
             "source-only retained request-local PRIMARY residents across token execution".into(),
         ),
         OracleScheduledResidencyMode::TokenBoundaryDirect
-        | OracleScheduledResidencyMode::TokenBoundaryDirectLogicalOnly => {
+        | OracleScheduledResidencyMode::TokenBoundaryDirectLogicalOnly
+        | OracleScheduledResidencyMode::TokenBoundaryDirectLogicalOnlyNoZeroFill => {
             for (&global_id, resident) in &outcome.residents {
                 if resident.buffer_pool_origin()
                     != BufferPoolOrigin::QualificationOracleFutureSource
@@ -1182,7 +1209,8 @@ async fn prefetch_position(
             outcome
         }
         OracleScheduledResidencyMode::TokenBoundaryDirect
-        | OracleScheduledResidencyMode::TokenBoundaryDirectLogicalOnly => {
+        | OracleScheduledResidencyMode::TokenBoundaryDirectLogicalOnly
+        | OracleScheduledResidencyMode::TokenBoundaryDirectLogicalOnlyNoZeroFill => {
             let task_engine = engine.clone();
             let task_counters = counters.clone();
             let task_readiness = readiness.clone();
@@ -1265,6 +1293,64 @@ struct OracleBoundaryObserver {
     layer_index: usize,
     experts_per_layer: u32,
     slot_bytes: u64,
+    payload_bytes: u64,
+    fill_policy: GpuNativePhysicalSlotFillPolicy,
+}
+
+fn record_physical_work_evidence(
+    counters: &mut OracleCounters,
+    fill_policy: GpuNativePhysicalSlotFillPolicy,
+    slot_bytes: u64,
+    payload_bytes: u64,
+    evidence: GpuNativePhysicalInstallEvidence,
+    total_us: u64,
+) {
+    let expected_zero_bytes = match fill_policy {
+        GpuNativePhysicalSlotFillPolicy::FullSlotZero => slot_bytes,
+        GpuNativePhysicalSlotFillPolicy::QualificationNoZeroFill => 0,
+    };
+    let bytes_match = evidence.physical_slot_bytes_staged == slot_bytes
+        && evidence.physical_slot_zero_fill_bytes == expected_zero_bytes
+        && evidence.physical_slot_epoch_write_bytes == 4
+        && evidence.physical_slot_payload_copy_bytes == payload_bytes
+        && evidence.direct_staging_writes == 1
+        && evidence.full_slot_vec_materializations == 0
+        && (fill_policy != GpuNativePhysicalSlotFillPolicy::QualificationNoZeroFill
+            || payload_bytes.checked_add(4) == Some(slot_bytes));
+    add_counter(
+        &mut counters.physical_install_evidence_errors,
+        u64::from(!bytes_match),
+    );
+
+    // Subphase timers are disjoint, individually rounded-down microseconds.
+    // Compare against their enclosing existing timers without tolerances or
+    // any cross-arm performance requirement. Zero-duration samples are valid.
+    let stage_us = evidence.individual_physical_stage_us;
+    let timings_match = evidence
+        .physical_slot_prepare_us
+        .checked_add(evidence.physical_queue_staging_us)
+        .is_some_and(|subphases| subphases <= stage_us)
+        && total_us
+            .checked_sub(stage_us)
+            .is_some_and(|commit_us| evidence.mapping_publication_us <= commit_us)
+        && total_us != u64::MAX;
+    add_counter(
+        &mut counters.physical_install_timing_errors,
+        u64::from(!timings_match),
+    );
+    macro_rules! add_evidence {
+        ($field:ident) => {
+            add_counter(&mut counters.$field, evidence.$field);
+        };
+    }
+    add_evidence!(physical_slot_zero_fill_bytes);
+    add_evidence!(physical_slot_epoch_write_bytes);
+    add_evidence!(physical_slot_payload_copy_bytes);
+    add_evidence!(physical_slot_prepare_us);
+    add_evidence!(physical_queue_staging_us);
+    add_evidence!(mapping_publication_us);
+    add_evidence!(individual_physical_stage_us);
+    add_counter(&mut counters.physical_install_total_us, total_us);
 }
 
 impl OracleBoundaryObserver {
@@ -1327,7 +1413,7 @@ impl GpuNativePhysicalInstallObserver for OracleBoundaryObserver {
         global_id: u32,
         residency: GpuNativeQ4ExpertResidency,
         evidence: GpuNativePhysicalInstallEvidence,
-        _physical_install_total_us: u64,
+        physical_install_total_us: u64,
     ) {
         self.record_install_identity(
             global_id,
@@ -1335,6 +1421,15 @@ impl GpuNativePhysicalInstallObserver for OracleBoundaryObserver {
             evidence.physical_slot_bytes_staged,
         );
         let mut values = self.counters.lock();
+        // Reuse the existing install-completion lock and existing timers.
+        record_physical_work_evidence(
+            &mut values,
+            self.fill_policy,
+            self.slot_bytes,
+            self.payload_bytes,
+            evidence,
+            physical_install_total_us,
+        );
         values.boundary_physical_installs += 1;
         add_counter(
             &mut values.boundary_physical_install_bytes,
@@ -1832,6 +1927,8 @@ fn install_future_at_boundary(
             layer_index,
             experts_per_layer,
             slot_bytes: manager.plan().geometry().slot_stride_bytes() as u64,
+            payload_bytes: manager.plan().geometry().logical_expert_bytes() as u64,
+            fill_policy: physical_fill_policy(mode),
         };
         counters.lock().boundary_replacement_sets_started += 1;
         let evictions_before = counters.lock().boundary_physical_evictions;
@@ -1839,6 +1936,7 @@ fn install_future_at_boundary(
             boundary,
             layer_index,
             &demands,
+            physical_fill_policy(mode),
             &observer,
         ) {
             Ok(_) => {
@@ -2603,6 +2701,9 @@ struct PhysicalSlotPlanEvidence {
 
 #[derive(Clone, Copy, Debug, Serialize)]
 struct TreatmentContract {
+    physical_fill_policy: GpuNativePhysicalSlotFillPolicy,
+    physical_zero_fill_accounting: &'static str,
+    concurrent_direct_staging_used: bool,
     logical_payload_mode: LogicalPayloadMode,
     logical_capacity_accounting: &'static str,
     physical_byte_source: &'static str,
@@ -2630,6 +2731,7 @@ const fn uses_isolated_oracle_source_pool(mode: OracleScheduledResidencyMode) ->
         mode,
         OracleScheduledResidencyMode::TokenBoundaryDirect
             | OracleScheduledResidencyMode::TokenBoundaryDirectLogicalOnly
+            | OracleScheduledResidencyMode::TokenBoundaryDirectLogicalOnlyNoZeroFill
     )
 }
 
@@ -2643,16 +2745,19 @@ const fn oracle_source_pool_configured_max_slots(mode: OracleScheduledResidencyM
 
 const fn treatment_contract(mode: OracleScheduledResidencyMode) -> TreatmentContract {
     TreatmentContract {
+        physical_fill_policy: physical_fill_policy(mode),
+        physical_zero_fill_accounting: "explicit host fill bytes only; epoch and payload writes counted separately; physical staged/H2D bytes are unchanged",
+        concurrent_direct_staging_used: uses_isolated_oracle_source_pool(mode),
         logical_payload_mode: logical_payload_mode(mode),
         logical_capacity_accounting: "sum of successful boundary admission transaction snapshots: before + newly charged bytes = after + evicted bytes; intervening ordinary demand is excluded",
         physical_byte_source: "GpuNativeDemandExpert::Install resident: Arc<ExpertResident>; production staging reads ExpertResident::data()",
         logical_only_data_access_policy: "increment run-scoped audit and panic; any nonzero audit rejects qualification including caught panics",
         source_overlap: true,
         late_source_policy: late_source_policy(mode),
-        independent_layer_source_tasks: matches!(mode, OracleScheduledResidencyMode::TokenBoundaryDirect | OracleScheduledResidencyMode::TokenBoundaryDirectLogicalOnly),
+        independent_layer_source_tasks: matches!(mode, OracleScheduledResidencyMode::TokenBoundaryDirect | OracleScheduledResidencyMode::TokenBoundaryDirectLogicalOnly | OracleScheduledResidencyMode::TokenBoundaryDirectLogicalOnlyNoZeroFill),
         per_layer_storage_batch_read_used: false,
         host_preparation_overlap: false,
-        token_boundary_h2d: matches!(mode, OracleScheduledResidencyMode::TokenBoundaryDirect | OracleScheduledResidencyMode::TokenBoundaryDirectLogicalOnly),
+        token_boundary_h2d: matches!(mode, OracleScheduledResidencyMode::TokenBoundaryDirect | OracleScheduledResidencyMode::TokenBoundaryDirectLogicalOnly | OracleScheduledResidencyMode::TokenBoundaryDirectLogicalOnlyNoZeroFill),
         demand_fallback: true,
         h2d_compute_overlap_claimed: false,
         same_ordered_queue: true,
@@ -2889,6 +2994,17 @@ fn accumulate_oracle(total: &mut OracleCounters, value: &OracleCounters) {
     add!(boundary_physical_install_order_checks);
     add!(boundary_physical_install_order_errors);
     add!(boundary_physical_install_bytes);
+    add!(physical_slot_zero_fill_bytes);
+    add!(physical_slot_epoch_write_bytes);
+    add!(physical_slot_payload_copy_bytes);
+    add!(physical_slot_prepare_us);
+    add!(physical_queue_staging_us);
+    add!(mapping_publication_us);
+    add!(individual_physical_stage_us);
+    add!(physical_install_total_us);
+    add!(physical_install_evidence_errors);
+    add!(physical_install_timing_errors);
+
     add!(boundary_physical_evictions);
     add!(boundary_physical_reinstalls);
     add!(boundary_stale_generation);
@@ -3036,6 +3152,70 @@ fn validate_logical_payload_counters(
     Ok(())
 }
 
+fn frozen_physical_geometry() -> GpuNativeQ4ExpertGeometry {
+    GpuNativeQ4ExpertGeometry::try_new(
+        EXPECTED_D_MODEL,
+        EXPECTED_D_FF,
+        EXPECTED_EXPERTS,
+        EXPECTED_TOP_K,
+    )
+    .expect("frozen ORACLE Q4 geometry is valid")
+}
+
+fn validate_physical_work_counters(
+    c: &OracleCounters,
+    mode: OracleScheduledResidencyMode,
+) -> Result<(), BenchmarkFailure> {
+    if logical_payload_mode(mode) != LogicalPayloadMode::QualificationLogicalOnly {
+        return Ok(());
+    }
+    let geometry = frozen_physical_geometry();
+    let slot_bytes = geometry.slot_stride_bytes() as u64;
+    let payload_bytes = geometry.logical_expert_bytes() as u64;
+    let installs = c.boundary_physical_installs;
+    let expected_staged = installs.checked_mul(slot_bytes);
+    let expected_zero = match physical_fill_policy(mode) {
+        GpuNativePhysicalSlotFillPolicy::FullSlotZero => expected_staged,
+        GpuNativePhysicalSlotFillPolicy::QualificationNoZeroFill => Some(0),
+    };
+    let stage_subphases = c
+        .physical_slot_prepare_us
+        .checked_add(c.physical_queue_staging_us);
+    let total_us = c
+        .individual_physical_stage_us
+        .checked_add(c.token_boundary_commit_us);
+    if installs == 0
+        || expected_staged.is_none()
+        || expected_staged != Some(c.boundary_physical_install_bytes)
+        || expected_zero != Some(c.physical_slot_zero_fill_bytes)
+        || installs.checked_mul(4) != Some(c.physical_slot_epoch_write_bytes)
+        || installs.checked_mul(payload_bytes) != Some(c.physical_slot_payload_copy_bytes)
+        || c.boundary_direct_staging_writes != installs
+        || c.boundary_full_slot_vec_materializations != 0
+        || c.boundary_physical_install_order_checks != installs
+        || c.boundary_physical_install_order_errors != 0
+        || c.boundary_stale_generation != 0
+        || c.boundary_install_failures != 0
+        || c.logical_only_data_accesses != 0
+        || c.physical_install_evidence_errors != 0
+        || c.physical_install_timing_errors != 0
+        || !stage_subphases.is_some_and(|us| us <= c.individual_physical_stage_us)
+        || c.mapping_publication_us > c.token_boundary_commit_us
+        || total_us.is_none()
+        || total_us == Some(u64::MAX)
+        || total_us != Some(c.physical_install_total_us)
+    {
+        return Err(BenchmarkFailure::new(
+            "postcondition",
+            "oracle-physical-work-reconciliation",
+            format!(
+                "ORACLE physical byte work, install or timing evidence did not reconcile: {c:?}"
+            ),
+        ));
+    }
+    Ok(())
+}
+
 fn validate_oracle_counters(
     counters: &OracleCounters,
     mode: OracleScheduledResidencyMode,
@@ -3045,6 +3225,7 @@ fn validate_oracle_counters(
     validate_logical_only_concurrency(mode, concurrency)?;
     validate_source_concurrency_mechanism(counters, mode, concurrency)?;
     validate_logical_payload_counters(counters, mode)?;
+    validate_physical_work_counters(counters, mode)?;
     let classified_source = counters
         .source_skipped_physical_current
         .saturating_add(counters.source_prefetch_ram_hits)
@@ -3448,7 +3629,9 @@ fn validate_logical_only_concurrency(
     mode: OracleScheduledResidencyMode,
     concurrency: usize,
 ) -> Result<(), BenchmarkFailure> {
-    if mode == OracleScheduledResidencyMode::TokenBoundaryDirectLogicalOnly && concurrency != 4 {
+    if logical_payload_mode(mode) == LogicalPayloadMode::QualificationLogicalOnly
+        && concurrency != 4
+    {
         return Err(artifact_failure(
             "logical-only-requires-frozen-c4",
             "logical-only payload treatment requires unchanged --oracle-source-concurrency=4",
@@ -3584,7 +3767,8 @@ pub(crate) async fn run_command(args: CommandArgs) -> Result<(), Box<dyn std::er
     let oracle_source_pool = match args.treatment_mode {
         OracleScheduledResidencyMode::SourceOnly => None,
         OracleScheduledResidencyMode::TokenBoundaryDirect
-        | OracleScheduledResidencyMode::TokenBoundaryDirectLogicalOnly => {
+        | OracleScheduledResidencyMode::TokenBoundaryDirectLogicalOnly
+        | OracleScheduledResidencyMode::TokenBoundaryDirectLogicalOnlyNoZeroFill => {
             Some(Arc::new(OracleFutureSourcePool::new(
                 ORACLE_FUTURE_SOURCE_POOL_SLOTS,
                 spec.cfg.model.expert_size,
@@ -3776,6 +3960,7 @@ pub(crate) async fn run_command(args: CommandArgs) -> Result<(), Box<dyn std::er
     for run in &measured {
         accumulate_oracle(&mut aggregate_oracle, &run.oracle);
     }
+    validate_physical_work_counters(&aggregate_oracle, args.treatment_mode)?;
     let all_measured_outputs_identical = measured.iter().all(|run| {
         run.correctness.generated_token_ids_sha256 == warmup.correctness.generated_token_ids_sha256
             && run.correctness.generated_text_sha256 == warmup.correctness.generated_text_sha256
@@ -4040,6 +4225,278 @@ mod tests {
         OracleScheduledResidencyMode::TokenBoundaryDirectLogicalOnly
     }
 
+    fn no_zero_fill_mode() -> OracleScheduledResidencyMode {
+        OracleScheduledResidencyMode::TokenBoundaryDirectLogicalOnlyNoZeroFill
+    }
+
+    #[test]
+    fn no_zero_fill_contract_preserves_logical_only_frozen_c4_source_and_boundary() {
+        assert_eq!(
+            OracleScheduledResidencyMode::from_str(
+                "token-boundary-direct-logical-only-no-zero-fill",
+                false,
+            )
+            .unwrap(),
+            no_zero_fill_mode()
+        );
+        assert_eq!(
+            serde_json::to_value(no_zero_fill_mode()).unwrap(),
+            "token-boundary-direct-logical-only-no-zero-fill"
+        );
+        let mut control = serde_json::to_value(treatment_contract(logical_only_mode())).unwrap();
+        let mut treatment = serde_json::to_value(treatment_contract(no_zero_fill_mode())).unwrap();
+        assert_eq!(
+            control
+                .as_object_mut()
+                .unwrap()
+                .remove("physical_fill_policy")
+                .unwrap(),
+            "full-slot-zero"
+        );
+        assert_eq!(
+            treatment
+                .as_object_mut()
+                .unwrap()
+                .remove("physical_fill_policy")
+                .unwrap(),
+            "qualification-no-zero-fill"
+        );
+        assert_eq!(
+            control
+                .as_object_mut()
+                .unwrap()
+                .remove("production_direct_staging_used")
+                .unwrap(),
+            true
+        );
+        assert_eq!(
+            treatment
+                .as_object_mut()
+                .unwrap()
+                .remove("production_direct_staging_used")
+                .unwrap(),
+            false
+        );
+        assert_eq!(control, treatment);
+        for mode in [logical_only_mode(), no_zero_fill_mode()] {
+            assert_eq!(
+                logical_payload_mode(mode),
+                LogicalPayloadMode::QualificationLogicalOnly
+            );
+            assert_eq!(
+                late_source_policy(mode),
+                LateSourcePolicy::AwaitResidualAtSafeBoundary
+            );
+            assert_eq!(oracle_source_pool_configured_max_slots(mode), 384);
+            assert!(treatment_contract(mode).concurrent_direct_staging_used);
+            validate_logical_only_concurrency(mode, 4).unwrap();
+            for concurrency in [0, 1, 2, 3, 5, 8, 48, usize::MAX] {
+                assert!(validate_logical_only_concurrency(mode, concurrency).is_err());
+            }
+            validate_source_concurrency_mechanism(
+                &valid_direct_source_mechanism_counters(),
+                mode,
+                4,
+            )
+            .unwrap();
+            let mut serialized = valid_direct_source_mechanism_counters();
+            serialized.source_prefetch_reads_peak_inflight = 1;
+            assert!(validate_source_concurrency_mechanism(&serialized, mode, 4).is_err());
+        }
+    }
+
+    fn set_valid_physical_work_counters(
+        c: &mut OracleCounters,
+        mode: OracleScheduledResidencyMode,
+    ) {
+        let n = c.boundary_physical_installs;
+        c.boundary_direct_staging_writes = n;
+        c.boundary_physical_install_bytes = n * 2_654_212;
+        c.physical_slot_zero_fill_bytes = if mode == no_zero_fill_mode() {
+            0
+        } else {
+            n * 2_654_212
+        };
+        c.physical_slot_epoch_write_bytes = n * 4;
+        c.physical_slot_payload_copy_bytes = n * 2_654_208;
+        c.physical_slot_prepare_us = n * 6;
+        c.physical_queue_staging_us = n * 3;
+        c.mapping_publication_us = n * 2;
+        c.individual_physical_stage_us = n * 11;
+        c.token_boundary_commit_us = n * 5;
+        c.physical_install_total_us = n * 16;
+    }
+
+    #[test]
+    fn no_zero_fill_physical_work_reconciliation_rejects_corrupted_bytes_timings_and_installs() {
+        let corruptions: &[fn(&mut OracleCounters)] = &[
+            |c| c.physical_slot_zero_fill_bytes += 1,
+            |c| c.physical_slot_payload_copy_bytes += 1,
+            |c| c.physical_slot_epoch_write_bytes += 1,
+            |c| c.boundary_physical_install_bytes += 1,
+            |c| c.boundary_direct_staging_writes -= 1,
+            |c| c.boundary_physical_installs = u64::MAX,
+            |c| c.boundary_physical_install_order_checks -= 1,
+            |c| c.boundary_physical_install_order_errors = 1,
+            |c| c.boundary_stale_generation = 1,
+            |c| c.boundary_install_failures = 1,
+            |c| c.logical_only_data_accesses = 1,
+            |c| c.boundary_full_slot_vec_materializations = 1,
+            |c| c.physical_install_evidence_errors = 1,
+            |c| c.physical_install_timing_errors = 1,
+            |c| c.physical_slot_prepare_us = c.individual_physical_stage_us + 1,
+            |c| c.physical_queue_staging_us = u64::MAX,
+            |c| c.mapping_publication_us = c.token_boundary_commit_us + 1,
+            |c| c.individual_physical_stage_us += 1,
+            |c| c.token_boundary_commit_us += 1,
+            |c| c.physical_install_total_us += 1,
+        ];
+        for mode in [logical_only_mode(), no_zero_fill_mode()] {
+            let mut good = valid_source_only_counters();
+            accumulate_oracle(&mut good, &valid_logical_only_counters());
+            set_valid_physical_work_counters(&mut good, mode);
+            validate_oracle_counters(&good, mode, 4, 8).unwrap();
+            for corrupt in corruptions {
+                let mut bad = good.clone();
+                corrupt(&mut bad);
+                assert!(
+                    validate_oracle_counters(&bad, mode, 4, 8).is_err(),
+                    "accepted {mode:?}: {bad:?}"
+                );
+            }
+            let mut wrong_arm = good;
+            wrong_arm.physical_slot_zero_fill_bytes = if mode == no_zero_fill_mode() {
+                2 * 2_654_212
+            } else {
+                0
+            };
+            assert!(validate_physical_work_counters(&wrong_arm, mode).is_err());
+        }
+    }
+
+    #[test]
+    fn no_zero_fill_completion_evidence_and_aggregation_preserve_exact_host_work_and_h2d() {
+        for mode in [logical_only_mode(), no_zero_fill_mode()] {
+            let policy = physical_fill_policy(mode);
+            let evidence = GpuNativePhysicalInstallEvidence {
+                direct_staging_writes: 1,
+                physical_slot_bytes_staged: 2_654_212,
+                physical_slot_zero_fill_bytes: if mode == no_zero_fill_mode() {
+                    0
+                } else {
+                    2_654_212
+                },
+                physical_slot_epoch_write_bytes: 4,
+                physical_slot_payload_copy_bytes: 2_654_208,
+                physical_slot_prepare_us: 6,
+                physical_queue_staging_us: 3,
+                mapping_publication_us: 2,
+                individual_physical_stage_us: 11,
+                ..GpuNativePhysicalInstallEvidence::default()
+            };
+            let mut observed = OracleCounters::default();
+            record_physical_work_evidence(
+                &mut observed,
+                policy,
+                2_654_212,
+                2_654_208,
+                evidence,
+                16,
+            );
+            assert_eq!(observed.physical_install_evidence_errors, 0);
+            assert_eq!(observed.physical_install_timing_errors, 0);
+            assert_eq!(
+                observed.physical_slot_zero_fill_bytes,
+                evidence.physical_slot_zero_fill_bytes
+            );
+            assert_eq!(observed.physical_slot_epoch_write_bytes, 4);
+            assert_eq!(observed.physical_slot_payload_copy_bytes, 2_654_208);
+            assert_eq!(observed.physical_slot_prepare_us, 6);
+            assert_eq!(observed.physical_queue_staging_us, 3);
+            assert_eq!(observed.mapping_publication_us, 2);
+            assert_eq!(observed.individual_physical_stage_us, 11);
+            assert_eq!(observed.physical_install_total_us, 16);
+            for corrupt in [
+                (|e: &mut GpuNativePhysicalInstallEvidence| e.physical_slot_zero_fill_bytes += 1)
+                    as fn(&mut GpuNativePhysicalInstallEvidence),
+                |e| e.physical_slot_epoch_write_bytes += 1,
+                |e| e.physical_slot_payload_copy_bytes += 1,
+                |e| e.physical_slot_bytes_staged += 1,
+                |e| e.direct_staging_writes = 0,
+                |e| e.full_slot_vec_materializations = 1,
+            ] {
+                let mut bad_evidence = evidence;
+                corrupt(&mut bad_evidence);
+                let mut bad = OracleCounters::default();
+                record_physical_work_evidence(
+                    &mut bad,
+                    policy,
+                    2_654_212,
+                    2_654_208,
+                    bad_evidence,
+                    16,
+                );
+                assert_eq!(bad.physical_install_evidence_errors, 1);
+            }
+            for corrupt in [
+                (|e: &mut GpuNativePhysicalInstallEvidence| e.physical_slot_prepare_us = 12)
+                    as fn(&mut GpuNativePhysicalInstallEvidence),
+                |e| e.physical_queue_staging_us = u64::MAX,
+                |e| e.mapping_publication_us = 6,
+                |e| e.individual_physical_stage_us = 17,
+            ] {
+                let mut bad_evidence = evidence;
+                corrupt(&mut bad_evidence);
+                let mut bad = OracleCounters::default();
+                record_physical_work_evidence(
+                    &mut bad,
+                    policy,
+                    2_654_212,
+                    2_654_208,
+                    bad_evidence,
+                    16,
+                );
+                assert_eq!(bad.physical_install_timing_errors, 1);
+            }
+            let mut one = valid_logical_only_counters();
+            set_valid_physical_work_counters(&mut one, mode);
+            let mut total = OracleCounters::default();
+            accumulate_oracle(&mut total, &one);
+            accumulate_oracle(&mut total, &one);
+            validate_physical_work_counters(&total, mode).unwrap();
+            let one_json = serde_json::to_value(one).unwrap();
+            let total_json = serde_json::to_value(total).unwrap();
+            for (name, value) in one_json.as_object().unwrap() {
+                if name.starts_with("physical_")
+                    || name == "mapping_publication_us"
+                    || name == "individual_physical_stage_us"
+                    || name == "token_boundary_commit_us"
+                    || name.starts_with("boundary_physical_")
+                {
+                    assert_eq!(
+                        total_json[name].as_u64().unwrap(),
+                        value.as_u64().unwrap() * 2,
+                        "{name}"
+                    );
+                }
+            }
+            let mut frozen = valid_logical_only_counters();
+            frozen.boundary_physical_installs = 89_676;
+            frozen.boundary_physical_install_order_checks = 89_676;
+            set_valid_physical_work_counters(&mut frozen, mode);
+            validate_physical_work_counters(&frozen, mode).unwrap();
+            assert_eq!(frozen.boundary_physical_install_bytes, 238_019_115_312);
+            assert_eq!(
+                frozen.physical_slot_zero_fill_bytes,
+                if mode == no_zero_fill_mode() {
+                    0
+                } else {
+                    238_019_115_312
+                }
+            );
+        }
+    }
+
     #[test]
     fn logical_only_contract_changes_payload_mode_and_preserves_direct_source_and_boundary_contract(
     ) {
@@ -4107,12 +4564,14 @@ mod tests {
         let caches = [
             GpuExpertCache::new(16, 0.0, 0),
             GpuExpertCache::new(16, 0.0, 0),
+            GpuExpertCache::new(16, 0.0, 0),
         ];
         let mut signatures = Vec::new();
         let mut retained = Vec::new();
         for (index, mode) in [
             OracleScheduledResidencyMode::TokenBoundaryDirect,
             logical_only_mode(),
+            no_zero_fill_mode(),
         ]
         .into_iter()
         .enumerate()
@@ -4177,10 +4636,10 @@ mod tests {
                 c.logical_materialization_bytes,
                 if index == 0 { 16 } else { 0 }
             );
-            assert_eq!(c.logical_only_admissions, if index == 1 { 2 } else { 0 });
+            assert_eq!(c.logical_only_admissions, if index != 0 { 2 } else { 0 });
             assert_eq!(
                 c.logical_only_charged_bytes,
-                if index == 1 { 16 } else { 0 }
+                if index != 0 { 16 } else { 0 }
             );
             assert_eq!(audit.load(Ordering::Relaxed), 0);
             signatures.push((
@@ -4193,13 +4652,14 @@ mod tests {
             retained.extend(admissions);
         }
         assert_eq!(signatures[0], signatures[1]);
+        assert_eq!(signatures[1], signatures[2]);
         drop(residents);
         assert!(weak.iter().all(|source| source.upgrade().is_none()));
         assert_eq!(pool.snapshot().current_in_use_slots, 0);
         assert_eq!(pool.snapshot().exhaustion_count, 0);
         assert_eq!(
             retained.len(),
-            4,
+            6,
             "logical admissions remain alive after all source leases return"
         );
     }
@@ -4321,6 +4781,8 @@ mod tests {
             layer_index: 1,
             experts_per_layer: 128,
             slot_bytes: 12,
+            payload_bytes: 8,
+            fill_policy: GpuNativePhysicalSlotFillPolicy::FullSlotZero,
         };
         let good = make();
         good.record_install_identity(130, GpuNativeQ4ExpertKey::new(1, 2, 7), 12);
@@ -4364,8 +4826,7 @@ mod tests {
     fn logical_only_inherits_source_pool_and_c4_fail_closed_gates() {
         let mut good = valid_source_only_counters();
         accumulate_oracle(&mut good, &valid_logical_only_counters());
-        good.boundary_direct_staging_writes = 2;
-        good.boundary_physical_install_bytes = 24;
+        set_valid_physical_work_counters(&mut good, logical_only_mode());
         validate_oracle_counters(&good, logical_only_mode(), 4, 8).unwrap();
         for corrupt in [
             (|c: &mut OracleCounters| c.qualification_owned_peak_slots = 385)
@@ -4485,8 +4946,8 @@ mod tests {
     }
 
     #[test]
-    fn v4_schema_and_predecessor_attempt_contracts_are_frozen() {
-        assert_eq!(SCHEMA, "mer.gpu-native-oracle-scheduled-residency.v4");
+    fn v5_schema_and_predecessor_attempt_contracts_are_frozen() {
+        assert_eq!(SCHEMA, "mer.gpu-native-oracle-scheduled-residency.v5");
         let first = PredecessorFirstAttemptEvidence {
             code_sha: PREDECESSOR_FIRST_ATTEMPT_CODE_SHA,
             result: "FAIL",

--- a/rust-engine/src/gpu_native_oracle_scheduled_residency.rs
+++ b/rust-engine/src/gpu_native_oracle_scheduled_residency.rs
@@ -2259,6 +2259,18 @@ struct TreatmentContract {
     production_primary_pool_capacity_unchanged: bool,
 }
 
+const fn uses_isolated_oracle_source_pool(mode: OracleScheduledResidencyMode) -> bool {
+    matches!(mode, OracleScheduledResidencyMode::TokenBoundaryDirect)
+}
+
+const fn oracle_source_pool_configured_max_slots(mode: OracleScheduledResidencyMode) -> usize {
+    if uses_isolated_oracle_source_pool(mode) {
+        ORACLE_FUTURE_SOURCE_POOL_SLOTS
+    } else {
+        0
+    }
+}
+
 const fn treatment_contract(mode: OracleScheduledResidencyMode) -> TreatmentContract {
     TreatmentContract {
         source_overlap: true,
@@ -2276,7 +2288,7 @@ const fn treatment_contract(mode: OracleScheduledResidencyMode) -> TreatmentCont
             OracleScheduledResidencyMode::TokenBoundaryDirect
         ),
         legacy_full_slot_vec_used: false,
-        future_source_pool_isolated_from_production_primary: true,
+        future_source_pool_isolated_from_production_primary: uses_isolated_oracle_source_pool(mode),
         production_primary_pool_capacity_unchanged: true,
     }
 }
@@ -2527,7 +2539,7 @@ fn validate_oracle_counters(
             != EXPECTED_SELECTED_IDS as u64
         || counters.qualification_owned_current_slots != 0
         || counters.qualification_owned_current_bytes != 0
-        || counters.qualification_owned_peak_slots > FROZEN_RAM_CACHE_SLOTS as u64
+        || counters.qualification_owned_peak_slots > ORACLE_FUTURE_SOURCE_POOL_SLOTS as u64
         || counters.qualification_owned_peak_bytes
             > (ORACLE_FUTURE_SOURCE_POOL_SLOTS as u64).saturating_mul(expert_bytes as u64)
         || counters.background_tasks_spawned > (EXPECTED_POSITIONS - 1) as u64
@@ -3141,7 +3153,9 @@ pub(crate) async fn run_command(args: CommandArgs) -> Result<(), Box<dyn std::er
             production_primary_pool_available_after_requests,
             production_primary_pool_buffer_size_bytes: runtime.engine.core.pool.buffer_size(),
             production_primary_pool_allocated_bytes: runtime.engine.core.pool.allocated_bytes(),
-            oracle_source_pool_configured_max_slots: ORACLE_FUTURE_SOURCE_POOL_SLOTS,
+            oracle_source_pool_configured_max_slots: oracle_source_pool_configured_max_slots(
+                args.treatment_mode,
+            ),
             oracle_source_pool_allocated_capacity_slots: pool_snapshot.capacity_slots,
             oracle_source_pool_buffer_size_bytes: pool_snapshot.buffer_size_bytes,
             oracle_source_pool_allocated_bytes: pool_snapshot.allocated_bytes,
@@ -3154,7 +3168,9 @@ pub(crate) async fn run_command(args: CommandArgs) -> Result<(), Box<dyn std::er
                 .is_some(),
             no_oracle_pool_accumulation_across_requests: true,
             oracle_source_buffers_released_before_runtime_shutdown: true,
-            future_source_pool_isolated_from_production_primary: true,
+            future_source_pool_isolated_from_production_primary: uses_isolated_oracle_source_pool(
+                args.treatment_mode,
+            ),
             production_primary_pool_capacity_unchanged: runtime.engine.core.pool.capacity()
                 == expected_production_primary_capacity,
         };
@@ -3484,6 +3500,11 @@ mod tests {
         assert!(!contract.token_boundary_h2d);
         assert!(!contract.production_direct_staging_used);
         assert!(!contract.h2d_compute_overlap_claimed);
+        assert!(!contract.future_source_pool_isolated_from_production_primary);
+        assert_eq!(
+            oracle_source_pool_configured_max_slots(OracleScheduledResidencyMode::SourceOnly),
+            0
+        );
         assert!(contract.demand_fallback);
     }
 
@@ -3523,42 +3544,63 @@ mod tests {
 
     #[test]
     fn v2_memory_report_distinguishes_production_and_oracle_planes() {
-        let evidence = SourceMemoryPlaneEvidence {
-            production_ram_cache_capacity_slots: 384,
-            production_ram_cache_max_resident_bytes: 384 * 4096,
-            production_primary_pool_capacity_slots: 385,
-            production_primary_headroom_slots: 1,
-            production_primary_pool_available_before_requests: 1,
-            production_primary_pool_available_after_requests: 1,
-            production_primary_pool_buffer_size_bytes: 4096,
-            production_primary_pool_allocated_bytes: 385 * 4096,
-            oracle_source_pool_configured_max_slots: 384,
-            oracle_source_pool_allocated_capacity_slots: 384,
-            oracle_source_pool_buffer_size_bytes: 4096,
-            oracle_source_pool_allocated_bytes: 384 * 4096,
-            oracle_source_pool_current_in_use_slots: 0,
-            oracle_source_pool_peak_in_use_slots: 384,
-            oracle_source_pool_exhaustion_count: 0,
-            oracle_source_nvme_reads: 4,
-            oracle_source_bytes: 4 * 4096,
-            oracle_source_pool_reused_across_warmup_and_measured_requests: true,
-            no_oracle_pool_accumulation_across_requests: true,
-            oracle_source_buffers_released_before_runtime_shutdown: true,
-            future_source_pool_isolated_from_production_primary: true,
-            production_primary_pool_capacity_unchanged: true,
+        let evidence_for = |mode| {
+            let isolated = uses_isolated_oracle_source_pool(mode);
+            SourceMemoryPlaneEvidence {
+                production_ram_cache_capacity_slots: 384,
+                production_ram_cache_max_resident_bytes: 384 * 4096,
+                production_primary_pool_capacity_slots: 385,
+                production_primary_headroom_slots: 1,
+                production_primary_pool_available_before_requests: 1,
+                production_primary_pool_available_after_requests: 1,
+                production_primary_pool_buffer_size_bytes: 4096,
+                production_primary_pool_allocated_bytes: 385 * 4096,
+                oracle_source_pool_configured_max_slots: oracle_source_pool_configured_max_slots(
+                    mode,
+                ),
+                oracle_source_pool_allocated_capacity_slots: if isolated { 384 } else { 0 },
+                oracle_source_pool_buffer_size_bytes: if isolated { 4096 } else { 0 },
+                oracle_source_pool_allocated_bytes: if isolated { 384 * 4096 } else { 0 },
+                oracle_source_pool_current_in_use_slots: 0,
+                oracle_source_pool_peak_in_use_slots: if isolated { 384 } else { 0 },
+                oracle_source_pool_exhaustion_count: 0,
+                oracle_source_nvme_reads: if isolated { 4 } else { 0 },
+                oracle_source_bytes: if isolated { 4 * 4096 } else { 0 },
+                oracle_source_pool_reused_across_warmup_and_measured_requests: isolated,
+                no_oracle_pool_accumulation_across_requests: true,
+                oracle_source_buffers_released_before_runtime_shutdown: true,
+                future_source_pool_isolated_from_production_primary: isolated,
+                production_primary_pool_capacity_unchanged: true,
+            }
         };
-        let value = serde_json::to_value(evidence).unwrap();
-        assert_eq!(value["production_ram_cache_capacity_slots"], 384);
-        assert_eq!(value["production_primary_pool_capacity_slots"], 385);
-        assert_eq!(value["production_primary_headroom_slots"], 1);
-        assert_eq!(value["oracle_source_pool_allocated_capacity_slots"], 384);
-        assert_eq!(value["oracle_source_pool_current_in_use_slots"], 0);
+        let source_only =
+            serde_json::to_value(evidence_for(OracleScheduledResidencyMode::SourceOnly)).unwrap();
+        assert_eq!(source_only["oracle_source_pool_configured_max_slots"], 0);
         assert_eq!(
-            value["oracle_source_pool_reused_across_warmup_and_measured_requests"],
+            source_only["oracle_source_pool_allocated_capacity_slots"],
+            0
+        );
+        assert_eq!(
+            source_only["future_source_pool_isolated_from_production_primary"],
+            false
+        );
+
+        let direct = serde_json::to_value(evidence_for(
+            OracleScheduledResidencyMode::TokenBoundaryDirect,
+        ))
+        .unwrap();
+        assert_eq!(direct["production_ram_cache_capacity_slots"], 384);
+        assert_eq!(direct["production_primary_pool_capacity_slots"], 385);
+        assert_eq!(direct["production_primary_headroom_slots"], 1);
+        assert_eq!(direct["oracle_source_pool_configured_max_slots"], 384);
+        assert_eq!(direct["oracle_source_pool_allocated_capacity_slots"], 384);
+        assert_eq!(direct["oracle_source_pool_current_in_use_slots"], 0);
+        assert_eq!(
+            direct["oracle_source_pool_reused_across_warmup_and_measured_requests"],
             true
         );
         assert_eq!(
-            value["future_source_pool_isolated_from_production_primary"],
+            direct["future_source_pool_isolated_from_production_primary"],
             true
         );
     }
@@ -3832,12 +3874,24 @@ mod tests {
             serde_json::to_value(direct).unwrap()["late_source_policy"],
             "await-residual-at-safe-boundary"
         );
-        for contract in [source_only, direct] {
-            assert!(!contract.production_predictor_used);
-            assert!(!contract.production_speculative_residency_used);
-            assert!(contract.future_source_pool_isolated_from_production_primary);
-            assert!(contract.production_primary_pool_capacity_unchanged);
-        }
+        assert!(!source_only.production_predictor_used);
+        assert!(!source_only.production_speculative_residency_used);
+        assert!(!source_only.future_source_pool_isolated_from_production_primary);
+        assert!(source_only.production_primary_pool_capacity_unchanged);
+        assert_eq!(
+            oracle_source_pool_configured_max_slots(OracleScheduledResidencyMode::SourceOnly),
+            0
+        );
+        assert!(!direct.production_predictor_used);
+        assert!(!direct.production_speculative_residency_used);
+        assert!(direct.future_source_pool_isolated_from_production_primary);
+        assert!(direct.production_primary_pool_capacity_unchanged);
+        assert_eq!(
+            oracle_source_pool_configured_max_slots(
+                OracleScheduledResidencyMode::TokenBoundaryDirect
+            ),
+            ORACLE_FUTURE_SOURCE_POOL_SLOTS
+        );
     }
 
     #[tokio::test]

--- a/rust-engine/src/gpu_native_oracle_scheduled_residency.rs
+++ b/rust-engine/src/gpu_native_oracle_scheduled_residency.rs
@@ -2764,7 +2764,9 @@ const fn treatment_contract(mode: OracleScheduledResidencyMode) -> TreatmentCont
         extra_flush_submit: false,
         production_predictor_used: false,
         production_speculative_residency_used: false,
-        production_direct_staging_used: matches!(mode, OracleScheduledResidencyMode::TokenBoundaryDirect | OracleScheduledResidencyMode::TokenBoundaryDirectLogicalOnly),
+        // FullSlotZero now selects the explicit concurrent control; only the
+        // historical no-zero arm matches ordinary production's fill policy.
+        production_direct_staging_used: matches!(mode, OracleScheduledResidencyMode::TokenBoundaryDirectLogicalOnlyNoZeroFill),
         legacy_full_slot_vec_used: false,
         future_source_pool_isolated_from_production_primary: uses_isolated_oracle_source_pool(mode),
         production_primary_pool_capacity_unchanged: true,
@@ -4267,7 +4269,7 @@ mod tests {
                 .unwrap()
                 .remove("production_direct_staging_used")
                 .unwrap(),
-            true
+            false
         );
         assert_eq!(
             treatment
@@ -4275,7 +4277,7 @@ mod tests {
                 .unwrap()
                 .remove("production_direct_staging_used")
                 .unwrap(),
-            false
+            true
         );
         assert_eq!(control, treatment);
         for mode in [logical_only_mode(), no_zero_fill_mode()] {
@@ -6015,7 +6017,7 @@ mod tests {
         assert!(!contract.per_layer_storage_batch_read_used);
         assert!(contract.token_boundary_h2d);
         assert!(contract.same_ordered_queue);
-        assert!(contract.production_direct_staging_used);
+        assert!(!contract.production_direct_staging_used);
         assert!(!contract.extra_flush_submit);
         assert!(!contract.h2d_compute_overlap_claimed);
     }

--- a/rust-engine/src/gpu_native_oracle_scheduled_residency.rs
+++ b/rust-engine/src/gpu_native_oracle_scheduled_residency.rs
@@ -11,6 +11,7 @@
 
 use crate::backend::gpu_native::{GpuNativePhysicalInstallEvidence, GpuNativeQ4ExpertResidency};
 use crate::backend::GpuDeviceIdentity;
+use crate::buffer_pool::{BufferPool, BufferPoolOrigin};
 use crate::engine::{Engine, RoutedExpertExecutionSnapshot};
 use crate::expert_cache::{ExpertResident, GpuDemandSetAdmission, GpuResident};
 use crate::gpu_native_oracle_routes::{OracleGeometry, OracleRouteRecord, OracleRouteTrace};
@@ -35,10 +36,11 @@ use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 
-pub(crate) const SCHEMA: &str = "mer.gpu-native-oracle-scheduled-residency.v1";
+pub(crate) const SCHEMA: &str = "mer.gpu-native-oracle-scheduled-residency.v2";
 pub(crate) const MODE: &str = "qualify-gpu-native-oracle-scheduled-residency";
 const ORACLE_ROUTE_SCHEMA: &str = "mer.gpu-native-oracle-route-trace.v1";
 const ORACLE_ROUTE_COMMAND_SHA: &str = "3576cb893586f5dd3f5c5e7355658762db02b534";
@@ -65,6 +67,8 @@ const FROZEN_OUTPUT_TOKENS: usize = 128;
 const FROZEN_WARMUP_RUNS: usize = 1;
 const FROZEN_MEASURED_RUNS: usize = 3;
 const FROZEN_RAM_CACHE_SLOTS: usize = 384;
+const ORACLE_FUTURE_SOURCE_POOL_SLOTS: usize = EXPECTED_LAYERS * EXPECTED_TOP_K;
+const PREDECESSOR_FIRST_ATTEMPT_CODE_SHA: &str = "d4e34cf302ee7f8d78b45d8e6dd8e7e524e716f3";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, ValueEnum)]
 #[serde(rename_all = "kebab-case")]
@@ -371,12 +375,23 @@ struct OracleCounters {
     future_experts_considered: u64,
     source_skipped_physical_current: u64,
     source_ram_hits: u64,
+    source_prefetch_ram_hits: u64,
     source_singleflight_hits: u64,
     source_position_inflight_skips: u64,
     source_reads_started: u64,
     source_reads_completed: u64,
     source_reads_failed: u64,
     source_bytes_read: u64,
+    oracle_source_nvme_reads: u64,
+    oracle_source_bytes: u64,
+    future_experts_deferred_current_demand_overlap: u64,
+    deferred_overlap_resolved_physical: u64,
+    deferred_overlap_resolved_production_ram: u64,
+    residual_boundary_source_reads: u64,
+    residual_boundary_source_failures: u64,
+    residual_boundary_source_bytes: u64,
+    residual_source_wait_us: u64,
+    oracle_source_pool_exhaustion_count: u64,
     source_prefetch_batches_started: u64,
     source_prefetch_batches_completed: u64,
     source_prefetch_batches_skipped_inflight: u64,
@@ -418,8 +433,129 @@ struct OracleCounters {
     background_tasks_drained: u64,
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize)]
+struct OracleFutureSourcePoolSnapshot {
+    capacity_slots: usize,
+    buffer_size_bytes: usize,
+    allocated_bytes: usize,
+    current_in_use_slots: usize,
+    peak_in_use_slots: usize,
+    exhaustion_count: u64,
+    nvme_reads: u64,
+    nvme_bytes: u64,
+}
+
+/// One bounded, qualification-owned source plane shared by warmup and all
+/// measured requests. It never inserts into the production RAM cache.
+pub(crate) struct OracleFutureSourcePool {
+    pool: BufferPool,
+    peak_in_use_slots: AtomicUsize,
+    exhaustion_count: AtomicU64,
+    nvme_reads: AtomicU64,
+    nvme_bytes: AtomicU64,
+}
+
+impl OracleFutureSourcePool {
+    pub(crate) fn new(capacity: usize, buffer_size: usize, block_align: usize) -> Self {
+        Self {
+            pool: BufferPool::new_qualification_oracle_future_source(
+                capacity,
+                buffer_size,
+                block_align,
+            ),
+            peak_in_use_slots: AtomicUsize::new(0),
+            exhaustion_count: AtomicU64::new(0),
+            nvme_reads: AtomicU64::new(0),
+            nvme_bytes: AtomicU64::new(0),
+        }
+    }
+
+    fn try_acquire(&self) -> Result<crate::buffer_pool::PooledBuffer, String> {
+        let Some(buffer) = self.pool.try_acquire() else {
+            self.exhaustion_count.fetch_add(1, Ordering::Relaxed);
+            return Err(format!(
+                "ORACLE future-source pool exhausted at capacity {}",
+                self.pool.capacity()
+            ));
+        };
+        let current = self
+            .pool
+            .capacity()
+            .saturating_sub(self.pool.primary_available());
+        self.peak_in_use_slots.fetch_max(current, Ordering::Relaxed);
+        Ok(buffer)
+    }
+
+    fn snapshot(&self) -> OracleFutureSourcePoolSnapshot {
+        OracleFutureSourcePoolSnapshot {
+            capacity_slots: self.pool.capacity(),
+            buffer_size_bytes: self.pool.buffer_size(),
+            allocated_bytes: self.pool.allocated_bytes(),
+            current_in_use_slots: self
+                .pool
+                .capacity()
+                .saturating_sub(self.pool.primary_available()),
+            peak_in_use_slots: self.peak_in_use_slots.load(Ordering::Relaxed),
+            exhaustion_count: self.exhaustion_count.load(Ordering::Relaxed),
+            nvme_reads: self.nvme_reads.load(Ordering::Relaxed),
+            nvme_bytes: self.nvme_bytes.load(Ordering::Relaxed),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn current_in_use_slots(&self) -> usize {
+        self.snapshot().current_in_use_slots
+    }
+}
+
+#[derive(Debug)]
+enum OracleSourceReadError {
+    PoolExhausted(String),
+    Io(String),
+    Fatal(String),
+}
+
+async fn read_oracle_future_source(
+    engine: &Arc<Engine>,
+    pool: &OracleFutureSourcePool,
+    global_id: u32,
+) -> Result<(Arc<ExpertResident>, usize), OracleSourceReadError> {
+    read_oracle_future_source_from_storage(&engine.core.storage, pool, global_id).await
+}
+
+async fn read_oracle_future_source_from_storage(
+    storage: &Arc<crate::io_provider::NvmeStorage>,
+    pool: &OracleFutureSourcePool,
+    global_id: u32,
+) -> Result<(Arc<ExpertResident>, usize), OracleSourceReadError> {
+    let mut buffer = pool
+        .try_acquire()
+        .map_err(OracleSourceReadError::PoolExhausted)?;
+    let bytes = storage
+        .read_expert(global_id, &mut buffer)
+        .await
+        .map_err(|error| OracleSourceReadError::Io(error.to_string()))?;
+    pool.nvme_reads.fetch_add(1, Ordering::Relaxed);
+    pool.nvme_bytes.fetch_add(bytes as u64, Ordering::Relaxed);
+    let resident = Arc::new(ExpertResident::new_with_block_align(
+        global_id,
+        buffer,
+        storage.config().block_align,
+    ));
+    if resident.buffer_pool_origin() != BufferPoolOrigin::QualificationOracleFutureSource {
+        return Err(OracleSourceReadError::Fatal(
+            "ORACLE future-source read returned a production-backed resident".into(),
+        ));
+    }
+    Ok((resident, bytes))
+}
+
 fn saturating_us(started: Instant) -> u64 {
     u64::try_from(started.elapsed().as_micros()).unwrap_or(u64::MAX)
+}
+
+const fn oracle_future_source_allocated_bytes(expert_file_bytes: usize) -> Option<usize> {
+    ORACLE_FUTURE_SOURCE_POOL_SLOTS.checked_mul(expert_file_bytes)
 }
 
 fn add_counter(target: &mut u64, value: u64) {
@@ -453,8 +589,34 @@ impl Drop for LayerBatchGuard {
 struct PrefetchOutcome {
     target_position: usize,
     residents: HashMap<u32, Arc<ExpertResident>>,
+    successful_ids: Vec<u32>,
+    deferred_overlap_ids: Vec<u32>,
     failed_ids: Vec<u32>,
     fatal_error: Option<String>,
+}
+
+fn validate_retained_source_origins(
+    mode: OracleScheduledResidencyMode,
+    outcome: &PrefetchOutcome,
+) -> Result<(), String> {
+    match mode {
+        OracleScheduledResidencyMode::SourceOnly if !outcome.residents.is_empty() => Err(
+            "source-only retained request-local PRIMARY residents across token execution".into(),
+        ),
+        OracleScheduledResidencyMode::TokenBoundaryDirect => {
+            for (&global_id, resident) in &outcome.residents {
+                if resident.buffer_pool_origin()
+                    != BufferPoolOrigin::QualificationOracleFutureSource
+                {
+                    return Err(format!(
+                        "token-boundary-direct retained production-backed future expert {global_id}"
+                    ));
+                }
+            }
+            Ok(())
+        }
+        OracleScheduledResidencyMode::SourceOnly => Ok(()),
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -465,7 +627,6 @@ struct SourceReadinessSnapshot {
 
 #[derive(Default)]
 struct SourceReadinessState {
-    physical_ready: HashSet<u32>,
     source_residents_ready: HashSet<u32>,
 }
 
@@ -482,10 +643,6 @@ enum BoundarySourceReadiness {
 }
 
 impl SourceReadiness {
-    fn mark_physical_ready(&self, global_id: u32) {
-        self.state.lock().physical_ready.insert(global_id);
-    }
-
     fn mark_source_resident_ready(&self, global_id: u32) {
         let mut state = self.state.lock();
         state.source_residents_ready.insert(global_id);
@@ -530,8 +687,7 @@ impl SourceReadiness {
                 ));
             }
             let live = current_readiness(global_id)?;
-            let physical_ready = state.physical_ready.contains(&global_id)
-                || live == BoundarySourceReadiness::Physical;
+            let physical_ready = live == BoundarySourceReadiness::Physical;
             let source_ready = state.source_residents_ready.contains(&global_id)
                 || live == BoundarySourceReadiness::SourceResident;
             required_ready += u64::from(physical_ready || source_ready);
@@ -550,29 +706,15 @@ impl SourceReadiness {
 
 struct PrefetchLease {
     outcome: PrefetchOutcome,
-    counters: Arc<Mutex<OracleCounters>>,
     _position_guard: tokio::sync::OwnedMutexGuard<()>,
 }
 
 impl PrefetchLease {
-    fn new(
-        outcome: PrefetchOutcome,
-        counters: Arc<Mutex<OracleCounters>>,
-        position_guard: tokio::sync::OwnedMutexGuard<()>,
-    ) -> Self {
+    fn new(outcome: PrefetchOutcome, position_guard: tokio::sync::OwnedMutexGuard<()>) -> Self {
         Self {
             outcome,
-            counters,
             _position_guard: position_guard,
         }
-    }
-}
-
-impl Drop for PrefetchLease {
-    fn drop(&mut self) {
-        let mut values = self.counters.lock();
-        values.qualification_owned_current_slots = 0;
-        values.qualification_owned_current_bytes = 0;
     }
 }
 
@@ -582,6 +724,50 @@ enum SourceDisposition {
     RamHit,
     SourceInFlight,
     StartSourceRead,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DirectFutureSourceDisposition {
+    AlreadyPhysical,
+    DeferredCurrentDemandOverlap,
+    IsolatedRead,
+}
+
+const fn direct_future_source_disposition(
+    physical_current: bool,
+    overlaps_current_demand: bool,
+) -> DirectFutureSourceDisposition {
+    if physical_current {
+        DirectFutureSourceDisposition::AlreadyPhysical
+    } else if overlaps_current_demand {
+        DirectFutureSourceDisposition::DeferredCurrentDemandOverlap
+    } else {
+        DirectFutureSourceDisposition::IsolatedRead
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DirectBoundarySourceDisposition {
+    Physical,
+    Isolated,
+    ProductionRam,
+    ResidualRead,
+}
+
+const fn direct_boundary_source_disposition(
+    physical_current: bool,
+    isolated_ready: bool,
+    production_ram_ready: bool,
+) -> DirectBoundarySourceDisposition {
+    if physical_current {
+        DirectBoundarySourceDisposition::Physical
+    } else if isolated_ready {
+        DirectBoundarySourceDisposition::Isolated
+    } else if production_ram_ready {
+        DirectBoundarySourceDisposition::ProductionRam
+    } else {
+        DirectBoundarySourceDisposition::ResidualRead
+    }
 }
 
 const fn source_disposition(
@@ -604,6 +790,9 @@ async fn prefetch_layer_batch(
     engine: Arc<Engine>,
     layer_index: usize,
     local_ids: Vec<u32>,
+    mode: OracleScheduledResidencyMode,
+    current_route_global_ids: Arc<HashSet<u32>>,
+    oracle_source_pool: Option<Arc<OracleFutureSourcePool>>,
     counters: Arc<Mutex<OracleCounters>>,
     readiness: Arc<SourceReadiness>,
 ) -> PrefetchOutcome {
@@ -637,25 +826,101 @@ async fn prefetch_layer_batch(
                 return outcome;
             }
         };
-        let ram_resident = (!physical_current)
-            .then(|| engine.core.cache.get(global_id))
-            .flatten();
-        let singleflight = !physical_current
-            && ram_resident.is_none()
-            && engine.core.in_flight.contains_key(&global_id);
-        match source_disposition(physical_current, ram_resident.is_some(), singleflight) {
-            SourceDisposition::AlreadyPhysical => {
-                counters.lock().source_skipped_physical_current += 1;
-                readiness.mark_physical_ready(global_id);
-                continue;
+        if mode == OracleScheduledResidencyMode::TokenBoundaryDirect {
+            match direct_future_source_disposition(
+                physical_current,
+                current_route_global_ids.contains(&global_id),
+            ) {
+                DirectFutureSourceDisposition::AlreadyPhysical => {
+                    counters.lock().source_skipped_physical_current += 1;
+                    outcome.successful_ids.push(global_id);
+                    continue;
+                }
+                DirectFutureSourceDisposition::DeferredCurrentDemandOverlap => {
+                    counters
+                        .lock()
+                        .future_experts_deferred_current_demand_overlap += 1;
+                    outcome.deferred_overlap_ids.push(global_id);
+                    continue;
+                }
+                DirectFutureSourceDisposition::IsolatedRead => {}
             }
+            let Some(pool) = oracle_source_pool.as_ref() else {
+                outcome.fatal_error =
+                    Some("token-boundary-direct has no isolated ORACLE source pool".into());
+                return outcome;
+            };
+            counters.lock().source_reads_started += 1;
+            let started = Instant::now();
+            match read_oracle_future_source(&engine, pool, global_id).await {
+                Ok((resident, bytes)) => {
+                    let pool_snapshot = pool.snapshot();
+                    let mut values = counters.lock();
+                    add_counter(&mut values.source_read_aggregate_us, saturating_us(started));
+                    values.source_reads_completed += 1;
+                    add_counter(&mut values.source_bytes_read, bytes as u64);
+                    values.oracle_source_nvme_reads += 1;
+                    add_counter(&mut values.oracle_source_bytes, bytes as u64);
+                    values.qualification_owned_current_slots =
+                        pool_snapshot.current_in_use_slots as u64;
+                    values.qualification_owned_current_bytes = (pool_snapshot.current_in_use_slots
+                        as u64)
+                        .saturating_mul(pool_snapshot.buffer_size_bytes as u64);
+                    values.qualification_owned_peak_slots = values
+                        .qualification_owned_peak_slots
+                        .max(pool_snapshot.current_in_use_slots as u64);
+                    values.qualification_owned_peak_bytes =
+                        values.qualification_owned_peak_bytes.max(
+                            (pool_snapshot.current_in_use_slots as u64)
+                                .saturating_mul(pool_snapshot.buffer_size_bytes as u64),
+                        );
+                    drop(values);
+                    readiness.mark_source_resident_ready(global_id);
+                    outcome.successful_ids.push(global_id);
+                    outcome.residents.insert(global_id, resident);
+                }
+                Err(OracleSourceReadError::Io(_error)) => {
+                    let mut values = counters.lock();
+                    add_counter(&mut values.source_read_aggregate_us, saturating_us(started));
+                    values.source_reads_failed += 1;
+                    outcome.failed_ids.push(global_id);
+                }
+                Err(OracleSourceReadError::PoolExhausted(error)) => {
+                    let mut values = counters.lock();
+                    values.source_reads_failed += 1;
+                    values.oracle_source_pool_exhaustion_count += 1;
+                    outcome.fatal_error = Some(error);
+                    return outcome;
+                }
+                Err(OracleSourceReadError::Fatal(error)) => {
+                    counters.lock().source_reads_failed += 1;
+                    outcome.fatal_error = Some(error);
+                    return outcome;
+                }
+            }
+            continue;
+        }
+
+        if physical_current {
+            counters.lock().source_skipped_physical_current += 1;
+            outcome.successful_ids.push(global_id);
+            continue;
+        }
+
+        // Source-only intentionally uses the ordinary cache/singleflight
+        // machinery, but never parks the returned PRIMARY Arc in the
+        // position outcome. Once fetch has installed the resident, the cache
+        // is the only long-lived owner and foreground eviction can recycle
+        // the buffer immediately.
+        let ram_resident = engine.core.cache.get(global_id);
+        let singleflight = ram_resident.is_none() && engine.core.in_flight.contains_key(&global_id);
+        match source_disposition(false, ram_resident.is_some(), singleflight) {
             SourceDisposition::RamHit => {
-                counters.lock().source_ram_hits += 1;
-                outcome.residents.insert(
-                    global_id,
-                    ram_resident.expect("RAM-hit disposition has a resident"),
-                );
-                readiness.mark_source_resident_ready(global_id);
+                let mut values = counters.lock();
+                values.source_ram_hits += 1;
+                values.source_prefetch_ram_hits += 1;
+                outcome.successful_ids.push(global_id);
+                drop(ram_resident);
                 continue;
             }
             SourceDisposition::SourceInFlight => {
@@ -664,6 +929,7 @@ async fn prefetch_layer_batch(
             SourceDisposition::StartSourceRead => {
                 counters.lock().source_reads_started += 1;
             }
+            SourceDisposition::AlreadyPhysical => unreachable!("physical current handled above"),
         }
         let started = Instant::now();
         match engine.fetch_with_retry(global_id).await {
@@ -673,18 +939,20 @@ async fn prefetch_layer_batch(
                 add_counter(&mut values.source_read_aggregate_us, elapsed);
                 if !singleflight {
                     values.source_reads_completed += 1;
-                    add_counter(&mut values.source_bytes_read, resident.data().len() as u64);
+                    add_counter(
+                        &mut values.source_bytes_read,
+                        engine.core.storage.config().expert_size as u64,
+                    );
                 }
                 drop(values);
-                readiness.mark_source_resident_ready(global_id);
-                outcome.residents.insert(global_id, resident);
+                outcome.successful_ids.push(global_id);
+                drop(resident);
             }
-            Err(error) => {
+            Err(_error) => {
                 if !singleflight {
                     counters.lock().source_reads_failed += 1;
                 }
                 outcome.failed_ids.push(global_id);
-                let _ = error;
             }
         }
     }
@@ -695,6 +963,9 @@ async fn prefetch_position(
     engine: Arc<Engine>,
     target_position: usize,
     routes: Vec<Vec<u32>>,
+    mode: OracleScheduledResidencyMode,
+    current_route_global_ids: Arc<HashSet<u32>>,
+    oracle_source_pool: Option<Arc<OracleFutureSourcePool>>,
     concurrency: usize,
     expert_bytes: usize,
     counters: Arc<Mutex<OracleCounters>>,
@@ -707,12 +978,24 @@ async fn prefetch_position(
         let counters = counters.clone();
         let readiness = readiness.clone();
         let semaphore = semaphore.clone();
+        let current_route_global_ids = current_route_global_ids.clone();
+        let oracle_source_pool = oracle_source_pool.clone();
         async move {
             let permit = semaphore
                 .acquire_owned()
                 .await
                 .expect("qualification semaphore remains open");
-            let result = prefetch_layer_batch(engine, layer_index, ids, counters, readiness).await;
+            let result = prefetch_layer_batch(
+                engine,
+                layer_index,
+                ids,
+                mode,
+                current_route_global_ids,
+                oracle_source_pool,
+                counters,
+                readiness,
+            )
+            .await;
             drop(permit);
             result
         }
@@ -730,22 +1013,22 @@ async fn prefetch_position(
             outcome.fatal_error = batch.fatal_error;
         }
         outcome.failed_ids.extend(batch.failed_ids);
+        outcome.successful_ids.extend(batch.successful_ids);
+        outcome
+            .deferred_overlap_ids
+            .extend(batch.deferred_overlap_ids);
         outcome.residents.extend(batch.residents);
     }
     let slots = outcome.residents.len() as u64;
-    let bytes = outcome
-        .residents
-        .values()
-        .map(|resident| resident.data().len() as u64)
-        .sum::<u64>();
+    let bytes = slots.saturating_mul(expert_bytes as u64);
     let mut values = counters.lock();
     add_counter(&mut values.source_prefetch_wall_us, saturating_us(started));
     values.qualification_owned_current_slots = slots;
     values.qualification_owned_current_bytes = bytes;
     values.qualification_owned_peak_slots = values.qualification_owned_peak_slots.max(slots);
     values.qualification_owned_peak_bytes = values.qualification_owned_peak_bytes.max(bytes);
-    if slots > FROZEN_RAM_CACHE_SLOTS as u64
-        || bytes > (FROZEN_RAM_CACHE_SLOTS as u64).saturating_mul(expert_bytes as u64)
+    if slots > ORACLE_FUTURE_SOURCE_POOL_SLOTS as u64
+        || bytes > (ORACLE_FUTURE_SOURCE_POOL_SLOTS as u64).saturating_mul(expert_bytes as u64)
     {
         outcome.fatal_error = Some(format!(
             "qualification temporary source state exceeded bound: slots={slots} bytes={bytes}"
@@ -923,6 +1206,121 @@ fn plan_boundary_replacement(
     })
 }
 
+async fn resolve_direct_sources_at_boundary(
+    engine: &Arc<Engine>,
+    routes: &[Vec<u32>],
+    prefetched: &PrefetchOutcome,
+    pool: &Arc<OracleFutureSourcePool>,
+    counters: &Arc<Mutex<OracleCounters>>,
+) -> Result<HashMap<u32, Arc<ExpertResident>>, String> {
+    validate_retained_source_origins(
+        OracleScheduledResidencyMode::TokenBoundaryDirect,
+        prefetched,
+    )?;
+
+    let manager = engine
+        .core
+        .gpu_native_residency
+        .as_ref()
+        .ok_or("GPU-native residency manager is absent")?;
+    let experts_per_layer = manager.plan().geometry().num_experts() as u32;
+    let deferred = prefetched
+        .deferred_overlap_ids
+        .iter()
+        .copied()
+        .collect::<HashSet<_>>();
+    let mut resolved = prefetched.residents.clone();
+    for (layer_index, local_ids) in routes.iter().enumerate() {
+        for global_id in future_global_ids(
+            layer_index,
+            local_ids,
+            manager.plan().num_layers(),
+            experts_per_layer,
+        )
+        .map_err(|error| error.to_string())?
+        {
+            let physical_current = manager
+                .has_current_for_demand(global_id)
+                .map_err(|error| error.to_string())?;
+            let isolated_ready = resolved.contains_key(&global_id);
+            let production_ram = (!physical_current && !isolated_ready)
+                .then(|| engine.core.cache.get(global_id))
+                .flatten();
+            match direct_boundary_source_disposition(
+                physical_current,
+                isolated_ready,
+                production_ram.is_some(),
+            ) {
+                DirectBoundarySourceDisposition::Physical => {
+                    if deferred.contains(&global_id) {
+                        counters.lock().deferred_overlap_resolved_physical += 1;
+                    }
+                    continue;
+                }
+                DirectBoundarySourceDisposition::Isolated => continue,
+                DirectBoundarySourceDisposition::ProductionRam => {
+                    let mut values = counters.lock();
+                    values.source_ram_hits += 1;
+                    if deferred.contains(&global_id) {
+                        values.deferred_overlap_resolved_production_ram += 1;
+                    }
+                    drop(values);
+                    // This PRIMARY Arc is acquired only after current-token
+                    // completion and is released before the next token begins.
+                    resolved.insert(
+                        global_id,
+                        production_ram.expect("production-RAM disposition has a resident"),
+                    );
+                    continue;
+                }
+                DirectBoundarySourceDisposition::ResidualRead => {}
+            }
+
+            let started = Instant::now();
+            let read = read_oracle_future_source(engine, pool, global_id).await;
+            let elapsed = saturating_us(started);
+            let mut values = counters.lock();
+            add_counter(&mut values.residual_source_wait_us, elapsed);
+            match read {
+                Ok((resident, bytes)) => {
+                    values.residual_boundary_source_reads += 1;
+                    values.oracle_source_nvme_reads += 1;
+                    add_counter(&mut values.oracle_source_bytes, bytes as u64);
+                    add_counter(&mut values.residual_boundary_source_bytes, bytes as u64);
+                    drop(values);
+                    resolved.insert(global_id, resident);
+                }
+                Err(OracleSourceReadError::Io(_error)) => {
+                    values.residual_boundary_source_failures += 1;
+                    values.source_failures_degraded_to_demand += 1;
+                    drop(values);
+                    // Correctness remains with the ordinary demand/recovery
+                    // path when an allowed residual source read genuinely
+                    // fails.
+                }
+                Err(OracleSourceReadError::PoolExhausted(error)) => {
+                    values.oracle_source_pool_exhaustion_count += 1;
+                    return Err(error);
+                }
+                Err(OracleSourceReadError::Fatal(error)) => return Err(error),
+            }
+        }
+    }
+    let snapshot = pool.snapshot();
+    let mut values = counters.lock();
+    values.qualification_owned_current_slots = snapshot.current_in_use_slots as u64;
+    values.qualification_owned_current_bytes =
+        (snapshot.current_in_use_slots as u64).saturating_mul(snapshot.buffer_size_bytes as u64);
+    values.qualification_owned_peak_slots = values
+        .qualification_owned_peak_slots
+        .max(snapshot.current_in_use_slots as u64);
+    values.qualification_owned_peak_bytes = values.qualification_owned_peak_bytes.max(
+        (snapshot.current_in_use_slots as u64).saturating_mul(snapshot.buffer_size_bytes as u64),
+    );
+    drop(values);
+    Ok(resolved)
+}
+
 fn prepare_logical_admissions(
     engine: &Arc<Engine>,
     global_ids: &[u32],
@@ -1032,7 +1430,6 @@ fn install_future_at_boundary(
             .iter()
             .any(|global_id| !residents.contains_key(global_id))
         {
-            counters.lock().source_failures_degraded_to_demand += 1;
             continue;
         }
 
@@ -1164,6 +1561,7 @@ struct OracleScheduler {
     mode: OracleScheduledResidencyMode,
     concurrency: usize,
     expert_bytes: usize,
+    oracle_source_pool: Option<Arc<OracleFutureSourcePool>>,
     source_position_gate: Arc<tokio::sync::Mutex<()>>,
     counters: Arc<Mutex<OracleCounters>>,
     state: Arc<Mutex<SchedulerState>>,
@@ -1254,6 +1652,7 @@ where
         &mut counters.lock(),
         &lease.outcome,
         readiness_at_boundary.source_residents_ready,
+        mode,
     );
     Ok(BoundarySourceResolution::Completed { lease, was_late })
 }
@@ -1263,9 +1662,26 @@ fn release_source_position_lease_before_next_token(
     lease: PrefetchLease,
     source_position_gate: &Arc<tokio::sync::Mutex<()>>,
     state: &Arc<Mutex<SchedulerState>>,
+    oracle_source_pool: Option<&Arc<OracleFutureSourcePool>>,
+    counters: &Arc<Mutex<OracleCounters>>,
 ) -> Result<(), String> {
     drop(lease);
     if mode == OracleScheduledResidencyMode::TokenBoundaryDirect {
+        let pool = oracle_source_pool
+            .ok_or("token-boundary-direct lost its isolated ORACLE source pool")?;
+        let snapshot = pool.snapshot();
+        {
+            let mut values = counters.lock();
+            values.qualification_owned_current_slots = snapshot.current_in_use_slots as u64;
+            values.qualification_owned_current_bytes = (snapshot.current_in_use_slots as u64)
+                .saturating_mul(snapshot.buffer_size_bytes as u64);
+        }
+        if snapshot.current_in_use_slots != 0 {
+            return Err(format!(
+                "prior-position ORACLE source lease retained {} buffers before the next token",
+                snapshot.current_in_use_slots
+            ));
+        }
         let position_guard = source_position_gate.clone().try_lock_owned().map_err(|_| {
             "token-boundary-direct retained the completed position lease before the next token"
                 .to_string()
@@ -1288,12 +1704,14 @@ impl OracleScheduler {
         mode: OracleScheduledResidencyMode,
         concurrency: usize,
         expert_bytes: usize,
+        oracle_source_pool: Option<Arc<OracleFutureSourcePool>>,
     ) -> Self {
         Self {
             engine,
             mode,
             concurrency,
             expert_bytes,
+            oracle_source_pool,
             source_position_gate: Arc::new(tokio::sync::Mutex::new(())),
             counters: Arc::new(Mutex::new(OracleCounters::default())),
             state: Arc::new(Mutex::new(SchedulerState {
@@ -1317,13 +1735,15 @@ impl OracleScheduler {
                 self.engine.clone(),
                 0,
                 routes,
+                OracleScheduledResidencyMode::SourceOnly,
+                Arc::new(HashSet::new()),
+                None,
                 self.concurrency,
                 self.expert_bytes,
                 self.counters.clone(),
                 readiness,
             )
             .await,
-            self.counters.clone(),
             position_guard,
         );
         if let Some(error) = lease.outcome.fatal_error.as_ref() {
@@ -1331,7 +1751,7 @@ impl OracleScheduler {
             return Err(error);
         }
         let mut values = self.counters.lock();
-        values.initial_position_source_priming_experts = lease.outcome.residents.len() as u64;
+        values.initial_position_source_priming_experts = lease.outcome.successful_ids.len() as u64;
         values.initial_position_source_priming_us = saturating_us(started);
         values.source_failures_degraded_to_demand += lease.outcome.failed_ids.len() as u64;
         drop(values);
@@ -1491,6 +1911,7 @@ impl OracleScheduler {
         let mut values = self.counters.lock();
         values.source_skipped_physical_current += physical;
         values.source_ram_hits += ram;
+        values.source_prefetch_ram_hits += ram;
         values.source_singleflight_hits += singleflight;
         values.source_position_inflight_skips += position_inflight;
         values.source_prefetch_batches_skipped_inflight += routes.len() as u64;
@@ -1581,11 +2002,23 @@ impl OracleScheduler {
         };
 
         if self.mode == OracleScheduledResidencyMode::TokenBoundaryDirect {
+            let pool = self
+                .oracle_source_pool
+                .as_ref()
+                .ok_or("token-boundary-direct has no isolated ORACLE source pool")?;
+            let resolved = resolve_direct_sources_at_boundary(
+                &self.engine,
+                &routes,
+                &lease.outcome,
+                pool,
+                &self.counters,
+            )
+            .await?;
             install_future_at_boundary(
                 &self.engine,
                 &mut boundary,
                 &routes,
-                &lease.outcome.residents,
+                &resolved,
                 self.counters.clone(),
             )?;
             let unavailable_after_install = self.future_not_physically_current_count(&routes)?;
@@ -1594,12 +2027,20 @@ impl OracleScheduler {
                 was_late,
                 unavailable_after_install,
             );
+            drop(resolved);
+        } else {
+            validate_retained_source_origins(
+                OracleScheduledResidencyMode::SourceOnly,
+                &lease.outcome,
+            )?;
         }
         release_source_position_lease_before_next_token(
             self.mode,
             lease,
             &self.source_position_gate,
             &self.state,
+            self.oracle_source_pool.as_ref(),
+            &self.counters,
         )
     }
 
@@ -1615,8 +2056,18 @@ impl OracleScheduler {
         }
         let trace = state.cursor.clone().finish()?;
         let mut counters = self.counters.lock().clone();
-        counters.qualification_owned_current_slots = 0;
-        counters.qualification_owned_current_bytes = 0;
+        if let Some(pool) = self.oracle_source_pool.as_ref() {
+            let snapshot = pool.snapshot();
+            counters.qualification_owned_current_slots = snapshot.current_in_use_slots as u64;
+            counters.qualification_owned_current_bytes = (snapshot.current_in_use_slots as u64)
+                .saturating_mul(snapshot.buffer_size_bytes as u64);
+            if snapshot.current_in_use_slots != 0 {
+                return Err(format!(
+                    "ORACLE source pool retained {} leases after request completion",
+                    snapshot.current_in_use_slots
+                ));
+            }
+        }
         Ok((counters, trace))
     }
 }
@@ -1625,9 +2076,12 @@ fn record_completed_source_outcome(
     counters: &mut OracleCounters,
     outcome: &PrefetchOutcome,
     source_residents_ready_at_boundary: u64,
+    mode: OracleScheduledResidencyMode,
 ) {
     counters.source_ready_before_boundary += source_residents_ready_at_boundary;
-    counters.source_failures_degraded_to_demand += outcome.failed_ids.len() as u64;
+    if mode == OracleScheduledResidencyMode::SourceOnly {
+        counters.source_failures_degraded_to_demand += outcome.failed_ids.len() as u64;
+    }
 }
 
 fn record_source_position_considered(counters: &mut OracleCounters, routes: &[Vec<u32>]) {
@@ -1709,7 +2163,23 @@ impl GpuNativeOracleScheduleHook for OracleScheduler {
         let counters = self.counters.clone();
         let concurrency = self.concurrency;
         let expert_bytes = self.expert_bytes;
+        let mode = self.mode;
+        let oracle_source_pool = self.oracle_source_pool.clone();
         let target_position = position + 1;
+        let current_routes = match state.cursor.routes_at(position) {
+            Ok(routes) => routes,
+            Err(error) => {
+                state.failure = Some(error);
+                return;
+            }
+        };
+        let current_route_global_ids = match self.required_future_global_ids(&current_routes) {
+            Ok(ids) => Arc::new(ids.into_iter().collect::<HashSet<_>>()),
+            Err(error) => {
+                state.failure = Some(error);
+                return;
+            }
+        };
         let readiness = Arc::new(SourceReadiness::default());
         let handle = match self.source_position_gate.clone().try_lock_owned() {
             Ok(position_guard) => {
@@ -1719,13 +2189,16 @@ impl GpuNativeOracleScheduleHook for OracleScheduler {
                         engine,
                         target_position,
                         routes,
+                        mode,
+                        current_route_global_ids,
+                        oracle_source_pool,
                         concurrency,
                         expert_bytes,
                         counters.clone(),
                         readiness_for_task,
                     )
                     .await;
-                    PrefetchLease::new(outcome, counters, position_guard)
+                    PrefetchLease::new(outcome, position_guard)
                 });
                 self.counters.lock().background_tasks_spawned += 1;
                 Some(handle)
@@ -1782,6 +2255,8 @@ struct TreatmentContract {
     production_speculative_residency_used: bool,
     production_direct_staging_used: bool,
     legacy_full_slot_vec_used: bool,
+    future_source_pool_isolated_from_production_primary: bool,
+    production_primary_pool_capacity_unchanged: bool,
 }
 
 const fn treatment_contract(mode: OracleScheduledResidencyMode) -> TreatmentContract {
@@ -1801,6 +2276,8 @@ const fn treatment_contract(mode: OracleScheduledResidencyMode) -> TreatmentCont
             OracleScheduledResidencyMode::TokenBoundaryDirect
         ),
         legacy_full_slot_vec_used: false,
+        future_source_pool_isolated_from_production_primary: true,
+        production_primary_pool_capacity_unchanged: true,
     }
 }
 
@@ -1824,6 +2301,43 @@ struct FrozenControlReferences {
     oracle_route_command_git_sha: &'static str,
     performance_controls_rerun: bool,
     hardware_results_embedded: bool,
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+struct PredecessorFirstAttemptEvidence {
+    code_sha: &'static str,
+    result: &'static str,
+    failure: &'static str,
+    requested: usize,
+    acquired: usize,
+    interpretation: &'static str,
+    first_attempt_rerun: bool,
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+struct SourceMemoryPlaneEvidence {
+    production_ram_cache_capacity_slots: usize,
+    production_ram_cache_max_resident_bytes: usize,
+    production_primary_pool_capacity_slots: usize,
+    production_primary_headroom_slots: usize,
+    production_primary_pool_available_before_requests: usize,
+    production_primary_pool_available_after_requests: usize,
+    production_primary_pool_buffer_size_bytes: usize,
+    production_primary_pool_allocated_bytes: usize,
+    oracle_source_pool_configured_max_slots: usize,
+    oracle_source_pool_allocated_capacity_slots: usize,
+    oracle_source_pool_buffer_size_bytes: usize,
+    oracle_source_pool_allocated_bytes: usize,
+    oracle_source_pool_current_in_use_slots: usize,
+    oracle_source_pool_peak_in_use_slots: usize,
+    oracle_source_pool_exhaustion_count: u64,
+    oracle_source_nvme_reads: u64,
+    oracle_source_bytes: u64,
+    oracle_source_pool_reused_across_warmup_and_measured_requests: bool,
+    no_oracle_pool_accumulation_across_requests: bool,
+    oracle_source_buffers_released_before_runtime_shutdown: bool,
+    future_source_pool_isolated_from_production_primary: bool,
+    production_primary_pool_capacity_unchanged: bool,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -1897,6 +2411,8 @@ struct OracleScheduledResidencyReport {
     physical_slot_plan: PhysicalSlotPlanEvidence,
     frozen_controls: FrozenControlReferences,
     frozen_workload: FrozenWorkloadEvidence,
+    predecessor_first_attempt: PredecessorFirstAttemptEvidence,
+    source_memory_planes: SourceMemoryPlaneEvidence,
     warmup: OracleRunResult,
     measured: Vec<OracleRunResult>,
     aggregate_measured_performance: Aggregate,
@@ -1916,12 +2432,23 @@ fn accumulate_oracle(total: &mut OracleCounters, value: &OracleCounters) {
     add!(future_experts_considered);
     add!(source_skipped_physical_current);
     add!(source_ram_hits);
+    add!(source_prefetch_ram_hits);
     add!(source_singleflight_hits);
     add!(source_position_inflight_skips);
     add!(source_reads_started);
     add!(source_reads_completed);
     add!(source_reads_failed);
     add!(source_bytes_read);
+    add!(oracle_source_nvme_reads);
+    add!(oracle_source_bytes);
+    add!(future_experts_deferred_current_demand_overlap);
+    add!(deferred_overlap_resolved_physical);
+    add!(deferred_overlap_resolved_production_ram);
+    add!(residual_boundary_source_reads);
+    add!(residual_boundary_source_failures);
+    add!(residual_boundary_source_bytes);
+    add!(residual_source_wait_us);
+    add!(oracle_source_pool_exhaustion_count);
     add!(source_prefetch_batches_started);
     add!(source_prefetch_batches_completed);
     add!(source_prefetch_batches_skipped_inflight);
@@ -1973,12 +2500,14 @@ fn validate_oracle_counters(
     counters: &OracleCounters,
     mode: OracleScheduledResidencyMode,
     concurrency: usize,
+    expert_bytes: usize,
 ) -> Result<(), BenchmarkFailure> {
     let classified_source = counters
         .source_skipped_physical_current
-        .saturating_add(counters.source_ram_hits)
+        .saturating_add(counters.source_prefetch_ram_hits)
         .saturating_add(counters.source_singleflight_hits)
         .saturating_add(counters.source_position_inflight_skips)
+        .saturating_add(counters.future_experts_deferred_current_demand_overlap)
         .saturating_add(counters.source_reads_started);
     if counters.future_experts_considered != EXPECTED_SELECTED_IDS as u64
         || classified_source != counters.future_experts_considered
@@ -1999,6 +2528,8 @@ fn validate_oracle_counters(
         || counters.qualification_owned_current_slots != 0
         || counters.qualification_owned_current_bytes != 0
         || counters.qualification_owned_peak_slots > FROZEN_RAM_CACHE_SLOTS as u64
+        || counters.qualification_owned_peak_bytes
+            > (ORACLE_FUTURE_SOURCE_POOL_SLOTS as u64).saturating_mul(expert_bytes as u64)
         || counters.background_tasks_spawned > (EXPECTED_POSITIONS - 1) as u64
         || counters.background_tasks_drained != counters.background_tasks_spawned
         || counters.source_end_of_trace != 1
@@ -2012,7 +2543,10 @@ fn validate_oracle_counters(
     if mode == OracleScheduledResidencyMode::SourceOnly
         && (counters.boundary_replacement_sets_started != 0
             || counters.boundary_physical_installs != 0
-            || counters.boundary_physical_evictions != 0)
+            || counters.boundary_physical_evictions != 0
+            || counters.oracle_source_nvme_reads != 0
+            || counters.oracle_source_bytes != 0
+            || counters.qualification_owned_peak_slots != 0)
     {
         return Err(BenchmarkFailure::new(
             "postcondition",
@@ -2034,6 +2568,19 @@ fn validate_oracle_counters(
             || counters.boundary_physical_evictions > counters.boundary_physical_installs
             || counters.boundary_replacement_sets_completed
                 > counters.boundary_replacement_sets_started
+            || counters.oracle_source_pool_exhaustion_count != 0
+            || counters.oracle_source_bytes
+                != counters
+                    .oracle_source_nvme_reads
+                    .saturating_mul(expert_bytes as u64)
+            || counters.residual_boundary_source_bytes
+                != counters
+                    .residual_boundary_source_reads
+                    .saturating_mul(expert_bytes as u64)
+            || counters
+                .deferred_overlap_resolved_physical
+                .saturating_add(counters.deferred_overlap_resolved_production_ram)
+                > counters.future_experts_deferred_current_demand_overlap
             || (counters.boundary_physical_installs == 0)
                 != (counters.boundary_physical_install_bytes == 0))
     {
@@ -2149,6 +2696,7 @@ async fn execute_oracle_request(
     treatment_mode: OracleScheduledResidencyMode,
     source_concurrency: usize,
     expert_bytes: usize,
+    oracle_source_pool: Option<Arc<OracleFutureSourcePool>>,
     prompt_ids: &[u32],
     run_index: usize,
 ) -> Result<OracleRunResult, Box<dyn std::error::Error>> {
@@ -2165,6 +2713,7 @@ async fn execute_oracle_request(
         treatment_mode,
         source_concurrency,
         expert_bytes,
+        oracle_source_pool,
     );
     let mut request = token_loop.create_request_state()?;
     let snapshots = RequestSnapshotStart::capture(runtime)?;
@@ -2266,7 +2815,7 @@ async fn execute_oracle_request(
     )?;
     oracle.ordinary_residency_miss_attempts = counters.token_loop_delta.residency_miss_attempts;
     oracle.ordinary_residency_services = counters.token_loop_delta.residency_services;
-    validate_oracle_counters(&oracle, treatment_mode, source_concurrency)?;
+    validate_oracle_counters(&oracle, treatment_mode, source_concurrency, expert_bytes)?;
 
     let output_text = runtime.tokenizer.decode(&generated_ids)?;
     let generated_token_ids_sha256 = crate::greedy_parity::token_ids_sha256(&generated_ids);
@@ -2454,13 +3003,69 @@ pub(crate) async fn run_command(args: CommandArgs) -> Result<(), Box<dyn std::er
         greedy: true,
     };
 
+    let expected_production_primary_capacity = FROZEN_RAM_CACHE_SLOTS + 1;
+    let expected_oracle_source_allocated_bytes =
+        oracle_future_source_allocated_bytes(spec.cfg.model.expert_size).ok_or_else(|| {
+            artifact_failure(
+                "oracle-source-pool-allocation-overflow",
+                "384-slot ORACLE source allocation exceeds usize",
+            )
+        })?;
+
     let runtime = crate::build_isolated_greedy_runtime(
         &spec,
         crate::RealCliRuntimeMode::IsolatedGpuNativeBenchmark,
         tokenizer,
     )
     .await?;
+    let production_primary_pool_available_before_requests =
+        runtime.engine.core.pool.primary_available();
+    let oracle_allocation_before =
+        crate::buffer_pool::expert_buffer_pool_qualification_oracle_bytes();
+    let oracle_source_pool = match args.treatment_mode {
+        OracleScheduledResidencyMode::SourceOnly => None,
+        OracleScheduledResidencyMode::TokenBoundaryDirect => {
+            Some(Arc::new(OracleFutureSourcePool::new(
+                ORACLE_FUTURE_SOURCE_POOL_SLOTS,
+                spec.cfg.model.expert_size,
+                spec.cfg.storage.block_align,
+            )))
+        }
+    };
     let execution = async {
+        if runtime.engine.core.cache.capacity() != FROZEN_RAM_CACHE_SLOTS
+            || runtime.engine.core.pool.capacity() != expected_production_primary_capacity
+            || runtime.engine.core.pool.shadow_capacity() != 0
+            || runtime.engine.core.pool.origin() != BufferPoolOrigin::Production
+        {
+            return Err(BenchmarkFailure::new(
+                "startup",
+                "production-primary-pool-contract-drift",
+                format!(
+                    "expected production cache/pool/shadow capacities {FROZEN_RAM_CACHE_SLOTS}/{expected_production_primary_capacity}/0, observed {}/{}/{}",
+                    runtime.engine.core.cache.capacity(),
+                    runtime.engine.core.pool.capacity(),
+                    runtime.engine.core.pool.shadow_capacity(),
+                ),
+            )
+            .into());
+        }
+        if let Some(pool) = oracle_source_pool.as_ref() {
+            let snapshot = pool.snapshot();
+            if pool.pool.origin() != BufferPoolOrigin::QualificationOracleFutureSource
+                || snapshot.capacity_slots != ORACLE_FUTURE_SOURCE_POOL_SLOTS
+                || snapshot.buffer_size_bytes != spec.cfg.model.expert_size
+                || snapshot.allocated_bytes != expected_oracle_source_allocated_bytes
+                || snapshot.current_in_use_slots != 0
+            {
+                return Err(BenchmarkFailure::new(
+                    "startup",
+                    "oracle-source-pool-contract-drift",
+                    format!("invalid isolated ORACLE source pool: {snapshot:?}"),
+                )
+                .into());
+            }
+        }
         let validated = validate_runtime(&runtime, &resolved_config_sha256, &oracle.trace)?;
         let warmup = crate::with_progress_timeout(
             format!("{MODE} warmup"),
@@ -2473,6 +3078,7 @@ pub(crate) async fn run_command(args: CommandArgs) -> Result<(), Box<dyn std::er
                 args.treatment_mode,
                 args.oracle_source_concurrency,
                 spec.cfg.model.expert_size,
+                oracle_source_pool.clone(),
                 &prompt_ids,
                 0,
             ),
@@ -2492,6 +3098,7 @@ pub(crate) async fn run_command(args: CommandArgs) -> Result<(), Box<dyn std::er
                         args.treatment_mode,
                         args.oracle_source_concurrency,
                         spec.cfg.model.expert_size,
+                        oracle_source_pool.clone(),
                         &prompt_ids,
                         run_index,
                     ),
@@ -2499,12 +3106,77 @@ pub(crate) async fn run_command(args: CommandArgs) -> Result<(), Box<dyn std::er
                 .await?,
             );
         }
-        Ok::<_, Box<dyn std::error::Error>>((validated, warmup, measured))
+        let production_primary_pool_available_after_requests =
+            runtime.engine.core.pool.primary_available();
+        let pool_snapshot = oracle_source_pool
+            .as_ref()
+            .map(|pool| pool.snapshot())
+            .unwrap_or_default();
+        if pool_snapshot.current_in_use_slots != 0
+            || pool_snapshot.peak_in_use_slots > pool_snapshot.capacity_slots
+            || pool_snapshot.exhaustion_count != 0
+            || pool_snapshot.nvme_bytes
+                != pool_snapshot
+                    .nvme_reads
+                    .saturating_mul(spec.cfg.model.expert_size as u64)
+        {
+            return Err(BenchmarkFailure::new(
+                "postcondition",
+                "oracle-source-pool-reconciliation",
+                format!("isolated ORACLE source pool did not reconcile: {pool_snapshot:?}"),
+            )
+            .into());
+        }
+        let source_memory_planes = SourceMemoryPlaneEvidence {
+            production_ram_cache_capacity_slots: FROZEN_RAM_CACHE_SLOTS,
+            production_ram_cache_max_resident_bytes: expected_oracle_source_allocated_bytes,
+            production_primary_pool_capacity_slots: runtime.engine.core.pool.capacity(),
+            production_primary_headroom_slots: runtime
+                .engine
+                .core
+                .pool
+                .capacity()
+                .saturating_sub(runtime.engine.core.cache.capacity()),
+            production_primary_pool_available_before_requests,
+            production_primary_pool_available_after_requests,
+            production_primary_pool_buffer_size_bytes: runtime.engine.core.pool.buffer_size(),
+            production_primary_pool_allocated_bytes: runtime.engine.core.pool.allocated_bytes(),
+            oracle_source_pool_configured_max_slots: ORACLE_FUTURE_SOURCE_POOL_SLOTS,
+            oracle_source_pool_allocated_capacity_slots: pool_snapshot.capacity_slots,
+            oracle_source_pool_buffer_size_bytes: pool_snapshot.buffer_size_bytes,
+            oracle_source_pool_allocated_bytes: pool_snapshot.allocated_bytes,
+            oracle_source_pool_current_in_use_slots: pool_snapshot.current_in_use_slots,
+            oracle_source_pool_peak_in_use_slots: pool_snapshot.peak_in_use_slots,
+            oracle_source_pool_exhaustion_count: pool_snapshot.exhaustion_count,
+            oracle_source_nvme_reads: pool_snapshot.nvme_reads,
+            oracle_source_bytes: pool_snapshot.nvme_bytes,
+            oracle_source_pool_reused_across_warmup_and_measured_requests: oracle_source_pool
+                .is_some(),
+            no_oracle_pool_accumulation_across_requests: true,
+            oracle_source_buffers_released_before_runtime_shutdown: true,
+            future_source_pool_isolated_from_production_primary: true,
+            production_primary_pool_capacity_unchanged: runtime.engine.core.pool.capacity()
+                == expected_production_primary_capacity,
+        };
+        Ok::<_, Box<dyn std::error::Error>>((validated, warmup, measured, source_memory_planes))
     }
     .await;
+    drop(oracle_source_pool);
+    let oracle_source_pool_released =
+        crate::buffer_pool::expert_buffer_pool_qualification_oracle_bytes()
+            == oracle_allocation_before;
     let shutdown = runtime.shutdown_isolated().await;
-    let (validated, warmup, measured, shutdown) = match (execution, shutdown) {
-        (Ok((validated, warmup, measured)), Ok(shutdown)) => {
+    let (validated, warmup, measured, source_memory_planes, shutdown) = match (execution, shutdown)
+    {
+        (Ok((validated, warmup, measured, source_memory_planes)), Ok(shutdown)) => {
+            if !oracle_source_pool_released {
+                return Err(BenchmarkFailure::new(
+                    "postcondition",
+                    "oracle-source-pool-shutdown-leak",
+                    "qualification-owned ORACLE source allocation survived pre-shutdown release",
+                )
+                .into());
+            }
             if !shutdown.controlled_shutdown_requested || !shutdown.all_runtime_resources_released {
                 return Err(BenchmarkFailure::new(
                     "postcondition",
@@ -2513,7 +3185,7 @@ pub(crate) async fn run_command(args: CommandArgs) -> Result<(), Box<dyn std::er
                 )
                 .into());
             }
-            (validated, warmup, measured, shutdown)
+            (validated, warmup, measured, source_memory_planes, shutdown)
         }
         (Err(error), Ok(_)) => return Err(error),
         (Ok(_), Err(error)) => return Err(error.into()),
@@ -2589,6 +3261,16 @@ pub(crate) async fn run_command(args: CommandArgs) -> Result<(), Box<dyn std::er
             shared_runtime_and_cache: true,
             initial_position_priming: "synchronous source-to-RAM priming is included in request/TTFT timing; no position-zero physical oracle install is performed",
         },
+        predecessor_first_attempt: PredecessorFirstAttemptEvidence {
+            code_sha: PREDECESSOR_FIRST_ATTEMPT_CODE_SHA,
+            result: "FAIL",
+            failure: "ProductionBatchPoolUnavailableAfterReservation",
+            requested: 8,
+            acquired: 1,
+            interpretation: "future source retained production-primary buffers across foreground demand",
+            first_attempt_rerun: false,
+        },
+        source_memory_planes,
         correctness: CorrectnessEvidence {
             warmup_matches_measured: all_measured_outputs_identical,
             all_measured_outputs_identical,
@@ -2622,8 +3304,53 @@ pub(crate) async fn run_command(args: CommandArgs) -> Result<(), Box<dyn std::er
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::atomic::{AtomicU64, Ordering};
+    use crate::io_provider::{NvmeStorage, StorageConfig};
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
     use std::time::Duration;
+
+    struct TempSourceDir {
+        path: PathBuf,
+    }
+
+    impl TempSourceDir {
+        fn with_experts(label: &str, count: u32, expert_size: usize) -> Self {
+            static COUNTER: AtomicU32 = AtomicU32::new(0);
+            let serial = COUNTER.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "mer-oracle-source-{label}-{}-{serial}",
+                std::process::id()
+            ));
+            std::fs::create_dir_all(&path).unwrap();
+            for id in 0..count {
+                std::fs::write(
+                    path.join(format!("expert_{id}.bin")),
+                    vec![id as u8; expert_size],
+                )
+                .unwrap();
+            }
+            Self { path }
+        }
+
+        fn storage(&self, expert_size: usize, block_align: usize) -> Arc<NvmeStorage> {
+            Arc::new(
+                NvmeStorage::new(StorageConfig {
+                    base_path: self.path.clone(),
+                    expert_size,
+                    block_align,
+                    use_direct_io: false,
+                    num_experts_per_layer: None,
+                })
+                .unwrap(),
+            )
+        }
+    }
+
+    impl Drop for TempSourceDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
 
     fn test_trace(positions: usize) -> Arc<OracleRouteTrace> {
         let geometry = OracleGeometry {
@@ -2682,13 +3409,12 @@ mod tests {
         let source_position_gate = Arc::new(tokio::sync::Mutex::new(()));
         let position_guard = source_position_gate.clone().lock_owned().await;
         let readiness = Arc::new(SourceReadiness::default());
-        let counters_for_task = counters.clone();
         let (send_outcome, receive_outcome) = tokio::sync::oneshot::channel();
         let handle = tokio::spawn(async move {
             let outcome = receive_outcome
                 .await
                 .expect("test controls source task completion");
-            PrefetchLease::new(outcome, counters_for_task, position_guard)
+            PrefetchLease::new(outcome, position_guard)
         });
         counters.lock().background_tasks_spawned += 1;
         (
@@ -2774,6 +3500,283 @@ mod tests {
         assert!(OracleScheduledResidencyMode::from_str("overlapped-h2d", false).is_err());
     }
 
+    #[test]
+    fn v2_schema_and_predecessor_failure_contract_are_frozen() {
+        assert_eq!(SCHEMA, "mer.gpu-native-oracle-scheduled-residency.v2");
+        let predecessor = PredecessorFirstAttemptEvidence {
+            code_sha: PREDECESSOR_FIRST_ATTEMPT_CODE_SHA,
+            result: "FAIL",
+            failure: "ProductionBatchPoolUnavailableAfterReservation",
+            requested: 8,
+            acquired: 1,
+            interpretation:
+                "future source retained production-primary buffers across foreground demand",
+            first_attempt_rerun: false,
+        };
+        let value = serde_json::to_value(predecessor).unwrap();
+        assert_eq!(value["code_sha"], PREDECESSOR_FIRST_ATTEMPT_CODE_SHA);
+        assert_eq!(value["result"], "FAIL");
+        assert_eq!(value["requested"], 8);
+        assert_eq!(value["acquired"], 1);
+        assert_eq!(value["first_attempt_rerun"], false);
+    }
+
+    #[test]
+    fn v2_memory_report_distinguishes_production_and_oracle_planes() {
+        let evidence = SourceMemoryPlaneEvidence {
+            production_ram_cache_capacity_slots: 384,
+            production_ram_cache_max_resident_bytes: 384 * 4096,
+            production_primary_pool_capacity_slots: 385,
+            production_primary_headroom_slots: 1,
+            production_primary_pool_available_before_requests: 1,
+            production_primary_pool_available_after_requests: 1,
+            production_primary_pool_buffer_size_bytes: 4096,
+            production_primary_pool_allocated_bytes: 385 * 4096,
+            oracle_source_pool_configured_max_slots: 384,
+            oracle_source_pool_allocated_capacity_slots: 384,
+            oracle_source_pool_buffer_size_bytes: 4096,
+            oracle_source_pool_allocated_bytes: 384 * 4096,
+            oracle_source_pool_current_in_use_slots: 0,
+            oracle_source_pool_peak_in_use_slots: 384,
+            oracle_source_pool_exhaustion_count: 0,
+            oracle_source_nvme_reads: 4,
+            oracle_source_bytes: 4 * 4096,
+            oracle_source_pool_reused_across_warmup_and_measured_requests: true,
+            no_oracle_pool_accumulation_across_requests: true,
+            oracle_source_buffers_released_before_runtime_shutdown: true,
+            future_source_pool_isolated_from_production_primary: true,
+            production_primary_pool_capacity_unchanged: true,
+        };
+        let value = serde_json::to_value(evidence).unwrap();
+        assert_eq!(value["production_ram_cache_capacity_slots"], 384);
+        assert_eq!(value["production_primary_pool_capacity_slots"], 385);
+        assert_eq!(value["production_primary_headroom_slots"], 1);
+        assert_eq!(value["oracle_source_pool_allocated_capacity_slots"], 384);
+        assert_eq!(value["oracle_source_pool_current_in_use_slots"], 0);
+        assert_eq!(
+            value["oracle_source_pool_reused_across_warmup_and_measured_requests"],
+            true
+        );
+        assert_eq!(
+            value["future_source_pool_isolated_from_production_primary"],
+            true
+        );
+    }
+
+    #[test]
+    fn exact_oracle_source_bound_uses_runtime_expert_file_bytes() {
+        assert_eq!(ORACLE_FUTURE_SOURCE_POOL_SLOTS, 48 * 8);
+        assert_eq!(
+            oracle_future_source_allocated_bytes(2_658_304),
+            Some(1_020_788_736)
+        );
+    }
+
+    #[test]
+    fn retained_source_origin_contract_fails_closed() {
+        let production_pool = BufferPool::new(1, 4096, 4096);
+        let production_resident = Arc::new(ExpertResident::new_with_block_align(
+            7,
+            production_pool.try_acquire().unwrap(),
+            4096,
+        ));
+        let mut outcome = PrefetchOutcome::default();
+        outcome.residents.insert(7, production_resident);
+        assert!(validate_retained_source_origins(
+            OracleScheduledResidencyMode::TokenBoundaryDirect,
+            &outcome,
+        )
+        .is_err());
+        assert!(validate_retained_source_origins(
+            OracleScheduledResidencyMode::SourceOnly,
+            &outcome,
+        )
+        .is_err());
+
+        let oracle_pool = OracleFutureSourcePool::new(1, 4096, 4096);
+        let oracle_resident = Arc::new(ExpertResident::new_with_block_align(
+            8,
+            oracle_pool.try_acquire().unwrap(),
+            4096,
+        ));
+        let mut isolated = PrefetchOutcome::default();
+        isolated.residents.insert(8, oracle_resident);
+        assert!(validate_retained_source_origins(
+            OracleScheduledResidencyMode::TokenBoundaryDirect,
+            &isolated,
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn isolated_oracle_retention_preserves_foreground_primary_capacity() {
+        const BUFFER_SIZE: usize = 4096;
+        let production_pool = BufferPool::new(3, BUFFER_SIZE, 4096);
+        let production_cache = crate::expert_cache::ExpertCache::new(2);
+        let insert_primary = |id| {
+            production_cache
+                .insert(Arc::new(ExpertResident::new_with_block_align(
+                    id,
+                    production_pool.try_acquire().unwrap(),
+                    4096,
+                )))
+                .unwrap_or_else(|_| panic!("test production-cache insert failed"));
+        };
+
+        insert_primary(0);
+        insert_primary(1);
+        assert_eq!(production_pool.primary_available(), 1);
+        let retained_victims = [
+            production_cache.get(0).unwrap(),
+            production_cache.get(1).unwrap(),
+        ];
+        drop(production_cache.evict_lru().unwrap());
+        drop(production_cache.evict_lru().unwrap());
+        assert_eq!(
+            production_pool.primary_available(),
+            1,
+            "request-local victim Arcs reproduce the one-headroom-buffer condition"
+        );
+        drop(retained_victims);
+        assert_eq!(production_pool.primary_available(), 3);
+
+        insert_primary(2);
+        insert_primary(3);
+        let oracle_pool = OracleFutureSourcePool::new(1, BUFFER_SIZE, 4096);
+        let retained_oracle = Arc::new(ExpertResident::new_with_block_align(
+            4,
+            oracle_pool.try_acquire().unwrap(),
+            4096,
+        ));
+        drop(production_cache.evict_lru().unwrap());
+        drop(production_cache.evict_lru().unwrap());
+        assert_eq!(production_pool.primary_available(), 3);
+
+        let foreground_a = production_pool.try_acquire().unwrap();
+        let foreground_b = production_pool.try_acquire().unwrap();
+        assert_eq!(production_pool.primary_available(), 1);
+        assert_eq!(oracle_pool.snapshot().current_in_use_slots, 1);
+        drop(foreground_a);
+        drop(foreground_b);
+        drop(retained_oracle);
+        assert_eq!(production_pool.primary_available(), 3);
+        assert_eq!(oracle_pool.snapshot().current_in_use_slots, 0);
+    }
+
+    #[test]
+    fn one_source_pool_is_reused_without_request_accumulation() {
+        let pool = Arc::new(OracleFutureSourcePool::new(2, 4096, 4096));
+        let allocation = Arc::as_ptr(&pool);
+        for _ in 0..(FROZEN_WARMUP_RUNS + FROZEN_MEASURED_RUNS) {
+            let request_pool = pool.clone();
+            assert_eq!(Arc::as_ptr(&request_pool), allocation);
+            let first = request_pool.try_acquire().unwrap();
+            let second = request_pool.try_acquire().unwrap();
+            assert_eq!(request_pool.snapshot().current_in_use_slots, 2);
+            drop(first);
+            drop(second);
+            assert_eq!(request_pool.snapshot().current_in_use_slots, 0);
+        }
+        let snapshot = pool.snapshot();
+        assert_eq!(snapshot.capacity_slots, 2);
+        assert_eq!(snapshot.allocated_bytes, 2 * 4096);
+        assert_eq!(snapshot.peak_in_use_slots, 2);
+        assert_eq!(snapshot.current_in_use_slots, 0);
+    }
+
+    #[test]
+    fn direct_source_and_boundary_resolution_orders_are_explicit() {
+        assert_eq!(
+            direct_future_source_disposition(true, true),
+            DirectFutureSourceDisposition::AlreadyPhysical
+        );
+        assert_eq!(
+            direct_future_source_disposition(false, true),
+            DirectFutureSourceDisposition::DeferredCurrentDemandOverlap
+        );
+        assert_eq!(
+            direct_future_source_disposition(false, false),
+            DirectFutureSourceDisposition::IsolatedRead
+        );
+        assert_eq!(
+            direct_boundary_source_disposition(true, true, true),
+            DirectBoundarySourceDisposition::Physical
+        );
+        assert_eq!(
+            direct_boundary_source_disposition(false, true, true),
+            DirectBoundarySourceDisposition::Isolated
+        );
+        assert_eq!(
+            direct_boundary_source_disposition(false, false, true),
+            DirectBoundarySourceDisposition::ProductionRam
+        );
+        assert_eq!(
+            direct_boundary_source_disposition(false, false, false),
+            DirectBoundarySourceDisposition::ResidualRead
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn direct_nvme_source_is_isolated_not_cached_and_recycled() {
+        const EXPERT_SIZE: usize = 4096;
+        let dir = TempSourceDir::with_experts("isolated", 2, EXPERT_SIZE);
+        let storage = dir.storage(EXPERT_SIZE, 4096);
+        let production_pool = BufferPool::new(1, EXPERT_SIZE, 4096);
+        let production_cache = crate::expert_cache::ExpertCache::new(2);
+        let production_available = production_pool.primary_available();
+        let oracle_pool = OracleFutureSourcePool::new(2, EXPERT_SIZE, 4096);
+
+        let (resident, bytes) = read_oracle_future_source_from_storage(&storage, &oracle_pool, 0)
+            .await
+            .unwrap();
+        assert_eq!(bytes, EXPERT_SIZE);
+        assert_eq!(
+            resident.buffer_pool_origin(),
+            BufferPoolOrigin::QualificationOracleFutureSource
+        );
+        assert_eq!(production_pool.primary_available(), production_available);
+        assert_eq!(production_cache.len(), 0);
+        assert_eq!(oracle_pool.current_in_use_slots(), 1);
+        let snapshot = oracle_pool.snapshot();
+        assert_eq!(snapshot.capacity_slots, 2);
+        assert_eq!(snapshot.allocated_bytes, 2 * EXPERT_SIZE);
+        assert_eq!(snapshot.peak_in_use_slots, 1);
+        assert_eq!(snapshot.nvme_reads, 1);
+        assert_eq!(snapshot.nvme_bytes, EXPERT_SIZE as u64);
+        drop(resident);
+        assert_eq!(oracle_pool.current_in_use_slots(), 0);
+
+        let (reused, _) = read_oracle_future_source_from_storage(&storage, &oracle_pool, 1)
+            .await
+            .unwrap();
+        assert_eq!(oracle_pool.current_in_use_slots(), 1);
+        drop(reused);
+        assert_eq!(oracle_pool.current_in_use_slots(), 0);
+        assert_eq!(oracle_pool.snapshot().nvme_reads, 2);
+        assert_eq!(production_cache.len(), 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn direct_source_pool_exhaustion_fails_closed_without_primary_fallback() {
+        const EXPERT_SIZE: usize = 4096;
+        let dir = TempSourceDir::with_experts("exhaustion", 2, EXPERT_SIZE);
+        let storage = dir.storage(EXPERT_SIZE, 4096);
+        let production_pool = BufferPool::new(1, EXPERT_SIZE, 4096);
+        let oracle_pool = OracleFutureSourcePool::new(1, EXPERT_SIZE, 4096);
+        let (held, _) = read_oracle_future_source_from_storage(&storage, &oracle_pool, 0)
+            .await
+            .unwrap();
+        let error = match read_oracle_future_source_from_storage(&storage, &oracle_pool, 1).await {
+            Ok(_) => panic!("exhausted ORACLE pool must not fall back to PRIMARY"),
+            Err(error) => error,
+        };
+        assert!(matches!(error, OracleSourceReadError::PoolExhausted(_)));
+        assert_eq!(oracle_pool.snapshot().exhaustion_count, 1);
+        assert_eq!(production_pool.primary_available(), 1);
+        drop(held);
+        assert_eq!(oracle_pool.current_in_use_slots(), 0);
+    }
+
     #[tokio::test]
     async fn source_layer_tasks_obey_bounded_concurrency() {
         let concurrency = 3usize;
@@ -2829,6 +3832,12 @@ mod tests {
             serde_json::to_value(direct).unwrap()["late_source_policy"],
             "await-residual-at-safe-boundary"
         );
+        for contract in [source_only, direct] {
+            assert!(!contract.production_predictor_used);
+            assert!(!contract.production_speculative_residency_used);
+            assert!(contract.future_source_pool_isolated_from_production_primary);
+            assert!(contract.production_primary_pool_capacity_unchanged);
+        }
     }
 
     #[tokio::test]
@@ -2878,14 +3887,19 @@ mod tests {
         let state = test_scheduler_state();
         let (active, send_outcome, source_position_gate, readiness) =
             pending_test_prefetch(1, counters.clone()).await;
-        readiness.mark_physical_ready(0);
         readiness.mark_source_resident_ready(1);
         let mut resolving = Box::pin(resolve_source_task_at_boundary(
             OracleScheduledResidencyMode::TokenBoundaryDirect,
             active,
             1,
             vec![0, 1, 2, 3],
-            |_| Ok(BoundarySourceReadiness::Unavailable),
+            |global_id| {
+                Ok(if global_id == 0 {
+                    BoundarySourceReadiness::Physical
+                } else {
+                    BoundarySourceReadiness::Unavailable
+                })
+            },
             counters.clone(),
             state.clone(),
         ));
@@ -2914,11 +3928,14 @@ mod tests {
         assert!(source_position_gate.clone().try_lock_owned().is_err());
         record_direct_late_fallback(&mut counters.lock(), was_late, 0);
         assert_eq!(counters.lock().source_late_degraded_to_demand, 0);
+        let oracle_pool = Arc::new(OracleFutureSourcePool::new(1, 4096, 4096));
         release_source_position_lease_before_next_token(
             OracleScheduledResidencyMode::TokenBoundaryDirect,
             lease,
             &source_position_gate,
             &state,
+            Some(&oracle_pool),
+            &counters,
         )
         .unwrap();
         assert!(source_position_gate.try_lock_owned().is_ok());
@@ -3022,16 +4039,20 @@ mod tests {
         record_direct_late_fallback(&mut counters.lock(), was_late, 1);
         record_demand_readiness(&mut counters.lock(), &[vec![false]]);
         {
-            let values = counters.lock();
-            assert_eq!(values.source_failures_degraded_to_demand, 1);
+            let mut values = counters.lock();
+            assert_eq!(values.source_failures_degraded_to_demand, 0);
+            values.source_failures_degraded_to_demand = 1;
             assert_eq!(values.source_late_degraded_to_demand, 1);
             assert_eq!(values.oracle_demand_fallback, 1);
         }
+        let oracle_pool = Arc::new(OracleFutureSourcePool::new(1, 4096, 4096));
         release_source_position_lease_before_next_token(
             OracleScheduledResidencyMode::TokenBoundaryDirect,
             lease,
             &source_position_gate,
             &state,
+            Some(&oracle_pool),
+            &counters,
         )
         .unwrap();
     }
@@ -3102,7 +4123,12 @@ mod tests {
             ..PrefetchOutcome::default()
         };
         let mut counters = OracleCounters::default();
-        record_completed_source_outcome(&mut counters, &outcome, 0);
+        record_completed_source_outcome(
+            &mut counters,
+            &outcome,
+            0,
+            OracleScheduledResidencyMode::SourceOnly,
+        );
         record_demand_readiness(&mut counters, &[vec![false, false]]);
         assert_eq!(counters.source_failures_degraded_to_demand, 2);
         assert_eq!(counters.oracle_demand_fallback, 1);
@@ -3260,6 +4286,7 @@ mod tests {
             &valid_source_only_counters(),
             OracleScheduledResidencyMode::SourceOnly,
             4,
+            4096,
         )
         .is_ok());
     }
@@ -3269,10 +4296,13 @@ mod tests {
         let mut counters = valid_source_only_counters();
         counters.boundary_replacement_sets_started = 1;
         counters.boundary_physical_installs = 1;
-        assert!(
-            validate_oracle_counters(&counters, OracleScheduledResidencyMode::SourceOnly, 4,)
-                .is_err()
-        );
+        assert!(validate_oracle_counters(
+            &counters,
+            OracleScheduledResidencyMode::SourceOnly,
+            4,
+            4096,
+        )
+        .is_err());
     }
 
     #[test]
@@ -3300,10 +4330,13 @@ mod tests {
     fn qualification_temporary_state_bound_is_fail_closed() {
         let mut counters = valid_source_only_counters();
         counters.qualification_owned_peak_slots = FROZEN_RAM_CACHE_SLOTS as u64 + 1;
-        assert!(
-            validate_oracle_counters(&counters, OracleScheduledResidencyMode::SourceOnly, 4,)
-                .is_err()
-        );
+        assert!(validate_oracle_counters(
+            &counters,
+            OracleScheduledResidencyMode::SourceOnly,
+            4,
+            4096,
+        )
+        .is_err());
     }
 
     #[tokio::test]

--- a/rust-engine/src/gpu_native_oracle_scheduled_residency.rs
+++ b/rust-engine/src/gpu_native_oracle_scheduled_residency.rs
@@ -32,7 +32,7 @@ use futures::{stream, StreamExt};
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::Arc;
@@ -71,6 +71,22 @@ const FROZEN_RAM_CACHE_SLOTS: usize = 384;
 pub(crate) enum OracleScheduledResidencyMode {
     SourceOnly,
     TokenBoundaryDirect,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+enum LateSourcePolicy {
+    NonblockingDemandFallback,
+    AwaitResidualAtSafeBoundary,
+}
+
+const fn late_source_policy(mode: OracleScheduledResidencyMode) -> LateSourcePolicy {
+    match mode {
+        OracleScheduledResidencyMode::SourceOnly => LateSourcePolicy::NonblockingDemandFallback,
+        OracleScheduledResidencyMode::TokenBoundaryDirect => {
+            LateSourcePolicy::AwaitResidualAtSafeBoundary
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -441,6 +457,97 @@ struct PrefetchOutcome {
     fatal_error: Option<String>,
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct SourceReadinessSnapshot {
+    required_ready: u64,
+    source_residents_ready: u64,
+}
+
+#[derive(Default)]
+struct SourceReadinessState {
+    physical_ready: HashSet<u32>,
+    source_residents_ready: HashSet<u32>,
+}
+
+#[derive(Default)]
+struct SourceReadiness {
+    state: Mutex<SourceReadinessState>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum BoundarySourceReadiness {
+    Physical,
+    SourceResident,
+    Unavailable,
+}
+
+impl SourceReadiness {
+    fn mark_physical_ready(&self, global_id: u32) {
+        self.state.lock().physical_ready.insert(global_id);
+    }
+
+    fn mark_source_resident_ready(&self, global_id: u32) {
+        let mut state = self.state.lock();
+        state.source_residents_ready.insert(global_id);
+    }
+
+    fn validate_snapshot(
+        snapshot: SourceReadinessSnapshot,
+        required_experts: u64,
+    ) -> Result<SourceReadinessSnapshot, String> {
+        if snapshot.source_residents_ready > snapshot.required_ready
+            || snapshot.required_ready > required_experts
+        {
+            return Err(format!(
+                "future source readiness is inconsistent: required_ready={} source_residents_ready={} required_experts={required_experts}",
+                snapshot.required_ready, snapshot.source_residents_ready
+            ));
+        }
+        Ok(snapshot)
+    }
+
+    fn snapshot_at_boundary<T, F>(
+        &self,
+        handle: &tokio::task::JoinHandle<T>,
+        required_global_ids: &[u32],
+        mut current_readiness: F,
+    ) -> Result<(SourceReadinessSnapshot, bool), String>
+    where
+        F: FnMut(u32) -> Result<BoundarySourceReadiness, String>,
+    {
+        // Source progress updates use this same lock. Holding it across
+        // `is_finished` ties the readiness count to the exact task-finished
+        // decision used at the boundary instead of rescanning a changing cache.
+        let state = self.state.lock();
+        let task_finished = handle.is_finished();
+        let mut required_ready = 0u64;
+        let mut source_residents_ready = 0u64;
+        let mut unique = HashSet::with_capacity(required_global_ids.len());
+        for &global_id in required_global_ids {
+            if !unique.insert(global_id) {
+                return Err(format!(
+                    "future source readiness contains duplicate global expert {global_id}"
+                ));
+            }
+            let live = current_readiness(global_id)?;
+            let physical_ready = state.physical_ready.contains(&global_id)
+                || live == BoundarySourceReadiness::Physical;
+            let source_ready = state.source_residents_ready.contains(&global_id)
+                || live == BoundarySourceReadiness::SourceResident;
+            required_ready += u64::from(physical_ready || source_ready);
+            source_residents_ready += u64::from(source_ready);
+        }
+        let snapshot = SourceReadinessSnapshot {
+            required_ready,
+            source_residents_ready,
+        };
+        Ok((
+            Self::validate_snapshot(snapshot, required_global_ids.len() as u64)?,
+            task_finished,
+        ))
+    }
+}
+
 struct PrefetchLease {
     outcome: PrefetchOutcome,
     counters: Arc<Mutex<OracleCounters>>,
@@ -498,6 +605,7 @@ async fn prefetch_layer_batch(
     layer_index: usize,
     local_ids: Vec<u32>,
     counters: Arc<Mutex<OracleCounters>>,
+    readiness: Arc<SourceReadiness>,
 ) -> PrefetchOutcome {
     let _guard = LayerBatchGuard::enter(counters.clone());
     let mut outcome = PrefetchOutcome::default();
@@ -538,6 +646,7 @@ async fn prefetch_layer_batch(
         match source_disposition(physical_current, ram_resident.is_some(), singleflight) {
             SourceDisposition::AlreadyPhysical => {
                 counters.lock().source_skipped_physical_current += 1;
+                readiness.mark_physical_ready(global_id);
                 continue;
             }
             SourceDisposition::RamHit => {
@@ -546,6 +655,7 @@ async fn prefetch_layer_batch(
                     global_id,
                     ram_resident.expect("RAM-hit disposition has a resident"),
                 );
+                readiness.mark_source_resident_ready(global_id);
                 continue;
             }
             SourceDisposition::SourceInFlight => {
@@ -566,6 +676,7 @@ async fn prefetch_layer_batch(
                     add_counter(&mut values.source_bytes_read, resident.data().len() as u64);
                 }
                 drop(values);
+                readiness.mark_source_resident_ready(global_id);
                 outcome.residents.insert(global_id, resident);
             }
             Err(error) => {
@@ -587,19 +698,21 @@ async fn prefetch_position(
     concurrency: usize,
     expert_bytes: usize,
     counters: Arc<Mutex<OracleCounters>>,
+    readiness: Arc<SourceReadiness>,
 ) -> PrefetchOutcome {
     let started = Instant::now();
     let semaphore = Arc::new(tokio::sync::Semaphore::new(concurrency));
     let batches = stream::iter(routes.into_iter().enumerate().map(|(layer_index, ids)| {
         let engine = engine.clone();
         let counters = counters.clone();
+        let readiness = readiness.clone();
         let semaphore = semaphore.clone();
         async move {
             let permit = semaphore
                 .acquire_owned()
                 .await
                 .expect("qualification semaphore remains open");
-            let result = prefetch_layer_batch(engine, layer_index, ids, counters).await;
+            let result = prefetch_layer_batch(engine, layer_index, ids, counters, readiness).await;
             drop(permit);
             result
         }
@@ -1027,6 +1140,15 @@ fn install_future_at_boundary(
 struct ActivePrefetch {
     target_position: usize,
     handle: Option<tokio::task::JoinHandle<PrefetchLease>>,
+    readiness: Arc<SourceReadiness>,
+}
+
+enum BoundarySourceResolution {
+    DeferredToDemand,
+    Completed {
+        lease: PrefetchLease,
+        was_late: bool,
+    },
 }
 
 struct SchedulerState {
@@ -1045,6 +1167,118 @@ struct OracleScheduler {
     source_position_gate: Arc<tokio::sync::Mutex<()>>,
     counters: Arc<Mutex<OracleCounters>>,
     state: Arc<Mutex<SchedulerState>>,
+}
+
+async fn resolve_source_task_at_boundary<F>(
+    mode: OracleScheduledResidencyMode,
+    active: ActivePrefetch,
+    expected_target_position: usize,
+    required_global_ids: Vec<u32>,
+    current_readiness: F,
+    counters: Arc<Mutex<OracleCounters>>,
+    state: Arc<Mutex<SchedulerState>>,
+) -> Result<BoundarySourceResolution, String>
+where
+    F: FnMut(u32) -> Result<BoundarySourceReadiness, String> + Send,
+{
+    if active.target_position != expected_target_position {
+        return Err(format!(
+            "future source task targets {}, expected {expected_target_position}",
+            active.target_position
+        ));
+    }
+    if mode == OracleScheduledResidencyMode::TokenBoundaryDirect
+        && !state.lock().background.is_empty()
+    {
+        return Err(
+            "token-boundary-direct retained a previous-position background source task".into(),
+        );
+    }
+
+    let Some(handle) = active.handle else {
+        if mode == OracleScheduledResidencyMode::TokenBoundaryDirect {
+            return Err(
+                "token-boundary-direct skipped future source because a prior position lease remained in flight"
+                    .into(),
+            );
+        }
+        return Err("source-only position-gate skip was not resolved at the boundary".into());
+    };
+    let required_experts = required_global_ids.len() as u64;
+    let (readiness_at_boundary, task_finished_at_boundary) = active
+        .readiness
+        .snapshot_at_boundary(&handle, &required_global_ids, current_readiness)?;
+    let was_late = !task_finished_at_boundary;
+    let late_experts = required_experts.saturating_sub(readiness_at_boundary.required_ready);
+
+    if was_late {
+        record_source_late(&mut counters.lock(), late_experts, late_source_policy(mode));
+        if mode == OracleScheduledResidencyMode::SourceOnly {
+            let state_for_task = state.clone();
+            let counters_for_task = counters.clone();
+            let discard = tokio::spawn(async move {
+                let joined = handle.await;
+                counters_for_task.lock().background_tasks_drained += 1;
+                match joined {
+                    Ok(lease) => {
+                        if let Some(error) = lease.outcome.fatal_error.as_ref() {
+                            state_for_task.lock().failure = Some(error.clone());
+                        }
+                    }
+                    Err(error) => {
+                        state_for_task.lock().failure =
+                            Some(format!("future source task failed to join: {error}"));
+                    }
+                }
+            });
+            state.lock().background.push(discard);
+            return Ok(BoundarySourceResolution::DeferredToDemand);
+        }
+    }
+
+    let wait_started = Instant::now();
+    let joined = handle.await;
+    add_counter(
+        &mut counters.lock().oracle_wait_before_next_token_us,
+        saturating_us(wait_started),
+    );
+    counters.lock().background_tasks_drained += 1;
+    let lease = joined.map_err(|error| format!("future source task failed to join: {error}"))?;
+    if lease.outcome.target_position != expected_target_position {
+        return Err("completed future source task returned the wrong position".into());
+    }
+    if let Some(error) = lease.outcome.fatal_error.as_ref() {
+        return Err(error.clone());
+    }
+    record_completed_source_outcome(
+        &mut counters.lock(),
+        &lease.outcome,
+        readiness_at_boundary.source_residents_ready,
+    );
+    Ok(BoundarySourceResolution::Completed { lease, was_late })
+}
+
+fn release_source_position_lease_before_next_token(
+    mode: OracleScheduledResidencyMode,
+    lease: PrefetchLease,
+    source_position_gate: &Arc<tokio::sync::Mutex<()>>,
+    state: &Arc<Mutex<SchedulerState>>,
+) -> Result<(), String> {
+    drop(lease);
+    if mode == OracleScheduledResidencyMode::TokenBoundaryDirect {
+        let position_guard = source_position_gate.clone().try_lock_owned().map_err(|_| {
+            "token-boundary-direct retained the completed position lease before the next token"
+                .to_string()
+        })?;
+        drop(position_guard);
+        if !state.lock().background.is_empty() {
+            return Err(
+                "token-boundary-direct accumulated a previous-position background source task"
+                    .into(),
+            );
+        }
+    }
+    Ok(())
 }
 
 impl OracleScheduler {
@@ -1077,6 +1311,7 @@ impl OracleScheduler {
         record_source_position_considered(&mut self.counters.lock(), &routes);
         let started = Instant::now();
         let position_guard = self.source_position_gate.clone().lock_owned().await;
+        let readiness = Arc::new(SourceReadiness::default());
         let lease = PrefetchLease::new(
             prefetch_position(
                 self.engine.clone(),
@@ -1085,6 +1320,7 @@ impl OracleScheduler {
                 self.concurrency,
                 self.expert_bytes,
                 self.counters.clone(),
+                readiness,
             )
             .await,
             self.counters.clone(),
@@ -1134,7 +1370,7 @@ impl OracleScheduler {
         Ok(())
     }
 
-    fn late_source_count(&self, routes: &[Vec<u32>]) -> Result<u64, String> {
+    fn future_not_physically_current_count(&self, routes: &[Vec<u32>]) -> Result<u64, String> {
         let manager = self
             .engine
             .core
@@ -1142,7 +1378,59 @@ impl OracleScheduler {
             .as_ref()
             .ok_or("GPU-native residency manager is absent")?;
         let experts_per_layer = manager.plan().geometry().num_experts() as u32;
-        let mut late = 0u64;
+        let mut unavailable = 0u64;
+        for (layer_index, local_ids) in routes.iter().enumerate() {
+            for global_id in future_global_ids(
+                layer_index,
+                local_ids,
+                manager.plan().num_layers(),
+                experts_per_layer,
+            )
+            .map_err(|error| error.to_string())?
+            {
+                if !manager
+                    .has_current_for_demand(global_id)
+                    .map_err(|error| error.to_string())?
+                {
+                    unavailable += 1;
+                }
+            }
+        }
+        Ok(unavailable)
+    }
+
+    fn required_future_global_ids(&self, routes: &[Vec<u32>]) -> Result<Vec<u32>, String> {
+        let manager = self
+            .engine
+            .core
+            .gpu_native_residency
+            .as_ref()
+            .ok_or("GPU-native residency manager is absent")?;
+        let experts_per_layer = manager.plan().geometry().num_experts() as u32;
+        let mut required = Vec::with_capacity(routes.iter().map(Vec::len).sum());
+        for (layer_index, local_ids) in routes.iter().enumerate() {
+            required.extend(
+                future_global_ids(
+                    layer_index,
+                    local_ids,
+                    manager.plan().num_layers(),
+                    experts_per_layer,
+                )
+                .map_err(|error| error.to_string())?,
+            );
+        }
+        Ok(required)
+    }
+
+    fn future_source_not_ready_count(&self, routes: &[Vec<u32>]) -> Result<u64, String> {
+        let manager = self
+            .engine
+            .core
+            .gpu_native_residency
+            .as_ref()
+            .ok_or("GPU-native residency manager is absent")?;
+        let experts_per_layer = manager.plan().geometry().num_experts() as u32;
+        let mut unavailable = 0u64;
         for (layer_index, local_ids) in routes.iter().enumerate() {
             for global_id in future_global_ids(
                 layer_index,
@@ -1157,11 +1445,11 @@ impl OracleScheduler {
                     .map_err(|error| error.to_string())?
                     && !self.engine.core.cache.contains(global_id)
                 {
-                    late += 1;
+                    unavailable += 1;
                 }
             }
         }
-        Ok(late)
+        Ok(unavailable)
     }
 
     fn record_position_gate_skip(&self, routes: &[Vec<u32>]) -> Result<(), String> {
@@ -1241,77 +1529,78 @@ impl OracleScheduler {
         let active = active.ok_or_else(|| {
             format!("position {position} completed without a scheduled future source task")
         })?;
-        if active.target_position != position + 1 {
-            return Err(format!(
-                "future source task targets {}, expected {}",
-                active.target_position,
-                position + 1
-            ));
+        if self.mode == OracleScheduledResidencyMode::SourceOnly && active.handle.is_none() {
+            if active.target_position != position + 1 {
+                return Err(format!(
+                    "future source task targets {}, expected {}",
+                    active.target_position,
+                    position + 1
+                ));
+            }
+            let late_experts = self.future_source_not_ready_count(&routes)?;
+            record_source_late(
+                &mut self.counters.lock(),
+                late_experts,
+                LateSourcePolicy::NonblockingDemandFallback,
+            );
+            return Ok(());
         }
-        let Some(handle) = active.handle else {
-            let late = self.late_source_count(&routes)?;
-            record_source_late(&mut self.counters.lock(), late);
+        let required_global_ids = self.required_future_global_ids(&routes)?;
+        let manager = self
+            .engine
+            .core
+            .gpu_native_residency
+            .as_ref()
+            .ok_or("GPU-native residency manager is absent")?
+            .clone();
+        let engine = self.engine.clone();
+        let BoundarySourceResolution::Completed { lease, was_late } =
+            resolve_source_task_at_boundary(
+                self.mode,
+                active,
+                position + 1,
+                required_global_ids,
+                move |global_id| {
+                    if manager
+                        .has_current_for_demand(global_id)
+                        .map_err(|error| error.to_string())?
+                    {
+                        Ok(BoundarySourceReadiness::Physical)
+                    } else if engine.core.cache.contains(global_id) {
+                        Ok(BoundarySourceReadiness::SourceResident)
+                    } else {
+                        Ok(BoundarySourceReadiness::Unavailable)
+                    }
+                },
+                self.counters.clone(),
+                self.state.clone(),
+            )
+            .await?
+        else {
             return Ok(());
         };
 
-        if !handle.is_finished() {
-            let late = self.late_source_count(&routes)?;
-            {
-                let mut values = self.counters.lock();
-                record_source_late(&mut values, late);
-            }
-            let state_for_task = self.state.clone();
-            let counters_for_task = self.counters.clone();
-            let discard = tokio::spawn(async move {
-                let joined = handle.await;
-                counters_for_task.lock().background_tasks_drained += 1;
-                match joined {
-                    Ok(lease) => {
-                        if let Some(error) = lease.outcome.fatal_error.as_ref() {
-                            state_for_task.lock().failure = Some(error.clone());
-                        }
-                    }
-                    Err(error) => {
-                        state_for_task.lock().failure =
-                            Some(format!("future source task failed to join: {error}"));
-                    }
-                }
-            });
-            self.state.lock().background.push(discard);
-            return Ok(());
-        }
-
-        let wait_started = Instant::now();
-        let joined = handle.await;
-        self.counters.lock().background_tasks_drained += 1;
-        let lease =
-            joined.map_err(|error| format!("future source task failed to join: {error}"))?;
-        let outcome = &lease.outcome;
-        if outcome.target_position != position + 1 {
-            return Err("completed future source task returned the wrong position".into());
-        }
-        if let Some(error) = outcome.fatal_error.as_ref() {
-            return Err(error.clone());
-        }
-        {
-            let mut values = self.counters.lock();
-            record_completed_source_outcome(&mut values, outcome);
-        }
         if self.mode == OracleScheduledResidencyMode::TokenBoundaryDirect {
             install_future_at_boundary(
                 &self.engine,
                 &mut boundary,
                 &routes,
-                &outcome.residents,
+                &lease.outcome.residents,
                 self.counters.clone(),
             )?;
+            let unavailable_after_install = self.future_not_physically_current_count(&routes)?;
+            record_direct_late_fallback(
+                &mut self.counters.lock(),
+                was_late,
+                unavailable_after_install,
+            );
         }
-        add_counter(
-            &mut self.counters.lock().oracle_wait_before_next_token_us,
-            saturating_us(wait_started),
-        );
-        drop(lease);
-        Ok(())
+        release_source_position_lease_before_next_token(
+            self.mode,
+            lease,
+            &self.source_position_gate,
+            &self.state,
+        )
     }
 
     async fn finish_request(&self) -> Result<(OracleCounters, OracleRouteTrace), String> {
@@ -1332,8 +1621,12 @@ impl OracleScheduler {
     }
 }
 
-fn record_completed_source_outcome(counters: &mut OracleCounters, outcome: &PrefetchOutcome) {
-    counters.source_ready_before_boundary += outcome.residents.len() as u64;
+fn record_completed_source_outcome(
+    counters: &mut OracleCounters,
+    outcome: &PrefetchOutcome,
+    source_residents_ready_at_boundary: u64,
+) {
+    counters.source_ready_before_boundary += source_residents_ready_at_boundary;
     counters.source_failures_degraded_to_demand += outcome.failed_ids.len() as u64;
 }
 
@@ -1341,9 +1634,21 @@ fn record_source_position_considered(counters: &mut OracleCounters, routes: &[Ve
     counters.future_experts_considered += routes.iter().map(Vec::len).sum::<usize>() as u64;
 }
 
-fn record_source_late(counters: &mut OracleCounters, late_experts: u64) {
+fn record_source_late(counters: &mut OracleCounters, late_experts: u64, policy: LateSourcePolicy) {
     counters.source_late_at_boundary += late_experts;
-    counters.source_late_degraded_to_demand += 1;
+    if policy == LateSourcePolicy::NonblockingDemandFallback {
+        counters.source_late_degraded_to_demand += 1;
+    }
+}
+
+fn record_direct_late_fallback(
+    counters: &mut OracleCounters,
+    was_late: bool,
+    unavailable_after_install: u64,
+) {
+    if was_late && unavailable_after_install != 0 {
+        counters.source_late_degraded_to_demand += 1;
+    }
 }
 
 fn record_demand_readiness(counters: &mut OracleCounters, current_by_layer: &[Vec<bool>]) {
@@ -1405,8 +1710,10 @@ impl GpuNativeOracleScheduleHook for OracleScheduler {
         let concurrency = self.concurrency;
         let expert_bytes = self.expert_bytes;
         let target_position = position + 1;
+        let readiness = Arc::new(SourceReadiness::default());
         let handle = match self.source_position_gate.clone().try_lock_owned() {
             Ok(position_guard) => {
+                let readiness_for_task = readiness.clone();
                 let handle = tokio::spawn(async move {
                     let outcome = prefetch_position(
                         engine,
@@ -1415,6 +1722,7 @@ impl GpuNativeOracleScheduleHook for OracleScheduler {
                         concurrency,
                         expert_bytes,
                         counters.clone(),
+                        readiness_for_task,
                     )
                     .await;
                     PrefetchLease::new(outcome, counters, position_guard)
@@ -1423,7 +1731,12 @@ impl GpuNativeOracleScheduleHook for OracleScheduler {
                 Some(handle)
             }
             Err(_) => {
-                if let Err(error) = self.record_position_gate_skip(&routes) {
+                if self.mode == OracleScheduledResidencyMode::TokenBoundaryDirect {
+                    state.failure = Some(
+                        "token-boundary-direct could not acquire the next position lease after the prior safe boundary"
+                            .into(),
+                    );
+                } else if let Err(error) = self.record_position_gate_skip(&routes) {
                     state.failure = Some(error);
                 }
                 None
@@ -1432,6 +1745,7 @@ impl GpuNativeOracleScheduleHook for OracleScheduler {
         state.active = Some(ActivePrefetch {
             target_position,
             handle,
+            readiness,
         });
     }
 
@@ -1457,6 +1771,7 @@ struct PhysicalSlotPlanEvidence {
 #[derive(Clone, Copy, Debug, Serialize)]
 struct TreatmentContract {
     source_overlap: bool,
+    late_source_policy: LateSourcePolicy,
     host_preparation_overlap: bool,
     token_boundary_h2d: bool,
     demand_fallback: bool,
@@ -1472,6 +1787,7 @@ struct TreatmentContract {
 const fn treatment_contract(mode: OracleScheduledResidencyMode) -> TreatmentContract {
     TreatmentContract {
         source_overlap: true,
+        late_source_policy: late_source_policy(mode),
         host_preparation_overlap: false,
         token_boundary_h2d: matches!(mode, OracleScheduledResidencyMode::TokenBoundaryDirect),
         demand_fallback: true,
@@ -1712,7 +2028,9 @@ fn validate_oracle_counters(
         ));
     }
     if mode == OracleScheduledResidencyMode::TokenBoundaryDirect
-        && (counters.boundary_direct_staging_writes != counters.boundary_physical_installs
+        && (counters.source_position_inflight_skips != 0
+            || counters.source_prefetch_batches_skipped_inflight != 0
+            || counters.boundary_direct_staging_writes != counters.boundary_physical_installs
             || counters.boundary_physical_evictions > counters.boundary_physical_installs
             || counters.boundary_replacement_sets_completed
                 > counters.boundary_replacement_sets_started
@@ -1722,7 +2040,7 @@ fn validate_oracle_counters(
         return Err(BenchmarkFailure::new(
             "postcondition",
             "oracle-physical-counter-reconciliation",
-            "ORACLE direct staging, install bytes, eviction, or replacement-set counters do not reconcile",
+            "ORACLE direct-mode position leases, direct staging, install bytes, eviction, or replacement-set counters do not reconcile",
         ));
     }
     Ok(())
@@ -2305,6 +2623,7 @@ pub(crate) async fn run_command(args: CommandArgs) -> Result<(), Box<dyn std::er
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::Duration;
 
     fn test_trace(positions: usize) -> Arc<OracleRouteTrace> {
         let geometry = OracleGeometry {
@@ -2338,6 +2657,56 @@ mod tests {
             oracle_ready_at_demand: EXPECTED_SELECTED_IDS as u64,
             source_end_of_trace: 1,
             ..OracleCounters::default()
+        }
+    }
+
+    fn test_scheduler_state() -> Arc<Mutex<SchedulerState>> {
+        Arc::new(Mutex::new(SchedulerState {
+            cursor: StrictRouteCursor::new(test_trace(2)),
+            submitted_position: None,
+            active: None,
+            background: Vec::new(),
+            failure: None,
+        }))
+    }
+
+    async fn pending_test_prefetch(
+        target_position: usize,
+        counters: Arc<Mutex<OracleCounters>>,
+    ) -> (
+        ActivePrefetch,
+        tokio::sync::oneshot::Sender<PrefetchOutcome>,
+        Arc<tokio::sync::Mutex<()>>,
+        Arc<SourceReadiness>,
+    ) {
+        let source_position_gate = Arc::new(tokio::sync::Mutex::new(()));
+        let position_guard = source_position_gate.clone().lock_owned().await;
+        let readiness = Arc::new(SourceReadiness::default());
+        let counters_for_task = counters.clone();
+        let (send_outcome, receive_outcome) = tokio::sync::oneshot::channel();
+        let handle = tokio::spawn(async move {
+            let outcome = receive_outcome
+                .await
+                .expect("test controls source task completion");
+            PrefetchLease::new(outcome, counters_for_task, position_guard)
+        });
+        counters.lock().background_tasks_spawned += 1;
+        (
+            ActivePrefetch {
+                target_position,
+                handle: Some(handle),
+                readiness: readiness.clone(),
+            },
+            send_outcome,
+            source_position_gate,
+            readiness,
+        )
+    }
+
+    fn successful_test_outcome(target_position: usize) -> PrefetchOutcome {
+        PrefetchOutcome {
+            target_position,
+            ..PrefetchOutcome::default()
         }
     }
 
@@ -2441,6 +2810,267 @@ mod tests {
     }
 
     #[test]
+    fn treatment_contract_records_distinct_late_source_policies() {
+        let source_only = treatment_contract(OracleScheduledResidencyMode::SourceOnly);
+        let direct = treatment_contract(OracleScheduledResidencyMode::TokenBoundaryDirect);
+        assert_eq!(
+            source_only.late_source_policy,
+            LateSourcePolicy::NonblockingDemandFallback
+        );
+        assert_eq!(
+            direct.late_source_policy,
+            LateSourcePolicy::AwaitResidualAtSafeBoundary
+        );
+        assert_eq!(
+            serde_json::to_value(source_only).unwrap()["late_source_policy"],
+            "nonblocking-demand-fallback"
+        );
+        assert_eq!(
+            serde_json::to_value(direct).unwrap()["late_source_policy"],
+            "await-residual-at-safe-boundary"
+        );
+    }
+
+    #[tokio::test]
+    async fn source_only_unfinished_task_does_not_wait_and_retains_demand_fallback() {
+        let counters = Arc::new(Mutex::new(OracleCounters::default()));
+        let state = test_scheduler_state();
+        let (active, send_outcome, source_position_gate, _) =
+            pending_test_prefetch(1, counters.clone()).await;
+
+        let resolution = tokio::time::timeout(
+            Duration::from_millis(100),
+            resolve_source_task_at_boundary(
+                OracleScheduledResidencyMode::SourceOnly,
+                active,
+                1,
+                vec![0, 1, 2, 3],
+                |_| Ok(BoundarySourceReadiness::Unavailable),
+                counters.clone(),
+                state.clone(),
+            ),
+        )
+        .await
+        .expect("source-only must not wait for an unfinished source task")
+        .unwrap();
+        assert!(matches!(
+            resolution,
+            BoundarySourceResolution::DeferredToDemand
+        ));
+        {
+            let values = counters.lock();
+            assert_eq!(values.source_late_at_boundary, 4);
+            assert_eq!(values.source_late_degraded_to_demand, 1);
+            assert_eq!(values.oracle_wait_before_next_token_us, 0);
+        }
+        record_demand_readiness(&mut counters.lock(), &[vec![false; 4]]);
+        assert_eq!(counters.lock().oracle_demand_fallback, 1);
+
+        assert!(send_outcome.send(successful_test_outcome(1)).is_ok());
+        let mut background = std::mem::take(&mut state.lock().background);
+        drain_background_tasks(&mut background).await.unwrap();
+        assert!(source_position_gate.try_lock_owned().is_ok());
+    }
+
+    #[tokio::test]
+    async fn token_boundary_direct_awaits_late_source_records_wait_and_releases_lease() {
+        let counters = Arc::new(Mutex::new(OracleCounters::default()));
+        let state = test_scheduler_state();
+        let (active, send_outcome, source_position_gate, readiness) =
+            pending_test_prefetch(1, counters.clone()).await;
+        readiness.mark_physical_ready(0);
+        readiness.mark_source_resident_ready(1);
+        let mut resolving = Box::pin(resolve_source_task_at_boundary(
+            OracleScheduledResidencyMode::TokenBoundaryDirect,
+            active,
+            1,
+            vec![0, 1, 2, 3],
+            |_| Ok(BoundarySourceReadiness::Unavailable),
+            counters.clone(),
+            state.clone(),
+        ));
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), resolving.as_mut())
+                .await
+                .is_err()
+        );
+        {
+            let values = counters.lock();
+            assert_eq!(values.source_late_at_boundary, 2);
+            assert_eq!(values.source_late_degraded_to_demand, 0);
+            assert_eq!(values.oracle_wait_before_next_token_us, 0);
+        }
+        assert!(send_outcome.send(successful_test_outcome(1)).is_ok());
+        let resolution = tokio::time::timeout(Duration::from_secs(1), resolving)
+            .await
+            .expect("direct mode must finish after the source task completes")
+            .unwrap();
+        let BoundarySourceResolution::Completed { lease, was_late } = resolution else {
+            panic!("direct mode must return the completed source lease");
+        };
+        assert!(was_late);
+        assert!(counters.lock().oracle_wait_before_next_token_us > 0);
+        assert!(source_position_gate.clone().try_lock_owned().is_err());
+        record_direct_late_fallback(&mut counters.lock(), was_late, 0);
+        assert_eq!(counters.lock().source_late_degraded_to_demand, 0);
+        release_source_position_lease_before_next_token(
+            OracleScheduledResidencyMode::TokenBoundaryDirect,
+            lease,
+            &source_position_gate,
+            &state,
+        )
+        .unwrap();
+        assert!(source_position_gate.try_lock_owned().is_ok());
+        assert!(state.lock().background.is_empty());
+    }
+
+    #[tokio::test]
+    async fn token_boundary_direct_rejects_a_previous_position_lease_skip() {
+        let counters = Arc::new(Mutex::new(OracleCounters::default()));
+        let state = test_scheduler_state();
+        let active = ActivePrefetch {
+            target_position: 1,
+            handle: None,
+            readiness: Arc::new(SourceReadiness::default()),
+        };
+        let error = resolve_source_task_at_boundary(
+            OracleScheduledResidencyMode::TokenBoundaryDirect,
+            active,
+            1,
+            vec![0, 1, 2, 3],
+            |_| Ok(BoundarySourceReadiness::Unavailable),
+            counters,
+            state,
+        )
+        .await
+        .err()
+        .expect("direct mode must fail closed instead of accumulating late positions");
+        assert!(error.contains("prior position lease remained in flight"));
+    }
+
+    #[tokio::test]
+    async fn token_boundary_direct_rejects_a_previous_position_background_task() {
+        let counters = Arc::new(Mutex::new(OracleCounters::default()));
+        let state = test_scheduler_state();
+        let (active, send_outcome, source_position_gate, _) =
+            pending_test_prefetch(1, counters.clone()).await;
+        state.lock().background.push(tokio::spawn(async {}));
+
+        let error = match resolve_source_task_at_boundary(
+            OracleScheduledResidencyMode::TokenBoundaryDirect,
+            active,
+            1,
+            vec![0],
+            |_| Ok(BoundarySourceReadiness::Unavailable),
+            counters,
+            state.clone(),
+        )
+        .await
+        {
+            Err(error) => error,
+            Ok(_) => panic!("direct mode must fail closed on a previous background task"),
+        };
+        assert!(error.contains("previous-position background source task"));
+
+        assert!(send_outcome.send(successful_test_outcome(1)).is_ok());
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if source_position_gate.clone().try_lock_owned().is_ok() {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("detached test source task must release its lease");
+        let mut background = std::mem::take(&mut state.lock().background);
+        drain_background_tasks(&mut background).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn direct_late_source_failure_preserves_demand_fallback() {
+        let counters = Arc::new(Mutex::new(OracleCounters::default()));
+        let state = test_scheduler_state();
+        let (active, send_outcome, source_position_gate, _) =
+            pending_test_prefetch(1, counters.clone()).await;
+        let mut resolving = Box::pin(resolve_source_task_at_boundary(
+            OracleScheduledResidencyMode::TokenBoundaryDirect,
+            active,
+            1,
+            vec![7],
+            |_| Ok(BoundarySourceReadiness::Unavailable),
+            counters.clone(),
+            state.clone(),
+        ));
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), resolving.as_mut())
+                .await
+                .is_err()
+        );
+        let outcome = PrefetchOutcome {
+            target_position: 1,
+            failed_ids: vec![7],
+            ..PrefetchOutcome::default()
+        };
+        assert!(send_outcome.send(outcome).is_ok());
+        let resolution = resolving.await.unwrap();
+        let BoundarySourceResolution::Completed { lease, was_late } = resolution else {
+            panic!("direct mode must join a source-read failure outcome");
+        };
+        assert!(was_late);
+        record_direct_late_fallback(&mut counters.lock(), was_late, 1);
+        record_demand_readiness(&mut counters.lock(), &[vec![false]]);
+        {
+            let values = counters.lock();
+            assert_eq!(values.source_failures_degraded_to_demand, 1);
+            assert_eq!(values.source_late_degraded_to_demand, 1);
+            assert_eq!(values.oracle_demand_fallback, 1);
+        }
+        release_source_position_lease_before_next_token(
+            OracleScheduledResidencyMode::TokenBoundaryDirect,
+            lease,
+            &source_position_gate,
+            &state,
+        )
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn fatal_source_task_error_still_fails_qualification() {
+        let counters = Arc::new(Mutex::new(OracleCounters::default()));
+        let state = test_scheduler_state();
+        let (active, send_outcome, source_position_gate, _) =
+            pending_test_prefetch(1, counters.clone()).await;
+        let mut resolving = Box::pin(resolve_source_task_at_boundary(
+            OracleScheduledResidencyMode::TokenBoundaryDirect,
+            active,
+            1,
+            vec![7],
+            |_| Ok(BoundarySourceReadiness::Unavailable),
+            counters,
+            state,
+        ));
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), resolving.as_mut())
+                .await
+                .is_err()
+        );
+        let outcome = PrefetchOutcome {
+            target_position: 1,
+            fatal_error: Some("physical identity corrupt".into()),
+            ..PrefetchOutcome::default()
+        };
+        assert!(send_outcome.send(outcome).is_ok());
+        let error = match resolving.await {
+            Err(error) => error,
+            Ok(_) => panic!("fatal source task error must fail qualification"),
+        };
+        assert_eq!(error, "physical identity corrupt");
+        assert!(source_position_gate.try_lock_owned().is_ok());
+    }
+
+    #[test]
     fn source_deduplication_uses_existing_singleflight() {
         assert_eq!(
             source_disposition(false, false, true),
@@ -2472,7 +3102,7 @@ mod tests {
             ..PrefetchOutcome::default()
         };
         let mut counters = OracleCounters::default();
-        record_completed_source_outcome(&mut counters, &outcome);
+        record_completed_source_outcome(&mut counters, &outcome, 0);
         record_demand_readiness(&mut counters, &[vec![false, false]]);
         assert_eq!(counters.source_failures_degraded_to_demand, 2);
         assert_eq!(counters.oracle_demand_fallback, 1);
@@ -2481,7 +3111,11 @@ mod tests {
     #[test]
     fn source_late_at_boundary_degrades_without_fake_readiness() {
         let mut counters = OracleCounters::default();
-        record_source_late(&mut counters, 8);
+        record_source_late(
+            &mut counters,
+            8,
+            LateSourcePolicy::NonblockingDemandFallback,
+        );
         record_demand_readiness(&mut counters, &[vec![false; 8]]);
         assert_eq!(counters.source_late_at_boundary, 8);
         assert_eq!(counters.source_late_degraded_to_demand, 1);

--- a/rust-engine/src/gpu_native_oracle_scheduled_residency.rs
+++ b/rust-engine/src/gpu_native_oracle_scheduled_residency.rs
@@ -1,0 +1,2690 @@
+//! ORACLE-0B-S qualification: perfect-future source scheduling on the current
+//! single-queue GPU-native architecture.
+//!
+//! Source work for position P+1 begins only after position P's ordinary queue
+//! submission. Destructive physical replacement is allowed only after the
+//! token loop supplies a non-cloneable boundary witness following the normal
+//! map, `device.poll(Maintain::Wait)`, report parse, and clean-status checks.
+//! Queue writes performed at that boundary intentionally serialize before the
+//! next token's commands on the same queue. This module never claims H2D
+//! overlap and never uses the production predictor/speculative path.
+
+use crate::backend::gpu_native::{GpuNativePhysicalInstallEvidence, GpuNativeQ4ExpertResidency};
+use crate::backend::GpuDeviceIdentity;
+use crate::engine::{Engine, RoutedExpertExecutionSnapshot};
+use crate::expert_cache::{ExpertResident, GpuDemandSetAdmission, GpuResident};
+use crate::gpu_native_oracle_routes::{OracleGeometry, OracleRouteRecord, OracleRouteTrace};
+use crate::gpu_native_real_benchmark::{
+    Aggregate, BenchmarkFailure, BenchmarkProvenance, PerRunResult, ProductionConfiguration,
+    RequestEvidence, RequestSnapshotStart, RunTiming, RuntimeContractEvidence,
+    RuntimeContractInput,
+};
+use crate::gpu_native_residency::{
+    GpuNativeDemandExpert, GpuNativePhysicalInstallObserver, GpuNativeTieredResidencyError,
+};
+use crate::gpu_native_token_loop::{
+    GpuNativeOracleScheduleHook, GpuNativeRecoverySnapshot, GpuNativeSafeTokenBoundary,
+    GpuNativeTokenLoopSnapshot,
+};
+use crate::greedy_parity::{BackgroundShutdownEvidence, ModelIdentityEvidence, ModelLoadEvidence};
+use clap::ValueEnum;
+use futures::{stream, StreamExt};
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Instant;
+
+pub(crate) const SCHEMA: &str = "mer.gpu-native-oracle-scheduled-residency.v1";
+pub(crate) const MODE: &str = "qualify-gpu-native-oracle-scheduled-residency";
+const ORACLE_ROUTE_SCHEMA: &str = "mer.gpu-native-oracle-route-trace.v1";
+const ORACLE_ROUTE_COMMAND_SHA: &str = "3576cb893586f5dd3f5c5e7355658762db02b534";
+const EXPECTED_ORDERED_ROUTE_SHA256: &str =
+    "f8834d1ab3b695d615ff43396c3bcb7d347116b19a1e6ae4f547bd07a0764d68";
+const EXPECTED_LEGACY_ROUTE_SHA256: &str =
+    "27a0d3022744202907d79317a1b0f728e759c94fec2e9f043d650590656a51e8";
+const FROZEN_PROMPT: &str =
+    "Write a Rust function that adds two i32 values and returns the result.";
+const EXPECTED_PROMPT_SHA256: &str =
+    "4c8a131a9eaca3a9526da12025dcc3507c8b43c5312840180e0148a013680413";
+const EXPECTED_PROMPT_TOKEN_IDS_SHA256: &str =
+    "6a4a4d916225833d9c1def33b56cdeb70b2a89b0aba6907f91d79178f3a3863b";
+const EXPECTED_ADAPTER_NAME: &str = "NVIDIA L4";
+const EXPECTED_POSITIONS: usize = 143;
+const EXPECTED_LAYERS: usize = 48;
+const EXPECTED_EXPERTS: usize = 128;
+const EXPECTED_TOP_K: usize = 8;
+const EXPECTED_D_MODEL: usize = 2048;
+const EXPECTED_D_FF: usize = 768;
+const EXPECTED_LAYER_RECORDS: usize = 6_864;
+const EXPECTED_SELECTED_IDS: usize = 54_912;
+const FROZEN_OUTPUT_TOKENS: usize = 128;
+const FROZEN_WARMUP_RUNS: usize = 1;
+const FROZEN_MEASURED_RUNS: usize = 3;
+const FROZEN_RAM_CACHE_SLOTS: usize = 384;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, ValueEnum)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum OracleScheduledResidencyMode {
+    SourceOnly,
+    TokenBoundaryDirect,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct CommandArgs {
+    pub(crate) config: PathBuf,
+    pub(crate) oracle_trace: PathBuf,
+    pub(crate) treatment_mode: OracleScheduledResidencyMode,
+    pub(crate) oracle_source_concurrency: usize,
+    pub(crate) report_out: PathBuf,
+    pub(crate) progress_watchdog: crate::rayon_autotune::ProgressWatchdogConfig,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct SourceOracleEvidence {
+    configured_path: String,
+    canonical_path: String,
+    byte_length: u64,
+    artifact_sha256: String,
+    schema: String,
+    complete: bool,
+    diagnostic_only: bool,
+    route_command_git_sha: String,
+    ordered_route_sequence_sha256: String,
+    legacy_selected_route_ids_sha256: String,
+    expected_generated_token_ids_sha256: String,
+    expected_generated_text_sha256: String,
+}
+
+#[derive(Clone)]
+struct ValidatedOracleArtifact {
+    evidence: SourceOracleEvidence,
+    trace: Arc<OracleRouteTrace>,
+}
+
+fn artifact_failure(code: &str, detail: impl Into<String>) -> BenchmarkFailure {
+    BenchmarkFailure::new("preflight", code, detail)
+}
+
+fn required_value<'a>(
+    root: &'a serde_json::Value,
+    pointer: &str,
+) -> Result<&'a serde_json::Value, BenchmarkFailure> {
+    root.pointer(pointer).ok_or_else(|| {
+        artifact_failure(
+            "oracle-artifact-field-missing",
+            format!("ORACLE-0A artifact is missing {pointer}"),
+        )
+    })
+}
+
+fn required_string(root: &serde_json::Value, pointer: &str) -> Result<String, BenchmarkFailure> {
+    required_value(root, pointer)?
+        .as_str()
+        .map(str::to_string)
+        .ok_or_else(|| {
+            artifact_failure(
+                "oracle-artifact-field-type",
+                format!("ORACLE-0A artifact field {pointer} is not a string"),
+            )
+        })
+}
+
+fn required_bool(root: &serde_json::Value, pointer: &str) -> Result<bool, BenchmarkFailure> {
+    required_value(root, pointer)?.as_bool().ok_or_else(|| {
+        artifact_failure(
+            "oracle-artifact-field-type",
+            format!("ORACLE-0A artifact field {pointer} is not a bool"),
+        )
+    })
+}
+
+fn required_u64(root: &serde_json::Value, pointer: &str) -> Result<u64, BenchmarkFailure> {
+    required_value(root, pointer)?.as_u64().ok_or_else(|| {
+        artifact_failure(
+            "oracle-artifact-field-type",
+            format!("ORACLE-0A artifact field {pointer} is not an unsigned integer"),
+        )
+    })
+}
+
+fn load_oracle_artifact(path: &Path) -> Result<ValidatedOracleArtifact, BenchmarkFailure> {
+    // One immutable byte snapshot is hashed and deserialized. The qualifier
+    // never reopens the source path after this read.
+    let bytes = std::fs::read(path).map_err(|error| {
+        artifact_failure(
+            "oracle-artifact-read-failed",
+            format!("failed to read {}: {error}", path.display()),
+        )
+    })?;
+    let artifact_sha256 = format!("{:x}", Sha256::digest(&bytes));
+    let root: serde_json::Value = serde_json::from_slice(&bytes)
+        .map_err(|error| artifact_failure("oracle-artifact-parse-failed", error.to_string()))?;
+    let schema = required_string(&root, "/schema")?;
+    let complete = required_bool(&root, "/complete")?;
+    let diagnostic_only = required_bool(&root, "/diagnostic_only")?;
+    let route_command_git_sha = required_string(&root, "/provenance/build/git_sha")?;
+    let prompt_sha256 = required_string(&root, "/request/prompt_sha256")?;
+    let prompt_token_ids_sha256 = required_string(&root, "/request/prompt_token_ids_sha256")?;
+    let requested_output_tokens = required_u64(&root, "/request/requested_output_tokens")?;
+    let greedy = required_bool(&root, "/request/greedy")?;
+    let expected_generated_token_ids_sha256 =
+        required_string(&root, "/measured/generated_token_ids_sha256")?;
+    let expected_generated_text_sha256 = required_string(&root, "/measured/generated_text_sha256")?;
+    let warmup_token_sha = required_string(&root, "/warmup/generated_token_ids_sha256")?;
+    let warmup_text_sha = required_string(&root, "/warmup/generated_text_sha256")?;
+    let trace_value = required_value(&root, "/trace")?.clone();
+    let trace: OracleRouteTrace = serde_json::from_value(trace_value)
+        .map_err(|error| artifact_failure("oracle-trace-parse-failed", error.to_string()))?;
+    trace
+        .validate()
+        .map_err(|error| artifact_failure("oracle-trace-invalid", error.to_string()))?;
+
+    let expected_geometry = OracleGeometry {
+        layers: EXPECTED_LAYERS,
+        experts: EXPECTED_EXPERTS,
+        top_k: EXPECTED_TOP_K,
+        d_model: EXPECTED_D_MODEL,
+        d_ff: EXPECTED_D_FF,
+    };
+    let source_model_identity_matches = required_string(&root, "/model_identity/architecture")?
+        == "qwen3_moe"
+        && required_u64(&root, "/model_identity/num_layers")? == EXPECTED_LAYERS as u64
+        && required_u64(&root, "/model_identity/num_experts_per_layer")? == EXPECTED_EXPERTS as u64
+        && required_u64(&root, "/model_identity/total_experts")? == 6_144
+        && required_u64(&root, "/model_identity/top_k")? == EXPECTED_TOP_K as u64
+        && required_u64(&root, "/model_identity/d_model")? == EXPECTED_D_MODEL as u64
+        && required_u64(&root, "/model_identity/d_ff")? == EXPECTED_D_FF as u64
+        && required_string(&root, "/model_identity/routed_expert_dtype")? == "q4_0";
+    if schema != ORACLE_ROUTE_SCHEMA
+        || trace.schema != ORACLE_ROUTE_SCHEMA
+        || !complete
+        || !diagnostic_only
+        || !source_model_identity_matches
+        || route_command_git_sha != ORACLE_ROUTE_COMMAND_SHA
+        || trace.geometry != expected_geometry
+        || prompt_sha256 != EXPECTED_PROMPT_SHA256
+        || prompt_token_ids_sha256 != EXPECTED_PROMPT_TOKEN_IDS_SHA256
+        || requested_output_tokens != FROZEN_OUTPUT_TOKENS as u64
+        || !greedy
+        || trace.total_positions != EXPECTED_POSITIONS
+        || trace.total_layer_records != EXPECTED_LAYER_RECORDS
+        || trace.total_selected_expert_ids != EXPECTED_SELECTED_IDS
+        || trace.ordered_route_sequence_sha256 != EXPECTED_ORDERED_ROUTE_SHA256
+        || trace.legacy_selected_route_ids_sha256 != EXPECTED_LEGACY_ROUTE_SHA256
+        || warmup_token_sha != expected_generated_token_ids_sha256
+        || warmup_text_sha != expected_generated_text_sha256
+    {
+        return Err(artifact_failure(
+            "oracle-artifact-contract-mismatch",
+            "ORACLE-0A artifact does not match the frozen schema, provenance, geometry, workload, totals, hashes, or deterministic output contract",
+        ));
+    }
+    let canonical_path = std::fs::canonicalize(path)
+        .map_err(|error| {
+            artifact_failure("oracle-artifact-canonicalize-failed", error.to_string())
+        })?
+        .display()
+        .to_string();
+    Ok(ValidatedOracleArtifact {
+        evidence: SourceOracleEvidence {
+            configured_path: path.display().to_string(),
+            canonical_path,
+            byte_length: bytes.len() as u64,
+            artifact_sha256,
+            schema,
+            complete,
+            diagnostic_only,
+            route_command_git_sha,
+            ordered_route_sequence_sha256: trace.ordered_route_sequence_sha256.clone(),
+            legacy_selected_route_ids_sha256: trace.legacy_selected_route_ids_sha256.clone(),
+            expected_generated_token_ids_sha256,
+            expected_generated_text_sha256,
+        },
+        trace: Arc::new(trace),
+    })
+}
+
+#[derive(Clone, Debug)]
+struct StrictRouteCursor {
+    trace: Arc<OracleRouteTrace>,
+    next_position: usize,
+    actual_records: Vec<OracleRouteRecord>,
+}
+
+impl StrictRouteCursor {
+    fn new(trace: Arc<OracleRouteTrace>) -> Self {
+        Self {
+            actual_records: Vec::with_capacity(trace.total_layer_records),
+            trace,
+            next_position: 0,
+        }
+    }
+
+    fn routes_at(&self, position: usize) -> Result<Vec<Vec<u32>>, String> {
+        if position >= self.trace.total_positions {
+            return Err(format!(
+                "route cursor exhausted at position {position}; trace has {} positions",
+                self.trace.total_positions
+            ));
+        }
+        let start = position
+            .checked_mul(self.trace.geometry.layers)
+            .ok_or("route cursor index overflow")?;
+        let end = start
+            .checked_add(self.trace.geometry.layers)
+            .ok_or("route cursor index overflow")?;
+        let records = self
+            .trace
+            .records
+            .get(start..end)
+            .ok_or("route cursor cannot form a complete position")?;
+        if records.len() != self.trace.geometry.layers {
+            return Err("route cursor returned a truncated layer set".into());
+        }
+        records
+            .iter()
+            .enumerate()
+            .map(|(layer_index, record)| {
+                if record.position != position || record.layer_index != layer_index {
+                    return Err(format!(
+                        "route cursor order mismatch at position {position} layer {layer_index}"
+                    ));
+                }
+                Ok(record.ordered_selected_expert_ids.clone())
+            })
+            .collect()
+    }
+
+    fn future_after(&self, position: usize) -> Result<Option<Vec<Vec<u32>>>, String> {
+        let future = position
+            .checked_add(1)
+            .ok_or("future route position overflow")?;
+        if future == self.trace.total_positions {
+            Ok(None)
+        } else if future > self.trace.total_positions {
+            Err("route cursor attempted to invent a position after end-of-trace".into())
+        } else {
+            self.routes_at(future).map(Some)
+        }
+    }
+
+    fn reconcile(&mut self, position: usize, actual: &[Vec<u32>]) -> Result<(), String> {
+        if position != self.next_position {
+            return Err(format!(
+                "route cursor expected position {}, observed {position}",
+                self.next_position
+            ));
+        }
+        let expected = self.routes_at(position)?;
+        if actual != expected {
+            return Err(format!(
+                "actual GPU router route differs from ORACLE-0A at position {position}"
+            ));
+        }
+        for (layer_index, ids) in actual.iter().enumerate() {
+            self.actual_records.push(OracleRouteRecord {
+                position,
+                layer_index,
+                ordered_selected_expert_ids: ids.clone(),
+            });
+        }
+        self.next_position += 1;
+        Ok(())
+    }
+
+    fn finish(self) -> Result<OracleRouteTrace, String> {
+        if self.next_position != self.trace.total_positions {
+            return Err(format!(
+                "route cursor stopped at {} of {} positions",
+                self.next_position, self.trace.total_positions
+            ));
+        }
+        OracleRouteTrace::try_new(self.trace.geometry, self.actual_records)
+            .map_err(|error| error.to_string())
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
+struct OracleCounters {
+    initial_position_source_priming_experts: u64,
+    initial_position_source_priming_us: u64,
+    future_experts_considered: u64,
+    source_skipped_physical_current: u64,
+    source_ram_hits: u64,
+    source_singleflight_hits: u64,
+    source_position_inflight_skips: u64,
+    source_reads_started: u64,
+    source_reads_completed: u64,
+    source_reads_failed: u64,
+    source_bytes_read: u64,
+    source_prefetch_batches_started: u64,
+    source_prefetch_batches_completed: u64,
+    source_prefetch_batches_skipped_inflight: u64,
+    source_prefetch_peak_inflight: u64,
+    source_ready_before_boundary: u64,
+    source_late_at_boundary: u64,
+    source_end_of_trace: u64,
+    future_physical_sets_considered: u64,
+    future_physical_experts_needed: u64,
+    boundary_replacement_sets_started: u64,
+    boundary_replacement_sets_completed: u64,
+    boundary_physical_installs: u64,
+    boundary_physical_install_bytes: u64,
+    boundary_physical_evictions: u64,
+    boundary_physical_reinstalls: u64,
+    boundary_stale_generation: u64,
+    boundary_install_failures: u64,
+    boundary_direct_staging_writes: u64,
+    boundary_full_slot_vec_materializations: u64,
+    oracle_ready_at_demand: u64,
+    oracle_not_ready_at_demand: u64,
+    oracle_demand_fallback: u64,
+    ordinary_residency_miss_attempts: u64,
+    ordinary_residency_services: u64,
+    source_prefetch_wall_us: u64,
+    source_read_aggregate_us: u64,
+    host_preparation_overlap_us: u64,
+    token_boundary_host_stage_us: u64,
+    token_boundary_physical_stage_us: u64,
+    token_boundary_commit_us: u64,
+    oracle_wait_before_next_token_us: u64,
+    qualification_owned_current_slots: u64,
+    qualification_owned_current_bytes: u64,
+    qualification_owned_peak_slots: u64,
+    qualification_owned_peak_bytes: u64,
+    source_failures_degraded_to_demand: u64,
+    source_late_degraded_to_demand: u64,
+    background_tasks_spawned: u64,
+    background_tasks_drained: u64,
+}
+
+fn saturating_us(started: Instant) -> u64 {
+    u64::try_from(started.elapsed().as_micros()).unwrap_or(u64::MAX)
+}
+
+fn add_counter(target: &mut u64, value: u64) {
+    *target = target.saturating_add(value);
+}
+
+struct LayerBatchGuard {
+    counters: Arc<Mutex<OracleCounters>>,
+}
+
+impl LayerBatchGuard {
+    fn enter(counters: Arc<Mutex<OracleCounters>>) -> Self {
+        let mut values = counters.lock();
+        values.source_prefetch_batches_started += 1;
+        let active = values
+            .source_prefetch_batches_started
+            .saturating_sub(values.source_prefetch_batches_completed);
+        values.source_prefetch_peak_inflight = values.source_prefetch_peak_inflight.max(active);
+        drop(values);
+        Self { counters }
+    }
+}
+
+impl Drop for LayerBatchGuard {
+    fn drop(&mut self) {
+        self.counters.lock().source_prefetch_batches_completed += 1;
+    }
+}
+
+#[derive(Default)]
+struct PrefetchOutcome {
+    target_position: usize,
+    residents: HashMap<u32, Arc<ExpertResident>>,
+    failed_ids: Vec<u32>,
+    fatal_error: Option<String>,
+}
+
+struct PrefetchLease {
+    outcome: PrefetchOutcome,
+    counters: Arc<Mutex<OracleCounters>>,
+    _position_guard: tokio::sync::OwnedMutexGuard<()>,
+}
+
+impl PrefetchLease {
+    fn new(
+        outcome: PrefetchOutcome,
+        counters: Arc<Mutex<OracleCounters>>,
+        position_guard: tokio::sync::OwnedMutexGuard<()>,
+    ) -> Self {
+        Self {
+            outcome,
+            counters,
+            _position_guard: position_guard,
+        }
+    }
+}
+
+impl Drop for PrefetchLease {
+    fn drop(&mut self) {
+        let mut values = self.counters.lock();
+        values.qualification_owned_current_slots = 0;
+        values.qualification_owned_current_bytes = 0;
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SourceDisposition {
+    AlreadyPhysical,
+    RamHit,
+    SourceInFlight,
+    StartSourceRead,
+}
+
+const fn source_disposition(
+    physical_current: bool,
+    ram_hit: bool,
+    source_in_flight: bool,
+) -> SourceDisposition {
+    if physical_current {
+        SourceDisposition::AlreadyPhysical
+    } else if ram_hit {
+        SourceDisposition::RamHit
+    } else if source_in_flight {
+        SourceDisposition::SourceInFlight
+    } else {
+        SourceDisposition::StartSourceRead
+    }
+}
+
+async fn prefetch_layer_batch(
+    engine: Arc<Engine>,
+    layer_index: usize,
+    local_ids: Vec<u32>,
+    counters: Arc<Mutex<OracleCounters>>,
+) -> PrefetchOutcome {
+    let _guard = LayerBatchGuard::enter(counters.clone());
+    let mut outcome = PrefetchOutcome::default();
+    let manager = match engine.core.gpu_native_residency.as_ref() {
+        Some(manager) => manager.clone(),
+        None => {
+            outcome.fatal_error = Some("GPU-native residency manager is absent".into());
+            return outcome;
+        }
+    };
+    let experts_per_layer = manager.plan().geometry().num_experts() as u32;
+    for local_id in local_ids {
+        let global_id = match crate::gpu_native_residency::layer_local_to_global(
+            layer_index,
+            local_id,
+            manager.plan().num_layers(),
+            experts_per_layer,
+        ) {
+            Ok(global_id) => global_id,
+            Err(error) => {
+                outcome.fatal_error = Some(error.to_string());
+                return outcome;
+            }
+        };
+        let physical_current = match manager.has_current_for_demand(global_id) {
+            Ok(current) => current,
+            Err(error) => {
+                outcome.fatal_error = Some(error.to_string());
+                return outcome;
+            }
+        };
+        let ram_resident = (!physical_current)
+            .then(|| engine.core.cache.get(global_id))
+            .flatten();
+        let singleflight = !physical_current
+            && ram_resident.is_none()
+            && engine.core.in_flight.contains_key(&global_id);
+        match source_disposition(physical_current, ram_resident.is_some(), singleflight) {
+            SourceDisposition::AlreadyPhysical => {
+                counters.lock().source_skipped_physical_current += 1;
+                continue;
+            }
+            SourceDisposition::RamHit => {
+                counters.lock().source_ram_hits += 1;
+                outcome.residents.insert(
+                    global_id,
+                    ram_resident.expect("RAM-hit disposition has a resident"),
+                );
+                continue;
+            }
+            SourceDisposition::SourceInFlight => {
+                counters.lock().source_singleflight_hits += 1;
+            }
+            SourceDisposition::StartSourceRead => {
+                counters.lock().source_reads_started += 1;
+            }
+        }
+        let started = Instant::now();
+        match engine.fetch_with_retry(global_id).await {
+            Ok(resident) => {
+                let elapsed = saturating_us(started);
+                let mut values = counters.lock();
+                add_counter(&mut values.source_read_aggregate_us, elapsed);
+                if !singleflight {
+                    values.source_reads_completed += 1;
+                    add_counter(&mut values.source_bytes_read, resident.data().len() as u64);
+                }
+                drop(values);
+                outcome.residents.insert(global_id, resident);
+            }
+            Err(error) => {
+                if !singleflight {
+                    counters.lock().source_reads_failed += 1;
+                }
+                outcome.failed_ids.push(global_id);
+                let _ = error;
+            }
+        }
+    }
+    outcome
+}
+
+async fn prefetch_position(
+    engine: Arc<Engine>,
+    target_position: usize,
+    routes: Vec<Vec<u32>>,
+    concurrency: usize,
+    expert_bytes: usize,
+    counters: Arc<Mutex<OracleCounters>>,
+) -> PrefetchOutcome {
+    let started = Instant::now();
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(concurrency));
+    let batches = stream::iter(routes.into_iter().enumerate().map(|(layer_index, ids)| {
+        let engine = engine.clone();
+        let counters = counters.clone();
+        let semaphore = semaphore.clone();
+        async move {
+            let permit = semaphore
+                .acquire_owned()
+                .await
+                .expect("qualification semaphore remains open");
+            let result = prefetch_layer_batch(engine, layer_index, ids, counters).await;
+            drop(permit);
+            result
+        }
+    }))
+    .buffer_unordered(concurrency)
+    .collect::<Vec<_>>()
+    .await;
+
+    let mut outcome = PrefetchOutcome {
+        target_position,
+        ..PrefetchOutcome::default()
+    };
+    for batch in batches {
+        if outcome.fatal_error.is_none() {
+            outcome.fatal_error = batch.fatal_error;
+        }
+        outcome.failed_ids.extend(batch.failed_ids);
+        outcome.residents.extend(batch.residents);
+    }
+    let slots = outcome.residents.len() as u64;
+    let bytes = outcome
+        .residents
+        .values()
+        .map(|resident| resident.data().len() as u64)
+        .sum::<u64>();
+    let mut values = counters.lock();
+    add_counter(&mut values.source_prefetch_wall_us, saturating_us(started));
+    values.qualification_owned_current_slots = slots;
+    values.qualification_owned_current_bytes = bytes;
+    values.qualification_owned_peak_slots = values.qualification_owned_peak_slots.max(slots);
+    values.qualification_owned_peak_bytes = values.qualification_owned_peak_bytes.max(bytes);
+    if slots > FROZEN_RAM_CACHE_SLOTS as u64
+        || bytes > (FROZEN_RAM_CACHE_SLOTS as u64).saturating_mul(expert_bytes as u64)
+    {
+        outcome.fatal_error = Some(format!(
+            "qualification temporary source state exceeded bound: slots={slots} bytes={bytes}"
+        ));
+    }
+    drop(values);
+    outcome
+}
+
+struct OracleBoundaryObserver {
+    counters: Arc<Mutex<OracleCounters>>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum BoundaryInstallErrorPolicy {
+    DegradeToDemand,
+    DegradeStaleGeneration,
+    FailClosed,
+}
+
+fn boundary_install_error_policy(
+    error: &GpuNativeTieredResidencyError,
+) -> BoundaryInstallErrorPolicy {
+    match error {
+        GpuNativeTieredResidencyError::LogicalAdmissionStale { .. }
+        | GpuNativeTieredResidencyError::StalePhysicalRequester { .. } => {
+            BoundaryInstallErrorPolicy::DegradeStaleGeneration
+        }
+        GpuNativeTieredResidencyError::PhysicalIdentityCorrupt { .. }
+        | GpuNativeTieredResidencyError::UnsafeOracleBoundary { .. } => {
+            BoundaryInstallErrorPolicy::FailClosed
+        }
+        _ => BoundaryInstallErrorPolicy::DegradeToDemand,
+    }
+}
+
+impl GpuNativePhysicalInstallObserver for OracleBoundaryObserver {
+    fn record_physical_victim(&self, _global_id: u32) {
+        self.counters.lock().boundary_physical_evictions += 1;
+    }
+
+    fn record_physical_install_attempt(&self) {}
+
+    fn record_direct_staging_failure(&self) {
+        self.counters.lock().boundary_install_failures += 1;
+    }
+
+    fn record_physical_install_completion(
+        &self,
+        _global_id: u32,
+        _residency: GpuNativeQ4ExpertResidency,
+        evidence: GpuNativePhysicalInstallEvidence,
+        _physical_install_total_us: u64,
+    ) {
+        let mut values = self.counters.lock();
+        values.boundary_physical_installs += 1;
+        add_counter(
+            &mut values.boundary_physical_install_bytes,
+            evidence.physical_slot_bytes_staged,
+        );
+        add_counter(
+            &mut values.boundary_direct_staging_writes,
+            evidence.direct_staging_writes,
+        );
+        add_counter(
+            &mut values.boundary_full_slot_vec_materializations,
+            evidence.full_slot_vec_materializations,
+        );
+    }
+
+    fn record_physical_install_set(
+        &self,
+        _width: usize,
+        _parallel: bool,
+        _caller_in_rayon_worker: bool,
+        _rayon_threads: usize,
+    ) {
+    }
+
+    fn record_reservation_attempt(&self) {}
+
+    fn record_reservation_success(
+        &self,
+        _global_id: u32,
+        _residency: GpuNativeQ4ExpertResidency,
+        _install_ticket: u64,
+    ) {
+    }
+
+    fn record_reservation_failure(&self) {
+        self.counters.lock().boundary_install_failures += 1;
+    }
+
+    fn record_physical_stage_started(&self) {}
+
+    fn record_physical_stage_completed(
+        &self,
+        _evidence: GpuNativePhysicalInstallEvidence,
+        _individual_stage_us: u64,
+    ) {
+    }
+
+    fn record_physical_stage_failed(&self) {
+        self.counters.lock().boundary_install_failures += 1;
+    }
+
+    fn record_parallel_stage_wall(&self, wall_us: u64) {
+        add_counter(
+            &mut self.counters.lock().token_boundary_physical_stage_us,
+            wall_us,
+        );
+    }
+
+    fn record_ordered_commit_attempt(&self) {}
+
+    fn record_ordered_commit_completed(&self, commit_us: u64) {
+        add_counter(
+            &mut self.counters.lock().token_boundary_commit_us,
+            commit_us,
+        );
+    }
+
+    fn record_ordered_commit_failed(&self, _violation: bool) {
+        self.counters.lock().boundary_install_failures += 1;
+    }
+
+    fn record_physical_reservation_wall(&self, _wall_us: u64) {}
+
+    fn record_physical_install_transaction_wall(&self, _wall_us: u64) {}
+
+    fn record_unpublished_physical_writes_after_failure(&self, _count: u64) {}
+}
+
+fn future_global_ids(
+    layer_index: usize,
+    local_ids: &[u32],
+    num_layers: usize,
+    experts_per_layer: u32,
+) -> Result<Vec<u32>, GpuNativeTieredResidencyError> {
+    local_ids
+        .iter()
+        .map(|&local_id| {
+            crate::gpu_native_residency::layer_local_to_global(
+                layer_index,
+                local_id,
+                num_layers,
+                experts_per_layer,
+            )
+        })
+        .collect()
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct BoundaryReplacementPlan {
+    physical_experts_needed: usize,
+    minimum_evictions: usize,
+}
+
+fn plan_boundary_replacement(
+    slot_capacity: usize,
+    resident_slots: usize,
+    physical_current: &[bool],
+) -> Result<BoundaryReplacementPlan, String> {
+    if resident_slots > slot_capacity || physical_current.len() > slot_capacity {
+        return Err(format!(
+            "future set cannot fit exact physical capacity: residents={resident_slots} future={} capacity={slot_capacity}",
+            physical_current.len()
+        ));
+    }
+    let physical_experts_needed = physical_current.iter().filter(|&&current| !current).count();
+    let free_slots = slot_capacity - resident_slots;
+    Ok(BoundaryReplacementPlan {
+        physical_experts_needed,
+        minimum_evictions: physical_experts_needed.saturating_sub(free_slots),
+    })
+}
+
+fn prepare_logical_admissions(
+    engine: &Arc<Engine>,
+    global_ids: &[u32],
+    residents: &HashMap<u32, Arc<ExpertResident>>,
+) -> Result<Vec<crate::expert_cache::GpuAdmission>, String> {
+    let gpu = engine.execution_context().gpu_expert_cache().clone();
+    let mut payloads = HashMap::with_capacity(global_ids.len());
+    for attempt in 0..2 {
+        match gpu
+            .demand_admit_set(global_ids, &payloads)
+            .map_err(|error| error.to_string())?
+        {
+            GpuDemandSetAdmission::Ready { admissions, .. } => return Ok(admissions),
+            GpuDemandSetAdmission::PayloadRequired(missing) if attempt == 0 => {
+                for global_id in missing {
+                    let resident = residents.get(&global_id).ok_or_else(|| {
+                        format!("future source for global expert {global_id} is not ready")
+                    })?;
+                    payloads.insert(
+                        global_id,
+                        Arc::new(GpuResident::new_with_dtype(
+                            global_id,
+                            resident.data().to_vec(),
+                            engine.core.options.dtype,
+                        )),
+                    );
+                }
+            }
+            GpuDemandSetAdmission::PayloadRequired(missing) => {
+                return Err(format!(
+                    "logical admission still requires payloads after complete preparation: {missing:?}"
+                ));
+            }
+        }
+    }
+    Err("logical admission attempt bound exhausted".into())
+}
+
+fn install_future_at_boundary(
+    engine: &Arc<Engine>,
+    boundary: &mut GpuNativeSafeTokenBoundary,
+    routes: &[Vec<u32>],
+    residents: &HashMap<u32, Arc<ExpertResident>>,
+    counters: Arc<Mutex<OracleCounters>>,
+) -> Result<(), String> {
+    let manager = engine
+        .core
+        .gpu_native_residency
+        .as_ref()
+        .cloned()
+        .ok_or("GPU-native residency manager is absent")?;
+    if routes.len() != manager.plan().num_layers() {
+        return Err(format!(
+            "future route has {} layers, expected {}",
+            routes.len(),
+            manager.plan().num_layers()
+        ));
+    }
+    let before = manager.snapshot();
+    let observer = OracleBoundaryObserver {
+        counters: counters.clone(),
+    };
+    let experts_per_layer = manager.plan().geometry().num_experts() as u32;
+    for (layer_index, local_ids) in routes.iter().enumerate() {
+        counters.lock().future_physical_sets_considered += 1;
+        let global_ids = future_global_ids(
+            layer_index,
+            local_ids,
+            manager.plan().num_layers(),
+            experts_per_layer,
+        )
+        .map_err(|error| error.to_string())?;
+        let mut physical_current = Vec::with_capacity(global_ids.len());
+        for &global_id in &global_ids {
+            match manager.has_current_for_demand(global_id) {
+                Ok(current) => physical_current.push(current),
+                Err(error @ GpuNativeTieredResidencyError::PhysicalIdentityCorrupt { .. }) => {
+                    return Err(error.to_string());
+                }
+                Err(error) => return Err(error.to_string()),
+            }
+        }
+        let missing = global_ids
+            .iter()
+            .copied()
+            .zip(physical_current.iter().copied())
+            .filter_map(|(global_id, current)| (!current).then_some(global_id))
+            .collect::<Vec<_>>();
+        let layer_snapshot = before
+            .layers
+            .get(layer_index)
+            .ok_or_else(|| format!("physical snapshot is missing layer {layer_index}"))?;
+        let replacement_plan = plan_boundary_replacement(
+            layer_snapshot.slot_capacity,
+            layer_snapshot.resident_slots,
+            &physical_current,
+        )?;
+        if replacement_plan.physical_experts_needed != missing.len() {
+            return Err("ORACLE boundary replacement plan disagrees with exact currentness".into());
+        }
+        counters.lock().future_physical_experts_needed +=
+            replacement_plan.physical_experts_needed as u64;
+        if missing.is_empty() {
+            continue;
+        }
+        if missing
+            .iter()
+            .any(|global_id| !residents.contains_key(global_id))
+        {
+            counters.lock().source_failures_degraded_to_demand += 1;
+            continue;
+        }
+
+        let gpu = engine.execution_context().gpu_expert_cache().clone();
+        let _logical_protection = gpu
+            .protect_demand_set(&missing)
+            .map_err(|error| error.to_string())?;
+        let host_started = Instant::now();
+        let admissions = match prepare_logical_admissions(engine, &missing, residents) {
+            Ok(admissions) => admissions,
+            Err(error) => {
+                let mut values = counters.lock();
+                add_counter(
+                    &mut values.token_boundary_host_stage_us,
+                    saturating_us(host_started),
+                );
+                values.boundary_install_failures += 1;
+                if error.contains("generation") {
+                    values.boundary_stale_generation += 1;
+                }
+                continue;
+            }
+        };
+        add_counter(
+            &mut counters.lock().token_boundary_host_stage_us,
+            saturating_us(host_started),
+        );
+        let admissions_by_id = missing
+            .iter()
+            .copied()
+            .zip(admissions)
+            .collect::<HashMap<_, _>>();
+        let demands = global_ids
+            .iter()
+            .copied()
+            .zip(physical_current.iter().copied())
+            .map(|(global_id, current)| {
+                if current {
+                    GpuNativeDemandExpert::current(global_id)
+                } else {
+                    GpuNativeDemandExpert::install(
+                        global_id,
+                        residents
+                            .get(&global_id)
+                            .expect("future source presence validated")
+                            .clone(),
+                        admissions_by_id
+                            .get(&global_id)
+                            .expect("logical admission returned every missing identity")
+                            .clone(),
+                    )
+                }
+            })
+            .collect::<Vec<_>>();
+        counters.lock().boundary_replacement_sets_started += 1;
+        let evictions_before = counters.lock().boundary_physical_evictions;
+        match manager.ensure_oracle_future_set_at_safe_boundary(
+            boundary,
+            layer_index,
+            &demands,
+            &observer,
+        ) {
+            Ok(_) => {
+                let mut values = counters.lock();
+                values.boundary_replacement_sets_completed += 1;
+                let observed_evictions = values
+                    .boundary_physical_evictions
+                    .saturating_sub(evictions_before);
+                if observed_evictions != replacement_plan.minimum_evictions as u64 {
+                    return Err(format!(
+                        "ORACLE boundary replacement evicted {observed_evictions} experts, expected {} for layer {layer_index}",
+                        replacement_plan.minimum_evictions
+                    ));
+                }
+            }
+            Err(error) => match boundary_install_error_policy(&error) {
+                BoundaryInstallErrorPolicy::DegradeStaleGeneration => {
+                    let mut values = counters.lock();
+                    values.boundary_stale_generation += 1;
+                    values.boundary_install_failures += 1;
+                }
+                BoundaryInstallErrorPolicy::FailClosed => return Err(error.to_string()),
+                BoundaryInstallErrorPolicy::DegradeToDemand => {
+                    counters.lock().boundary_install_failures += 1;
+                }
+            },
+        }
+    }
+    let after = manager.snapshot();
+    if before.model_slot_capacity != after.model_slot_capacity
+        || before.model_arena_allocation_bytes != after.model_arena_allocation_bytes
+        || after
+            .layers
+            .iter()
+            .any(|layer| layer.resident_slots > layer.slot_capacity)
+    {
+        return Err("ORACLE boundary replacement changed or exceeded physical capacity".into());
+    }
+    counters.lock().boundary_physical_reinstalls += after
+        .physical_reinstalls
+        .saturating_sub(before.physical_reinstalls);
+    Ok(())
+}
+
+struct ActivePrefetch {
+    target_position: usize,
+    handle: Option<tokio::task::JoinHandle<PrefetchLease>>,
+}
+
+struct SchedulerState {
+    cursor: StrictRouteCursor,
+    submitted_position: Option<usize>,
+    active: Option<ActivePrefetch>,
+    background: Vec<tokio::task::JoinHandle<()>>,
+    failure: Option<String>,
+}
+
+struct OracleScheduler {
+    engine: Arc<Engine>,
+    mode: OracleScheduledResidencyMode,
+    concurrency: usize,
+    expert_bytes: usize,
+    source_position_gate: Arc<tokio::sync::Mutex<()>>,
+    counters: Arc<Mutex<OracleCounters>>,
+    state: Arc<Mutex<SchedulerState>>,
+}
+
+impl OracleScheduler {
+    fn new(
+        engine: Arc<Engine>,
+        trace: Arc<OracleRouteTrace>,
+        mode: OracleScheduledResidencyMode,
+        concurrency: usize,
+        expert_bytes: usize,
+    ) -> Self {
+        Self {
+            engine,
+            mode,
+            concurrency,
+            expert_bytes,
+            source_position_gate: Arc::new(tokio::sync::Mutex::new(())),
+            counters: Arc::new(Mutex::new(OracleCounters::default())),
+            state: Arc::new(Mutex::new(SchedulerState {
+                cursor: StrictRouteCursor::new(trace),
+                submitted_position: None,
+                active: None,
+                background: Vec::new(),
+                failure: None,
+            })),
+        }
+    }
+
+    async fn prime_initial_position(&self) -> Result<(), String> {
+        let routes = self.state.lock().cursor.routes_at(0)?;
+        record_source_position_considered(&mut self.counters.lock(), &routes);
+        let started = Instant::now();
+        let position_guard = self.source_position_gate.clone().lock_owned().await;
+        let lease = PrefetchLease::new(
+            prefetch_position(
+                self.engine.clone(),
+                0,
+                routes,
+                self.concurrency,
+                self.expert_bytes,
+                self.counters.clone(),
+            )
+            .await,
+            self.counters.clone(),
+            position_guard,
+        );
+        if let Some(error) = lease.outcome.fatal_error.as_ref() {
+            let error = error.clone();
+            return Err(error);
+        }
+        let mut values = self.counters.lock();
+        values.initial_position_source_priming_experts = lease.outcome.residents.len() as u64;
+        values.initial_position_source_priming_us = saturating_us(started);
+        values.source_failures_degraded_to_demand += lease.outcome.failed_ids.len() as u64;
+        drop(values);
+        drop(lease);
+        Ok(())
+    }
+
+    fn observe_demand_readiness(&self, position: usize) -> Result<(), String> {
+        let routes = self.state.lock().cursor.routes_at(position)?;
+        let manager = self
+            .engine
+            .core
+            .gpu_native_residency
+            .as_ref()
+            .ok_or("GPU-native residency manager is absent")?;
+        let experts_per_layer = manager.plan().geometry().num_experts() as u32;
+        let mut current_by_layer = Vec::with_capacity(routes.len());
+        for (layer_index, local_ids) in routes.iter().enumerate() {
+            let global_ids = future_global_ids(
+                layer_index,
+                local_ids,
+                manager.plan().num_layers(),
+                experts_per_layer,
+            )
+            .map_err(|error| error.to_string())?;
+            let mut layer_current = Vec::with_capacity(global_ids.len());
+            for global_id in global_ids {
+                match manager.has_current_for_demand(global_id) {
+                    Ok(current) => layer_current.push(current),
+                    Err(error) => return Err(error.to_string()),
+                }
+            }
+            current_by_layer.push(layer_current);
+        }
+        record_demand_readiness(&mut self.counters.lock(), &current_by_layer);
+        Ok(())
+    }
+
+    fn late_source_count(&self, routes: &[Vec<u32>]) -> Result<u64, String> {
+        let manager = self
+            .engine
+            .core
+            .gpu_native_residency
+            .as_ref()
+            .ok_or("GPU-native residency manager is absent")?;
+        let experts_per_layer = manager.plan().geometry().num_experts() as u32;
+        let mut late = 0u64;
+        for (layer_index, local_ids) in routes.iter().enumerate() {
+            for global_id in future_global_ids(
+                layer_index,
+                local_ids,
+                manager.plan().num_layers(),
+                experts_per_layer,
+            )
+            .map_err(|error| error.to_string())?
+            {
+                if !manager
+                    .has_current_for_demand(global_id)
+                    .map_err(|error| error.to_string())?
+                    && !self.engine.core.cache.contains(global_id)
+                {
+                    late += 1;
+                }
+            }
+        }
+        Ok(late)
+    }
+
+    fn record_position_gate_skip(&self, routes: &[Vec<u32>]) -> Result<(), String> {
+        let manager = self
+            .engine
+            .core
+            .gpu_native_residency
+            .as_ref()
+            .ok_or("GPU-native residency manager is absent")?;
+        let experts_per_layer = manager.plan().geometry().num_experts() as u32;
+        let mut physical = 0u64;
+        let mut ram = 0u64;
+        let mut singleflight = 0u64;
+        let mut position_inflight = 0u64;
+        for (layer_index, local_ids) in routes.iter().enumerate() {
+            for global_id in future_global_ids(
+                layer_index,
+                local_ids,
+                manager.plan().num_layers(),
+                experts_per_layer,
+            )
+            .map_err(|error| error.to_string())?
+            {
+                let current = manager
+                    .has_current_for_demand(global_id)
+                    .map_err(|error| error.to_string())?;
+                match source_disposition(
+                    current,
+                    !current && self.engine.core.cache.contains(global_id),
+                    !current && self.engine.core.in_flight.contains_key(&global_id),
+                ) {
+                    SourceDisposition::AlreadyPhysical => physical += 1,
+                    SourceDisposition::RamHit => ram += 1,
+                    SourceDisposition::SourceInFlight => singleflight += 1,
+                    SourceDisposition::StartSourceRead => position_inflight += 1,
+                }
+            }
+        }
+        let mut values = self.counters.lock();
+        values.source_skipped_physical_current += physical;
+        values.source_ram_hits += ram;
+        values.source_singleflight_hits += singleflight;
+        values.source_position_inflight_skips += position_inflight;
+        values.source_prefetch_batches_skipped_inflight += routes.len() as u64;
+        Ok(())
+    }
+
+    async fn complete_boundary(
+        &self,
+        mut boundary: GpuNativeSafeTokenBoundary,
+        actual_routes: &[Vec<u32>],
+    ) -> Result<(), String> {
+        let position = boundary.position();
+        let (future_routes, active, prior_failure) = {
+            let mut state = self.state.lock();
+            state.cursor.reconcile(position, actual_routes)?;
+            if state.submitted_position != Some(position) {
+                return Err(format!(
+                    "safe boundary for position {position} has no matching submitted-token record"
+                ));
+            }
+            state.submitted_position = None;
+            let future_routes = state.cursor.future_after(position)?;
+            let active = state.active.take();
+            (future_routes, active, state.failure.clone())
+        };
+        if let Some(error) = prior_failure {
+            return Err(error);
+        }
+
+        let Some(routes) = future_routes else {
+            if active.is_some() {
+                return Err("end-of-trace unexpectedly retained a future source task".into());
+            }
+            return Ok(());
+        };
+        let active = active.ok_or_else(|| {
+            format!("position {position} completed without a scheduled future source task")
+        })?;
+        if active.target_position != position + 1 {
+            return Err(format!(
+                "future source task targets {}, expected {}",
+                active.target_position,
+                position + 1
+            ));
+        }
+        let Some(handle) = active.handle else {
+            let late = self.late_source_count(&routes)?;
+            record_source_late(&mut self.counters.lock(), late);
+            return Ok(());
+        };
+
+        if !handle.is_finished() {
+            let late = self.late_source_count(&routes)?;
+            {
+                let mut values = self.counters.lock();
+                record_source_late(&mut values, late);
+            }
+            let state_for_task = self.state.clone();
+            let counters_for_task = self.counters.clone();
+            let discard = tokio::spawn(async move {
+                let joined = handle.await;
+                counters_for_task.lock().background_tasks_drained += 1;
+                match joined {
+                    Ok(lease) => {
+                        if let Some(error) = lease.outcome.fatal_error.as_ref() {
+                            state_for_task.lock().failure = Some(error.clone());
+                        }
+                    }
+                    Err(error) => {
+                        state_for_task.lock().failure =
+                            Some(format!("future source task failed to join: {error}"));
+                    }
+                }
+            });
+            self.state.lock().background.push(discard);
+            return Ok(());
+        }
+
+        let wait_started = Instant::now();
+        let joined = handle.await;
+        self.counters.lock().background_tasks_drained += 1;
+        let lease =
+            joined.map_err(|error| format!("future source task failed to join: {error}"))?;
+        let outcome = &lease.outcome;
+        if outcome.target_position != position + 1 {
+            return Err("completed future source task returned the wrong position".into());
+        }
+        if let Some(error) = outcome.fatal_error.as_ref() {
+            return Err(error.clone());
+        }
+        {
+            let mut values = self.counters.lock();
+            record_completed_source_outcome(&mut values, outcome);
+        }
+        if self.mode == OracleScheduledResidencyMode::TokenBoundaryDirect {
+            install_future_at_boundary(
+                &self.engine,
+                &mut boundary,
+                &routes,
+                &outcome.residents,
+                self.counters.clone(),
+            )?;
+        }
+        add_counter(
+            &mut self.counters.lock().oracle_wait_before_next_token_us,
+            saturating_us(wait_started),
+        );
+        drop(lease);
+        Ok(())
+    }
+
+    async fn finish_request(&self) -> Result<(OracleCounters, OracleRouteTrace), String> {
+        let mut background = std::mem::take(&mut self.state.lock().background);
+        drain_background_tasks(&mut background).await?;
+        let mut state = self.state.lock();
+        if state.active.is_some() || state.submitted_position.is_some() {
+            return Err("oracle scheduler retained active state after request completion".into());
+        }
+        if let Some(error) = state.failure.take() {
+            return Err(error);
+        }
+        let trace = state.cursor.clone().finish()?;
+        let mut counters = self.counters.lock().clone();
+        counters.qualification_owned_current_slots = 0;
+        counters.qualification_owned_current_bytes = 0;
+        Ok((counters, trace))
+    }
+}
+
+fn record_completed_source_outcome(counters: &mut OracleCounters, outcome: &PrefetchOutcome) {
+    counters.source_ready_before_boundary += outcome.residents.len() as u64;
+    counters.source_failures_degraded_to_demand += outcome.failed_ids.len() as u64;
+}
+
+fn record_source_position_considered(counters: &mut OracleCounters, routes: &[Vec<u32>]) {
+    counters.future_experts_considered += routes.iter().map(Vec::len).sum::<usize>() as u64;
+}
+
+fn record_source_late(counters: &mut OracleCounters, late_experts: u64) {
+    counters.source_late_at_boundary += late_experts;
+    counters.source_late_degraded_to_demand += 1;
+}
+
+fn record_demand_readiness(counters: &mut OracleCounters, current_by_layer: &[Vec<bool>]) {
+    for layer in current_by_layer {
+        let ready = layer.iter().filter(|&&current| current).count() as u64;
+        counters.oracle_ready_at_demand += ready;
+        counters.oracle_not_ready_at_demand += layer.len() as u64 - ready;
+        counters.oracle_demand_fallback += u64::from(ready != layer.len() as u64);
+    }
+}
+
+async fn drain_background_tasks(
+    tasks: &mut Vec<tokio::task::JoinHandle<()>>,
+) -> Result<(), String> {
+    for task in tasks.drain(..) {
+        task.await
+            .map_err(|error| format!("background source drain failed: {error}"))?;
+    }
+    Ok(())
+}
+
+impl GpuNativeOracleScheduleHook for OracleScheduler {
+    fn on_token_submitted(&self, position: usize) {
+        let mut state = self.state.lock();
+        if state.failure.is_some() {
+            return;
+        }
+        if state.submitted_position == Some(position) {
+            // Recovery may submit more than one segment for the same logical
+            // token. Perfect-future source work is scheduled exactly once.
+            return;
+        }
+        if state.submitted_position.is_some() || position != state.cursor.next_position {
+            state.failure = Some(format!(
+                "submission progression mismatch: next={} submitted={position}",
+                state.cursor.next_position
+            ));
+            return;
+        }
+        state.submitted_position = Some(position);
+        let routes = match state.cursor.future_after(position) {
+            Ok(Some(routes)) => routes,
+            Ok(None) => {
+                self.counters.lock().source_end_of_trace += 1;
+                return;
+            }
+            Err(error) => {
+                state.failure = Some(error);
+                return;
+            }
+        };
+        if state.active.is_some() {
+            state.failure = Some("future source task slot was already occupied".into());
+            return;
+        }
+        record_source_position_considered(&mut self.counters.lock(), &routes);
+        let engine = self.engine.clone();
+        let counters = self.counters.clone();
+        let concurrency = self.concurrency;
+        let expert_bytes = self.expert_bytes;
+        let target_position = position + 1;
+        let handle = match self.source_position_gate.clone().try_lock_owned() {
+            Ok(position_guard) => {
+                let handle = tokio::spawn(async move {
+                    let outcome = prefetch_position(
+                        engine,
+                        target_position,
+                        routes,
+                        concurrency,
+                        expert_bytes,
+                        counters.clone(),
+                    )
+                    .await;
+                    PrefetchLease::new(outcome, counters, position_guard)
+                });
+                self.counters.lock().background_tasks_spawned += 1;
+                Some(handle)
+            }
+            Err(_) => {
+                if let Err(error) = self.record_position_gate_skip(&routes) {
+                    state.failure = Some(error);
+                }
+                None
+            }
+        };
+        state.active = Some(ActivePrefetch {
+            target_position,
+            handle,
+        });
+    }
+
+    fn on_safe_token_boundary<'a>(
+        &'a self,
+        _engine: &'a Arc<Engine>,
+        boundary: GpuNativeSafeTokenBoundary,
+        actual_routes: &'a [Vec<u32>],
+    ) -> Pin<Box<dyn std::future::Future<Output = Result<(), String>> + Send + 'a>> {
+        Box::pin(async move { self.complete_boundary(boundary, actual_routes).await })
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct PhysicalSlotPlanEvidence {
+    model_expert_budget_bytes: u64,
+    model_arena_allocation_bytes: u64,
+    model_slot_capacity: usize,
+    per_layer_slot_capacity: Vec<usize>,
+    no_extra_physical_vram_capacity: bool,
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+struct TreatmentContract {
+    source_overlap: bool,
+    host_preparation_overlap: bool,
+    token_boundary_h2d: bool,
+    demand_fallback: bool,
+    h2d_compute_overlap_claimed: bool,
+    same_ordered_queue: bool,
+    extra_flush_submit: bool,
+    production_predictor_used: bool,
+    production_speculative_residency_used: bool,
+    production_direct_staging_used: bool,
+    legacy_full_slot_vec_used: bool,
+}
+
+const fn treatment_contract(mode: OracleScheduledResidencyMode) -> TreatmentContract {
+    TreatmentContract {
+        source_overlap: true,
+        host_preparation_overlap: false,
+        token_boundary_h2d: matches!(mode, OracleScheduledResidencyMode::TokenBoundaryDirect),
+        demand_fallback: true,
+        h2d_compute_overlap_claimed: false,
+        same_ordered_queue: true,
+        extra_flush_submit: false,
+        production_predictor_used: false,
+        production_speculative_residency_used: false,
+        production_direct_staging_used: matches!(
+            mode,
+            OracleScheduledResidencyMode::TokenBoundaryDirect
+        ),
+        legacy_full_slot_vec_used: false,
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct FrozenWorkloadEvidence {
+    prompt: &'static str,
+    prompt_sha256: &'static str,
+    prompt_token_ids_sha256: &'static str,
+    output_tokens: usize,
+    greedy: bool,
+    warmup_runs: usize,
+    measured_runs: usize,
+    repeated_trace_per_request: bool,
+    shared_runtime_and_cache: bool,
+    initial_position_priming: &'static str,
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+struct FrozenControlReferences {
+    frozen_parent_git_sha: &'static str,
+    oracle_route_command_git_sha: &'static str,
+    performance_controls_rerun: bool,
+    hardware_results_embedded: bool,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct RunCorrectness {
+    generated_token_ids_sha256: String,
+    generated_text_sha256: String,
+    actual_route_sequence_sha256: String,
+    actual_legacy_route_sha256: String,
+    generated_tokens_match_frozen_demand_only: bool,
+    generated_text_matches_frozen_demand_only: bool,
+    actual_route_matches_oracle: bool,
+    actual_legacy_route_matches_oracle: bool,
+    no_fatal_failures: bool,
+}
+
+fn frozen_output_matches(
+    generated_token_sha: &str,
+    generated_text_sha: &str,
+    expected_token_sha: &str,
+    expected_text_sha: &str,
+) -> (bool, bool) {
+    (
+        generated_token_sha == expected_token_sha,
+        generated_text_sha == expected_text_sha,
+    )
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct OracleRunResult {
+    run_index: usize,
+    benchmark: PerRunResult,
+    oracle: OracleCounters,
+    correctness: RunCorrectness,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct AggregateOracleCounters {
+    measured_runs: usize,
+    totals: OracleCounters,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct CorrectnessEvidence {
+    warmup_matches_measured: bool,
+    all_measured_outputs_identical: bool,
+    all_actual_routes_match_oracle: bool,
+    generated_token_ids_sha256: String,
+    generated_text_sha256: String,
+    actual_route_sequence_sha256: String,
+    actual_legacy_route_sha256: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct OracleScheduledResidencyReport {
+    schema: &'static str,
+    mode: &'static str,
+    complete: bool,
+    failure: Option<BenchmarkFailure>,
+    diagnostic_only: bool,
+    provenance: BenchmarkProvenance,
+    source_oracle: SourceOracleEvidence,
+    model_identity: ModelIdentityEvidence,
+    model_load: ModelLoadEvidence,
+    adapter_identity: GpuDeviceIdentity,
+    runtime_contract: RuntimeContractEvidence,
+    request: RequestEvidence,
+    production_configuration: ProductionConfiguration,
+    treatment_mode: OracleScheduledResidencyMode,
+    oracle_source_concurrency: usize,
+    treatment_contract: TreatmentContract,
+    physical_slot_plan: PhysicalSlotPlanEvidence,
+    frozen_controls: FrozenControlReferences,
+    frozen_workload: FrozenWorkloadEvidence,
+    warmup: OracleRunResult,
+    measured: Vec<OracleRunResult>,
+    aggregate_measured_performance: Aggregate,
+    aggregate_measured_oracle: AggregateOracleCounters,
+    correctness: CorrectnessEvidence,
+    shutdown: BackgroundShutdownEvidence,
+}
+
+fn accumulate_oracle(total: &mut OracleCounters, value: &OracleCounters) {
+    macro_rules! add {
+        ($field:ident) => {
+            total.$field = total.$field.saturating_add(value.$field)
+        };
+    }
+    add!(initial_position_source_priming_experts);
+    add!(initial_position_source_priming_us);
+    add!(future_experts_considered);
+    add!(source_skipped_physical_current);
+    add!(source_ram_hits);
+    add!(source_singleflight_hits);
+    add!(source_position_inflight_skips);
+    add!(source_reads_started);
+    add!(source_reads_completed);
+    add!(source_reads_failed);
+    add!(source_bytes_read);
+    add!(source_prefetch_batches_started);
+    add!(source_prefetch_batches_completed);
+    add!(source_prefetch_batches_skipped_inflight);
+    total.source_prefetch_peak_inflight = total
+        .source_prefetch_peak_inflight
+        .max(value.source_prefetch_peak_inflight);
+    add!(source_ready_before_boundary);
+    add!(source_late_at_boundary);
+    add!(source_end_of_trace);
+    add!(future_physical_sets_considered);
+    add!(future_physical_experts_needed);
+    add!(boundary_replacement_sets_started);
+    add!(boundary_replacement_sets_completed);
+    add!(boundary_physical_installs);
+    add!(boundary_physical_install_bytes);
+    add!(boundary_physical_evictions);
+    add!(boundary_physical_reinstalls);
+    add!(boundary_stale_generation);
+    add!(boundary_install_failures);
+    add!(boundary_direct_staging_writes);
+    add!(boundary_full_slot_vec_materializations);
+    add!(oracle_ready_at_demand);
+    add!(oracle_not_ready_at_demand);
+    add!(oracle_demand_fallback);
+    add!(ordinary_residency_miss_attempts);
+    add!(ordinary_residency_services);
+    add!(source_prefetch_wall_us);
+    add!(source_read_aggregate_us);
+    add!(host_preparation_overlap_us);
+    add!(token_boundary_host_stage_us);
+    add!(token_boundary_physical_stage_us);
+    add!(token_boundary_commit_us);
+    add!(oracle_wait_before_next_token_us);
+    total.qualification_owned_current_slots = value.qualification_owned_current_slots;
+    total.qualification_owned_current_bytes = value.qualification_owned_current_bytes;
+    total.qualification_owned_peak_slots = total
+        .qualification_owned_peak_slots
+        .max(value.qualification_owned_peak_slots);
+    total.qualification_owned_peak_bytes = total
+        .qualification_owned_peak_bytes
+        .max(value.qualification_owned_peak_bytes);
+    add!(source_failures_degraded_to_demand);
+    add!(source_late_degraded_to_demand);
+    add!(background_tasks_spawned);
+    add!(background_tasks_drained);
+}
+
+fn validate_oracle_counters(
+    counters: &OracleCounters,
+    mode: OracleScheduledResidencyMode,
+    concurrency: usize,
+) -> Result<(), BenchmarkFailure> {
+    let classified_source = counters
+        .source_skipped_physical_current
+        .saturating_add(counters.source_ram_hits)
+        .saturating_add(counters.source_singleflight_hits)
+        .saturating_add(counters.source_position_inflight_skips)
+        .saturating_add(counters.source_reads_started);
+    if counters.future_experts_considered != EXPECTED_SELECTED_IDS as u64
+        || classified_source != counters.future_experts_considered
+        || counters.source_reads_started
+            != counters
+                .source_reads_completed
+                .saturating_add(counters.source_reads_failed)
+        || counters
+            .source_prefetch_batches_started
+            .saturating_add(counters.source_prefetch_batches_skipped_inflight)
+            != EXPECTED_LAYER_RECORDS as u64
+        || counters.source_prefetch_batches_completed != counters.source_prefetch_batches_started
+        || counters.source_prefetch_peak_inflight > concurrency as u64
+        || counters
+            .oracle_ready_at_demand
+            .saturating_add(counters.oracle_not_ready_at_demand)
+            != EXPECTED_SELECTED_IDS as u64
+        || counters.qualification_owned_current_slots != 0
+        || counters.qualification_owned_current_bytes != 0
+        || counters.qualification_owned_peak_slots > FROZEN_RAM_CACHE_SLOTS as u64
+        || counters.background_tasks_spawned > (EXPECTED_POSITIONS - 1) as u64
+        || counters.background_tasks_drained != counters.background_tasks_spawned
+        || counters.source_end_of_trace != 1
+    {
+        return Err(BenchmarkFailure::new(
+            "postcondition",
+            "oracle-counter-reconciliation",
+            format!("ORACLE source/physical/accounting counters do not reconcile: {counters:?}"),
+        ));
+    }
+    if mode == OracleScheduledResidencyMode::SourceOnly
+        && (counters.boundary_replacement_sets_started != 0
+            || counters.boundary_physical_installs != 0
+            || counters.boundary_physical_evictions != 0)
+    {
+        return Err(BenchmarkFailure::new(
+            "postcondition",
+            "source-only-physical-mutation",
+            "source-only treatment recorded destructive physical work",
+        ));
+    }
+    if counters.boundary_full_slot_vec_materializations != 0 {
+        return Err(BenchmarkFailure::new(
+            "postcondition",
+            "legacy-physical-path-used",
+            "ORACLE token-boundary treatment materialized a legacy full-slot Vec",
+        ));
+    }
+    if mode == OracleScheduledResidencyMode::TokenBoundaryDirect
+        && (counters.boundary_direct_staging_writes != counters.boundary_physical_installs
+            || counters.boundary_physical_evictions > counters.boundary_physical_installs
+            || counters.boundary_replacement_sets_completed
+                > counters.boundary_replacement_sets_started
+            || (counters.boundary_physical_installs == 0)
+                != (counters.boundary_physical_install_bytes == 0))
+    {
+        return Err(BenchmarkFailure::new(
+            "postcondition",
+            "oracle-physical-counter-reconciliation",
+            "ORACLE direct staging, install bytes, eviction, or replacement-set counters do not reconcile",
+        ));
+    }
+    Ok(())
+}
+
+struct ValidatedRuntime {
+    model_load: ModelLoadEvidence,
+    adapter_identity: GpuDeviceIdentity,
+    runtime_contract: RuntimeContractEvidence,
+    physical_slot_plan: PhysicalSlotPlanEvidence,
+}
+
+fn validate_runtime(
+    runtime: &crate::BenchRealRuntime,
+    resolved_config_sha256: &str,
+    trace: &OracleRouteTrace,
+) -> Result<ValidatedRuntime, BenchmarkFailure> {
+    let observed_config_sha256 = crate::resolved_real_runtime_identity_sha256(
+        &runtime.cfg,
+        runtime.model.config.architecture,
+        runtime.model.config.first_k_dense_replace,
+        &runtime.model.config.advanced,
+    )
+    .map_err(|error| {
+        BenchmarkFailure::new(
+            "startup",
+            "runtime-config-identity-unavailable",
+            error.to_string(),
+        )
+    })?;
+    if observed_config_sha256 != resolved_config_sha256 || runtime.cfg.storage.predict_fanout != 0 {
+        return Err(BenchmarkFailure::new(
+            "startup",
+            "runtime-contract-drift",
+            "resolved runtime identity drifted or production predictor fanout is nonzero",
+        ));
+    }
+    let token_loop = runtime.gpu_native_token_loop.as_ref().ok_or_else(|| {
+        BenchmarkFailure::new(
+            "startup",
+            "missing-gpu-native-token-loop",
+            "ORACLE-0B-S requires the authoritative GPU-native token loop",
+        )
+    })?;
+    if OracleGeometry::from(token_loop.model_geometry()) != trace.geometry
+        || token_loop.snapshot() != GpuNativeTokenLoopSnapshot::default()
+        || token_loop.recovery_snapshot() != GpuNativeRecoverySnapshot::default()
+        || runtime.engine.routed_expert_execution_snapshot()
+            != RoutedExpertExecutionSnapshot::default()
+    {
+        return Err(BenchmarkFailure::new(
+            "startup",
+            "runtime-initial-state-invalid",
+            "runtime geometry differs from ORACLE-0A or fresh counters are nonzero",
+        ));
+    }
+    let model_load = crate::greedy_parity_model_load(runtime);
+    let contract_input = RuntimeContractInput {
+        real_transformer_enabled: runtime.cfg.real_transformer.enabled,
+        real_transformer_gpu_native: runtime.cfg.real_transformer.gpu_native,
+        compute_offload: runtime.cfg.real_transformer.compute_offload,
+        legacy_execution_plan: runtime.engine.execution_context().plan().into(),
+        token_loop_geometry: Some(token_loop.model_geometry()),
+        authoritative_device: runtime.engine.gpu_device_identity(),
+        model_load: model_load.clone(),
+        routed_failure_policy: runtime.engine.routed_expert_gpu_failure_policy(),
+    };
+    let (runtime_contract, adapter_identity) =
+        crate::gpu_native_real_benchmark::validate_runtime_contract(
+            &contract_input,
+            EXPECTED_ADAPTER_NAME,
+        )?;
+    let snapshot = runtime
+        .engine
+        .gpu_native_residency_snapshot()
+        .ok_or_else(|| {
+            BenchmarkFailure::new(
+                "startup",
+                "missing-physical-slot-plan",
+                "GPU-native residency snapshot is unavailable",
+            )
+        })?;
+    Ok(ValidatedRuntime {
+        model_load,
+        adapter_identity,
+        runtime_contract,
+        physical_slot_plan: PhysicalSlotPlanEvidence {
+            model_expert_budget_bytes: snapshot.model_expert_budget_bytes,
+            model_arena_allocation_bytes: snapshot.model_arena_allocation_bytes,
+            model_slot_capacity: snapshot.model_slot_capacity,
+            per_layer_slot_capacity: snapshot
+                .layers
+                .iter()
+                .map(|layer| layer.slot_capacity)
+                .collect(),
+            no_extra_physical_vram_capacity: true,
+        },
+    })
+}
+
+async fn execute_oracle_request(
+    runtime: &crate::BenchRealRuntime,
+    trace: Arc<OracleRouteTrace>,
+    expected_token_sha: &str,
+    expected_text_sha: &str,
+    treatment_mode: OracleScheduledResidencyMode,
+    source_concurrency: usize,
+    expert_bytes: usize,
+    prompt_ids: &[u32],
+    run_index: usize,
+) -> Result<OracleRunResult, Box<dyn std::error::Error>> {
+    let token_loop = runtime.gpu_native_token_loop.as_ref().ok_or_else(|| {
+        BenchmarkFailure::new(
+            "startup",
+            "missing-gpu-native-token-loop",
+            "ORACLE-0B-S request has no GPU-native token loop",
+        )
+    })?;
+    let scheduler = OracleScheduler::new(
+        runtime.engine.clone(),
+        trace,
+        treatment_mode,
+        source_concurrency,
+        expert_bytes,
+    );
+    let mut request = token_loop.create_request_state()?;
+    let snapshots = RequestSnapshotStart::capture(runtime)?;
+    let request_started = Instant::now();
+    scheduler
+        .prime_initial_position()
+        .await
+        .map_err(|error| BenchmarkFailure::new("inference", "initial-source-prime", error))?;
+
+    let mut completed_positions = 0usize;
+    let mut generated_ids = Vec::with_capacity(FROZEN_OUTPUT_TOKENS);
+    while completed_positions < prompt_ids.len() {
+        let token_id = prompt_ids[completed_positions];
+        let sample = completed_positions + 1 == prompt_ids.len();
+        scheduler
+            .observe_demand_readiness(completed_positions)
+            .map_err(|error| {
+                BenchmarkFailure::new("inference", "oracle-demand-probe-failed", error)
+            })?;
+        let sampled = token_loop
+            .step_token_oracle_scheduled(
+                &runtime.engine,
+                &mut request,
+                token_id,
+                completed_positions,
+                sample,
+                &scheduler,
+            )
+            .await?;
+        completed_positions += 1;
+        if sample {
+            generated_ids.push(sampled.ok_or_else(|| {
+                BenchmarkFailure::new(
+                    "inference",
+                    "missing-first-generated-token",
+                    "final prompt position produced no sampled token",
+                )
+            })?);
+        } else if sampled.is_some() {
+            return Err(BenchmarkFailure::new(
+                "inference",
+                "unexpected-prefix-sample",
+                "prompt prefix position unexpectedly produced a sampled token",
+            )
+            .into());
+        }
+    }
+    let prompt_seconds = request_started.elapsed().as_secs_f64();
+    let decode_started = Instant::now();
+    let mut decode_latencies = Vec::with_capacity(FROZEN_OUTPUT_TOKENS - 1);
+    while generated_ids.len() < FROZEN_OUTPUT_TOKENS {
+        let token_id = *generated_ids.last().ok_or_else(|| {
+            BenchmarkFailure::new(
+                "inference",
+                "missing-generated-seed",
+                "decode has no preceding generated token",
+            )
+        })?;
+        scheduler
+            .observe_demand_readiness(completed_positions)
+            .map_err(|error| {
+                BenchmarkFailure::new("inference", "oracle-demand-probe-failed", error)
+            })?;
+        let step_started = Instant::now();
+        let sampled = token_loop
+            .step_token_oracle_scheduled(
+                &runtime.engine,
+                &mut request,
+                token_id,
+                completed_positions,
+                true,
+                &scheduler,
+            )
+            .await?
+            .ok_or_else(|| {
+                BenchmarkFailure::new(
+                    "inference",
+                    "missing-decode-token",
+                    format!("position {completed_positions} produced no sampled token"),
+                )
+            })?;
+        decode_latencies.push(step_started.elapsed().as_secs_f64());
+        generated_ids.push(sampled);
+        completed_positions += 1;
+    }
+    let decode_seconds = decode_started.elapsed().as_secs_f64();
+    let (mut oracle, actual_trace) = scheduler
+        .finish_request()
+        .await
+        .map_err(|error| BenchmarkFailure::new("postcondition", "oracle-finish-failed", error))?;
+    let counters = snapshots.finish(runtime)?;
+    crate::gpu_native_real_benchmark::validate_request_postconditions(
+        prompt_ids.len(),
+        FROZEN_OUTPUT_TOKENS,
+        generated_ids.len(),
+        counters.token_loop_delta,
+        counters.recovery_delta,
+        counters.routed_execution_delta,
+    )?;
+    oracle.ordinary_residency_miss_attempts = counters.token_loop_delta.residency_miss_attempts;
+    oracle.ordinary_residency_services = counters.token_loop_delta.residency_services;
+    validate_oracle_counters(&oracle, treatment_mode, source_concurrency)?;
+
+    let output_text = runtime.tokenizer.decode(&generated_ids)?;
+    let generated_token_ids_sha256 = crate::greedy_parity::token_ids_sha256(&generated_ids);
+    let generated_text_sha256 = crate::greedy_parity::sha256_hex(output_text.as_bytes());
+    let (generated_tokens_match_frozen_demand_only, generated_text_matches_frozen_demand_only) =
+        frozen_output_matches(
+            &generated_token_ids_sha256,
+            &generated_text_sha256,
+            expected_token_sha,
+            expected_text_sha,
+        );
+    let correctness = RunCorrectness {
+        generated_tokens_match_frozen_demand_only,
+        generated_text_matches_frozen_demand_only,
+        actual_route_matches_oracle: actual_trace.ordered_route_sequence_sha256
+            == EXPECTED_ORDERED_ROUTE_SHA256,
+        actual_legacy_route_matches_oracle: actual_trace.legacy_selected_route_ids_sha256
+            == EXPECTED_LEGACY_ROUTE_SHA256,
+        no_fatal_failures: counters.token_loop_delta.fatal_failures == 0
+            && counters.token_loop_delta.no_progress_failures == 0,
+        generated_token_ids_sha256: generated_token_ids_sha256.clone(),
+        generated_text_sha256: generated_text_sha256.clone(),
+        actual_route_sequence_sha256: actual_trace.ordered_route_sequence_sha256,
+        actual_legacy_route_sha256: actual_trace.legacy_selected_route_ids_sha256,
+    };
+    if !correctness.generated_tokens_match_frozen_demand_only
+        || !correctness.generated_text_matches_frozen_demand_only
+        || !correctness.actual_route_matches_oracle
+        || !correctness.actual_legacy_route_matches_oracle
+        || !correctness.no_fatal_failures
+    {
+        return Err(BenchmarkFailure::new(
+            "postcondition",
+            "oracle-correctness-mismatch",
+            "tokens, text, actual routes, or failure counters differ from frozen ORACLE-0A demand-only evidence",
+        )
+        .into());
+    }
+    let benchmark = PerRunResult {
+        run_index,
+        prompt_tokens: prompt_ids.len(),
+        requested_output_tokens: FROZEN_OUTPUT_TOKENS,
+        generated_tokens: generated_ids.len(),
+        generated_token_ids: generated_ids,
+        generated_token_ids_sha256,
+        generated_text_sha256,
+        timing: RunTiming::from_measurement(
+            FROZEN_OUTPUT_TOKENS,
+            prompt_seconds,
+            prompt_seconds,
+            decode_seconds,
+            decode_latencies,
+        )?,
+        counters,
+    };
+    Ok(OracleRunResult {
+        run_index,
+        benchmark,
+        oracle,
+        correctness,
+    })
+}
+
+fn emit_report(
+    report: &OracleScheduledResidencyReport,
+    path: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut bytes = serde_json::to_vec_pretty(report)?;
+    bytes.push(b'\n');
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, bytes)?;
+    eprintln!(
+        "GPU-native ORACLE-0B-S report written to {}",
+        path.display()
+    );
+    Ok(())
+}
+
+pub(crate) async fn run_command(args: CommandArgs) -> Result<(), Box<dyn std::error::Error>> {
+    if args.oracle_source_concurrency == 0 || args.oracle_source_concurrency > EXPECTED_LAYERS {
+        return Err(artifact_failure(
+            "invalid-oracle-source-concurrency",
+            format!(
+                "--oracle-source-concurrency must be in 1..={EXPECTED_LAYERS}; observed {}",
+                args.oracle_source_concurrency
+            ),
+        )
+        .into());
+    }
+    let oracle = load_oracle_artifact(&args.oracle_trace)?;
+    let build = crate::qualification::BuildProvenance::embedded();
+    crate::gpu_native_real_benchmark::validate_preflight_provenance(&build)?;
+    let cfg = crate::config::Config::from_file(&args.config)?;
+    crate::gpu_native_real_benchmark::validate_source_config(&cfg)?;
+    if cfg.storage.predict_fanout != 0 {
+        return Err(artifact_failure(
+            "production-predictor-enabled",
+            "ORACLE-0B-S requires storage.predict_fanout=0 and never overrides it",
+        )
+        .into());
+    }
+    let (artifacts, artifact_errors) = crate::qualification_artifacts(&args.config, &cfg);
+    crate::gpu_native_real_benchmark::validate_artifacts(&artifacts, &artifact_errors)?;
+    let expert_metadata =
+        crate::qualification::read_expert_metadata(&cfg.model.data_dir.join("metadata.json"))
+            .map_err(|error| {
+                BenchmarkFailure::new("preflight", "expert-metadata-unavailable", error)
+            })?;
+    crate::gpu_native_real_benchmark::validate_expert_metadata(&expert_metadata)?;
+    let spec = crate::resolve_real_cli_spec_from_config(
+        cfg,
+        crate::RealCliRuntimeMode::IsolatedGpuNativeBenchmark,
+    )?;
+    let model_identity = crate::greedy_parity_model_identity(&spec);
+    if !model_identity.is_qwen3_coder_30b_a3b_q4_0() {
+        return Err(artifact_failure(
+            "wrong-model-identity",
+            format!("requires exact Qwen3-Coder 30B-A3B Q4_0; observed {model_identity:?}"),
+        )
+        .into());
+    }
+    let resolved_config_sha256 = crate::resolved_real_cli_spec_sha256(&spec)?;
+    let tokenizer = crate::load_real_cli_tokenizer(
+        &spec.cfg,
+        crate::RealCliRuntimeMode::IsolatedGpuNativeBenchmark,
+    )?;
+    let prompt_ids = tokenizer.encode(FROZEN_PROMPT)?;
+    let prompt_sha256 = crate::greedy_parity::sha256_hex(FROZEN_PROMPT.as_bytes());
+    let prompt_token_ids_sha256 = crate::greedy_parity::token_ids_sha256(&prompt_ids);
+    if prompt_sha256 != EXPECTED_PROMPT_SHA256
+        || prompt_token_ids_sha256 != EXPECTED_PROMPT_TOKEN_IDS_SHA256
+        || prompt_ids
+            .len()
+            .checked_add(FROZEN_OUTPUT_TOKENS)
+            .and_then(|value| value.checked_sub(1))
+            != Some(EXPECTED_POSITIONS)
+    {
+        return Err(artifact_failure(
+            "frozen-workload-identity-mismatch",
+            "frozen prompt/tokenization/output shape differs from ORACLE-0A",
+        )
+        .into());
+    }
+    let production_configuration =
+        ProductionConfiguration::from_config(&spec.cfg, &expert_metadata);
+    if production_configuration.cache_residency.ram_cache_slots != FROZEN_RAM_CACHE_SLOTS {
+        return Err(artifact_failure(
+            "ram-cache-slot-count-mismatch",
+            format!(
+                "ORACLE-0B-S requires the frozen {FROZEN_RAM_CACHE_SLOTS}-slot RAM cache; observed {}",
+                production_configuration.cache_residency.ram_cache_slots
+            ),
+        )
+        .into());
+    }
+    let (executable, executable_sha256) = crate::current_executable_identity()?;
+    let executable_canonical_path = std::fs::canonicalize(&executable)?.display().to_string();
+    if !crate::gpu_native_real_benchmark::is_hex(&executable_sha256, 64)
+        || !crate::gpu_native_real_benchmark::is_hex(&resolved_config_sha256, 64)
+    {
+        return Err(artifact_failure(
+            "provenance-unavailable",
+            "executable or resolved-config SHA256 was unavailable",
+        )
+        .into());
+    }
+    let provenance = BenchmarkProvenance {
+        build,
+        executable_canonical_path,
+        executable_sha256,
+        resolved_config_sha256: resolved_config_sha256.clone(),
+        artifacts,
+        expert_metadata,
+    };
+    let request = RequestEvidence {
+        prompt_sha256,
+        prompt_token_ids_sha256,
+        prompt_token_count: prompt_ids.len(),
+        requested_output_tokens: FROZEN_OUTPUT_TOKENS,
+        greedy: true,
+    };
+
+    let runtime = crate::build_isolated_greedy_runtime(
+        &spec,
+        crate::RealCliRuntimeMode::IsolatedGpuNativeBenchmark,
+        tokenizer,
+    )
+    .await?;
+    let execution = async {
+        let validated = validate_runtime(&runtime, &resolved_config_sha256, &oracle.trace)?;
+        let warmup = crate::with_progress_timeout(
+            format!("{MODE} warmup"),
+            args.progress_watchdog,
+            execute_oracle_request(
+                &runtime,
+                oracle.trace.clone(),
+                &oracle.evidence.expected_generated_token_ids_sha256,
+                &oracle.evidence.expected_generated_text_sha256,
+                args.treatment_mode,
+                args.oracle_source_concurrency,
+                spec.cfg.model.expert_size,
+                &prompt_ids,
+                0,
+            ),
+        )
+        .await?;
+        let mut measured = Vec::with_capacity(FROZEN_MEASURED_RUNS);
+        for run_index in 0..FROZEN_MEASURED_RUNS {
+            measured.push(
+                crate::with_progress_timeout(
+                    format!("{MODE} measured run {run_index}"),
+                    args.progress_watchdog,
+                    execute_oracle_request(
+                        &runtime,
+                        oracle.trace.clone(),
+                        &oracle.evidence.expected_generated_token_ids_sha256,
+                        &oracle.evidence.expected_generated_text_sha256,
+                        args.treatment_mode,
+                        args.oracle_source_concurrency,
+                        spec.cfg.model.expert_size,
+                        &prompt_ids,
+                        run_index,
+                    ),
+                )
+                .await?,
+            );
+        }
+        Ok::<_, Box<dyn std::error::Error>>((validated, warmup, measured))
+    }
+    .await;
+    let shutdown = runtime.shutdown_isolated().await;
+    let (validated, warmup, measured, shutdown) = match (execution, shutdown) {
+        (Ok((validated, warmup, measured)), Ok(shutdown)) => {
+            if !shutdown.controlled_shutdown_requested || !shutdown.all_runtime_resources_released {
+                return Err(BenchmarkFailure::new(
+                    "postcondition",
+                    "runtime-shutdown-incomplete",
+                    format!("controlled isolated shutdown was incomplete: {shutdown:?}"),
+                )
+                .into());
+            }
+            (validated, warmup, measured, shutdown)
+        }
+        (Err(error), Ok(_)) => return Err(error),
+        (Ok(_), Err(error)) => return Err(error.into()),
+        (Err(execution), Err(shutdown)) => {
+            return Err(BenchmarkFailure::new(
+                "postcondition",
+                "execution-and-shutdown-failed",
+                format!("{execution}; {shutdown}"),
+            )
+            .into())
+        }
+    };
+
+    let measured_benchmarks = measured
+        .iter()
+        .map(|run| run.benchmark.clone())
+        .collect::<Vec<_>>();
+    let aggregate_measured_performance =
+        crate::gpu_native_real_benchmark::aggregate(&measured_benchmarks)?;
+    let mut aggregate_oracle = OracleCounters::default();
+    for run in &measured {
+        accumulate_oracle(&mut aggregate_oracle, &run.oracle);
+    }
+    let all_measured_outputs_identical = measured.iter().all(|run| {
+        run.correctness.generated_token_ids_sha256 == warmup.correctness.generated_token_ids_sha256
+            && run.correctness.generated_text_sha256 == warmup.correctness.generated_text_sha256
+    });
+    let all_actual_routes_match_oracle = measured.iter().all(|run| {
+        run.correctness.actual_route_matches_oracle
+            && run.correctness.actual_legacy_route_matches_oracle
+    });
+    if !all_measured_outputs_identical || !all_actual_routes_match_oracle {
+        return Err(BenchmarkFailure::new(
+            "postcondition",
+            "cross-request-correctness-mismatch",
+            "warmup and measured output or actual-route hashes differ",
+        )
+        .into());
+    }
+    let report = OracleScheduledResidencyReport {
+        schema: SCHEMA,
+        mode: MODE,
+        complete: true,
+        failure: None,
+        diagnostic_only: true,
+        provenance,
+        source_oracle: oracle.evidence,
+        model_identity,
+        model_load: validated.model_load,
+        adapter_identity: validated.adapter_identity,
+        runtime_contract: validated.runtime_contract,
+        request,
+        production_configuration,
+        treatment_mode: args.treatment_mode,
+        oracle_source_concurrency: args.oracle_source_concurrency,
+        treatment_contract: treatment_contract(args.treatment_mode),
+        physical_slot_plan: validated.physical_slot_plan,
+        frozen_controls: FrozenControlReferences {
+            frozen_parent_git_sha: ORACLE_ROUTE_COMMAND_SHA,
+            oracle_route_command_git_sha: ORACLE_ROUTE_COMMAND_SHA,
+            performance_controls_rerun: false,
+            hardware_results_embedded: false,
+        },
+        frozen_workload: FrozenWorkloadEvidence {
+            prompt: FROZEN_PROMPT,
+            prompt_sha256: EXPECTED_PROMPT_SHA256,
+            prompt_token_ids_sha256: EXPECTED_PROMPT_TOKEN_IDS_SHA256,
+            output_tokens: FROZEN_OUTPUT_TOKENS,
+            greedy: true,
+            warmup_runs: FROZEN_WARMUP_RUNS,
+            measured_runs: FROZEN_MEASURED_RUNS,
+            repeated_trace_per_request: true,
+            shared_runtime_and_cache: true,
+            initial_position_priming: "synchronous source-to-RAM priming is included in request/TTFT timing; no position-zero physical oracle install is performed",
+        },
+        correctness: CorrectnessEvidence {
+            warmup_matches_measured: all_measured_outputs_identical,
+            all_measured_outputs_identical,
+            all_actual_routes_match_oracle,
+            generated_token_ids_sha256: warmup
+                .correctness
+                .generated_token_ids_sha256
+                .clone(),
+            generated_text_sha256: warmup.correctness.generated_text_sha256.clone(),
+            actual_route_sequence_sha256: warmup
+                .correctness
+                .actual_route_sequence_sha256
+                .clone(),
+            actual_legacy_route_sha256: warmup
+                .correctness
+                .actual_legacy_route_sha256
+                .clone(),
+        },
+        warmup,
+        measured,
+        aggregate_measured_performance,
+        aggregate_measured_oracle: AggregateOracleCounters {
+            measured_runs: FROZEN_MEASURED_RUNS,
+            totals: aggregate_oracle,
+        },
+        shutdown,
+    };
+    emit_report(&report, &args.report_out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    fn test_trace(positions: usize) -> Arc<OracleRouteTrace> {
+        let geometry = OracleGeometry {
+            layers: 2,
+            experts: 4,
+            top_k: 2,
+            d_model: 8,
+            d_ff: 4,
+        };
+        let mut records = Vec::with_capacity(positions * geometry.layers);
+        for position in 0..positions {
+            for layer_index in 0..geometry.layers {
+                let first = ((position + layer_index) % geometry.experts) as u32;
+                records.push(OracleRouteRecord {
+                    position,
+                    layer_index,
+                    ordered_selected_expert_ids: vec![first, (first + 1) % 4],
+                });
+            }
+        }
+        Arc::new(OracleRouteTrace::try_new(geometry, records).unwrap())
+    }
+
+    fn valid_source_only_counters() -> OracleCounters {
+        OracleCounters {
+            future_experts_considered: EXPECTED_SELECTED_IDS as u64,
+            source_skipped_physical_current: EXPECTED_SELECTED_IDS as u64,
+            source_prefetch_batches_started: EXPECTED_LAYER_RECORDS as u64,
+            source_prefetch_batches_completed: EXPECTED_LAYER_RECORDS as u64,
+            source_prefetch_peak_inflight: 4,
+            oracle_ready_at_demand: EXPECTED_SELECTED_IDS as u64,
+            source_end_of_trace: 1,
+            ..OracleCounters::default()
+        }
+    }
+
+    #[test]
+    fn exact_route_cursor_progression() {
+        let trace = test_trace(3);
+        let mut cursor = StrictRouteCursor::new(trace.clone());
+        for position in 0..3 {
+            let routes = cursor.routes_at(position).unwrap();
+            cursor.reconcile(position, &routes).unwrap();
+        }
+        let actual = cursor.finish().unwrap();
+        assert_eq!(actual.records, trace.records);
+        assert_eq!(
+            actual.ordered_route_sequence_sha256,
+            trace.ordered_route_sequence_sha256
+        );
+    }
+
+    #[test]
+    fn route_cursor_fails_closed_at_end_of_trace() {
+        let trace = test_trace(2);
+        let cursor = StrictRouteCursor::new(trace);
+        assert!(cursor.routes_at(2).is_err());
+        assert!(cursor.future_after(1).unwrap().is_none());
+        assert!(cursor.future_after(2).is_err());
+        assert!(cursor.finish().is_err());
+    }
+
+    #[test]
+    fn identical_trace_repeats_for_warmup_and_three_measurements() {
+        let trace = test_trace(3);
+        for _request in 0..(FROZEN_WARMUP_RUNS + FROZEN_MEASURED_RUNS) {
+            let mut cursor = StrictRouteCursor::new(trace.clone());
+            for position in 0..trace.total_positions {
+                let routes = cursor.routes_at(position).unwrap();
+                cursor.reconcile(position, &routes).unwrap();
+            }
+            assert_eq!(
+                cursor.finish().unwrap().ordered_route_sequence_sha256,
+                trace.ordered_route_sequence_sha256
+            );
+        }
+    }
+
+    #[test]
+    fn source_only_contract_never_mutates_physical_residency() {
+        let contract = treatment_contract(OracleScheduledResidencyMode::SourceOnly);
+        assert!(!contract.token_boundary_h2d);
+        assert!(!contract.production_direct_staging_used);
+        assert!(!contract.h2d_compute_overlap_claimed);
+        assert!(contract.demand_fallback);
+    }
+
+    #[test]
+    fn treatment_mode_cli_values_are_exact() {
+        assert_eq!(
+            OracleScheduledResidencyMode::from_str("source-only", false).unwrap(),
+            OracleScheduledResidencyMode::SourceOnly
+        );
+        assert_eq!(
+            OracleScheduledResidencyMode::from_str("token-boundary-direct", false).unwrap(),
+            OracleScheduledResidencyMode::TokenBoundaryDirect
+        );
+        assert!(OracleScheduledResidencyMode::from_str("overlapped-h2d", false).is_err());
+    }
+
+    #[tokio::test]
+    async fn source_layer_tasks_obey_bounded_concurrency() {
+        let concurrency = 3usize;
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(concurrency));
+        let counters = Arc::new(Mutex::new(OracleCounters::default()));
+        let mut tasks = Vec::new();
+        for _ in 0..12 {
+            let semaphore = semaphore.clone();
+            let counters = counters.clone();
+            tasks.push(tokio::spawn(async move {
+                let _permit = semaphore.acquire_owned().await.unwrap();
+                let _guard = LayerBatchGuard::enter(counters);
+                for _ in 0..4 {
+                    tokio::task::yield_now().await;
+                }
+            }));
+        }
+        for task in tasks {
+            task.await.unwrap();
+        }
+        let values = counters.lock();
+        assert_eq!(values.source_prefetch_batches_started, 12);
+        assert_eq!(values.source_prefetch_batches_completed, 12);
+        assert!(values.source_prefetch_peak_inflight <= concurrency as u64);
+    }
+
+    #[tokio::test]
+    async fn qualification_source_position_state_has_one_bounded_lease() {
+        let gate = Arc::new(tokio::sync::Mutex::new(()));
+        let first = gate.clone().lock_owned().await;
+        assert!(gate.clone().try_lock_owned().is_err());
+        drop(first);
+        assert!(gate.try_lock_owned().is_ok());
+    }
+
+    #[test]
+    fn source_deduplication_uses_existing_singleflight() {
+        assert_eq!(
+            source_disposition(false, false, true),
+            SourceDisposition::SourceInFlight
+        );
+    }
+
+    #[test]
+    fn source_ram_hit_skips_read() {
+        assert_eq!(
+            source_disposition(false, true, false),
+            SourceDisposition::RamHit
+        );
+    }
+
+    #[test]
+    fn physical_current_expert_skips_all_source_work() {
+        assert_eq!(
+            source_disposition(true, true, true),
+            SourceDisposition::AlreadyPhysical
+        );
+    }
+
+    #[test]
+    fn future_source_failure_degrades_to_ordinary_demand() {
+        let outcome = PrefetchOutcome {
+            target_position: 1,
+            failed_ids: vec![7, 8],
+            ..PrefetchOutcome::default()
+        };
+        let mut counters = OracleCounters::default();
+        record_completed_source_outcome(&mut counters, &outcome);
+        record_demand_readiness(&mut counters, &[vec![false, false]]);
+        assert_eq!(counters.source_failures_degraded_to_demand, 2);
+        assert_eq!(counters.oracle_demand_fallback, 1);
+    }
+
+    #[test]
+    fn source_late_at_boundary_degrades_without_fake_readiness() {
+        let mut counters = OracleCounters::default();
+        record_source_late(&mut counters, 8);
+        record_demand_readiness(&mut counters, &[vec![false; 8]]);
+        assert_eq!(counters.source_late_at_boundary, 8);
+        assert_eq!(counters.source_late_degraded_to_demand, 1);
+        assert_eq!(counters.oracle_ready_at_demand, 0);
+        assert_eq!(counters.oracle_demand_fallback, 1);
+    }
+
+    #[test]
+    fn boundary_replacement_preserves_exact_physical_capacity() {
+        assert!(plan_boundary_replacement(8, 8, &[false; 9]).is_err());
+        assert!(plan_boundary_replacement(8, 9, &[false; 8]).is_err());
+        let plan = plan_boundary_replacement(8, 4, &[false; 8]).unwrap();
+        assert_eq!(plan.physical_experts_needed, 8);
+        assert_eq!(plan.minimum_evictions, 4);
+    }
+
+    #[test]
+    fn two_gib_top_k_equals_capacity_requires_destructive_replacement() {
+        let plan = plan_boundary_replacement(8, 8, &[false; 8]).unwrap();
+        assert_eq!(plan.physical_experts_needed, 8);
+        assert_eq!(plan.minimum_evictions, 8);
+    }
+
+    #[test]
+    fn protected_future_members_are_not_counted_as_victims() {
+        let plan =
+            plan_boundary_replacement(8, 8, &[true, true, true, true, true, true, true, false])
+                .unwrap();
+        assert_eq!(plan.physical_experts_needed, 1);
+        assert_eq!(plan.minimum_evictions, 1);
+    }
+
+    #[test]
+    fn stale_logical_generation_fails_closed_to_demand() {
+        let error = GpuNativeTieredResidencyError::LogicalAdmissionStale {
+            global_id: 9,
+            generation: 4,
+        };
+        assert_eq!(
+            boundary_install_error_policy(&error),
+            BoundaryInstallErrorPolicy::DegradeStaleGeneration
+        );
+    }
+
+    #[test]
+    fn physical_identity_corruption_is_a_fatal_qualification_failure() {
+        let error = GpuNativeTieredResidencyError::PhysicalIdentityCorrupt { global_id: 9 };
+        assert_eq!(
+            boundary_install_error_policy(&error),
+            BoundaryInstallErrorPolicy::FailClosed
+        );
+    }
+
+    #[test]
+    fn unsafe_or_reused_boundary_is_a_fatal_qualification_failure() {
+        let error = GpuNativeTieredResidencyError::UnsafeOracleBoundary {
+            layer_index: 4,
+            detail: "reused".into(),
+        };
+        assert_eq!(
+            boundary_install_error_policy(&error),
+            BoundaryInstallErrorPolicy::FailClosed
+        );
+    }
+
+    #[test]
+    fn no_fake_physical_hit_is_reported() {
+        let mut counters = OracleCounters::default();
+        record_demand_readiness(&mut counters, &[vec![false, false], vec![false, false]]);
+        assert_eq!(counters.oracle_ready_at_demand, 0);
+        assert_eq!(counters.oracle_not_ready_at_demand, 4);
+    }
+
+    #[test]
+    fn demand_fallback_remains_active_for_any_incomplete_layer_set() {
+        let mut counters = OracleCounters::default();
+        record_demand_readiness(
+            &mut counters,
+            &[vec![true, true], vec![true, false], vec![false, true]],
+        );
+        assert_eq!(counters.oracle_ready_at_demand, 4);
+        assert_eq!(counters.oracle_not_ready_at_demand, 2);
+        assert_eq!(counters.oracle_demand_fallback, 2);
+    }
+
+    #[test]
+    fn full_15576_mib_capacity_needs_zero_unnecessary_replacement() {
+        let plan = plan_boundary_replacement(128, 128, &[true; EXPECTED_TOP_K]).unwrap();
+        assert_eq!(plan.physical_experts_needed, 0);
+        assert_eq!(plan.minimum_evictions, 0);
+    }
+
+    #[test]
+    fn actual_route_mismatch_fails_qualification() {
+        let trace = test_trace(1);
+        let mut cursor = StrictRouteCursor::new(trace);
+        let mut actual = cursor.routes_at(0).unwrap();
+        actual[0].swap(0, 1);
+        assert!(cursor.reconcile(0, &actual).is_err());
+    }
+
+    #[test]
+    fn token_or_text_hash_mismatch_fails_qualification() {
+        assert_eq!(
+            frozen_output_matches("token", "text", "token", "text"),
+            (true, true)
+        );
+        assert_eq!(
+            frozen_output_matches("wrong", "text", "token", "text"),
+            (false, true)
+        );
+        assert_eq!(
+            frozen_output_matches("token", "wrong", "token", "text"),
+            (true, false)
+        );
+    }
+
+    #[test]
+    fn warmup_counters_are_excluded_from_measured_aggregate() {
+        let warmup = OracleCounters {
+            future_experts_considered: 99,
+            ..OracleCounters::default()
+        };
+        let measured = OracleCounters {
+            future_experts_considered: 7,
+            ..OracleCounters::default()
+        };
+        let mut aggregate = OracleCounters::default();
+        for _ in 0..FROZEN_MEASURED_RUNS {
+            accumulate_oracle(&mut aggregate, &measured);
+        }
+        assert_eq!(aggregate.future_experts_considered, 21);
+        assert_ne!(
+            aggregate.future_experts_considered,
+            21 + warmup.future_experts_considered
+        );
+    }
+
+    #[test]
+    fn source_physical_and_accounting_counters_reconcile() {
+        assert!(validate_oracle_counters(
+            &valid_source_only_counters(),
+            OracleScheduledResidencyMode::SourceOnly,
+            4,
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn source_only_counter_validation_rejects_physical_mutation() {
+        let mut counters = valid_source_only_counters();
+        counters.boundary_replacement_sets_started = 1;
+        counters.boundary_physical_installs = 1;
+        assert!(
+            validate_oracle_counters(&counters, OracleScheduledResidencyMode::SourceOnly, 4,)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn serialized_h2d_contract_uses_one_ordered_queue_without_flush_submit() {
+        let contract = treatment_contract(OracleScheduledResidencyMode::TokenBoundaryDirect);
+        assert!(contract.token_boundary_h2d);
+        assert!(contract.same_ordered_queue);
+        assert!(contract.production_direct_staging_used);
+        assert!(!contract.extra_flush_submit);
+        assert!(!contract.h2d_compute_overlap_claimed);
+    }
+
+    #[test]
+    fn initial_position_priming_is_explicitly_counted() {
+        let trace = test_trace(1);
+        let routes = StrictRouteCursor::new(trace).routes_at(0).unwrap();
+        let mut counters = OracleCounters::default();
+        record_source_position_considered(&mut counters, &routes);
+        counters.initial_position_source_priming_experts = 4;
+        assert_eq!(counters.future_experts_considered, 4);
+        assert_eq!(counters.initial_position_source_priming_experts, 4);
+    }
+
+    #[test]
+    fn qualification_temporary_state_bound_is_fail_closed() {
+        let mut counters = valid_source_only_counters();
+        counters.qualification_owned_peak_slots = FROZEN_RAM_CACHE_SLOTS as u64 + 1;
+        assert!(
+            validate_oracle_counters(&counters, OracleScheduledResidencyMode::SourceOnly, 4,)
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn all_background_tasks_drain_before_request_shutdown() {
+        let completed = Arc::new(AtomicU64::new(0));
+        let mut tasks = Vec::new();
+        for _ in 0..4 {
+            let completed = completed.clone();
+            tasks.push(tokio::spawn(async move {
+                tokio::task::yield_now().await;
+                completed.fetch_add(1, Ordering::Relaxed);
+            }));
+        }
+        drain_background_tasks(&mut tasks).await.unwrap();
+        assert!(tasks.is_empty());
+        assert_eq!(completed.load(Ordering::Relaxed), 4);
+    }
+}

--- a/rust-engine/src/gpu_native_oracle_scheduled_residency.rs
+++ b/rust-engine/src/gpu_native_oracle_scheduled_residency.rs
@@ -9,11 +9,13 @@
 //! next token's commands on the same queue. This module never claims H2D
 //! overlap and never uses the production predictor/speculative path.
 
-use crate::backend::gpu_native::{GpuNativePhysicalInstallEvidence, GpuNativeQ4ExpertResidency};
+use crate::backend::gpu_native::{
+    GpuNativePhysicalInstallEvidence, GpuNativeQ4ExpertKey, GpuNativeQ4ExpertResidency,
+};
 use crate::backend::GpuDeviceIdentity;
 use crate::buffer_pool::{BufferPool, BufferPoolOrigin};
 use crate::engine::{Engine, RoutedExpertExecutionSnapshot};
-use crate::expert_cache::{ExpertResident, GpuDemandSetAdmission, GpuResident};
+use crate::expert_cache::{ExpertResident, GpuDemandSetAdmission, GpuExpertCache, GpuResident};
 use crate::gpu_native_oracle_routes::{OracleGeometry, OracleRouteRecord, OracleRouteTrace};
 use crate::gpu_native_real_benchmark::{
     Aggregate, BenchmarkFailure, BenchmarkProvenance, PerRunResult, ProductionConfiguration,
@@ -41,8 +43,10 @@ use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 
-pub(crate) const SCHEMA: &str = "mer.gpu-native-oracle-scheduled-residency.v3";
+pub(crate) const SCHEMA: &str = "mer.gpu-native-oracle-scheduled-residency.v4";
 pub(crate) const MODE: &str = "qualify-gpu-native-oracle-scheduled-residency";
+const FROZEN_PAYLOAD_CONTROL_SHA: &str = "4eb143b34b00826e2031b313f3734bace18a7ecc";
+const FROZEN_PAYLOAD_CONTROL_TREE: &str = "37600e48e6dc3552f4a5b33e643351d4243280f5";
 const ORACLE_ROUTE_SCHEMA: &str = "mer.gpu-native-oracle-route-trace.v1";
 const ORACLE_ROUTE_COMMAND_SHA: &str = "3576cb893586f5dd3f5c5e7355658762db02b534";
 const EXPECTED_ORDERED_ROUTE_SHA256: &str =
@@ -81,6 +85,23 @@ const PREDECESSOR_SECOND_ATTEMPT_RUNNER_SHA256: &str =
 pub(crate) enum OracleScheduledResidencyMode {
     SourceOnly,
     TokenBoundaryDirect,
+    TokenBoundaryDirectLogicalOnly,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+enum LogicalPayloadMode {
+    Materialized,
+    QualificationLogicalOnly,
+}
+
+const fn logical_payload_mode(mode: OracleScheduledResidencyMode) -> LogicalPayloadMode {
+    match mode {
+        OracleScheduledResidencyMode::TokenBoundaryDirectLogicalOnly => {
+            LogicalPayloadMode::QualificationLogicalOnly
+        }
+        _ => LogicalPayloadMode::Materialized,
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
@@ -93,7 +114,8 @@ enum LateSourcePolicy {
 const fn late_source_policy(mode: OracleScheduledResidencyMode) -> LateSourcePolicy {
     match mode {
         OracleScheduledResidencyMode::SourceOnly => LateSourcePolicy::NonblockingDemandFallback,
-        OracleScheduledResidencyMode::TokenBoundaryDirect => {
+        OracleScheduledResidencyMode::TokenBoundaryDirect
+        | OracleScheduledResidencyMode::TokenBoundaryDirectLogicalOnly => {
             LateSourcePolicy::AwaitResidualAtSafeBoundary
         }
     }
@@ -376,6 +398,20 @@ impl StrictRouteCursor {
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
 struct OracleCounters {
+    logical_materializations: u64,
+    logical_materialization_bytes: u64,
+    logical_only_admissions: u64,
+    logical_only_charged_bytes: u64,
+    logical_expected_payload_bytes: u64,
+    logical_only_data_accesses: u64,
+    logical_admission_transactions: u64,
+    logical_admissions_returned: u64,
+    logical_new_generations: u64,
+    logical_current_generations_validated: u64,
+    logical_newly_admitted_bytes: u64,
+    logical_gpu_used_bytes_before: u64,
+    logical_gpu_used_bytes_after: u64,
+    logical_gpu_evicted_bytes: u64,
     initial_position_source_priming_experts: u64,
     initial_position_source_priming_us: u64,
     future_experts_considered: u64,
@@ -415,6 +451,8 @@ struct OracleCounters {
     boundary_replacement_sets_started: u64,
     boundary_replacement_sets_completed: u64,
     boundary_physical_installs: u64,
+    boundary_physical_install_order_checks: u64,
+    boundary_physical_install_order_errors: u64,
     boundary_physical_install_bytes: u64,
     boundary_physical_evictions: u64,
     boundary_physical_reinstalls: u64,
@@ -704,7 +742,8 @@ fn validate_retained_source_origins(
         OracleScheduledResidencyMode::SourceOnly if !outcome.residents.is_empty() => Err(
             "source-only retained request-local PRIMARY residents across token execution".into(),
         ),
-        OracleScheduledResidencyMode::TokenBoundaryDirect => {
+        OracleScheduledResidencyMode::TokenBoundaryDirect
+        | OracleScheduledResidencyMode::TokenBoundaryDirectLogicalOnly => {
             for (&global_id, resident) in &outcome.residents {
                 if resident.buffer_pool_origin()
                     != BufferPoolOrigin::QualificationOracleFutureSource
@@ -928,7 +967,7 @@ async fn prefetch_layer_batch(
                 return outcome;
             }
         };
-        if mode == OracleScheduledResidencyMode::TokenBoundaryDirect {
+        if uses_isolated_oracle_source_pool(mode) {
             match direct_future_source_disposition(
                 physical_current,
                 current_route_global_ids.contains(&global_id),
@@ -1093,7 +1132,7 @@ async fn prefetch_position(
     readiness: Arc<SourceReadiness>,
 ) -> PrefetchOutcome {
     let started = Instant::now();
-    let direct_read_batches_before = if mode == OracleScheduledResidencyMode::TokenBoundaryDirect {
+    let direct_read_batches_before = if uses_isolated_oracle_source_pool(mode) {
         counters.lock().source_prefetch_read_batches_with_work
     } else {
         0
@@ -1142,7 +1181,8 @@ async fn prefetch_position(
             }
             outcome
         }
-        OracleScheduledResidencyMode::TokenBoundaryDirect => {
+        OracleScheduledResidencyMode::TokenBoundaryDirect
+        | OracleScheduledResidencyMode::TokenBoundaryDirectLogicalOnly => {
             let task_engine = engine.clone();
             let task_counters = counters.clone();
             let task_readiness = readiness.clone();
@@ -1189,7 +1229,7 @@ async fn prefetch_position(
             }
         }
     };
-    if mode == OracleScheduledResidencyMode::TokenBoundaryDirect {
+    if uses_isolated_oracle_source_pool(mode) {
         let mut values = counters.lock();
         if values
             .source_prefetch_read_batches_with_work
@@ -1220,6 +1260,32 @@ async fn prefetch_position(
 
 struct OracleBoundaryObserver {
     counters: Arc<Mutex<OracleCounters>>,
+    expected_installs: Vec<(u32, u64)>,
+    completed_installs: Mutex<usize>,
+    layer_index: usize,
+    experts_per_layer: u32,
+    slot_bytes: u64,
+}
+
+impl OracleBoundaryObserver {
+    fn record_install_identity(
+        &self,
+        global_id: u32,
+        key: GpuNativeQ4ExpertKey,
+        physical_bytes: u64,
+    ) {
+        let mut completed = self.completed_installs.lock();
+        let matches = self.expected_installs.get(*completed)
+            == Some(&(global_id, key.logical_generation()))
+            && key.layer_index() == self.layer_index
+            && key.expert_id() == global_id % self.experts_per_layer
+            && physical_bytes == self.slot_bytes;
+        *completed += 1;
+        drop(completed);
+        let mut values = self.counters.lock();
+        values.boundary_physical_install_order_checks += 1;
+        values.boundary_physical_install_order_errors += u64::from(!matches);
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -1258,11 +1324,16 @@ impl GpuNativePhysicalInstallObserver for OracleBoundaryObserver {
 
     fn record_physical_install_completion(
         &self,
-        _global_id: u32,
-        _residency: GpuNativeQ4ExpertResidency,
+        global_id: u32,
+        residency: GpuNativeQ4ExpertResidency,
         evidence: GpuNativePhysicalInstallEvidence,
         _physical_install_total_us: u64,
     ) {
+        self.record_install_identity(
+            global_id,
+            residency.key(),
+            evidence.physical_slot_bytes_staged,
+        );
         let mut values = self.counters.lock();
         values.boundary_physical_installs += 1;
         add_counter(
@@ -1502,31 +1573,111 @@ async fn resolve_direct_sources_at_boundary(
 }
 
 fn prepare_logical_admissions(
-    engine: &Arc<Engine>,
+    gpu: &GpuExpertCache,
+    dtype: crate::inference::WeightDtype,
     global_ids: &[u32],
     residents: &HashMap<u32, Arc<ExpertResident>>,
+    mode: OracleScheduledResidencyMode,
+    counters: &Mutex<OracleCounters>,
+    data_accesses: &Arc<AtomicU64>,
 ) -> Result<Vec<crate::expert_cache::GpuAdmission>, String> {
-    let gpu = engine.execution_context().gpu_expert_cache().clone();
     let mut payloads = HashMap::with_capacity(global_ids.len());
     for attempt in 0..2 {
+        let used_before = gpu.used_bytes();
         match gpu
             .demand_admit_set(global_ids, &payloads)
             .map_err(|error| error.to_string())?
         {
-            GpuDemandSetAdmission::Ready { admissions, .. } => return Ok(admissions),
+            GpuDemandSetAdmission::Ready {
+                admissions,
+                newly_admitted,
+            } => {
+                // Boundary execution is serialized and selected IDs are protected.
+                // Validate the returned order, ordinary generation, and exact
+                // payload charge without ever reading GpuResident::data().
+                if admissions.len() != global_ids.len() || newly_admitted != payloads.len() {
+                    return Err(
+                        "ORACLE logical admission count changed during boundary preparation".into(),
+                    );
+                }
+                for (&id, admission) in global_ids.iter().zip(&admissions) {
+                    let source = residents
+                        .get(&id)
+                        .ok_or("ORACLE admission source disappeared")?;
+                    if admission.resident().id != id
+                        || !gpu.contains_generation(id, admission.generation())
+                        || admission.generation() == 0
+                        || admission.byte_len() != source.data().len()
+                        || crate::backend::GpuStorage::byte_len(admission.resident().as_ref())
+                            != source.data().len()
+                    {
+                        return Err(
+                            "ORACLE logical admission identity/generation/byte charge mismatch"
+                                .into(),
+                        );
+                    }
+                }
+                let new_bytes = payloads
+                    .values()
+                    .map(|payload| payload.byte_len() as u64)
+                    .sum::<u64>();
+                let used_after = gpu.used_bytes();
+                let evicted_bytes = used_before
+                    .checked_add(new_bytes)
+                    .and_then(|sum| sum.checked_sub(used_after))
+                    .ok_or("ORACLE logical GPU byte accounting underflow/overflow")?;
+                if used_after > gpu.capacity_bytes() as u64 {
+                    return Err("ORACLE logical GPU admission exceeded unchanged capacity".into());
+                }
+                let mut values = counters.lock();
+                values.logical_admission_transactions += 1;
+                values.logical_admissions_returned += admissions.len() as u64;
+                values.logical_current_generations_validated += admissions.len() as u64;
+                values.logical_new_generations += newly_admitted as u64;
+                values.logical_newly_admitted_bytes += new_bytes;
+                values.logical_gpu_used_bytes_before += used_before;
+                values.logical_gpu_used_bytes_after += used_after;
+                values.logical_gpu_evicted_bytes += evicted_bytes;
+                return Ok(admissions);
+            }
             GpuDemandSetAdmission::PayloadRequired(missing) if attempt == 0 => {
                 for global_id in missing {
                     let resident = residents.get(&global_id).ok_or_else(|| {
                         format!("future source for global expert {global_id} is not ready")
                     })?;
-                    payloads.insert(
-                        global_id,
-                        Arc::new(GpuResident::new_with_dtype(
-                            global_id,
-                            resident.data().to_vec(),
-                            engine.core.options.dtype,
-                        )),
-                    );
+                    let charged_bytes = resident.data().len();
+                    if resident.id != global_id || charged_bytes == 0 {
+                        return Err(
+                            "ORACLE logical source identity or byte charge is invalid".into()
+                        );
+                    }
+                    let payload = match logical_payload_mode(mode) {
+                        LogicalPayloadMode::Materialized => {
+                            let payload = GpuResident::new_with_dtype(
+                                global_id,
+                                resident.data().to_vec(),
+                                dtype,
+                            );
+                            let mut values = counters.lock();
+                            values.logical_materializations += 1;
+                            values.logical_materialization_bytes += charged_bytes as u64;
+                            payload
+                        }
+                        LogicalPayloadMode::QualificationLogicalOnly => {
+                            let payload = GpuResident::new_qualification_logical_only(
+                                global_id,
+                                charged_bytes,
+                                dtype,
+                                data_accesses.clone(),
+                            );
+                            let mut values = counters.lock();
+                            values.logical_only_admissions += 1;
+                            values.logical_only_charged_bytes += charged_bytes as u64;
+                            payload
+                        }
+                    };
+                    counters.lock().logical_expected_payload_bytes += charged_bytes as u64;
+                    payloads.insert(global_id, Arc::new(payload));
                 }
             }
             GpuDemandSetAdmission::PayloadRequired(missing) => {
@@ -1545,6 +1696,8 @@ fn install_future_at_boundary(
     routes: &[Vec<u32>],
     residents: &HashMap<u32, Arc<ExpertResident>>,
     counters: Arc<Mutex<OracleCounters>>,
+    mode: OracleScheduledResidencyMode,
+    data_accesses: &Arc<AtomicU64>,
 ) -> Result<(), String> {
     let manager = engine
         .core
@@ -1560,9 +1713,6 @@ fn install_future_at_boundary(
         ));
     }
     let before = manager.snapshot();
-    let observer = OracleBoundaryObserver {
-        counters: counters.clone(),
-    };
     let experts_per_layer = manager.plan().geometry().num_experts() as u32;
     for (layer_index, local_ids) in routes.iter().enumerate() {
         counters.lock().future_physical_sets_considered += 1;
@@ -1618,7 +1768,15 @@ fn install_future_at_boundary(
             .protect_demand_set(&missing)
             .map_err(|error| error.to_string())?;
         let host_started = Instant::now();
-        let admissions = match prepare_logical_admissions(engine, &missing, residents) {
+        let admissions = match prepare_logical_admissions(
+            &gpu,
+            engine.core.options.dtype,
+            &missing,
+            residents,
+            mode,
+            &counters,
+            data_accesses,
+        ) {
             Ok(admissions) => admissions,
             Err(error) => {
                 let mut values = counters.lock();
@@ -1664,6 +1822,17 @@ fn install_future_at_boundary(
                 }
             })
             .collect::<Vec<_>>();
+        let observer = OracleBoundaryObserver {
+            counters: counters.clone(),
+            expected_installs: missing
+                .iter()
+                .map(|id| (*id, admissions_by_id[id].generation()))
+                .collect(),
+            completed_installs: Mutex::new(0),
+            layer_index,
+            experts_per_layer,
+            slot_bytes: manager.plan().geometry().slot_stride_bytes() as u64,
+        };
         counters.lock().boundary_replacement_sets_started += 1;
         let evictions_before = counters.lock().boundary_physical_evictions;
         match manager.ensure_oracle_future_set_at_safe_boundary(
@@ -1675,6 +1844,13 @@ fn install_future_at_boundary(
             Ok(_) => {
                 let mut values = counters.lock();
                 values.boundary_replacement_sets_completed += 1;
+                if *observer.completed_installs.lock() != missing.len()
+                    || values.boundary_physical_install_order_errors != 0
+                {
+                    return Err(
+                        "ORACLE physical install count/order/generation/bytes mismatch".into(),
+                    );
+                }
                 let observed_evictions = values
                     .boundary_physical_evictions
                     .saturating_sub(evictions_before);
@@ -1744,6 +1920,7 @@ struct OracleScheduler {
     oracle_source_pool: Option<Arc<OracleFutureSourcePool>>,
     source_position_gate: Arc<tokio::sync::Mutex<()>>,
     counters: Arc<Mutex<OracleCounters>>,
+    logical_data_accesses: Arc<AtomicU64>,
     state: Arc<Mutex<SchedulerState>>,
 }
 
@@ -1765,16 +1942,14 @@ where
             active.target_position
         ));
     }
-    if mode == OracleScheduledResidencyMode::TokenBoundaryDirect
-        && !state.lock().background.is_empty()
-    {
+    if uses_isolated_oracle_source_pool(mode) && !state.lock().background.is_empty() {
         return Err(
             "token-boundary-direct retained a previous-position background source task".into(),
         );
     }
 
     let Some(handle) = active.handle else {
-        if mode == OracleScheduledResidencyMode::TokenBoundaryDirect {
+        if uses_isolated_oracle_source_pool(mode) {
             return Err(
                 "token-boundary-direct skipped future source because a prior position lease remained in flight"
                     .into(),
@@ -1846,7 +2021,7 @@ fn release_source_position_lease_before_next_token(
     counters: &Arc<Mutex<OracleCounters>>,
 ) -> Result<(), String> {
     drop(lease);
-    if mode == OracleScheduledResidencyMode::TokenBoundaryDirect {
+    if uses_isolated_oracle_source_pool(mode) {
         let pool = oracle_source_pool
             .ok_or("token-boundary-direct lost its isolated ORACLE source pool")?;
         let snapshot = pool.snapshot();
@@ -1885,6 +2060,7 @@ impl OracleScheduler {
         concurrency: usize,
         expert_bytes: usize,
         oracle_source_pool: Option<Arc<OracleFutureSourcePool>>,
+        logical_data_accesses: Arc<AtomicU64>,
     ) -> Self {
         Self {
             engine,
@@ -1894,6 +2070,7 @@ impl OracleScheduler {
             oracle_source_pool,
             source_position_gate: Arc::new(tokio::sync::Mutex::new(())),
             counters: Arc::new(Mutex::new(OracleCounters::default())),
+            logical_data_accesses,
             state: Arc::new(Mutex::new(SchedulerState {
                 cursor: StrictRouteCursor::new(trace),
                 submitted_position: None,
@@ -2181,7 +2358,7 @@ impl OracleScheduler {
             return Ok(());
         };
 
-        if self.mode == OracleScheduledResidencyMode::TokenBoundaryDirect {
+        if uses_isolated_oracle_source_pool(self.mode) {
             let pool = self
                 .oracle_source_pool
                 .as_ref()
@@ -2200,6 +2377,8 @@ impl OracleScheduler {
                 &routes,
                 &resolved,
                 self.counters.clone(),
+                self.mode,
+                &self.logical_data_accesses,
             )?;
             let unavailable_after_install = self.future_not_physically_current_count(&routes)?;
             record_direct_late_fallback(
@@ -2236,6 +2415,7 @@ impl OracleScheduler {
         }
         let trace = state.cursor.clone().finish()?;
         let mut counters = self.counters.lock().clone();
+        counters.logical_only_data_accesses = self.logical_data_accesses.load(Ordering::Relaxed);
         if let Some(pool) = self.oracle_source_pool.as_ref() {
             let snapshot = pool.snapshot();
             counters.qualification_owned_current_slots = snapshot.current_in_use_slots as u64;
@@ -2384,7 +2564,7 @@ impl GpuNativeOracleScheduleHook for OracleScheduler {
                 Some(handle)
             }
             Err(_) => {
-                if self.mode == OracleScheduledResidencyMode::TokenBoundaryDirect {
+                if uses_isolated_oracle_source_pool(self.mode) {
                     state.failure = Some(
                         "token-boundary-direct could not acquire the next position lease after the prior safe boundary"
                             .into(),
@@ -2423,6 +2603,10 @@ struct PhysicalSlotPlanEvidence {
 
 #[derive(Clone, Copy, Debug, Serialize)]
 struct TreatmentContract {
+    logical_payload_mode: LogicalPayloadMode,
+    logical_capacity_accounting: &'static str,
+    physical_byte_source: &'static str,
+    logical_only_data_access_policy: &'static str,
     source_overlap: bool,
     late_source_policy: LateSourcePolicy,
     independent_layer_source_tasks: bool,
@@ -2442,7 +2626,11 @@ struct TreatmentContract {
 }
 
 const fn uses_isolated_oracle_source_pool(mode: OracleScheduledResidencyMode) -> bool {
-    matches!(mode, OracleScheduledResidencyMode::TokenBoundaryDirect)
+    matches!(
+        mode,
+        OracleScheduledResidencyMode::TokenBoundaryDirect
+            | OracleScheduledResidencyMode::TokenBoundaryDirectLogicalOnly
+    )
 }
 
 const fn oracle_source_pool_configured_max_slots(mode: OracleScheduledResidencyMode) -> usize {
@@ -2455,25 +2643,23 @@ const fn oracle_source_pool_configured_max_slots(mode: OracleScheduledResidencyM
 
 const fn treatment_contract(mode: OracleScheduledResidencyMode) -> TreatmentContract {
     TreatmentContract {
+        logical_payload_mode: logical_payload_mode(mode),
+        logical_capacity_accounting: "sum of successful boundary admission transaction snapshots: before + newly charged bytes = after + evicted bytes; intervening ordinary demand is excluded",
+        physical_byte_source: "GpuNativeDemandExpert::Install resident: Arc<ExpertResident>; production staging reads ExpertResident::data()",
+        logical_only_data_access_policy: "increment run-scoped audit and panic; any nonzero audit rejects qualification including caught panics",
         source_overlap: true,
         late_source_policy: late_source_policy(mode),
-        independent_layer_source_tasks: matches!(
-            mode,
-            OracleScheduledResidencyMode::TokenBoundaryDirect
-        ),
+        independent_layer_source_tasks: matches!(mode, OracleScheduledResidencyMode::TokenBoundaryDirect | OracleScheduledResidencyMode::TokenBoundaryDirectLogicalOnly),
         per_layer_storage_batch_read_used: false,
         host_preparation_overlap: false,
-        token_boundary_h2d: matches!(mode, OracleScheduledResidencyMode::TokenBoundaryDirect),
+        token_boundary_h2d: matches!(mode, OracleScheduledResidencyMode::TokenBoundaryDirect | OracleScheduledResidencyMode::TokenBoundaryDirectLogicalOnly),
         demand_fallback: true,
         h2d_compute_overlap_claimed: false,
         same_ordered_queue: true,
         extra_flush_submit: false,
         production_predictor_used: false,
         production_speculative_residency_used: false,
-        production_direct_staging_used: matches!(
-            mode,
-            OracleScheduledResidencyMode::TokenBoundaryDirect
-        ),
+        production_direct_staging_used: matches!(mode, OracleScheduledResidencyMode::TokenBoundaryDirect | OracleScheduledResidencyMode::TokenBoundaryDirectLogicalOnly),
         legacy_full_slot_vec_used: false,
         future_source_pool_isolated_from_production_primary: uses_isolated_oracle_source_pool(mode),
         production_primary_pool_capacity_unchanged: true,
@@ -2496,6 +2682,8 @@ struct FrozenWorkloadEvidence {
 
 #[derive(Clone, Copy, Debug, Serialize)]
 struct FrozenControlReferences {
+    logical_payload_control_git_sha: &'static str,
+    logical_payload_control_tree_sha: &'static str,
     frozen_parent_git_sha: &'static str,
     oracle_route_command_git_sha: &'static str,
     performance_controls_rerun: bool,
@@ -2618,6 +2806,7 @@ struct OracleScheduledResidencyReport {
     request: RequestEvidence,
     production_configuration: ProductionConfiguration,
     treatment_mode: OracleScheduledResidencyMode,
+    logical_payload_mode: LogicalPayloadMode,
     oracle_source_concurrency: usize,
     treatment_contract: TreatmentContract,
     physical_slot_plan: PhysicalSlotPlanEvidence,
@@ -2640,6 +2829,20 @@ fn accumulate_oracle(total: &mut OracleCounters, value: &OracleCounters) {
             total.$field = total.$field.saturating_add(value.$field)
         };
     }
+    add!(logical_materializations);
+    add!(logical_materialization_bytes);
+    add!(logical_only_admissions);
+    add!(logical_only_charged_bytes);
+    add!(logical_expected_payload_bytes);
+    add!(logical_only_data_accesses);
+    add!(logical_admission_transactions);
+    add!(logical_admissions_returned);
+    add!(logical_new_generations);
+    add!(logical_current_generations_validated);
+    add!(logical_newly_admitted_bytes);
+    add!(logical_gpu_used_bytes_before);
+    add!(logical_gpu_used_bytes_after);
+    add!(logical_gpu_evicted_bytes);
     add!(initial_position_source_priming_experts);
     add!(initial_position_source_priming_us);
     add!(future_experts_considered);
@@ -2683,6 +2886,8 @@ fn accumulate_oracle(total: &mut OracleCounters, value: &OracleCounters) {
     add!(boundary_replacement_sets_started);
     add!(boundary_replacement_sets_completed);
     add!(boundary_physical_installs);
+    add!(boundary_physical_install_order_checks);
+    add!(boundary_physical_install_order_errors);
     add!(boundary_physical_install_bytes);
     add!(boundary_physical_evictions);
     add!(boundary_physical_reinstalls);
@@ -2778,13 +2983,68 @@ fn validate_source_concurrency_mechanism(
     Ok(())
 }
 
+fn validate_logical_payload_counters(
+    counters: &OracleCounters,
+    mode: OracleScheduledResidencyMode,
+) -> Result<(), BenchmarkFailure> {
+    let c = counters;
+    let before_plus_new = c
+        .logical_gpu_used_bytes_before
+        .checked_add(c.logical_newly_admitted_bytes);
+    let after_plus_evicted = c
+        .logical_gpu_used_bytes_after
+        .checked_add(c.logical_gpu_evicted_bytes);
+    let fail = || {
+        BenchmarkFailure::new("postcondition", "oracle-logical-payload-reconciliation",
+        format!("ORACLE logical payload, charge, generation or data-access evidence did not reconcile: {c:?}"))
+    };
+    if c.logical_only_data_accesses != 0
+        || c.logical_admissions_returned != c.logical_current_generations_validated
+        || before_plus_new.is_none()
+        || before_plus_new != after_plus_evicted
+        || c.logical_materialization_bytes
+            .checked_add(c.logical_only_charged_bytes)
+            != Some(c.logical_expected_payload_bytes)
+    {
+        return Err(fail());
+    }
+    match logical_payload_mode(mode) {
+        LogicalPayloadMode::Materialized => {
+            if c.logical_only_admissions != 0 || c.logical_only_charged_bytes != 0 {
+                return Err(fail());
+            }
+        }
+        LogicalPayloadMode::QualificationLogicalOnly => {
+            if c.logical_materializations != 0
+                || c.logical_materialization_bytes != 0
+                || c.logical_only_admissions == 0
+                || c.logical_only_charged_bytes == 0
+                || c.logical_only_admissions != c.logical_new_generations
+                || c.logical_only_charged_bytes != c.logical_newly_admitted_bytes
+                || c.logical_admission_transactions == 0
+                || c.logical_admissions_returned < c.logical_new_generations
+                || c.logical_admissions_returned != c.boundary_physical_installs
+                || c.boundary_physical_install_order_checks != c.boundary_physical_installs
+                || c.boundary_physical_install_order_errors != 0
+                || c.boundary_stale_generation != 0
+                || c.boundary_install_failures != 0
+            {
+                return Err(fail());
+            }
+        }
+    }
+    Ok(())
+}
+
 fn validate_oracle_counters(
     counters: &OracleCounters,
     mode: OracleScheduledResidencyMode,
     concurrency: usize,
     expert_bytes: usize,
 ) -> Result<(), BenchmarkFailure> {
+    validate_logical_only_concurrency(mode, concurrency)?;
     validate_source_concurrency_mechanism(counters, mode, concurrency)?;
+    validate_logical_payload_counters(counters, mode)?;
     let classified_source = counters
         .source_skipped_physical_current
         .saturating_add(counters.source_prefetch_ram_hits)
@@ -2844,7 +3104,7 @@ fn validate_oracle_counters(
             "ORACLE token-boundary treatment materialized a legacy full-slot Vec",
         ));
     }
-    if mode == OracleScheduledResidencyMode::TokenBoundaryDirect
+    if uses_isolated_oracle_source_pool(mode)
         && (counters.source_position_inflight_skips != 0
             || counters.source_prefetch_batches_skipped_inflight != 0
             || counters.boundary_direct_staging_writes != counters.boundary_physical_installs
@@ -2980,6 +3240,7 @@ async fn execute_oracle_request(
     source_concurrency: usize,
     expert_bytes: usize,
     oracle_source_pool: Option<Arc<OracleFutureSourcePool>>,
+    logical_data_accesses: Arc<AtomicU64>,
     prompt_ids: &[u32],
     run_index: usize,
 ) -> Result<OracleRunResult, Box<dyn std::error::Error>> {
@@ -2997,6 +3258,7 @@ async fn execute_oracle_request(
         source_concurrency,
         expert_bytes,
         oracle_source_pool,
+        logical_data_accesses,
     );
     let mut request = token_loop.create_request_state()?;
     let snapshots = RequestSnapshotStart::capture(runtime)?;
@@ -3182,6 +3444,19 @@ fn emit_report(
     Ok(())
 }
 
+fn validate_logical_only_concurrency(
+    mode: OracleScheduledResidencyMode,
+    concurrency: usize,
+) -> Result<(), BenchmarkFailure> {
+    if mode == OracleScheduledResidencyMode::TokenBoundaryDirectLogicalOnly && concurrency != 4 {
+        return Err(artifact_failure(
+            "logical-only-requires-frozen-c4",
+            "logical-only payload treatment requires unchanged --oracle-source-concurrency=4",
+        ));
+    }
+    Ok(())
+}
+
 pub(crate) async fn run_command(args: CommandArgs) -> Result<(), Box<dyn std::error::Error>> {
     if args.oracle_source_concurrency == 0 || args.oracle_source_concurrency > EXPECTED_LAYERS {
         return Err(artifact_failure(
@@ -3193,6 +3468,7 @@ pub(crate) async fn run_command(args: CommandArgs) -> Result<(), Box<dyn std::er
         )
         .into());
     }
+    validate_logical_only_concurrency(args.treatment_mode, args.oracle_source_concurrency)?;
     let oracle = load_oracle_artifact(&args.oracle_trace)?;
     let build = crate::qualification::BuildProvenance::embedded();
     crate::gpu_native_real_benchmark::validate_preflight_provenance(&build)?;
@@ -3307,7 +3583,8 @@ pub(crate) async fn run_command(args: CommandArgs) -> Result<(), Box<dyn std::er
         crate::buffer_pool::expert_buffer_pool_qualification_oracle_bytes();
     let oracle_source_pool = match args.treatment_mode {
         OracleScheduledResidencyMode::SourceOnly => None,
-        OracleScheduledResidencyMode::TokenBoundaryDirect => {
+        OracleScheduledResidencyMode::TokenBoundaryDirect
+        | OracleScheduledResidencyMode::TokenBoundaryDirectLogicalOnly => {
             Some(Arc::new(OracleFutureSourcePool::new(
                 ORACLE_FUTURE_SOURCE_POOL_SLOTS,
                 spec.cfg.model.expert_size,
@@ -3315,6 +3592,7 @@ pub(crate) async fn run_command(args: CommandArgs) -> Result<(), Box<dyn std::er
             )))
         }
     };
+    let logical_data_accesses = Arc::new(AtomicU64::new(0));
     let execution = async {
         if runtime.engine.core.cache.capacity() != FROZEN_RAM_CACHE_SLOTS
             || runtime.engine.core.pool.capacity() != expected_production_primary_capacity
@@ -3362,6 +3640,7 @@ pub(crate) async fn run_command(args: CommandArgs) -> Result<(), Box<dyn std::er
                 args.oracle_source_concurrency,
                 spec.cfg.model.expert_size,
                 oracle_source_pool.clone(),
+                logical_data_accesses.clone(),
                 &prompt_ids,
                 0,
             ),
@@ -3382,6 +3661,7 @@ pub(crate) async fn run_command(args: CommandArgs) -> Result<(), Box<dyn std::er
                         args.oracle_source_concurrency,
                         spec.cfg.model.expert_size,
                         oracle_source_pool.clone(),
+                        logical_data_accesses.clone(),
                         &prompt_ids,
                         run_index,
                     ),
@@ -3512,6 +3792,13 @@ pub(crate) async fn run_command(args: CommandArgs) -> Result<(), Box<dyn std::er
         )
         .into());
     }
+    if logical_data_accesses.load(Ordering::Relaxed) != 0 {
+        return Err(artifact_failure(
+            "logical-only-payload-data-access",
+            "qualification logical-only payload data was accessed",
+        )
+        .into());
+    }
     let report = OracleScheduledResidencyReport {
         schema: SCHEMA,
         mode: MODE,
@@ -3527,10 +3814,13 @@ pub(crate) async fn run_command(args: CommandArgs) -> Result<(), Box<dyn std::er
         request,
         production_configuration,
         treatment_mode: args.treatment_mode,
+        logical_payload_mode: logical_payload_mode(args.treatment_mode),
         oracle_source_concurrency: args.oracle_source_concurrency,
         treatment_contract: treatment_contract(args.treatment_mode),
         physical_slot_plan: validated.physical_slot_plan,
         frozen_controls: FrozenControlReferences {
+            logical_payload_control_git_sha: FROZEN_PAYLOAD_CONTROL_SHA,
+            logical_payload_control_tree_sha: FROZEN_PAYLOAD_CONTROL_TREE,
             frozen_parent_git_sha: ORACLE_ROUTE_COMMAND_SHA,
             oracle_route_command_git_sha: ORACLE_ROUTE_COMMAND_SHA,
             performance_controls_rerun: false,
@@ -3746,6 +4036,383 @@ mod tests {
         }
     }
 
+    fn logical_only_mode() -> OracleScheduledResidencyMode {
+        OracleScheduledResidencyMode::TokenBoundaryDirectLogicalOnly
+    }
+
+    #[test]
+    fn logical_only_contract_changes_payload_mode_and_preserves_direct_source_and_boundary_contract(
+    ) {
+        assert_eq!(
+            OracleScheduledResidencyMode::from_str("token-boundary-direct-logical-only", false)
+                .unwrap(),
+            logical_only_mode()
+        );
+        let control = OracleScheduledResidencyMode::TokenBoundaryDirect;
+        assert_eq!(
+            logical_payload_mode(control),
+            LogicalPayloadMode::Materialized
+        );
+        let mut control_json = serde_json::to_value(treatment_contract(control)).unwrap();
+        let mut treatment_json =
+            serde_json::to_value(treatment_contract(logical_only_mode())).unwrap();
+        assert_eq!(
+            control_json
+                .as_object_mut()
+                .unwrap()
+                .remove("logical_payload_mode")
+                .unwrap(),
+            "materialized"
+        );
+        assert_eq!(
+            treatment_json
+                .as_object_mut()
+                .unwrap()
+                .remove("logical_payload_mode")
+                .unwrap(),
+            "qualification-logical-only"
+        );
+        assert_eq!(control_json, treatment_json);
+        assert_eq!(
+            oracle_source_pool_configured_max_slots(logical_only_mode()),
+            384
+        );
+        assert!(validate_logical_only_concurrency(logical_only_mode(), 4).is_ok());
+        for concurrency in [1, 2, 3, 8] {
+            assert!(validate_logical_only_concurrency(logical_only_mode(), concurrency).is_err());
+            assert!(validate_logical_only_concurrency(control, concurrency).is_ok());
+        }
+    }
+
+    #[test]
+    fn logical_only_oracle_preparation_matches_control_and_releases_real_source_leases() {
+        use crate::inference::WeightDtype;
+        let pool = OracleFutureSourcePool::new(2, 72, 8);
+        let mut residents = HashMap::new();
+        for id in [2, 1] {
+            // A real UTH header proves the logical charge is the stripped
+            // ExpertResident payload length, not the larger source-pool slot.
+            let mut bytes = Vec::new();
+            crate::tensor_header::TensorHeader::for_swiglu_expert(WeightDtype::Q4_0, 32, 32)
+                .write_padded(8, &mut bytes);
+            bytes.extend_from_slice(&[id as u8; 8]);
+            assert_eq!(bytes.len(), 72);
+            let mut buffer = pool.try_acquire().unwrap();
+            buffer.as_mut_slice().copy_from_slice(&bytes);
+            let source = Arc::new(ExpertResident::new_with_block_align(id, buffer, 8));
+            assert_eq!(source.data().len(), 8);
+            residents.insert(id, source);
+        }
+        let weak = residents.values().map(Arc::downgrade).collect::<Vec<_>>();
+        let caches = [
+            GpuExpertCache::new(16, 0.0, 0),
+            GpuExpertCache::new(16, 0.0, 0),
+        ];
+        let mut signatures = Vec::new();
+        let mut retained = Vec::new();
+        for (index, mode) in [
+            OracleScheduledResidencyMode::TokenBoundaryDirect,
+            logical_only_mode(),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let audit = Arc::new(AtomicU64::new(0));
+            let counters = Mutex::new(OracleCounters::default());
+            let admissions = prepare_logical_admissions(
+                &caches[index],
+                WeightDtype::Q4_0,
+                &[2, 1],
+                &residents,
+                mode,
+                &counters,
+                &audit,
+            )
+            .unwrap();
+            for admission in &admissions {
+                let id = admission.resident().id;
+                let source = &residents[&id];
+                crate::gpu_native_residency::validate_qualification_physical_source_for_test(
+                    &caches[index],
+                    id,
+                    source,
+                    admission,
+                )
+                .unwrap();
+                let demand = GpuNativeDemandExpert::install(id, source.clone(), admission.clone());
+                match demand {
+                    GpuNativeDemandExpert::Install { resident, .. } => {
+                        assert!(Arc::ptr_eq(&resident, source));
+                        assert_eq!(resident.data().as_ptr(), source.data().as_ptr());
+                    }
+                    _ => panic!("expected physical install source"),
+                }
+                if index == 0 {
+                    assert_eq!(admission.resident().data(), source.data());
+                    assert_ne!(admission.resident().data().as_ptr(), source.data().as_ptr());
+                }
+                assert_eq!(Arc::strong_count(source), 1);
+            }
+            let repeated = prepare_logical_admissions(
+                &caches[index],
+                WeightDtype::Q4_0,
+                &[1, 2],
+                &residents,
+                mode,
+                &counters,
+                &audit,
+            )
+            .unwrap();
+            assert_eq!(repeated[0].generation(), admissions[1].generation());
+            let c = counters.lock();
+            assert_eq!(c.logical_expected_payload_bytes, 16);
+            assert_eq!(c.logical_newly_admitted_bytes, 16);
+            assert_eq!(c.logical_new_generations, 2);
+            assert_eq!(c.logical_current_generations_validated, 4);
+            assert_eq!(c.logical_gpu_used_bytes_before, 16);
+            assert_eq!(c.logical_gpu_used_bytes_after, 32);
+            assert_eq!(c.logical_gpu_evicted_bytes, 0);
+            assert_eq!(c.logical_materializations, if index == 0 { 2 } else { 0 });
+            assert_eq!(
+                c.logical_materialization_bytes,
+                if index == 0 { 16 } else { 0 }
+            );
+            assert_eq!(c.logical_only_admissions, if index == 1 { 2 } else { 0 });
+            assert_eq!(
+                c.logical_only_charged_bytes,
+                if index == 1 { 16 } else { 0 }
+            );
+            assert_eq!(audit.load(Ordering::Relaxed), 0);
+            signatures.push((
+                admissions
+                    .iter()
+                    .map(|a| (a.resident().id, a.generation(), a.byte_len()))
+                    .collect::<Vec<_>>(),
+                caches[index].used_bytes(),
+            ));
+            retained.extend(admissions);
+        }
+        assert_eq!(signatures[0], signatures[1]);
+        drop(residents);
+        assert!(weak.iter().all(|source| source.upgrade().is_none()));
+        assert_eq!(pool.snapshot().current_in_use_slots, 0);
+        assert_eq!(pool.snapshot().exhaustion_count, 0);
+        assert_eq!(
+            retained.len(),
+            4,
+            "logical admissions remain alive after all source leases return"
+        );
+    }
+
+    #[test]
+    fn logical_only_cache_cannot_accumulate_isolated_source_pool_leases() {
+        use crate::inference::WeightDtype;
+        let pool = OracleFutureSourcePool::new(1, 8, 8);
+        let cache = GpuExpertCache::new(400 * 8, 0.0, 0);
+        let counters = Mutex::new(OracleCounters::default());
+        let audit = Arc::new(AtomicU64::new(0));
+        for id in 0..400 {
+            let mut buffer = pool.try_acquire().unwrap();
+            buffer.as_mut_slice().fill(id as u8);
+            let source = Arc::new(ExpertResident::new(id, buffer));
+            let weak = Arc::downgrade(&source);
+            let residents = HashMap::from([(id, source)]);
+            prepare_logical_admissions(
+                &cache,
+                WeightDtype::Q4_0,
+                &[id],
+                &residents,
+                logical_only_mode(),
+                &counters,
+                &audit,
+            )
+            .unwrap();
+            drop(residents);
+            assert!(weak.upgrade().is_none());
+            assert_eq!(pool.snapshot().current_in_use_slots, 0);
+        }
+        assert_eq!(cache.used_bytes(), 400 * 8);
+        assert_eq!(pool.snapshot().peak_in_use_slots, 1);
+        assert_eq!(pool.snapshot().exhaustion_count, 0);
+        assert_eq!(pool.snapshot().nvme_reads, 0);
+        assert_eq!(audit.load(Ordering::Relaxed), 0);
+    }
+
+    fn valid_logical_only_counters() -> OracleCounters {
+        OracleCounters {
+            logical_only_admissions: 2,
+            logical_only_charged_bytes: 16,
+            logical_expected_payload_bytes: 16,
+            logical_admission_transactions: 1,
+            logical_admissions_returned: 2,
+            logical_new_generations: 2,
+            logical_current_generations_validated: 2,
+            logical_newly_admitted_bytes: 16,
+            logical_gpu_used_bytes_before: 8,
+            logical_gpu_used_bytes_after: 16,
+            logical_gpu_evicted_bytes: 8,
+            boundary_physical_installs: 2,
+            boundary_physical_install_order_checks: 2,
+            ..OracleCounters::default()
+        }
+    }
+
+    #[test]
+    fn logical_only_payload_gates_reject_each_counter_violation_and_caught_data_access() {
+        let good = valid_logical_only_counters();
+        validate_logical_payload_counters(&good, logical_only_mode()).unwrap();
+        assert!(
+            validate_logical_payload_counters(&OracleCounters::default(), logical_only_mode())
+                .is_err()
+        );
+        let corruptions: &[fn(&mut OracleCounters)] = &[
+            |c| c.logical_materializations = 1,
+            |c| c.logical_materialization_bytes = 8,
+            |c| c.logical_only_admissions = 0,
+            |c| c.logical_only_charged_bytes = 0,
+            |c| c.logical_expected_payload_bytes += 1,
+            |c| c.logical_only_data_accesses = 1,
+            |c| c.logical_admission_transactions = 0,
+            |c| c.logical_admissions_returned += 1,
+            |c| c.logical_new_generations += 1,
+            |c| c.logical_current_generations_validated -= 1,
+            |c| c.logical_newly_admitted_bytes += 1,
+            |c| c.logical_gpu_used_bytes_before += 1,
+            |c| c.logical_gpu_used_bytes_after += 1,
+            |c| c.logical_gpu_evicted_bytes += 1,
+            |c| {
+                c.logical_gpu_used_bytes_before = u64::MAX;
+                c.logical_gpu_used_bytes_after = u64::MAX;
+            },
+            |c| c.boundary_physical_installs -= 1,
+            |c| c.boundary_physical_install_order_checks -= 1,
+            |c| c.boundary_physical_install_order_errors = 1,
+            |c| c.boundary_stale_generation = 1,
+            |c| c.boundary_install_failures = 1,
+        ];
+        for corrupt in corruptions {
+            let mut bad = good.clone();
+            corrupt(&mut bad);
+            assert!(
+                validate_logical_payload_counters(&bad, logical_only_mode()).is_err(),
+                "accepted {bad:?}"
+            );
+        }
+        let audit = Arc::new(AtomicU64::new(0));
+        let resident = GpuResident::new_qualification_logical_only(
+            1,
+            8,
+            crate::inference::WeightDtype::Q4_0,
+            audit.clone(),
+        );
+        assert!(std::panic::catch_unwind(|| resident.data()).is_err());
+        drop(resident);
+        let mut caught = good;
+        caught.logical_only_data_accesses = audit.load(Ordering::Relaxed);
+        assert!(validate_logical_payload_counters(&caught, logical_only_mode()).is_err());
+    }
+
+    #[test]
+    fn logical_only_completion_audit_rejects_install_order_identity_generation_and_byte_drift() {
+        let make = || OracleBoundaryObserver {
+            counters: Arc::new(Mutex::new(OracleCounters::default())),
+            expected_installs: vec![(130, 7), (129, 8)],
+            completed_installs: Mutex::new(0),
+            layer_index: 1,
+            experts_per_layer: 128,
+            slot_bytes: 12,
+        };
+        let good = make();
+        good.record_install_identity(130, GpuNativeQ4ExpertKey::new(1, 2, 7), 12);
+        good.record_install_identity(129, GpuNativeQ4ExpertKey::new(1, 1, 8), 12);
+        assert_eq!(*good.completed_installs.lock(), 2);
+        assert_eq!(
+            good.counters.lock().boundary_physical_install_order_checks,
+            2
+        );
+        assert_eq!(
+            good.counters.lock().boundary_physical_install_order_errors,
+            0
+        );
+        for (id, layer, expert, generation, bytes) in [
+            (129, 1, 1, 8, 12), // valid second identity presented out of order
+            (130, 0, 2, 7, 12), // wrong layer
+            (130, 1, 3, 7, 12), // wrong local expert
+            (130, 1, 2, 9, 12), // wrong logical generation
+            (130, 1, 2, 7, 8),  // wrong physical slot byte count
+        ] {
+            let bad = make();
+            bad.record_install_identity(
+                id,
+                GpuNativeQ4ExpertKey::new(layer, expert, generation),
+                bytes,
+            );
+            assert_eq!(
+                bad.counters.lock().boundary_physical_install_order_errors,
+                1
+            );
+        }
+        good.record_install_identity(129, GpuNativeQ4ExpertKey::new(1, 1, 8), 12);
+        assert_eq!(
+            good.counters.lock().boundary_physical_install_order_errors,
+            1,
+            "extra install fails closed"
+        );
+    }
+
+    #[test]
+    fn logical_only_inherits_source_pool_and_c4_fail_closed_gates() {
+        let mut good = valid_source_only_counters();
+        accumulate_oracle(&mut good, &valid_logical_only_counters());
+        good.boundary_direct_staging_writes = 2;
+        good.boundary_physical_install_bytes = 24;
+        validate_oracle_counters(&good, logical_only_mode(), 4, 8).unwrap();
+        for corrupt in [
+            (|c: &mut OracleCounters| c.qualification_owned_peak_slots = 385)
+                as fn(&mut OracleCounters),
+            |c| c.qualification_owned_current_slots = 1,
+            |c| c.oracle_source_pool_exhaustion_count = 1,
+            |c| c.source_prefetch_peak_inflight = 5,
+            |c| c.source_prefetch_reads_peak_inflight = 5,
+            |c| c.source_prefetch_reads_current_inflight = 1,
+            |c| c.source_reads_started += 1,
+            |c| c.oracle_source_nvme_reads += 1,
+            |c| c.boundary_full_slot_vec_materializations = 1,
+        ] {
+            let mut bad = good.clone();
+            corrupt(&mut bad);
+            assert!(validate_oracle_counters(&bad, logical_only_mode(), 4, 8).is_err());
+        }
+        let c4 = valid_direct_source_mechanism_counters();
+        validate_source_concurrency_mechanism(&c4, logical_only_mode(), 4).unwrap();
+        let mut serialized = c4;
+        serialized.source_prefetch_reads_peak_inflight = 1;
+        assert!(
+            validate_source_concurrency_mechanism(&serialized, logical_only_mode(), 4).is_err()
+        );
+    }
+
+    #[test]
+    fn logical_only_counter_aggregation_preserves_all_added_evidence() {
+        let one = valid_logical_only_counters();
+        let mut total = OracleCounters::default();
+        accumulate_oracle(&mut total, &one);
+        accumulate_oracle(&mut total, &one);
+        let one_json = serde_json::to_value(one).unwrap();
+        let total_json = serde_json::to_value(total.clone()).unwrap();
+        for (name, value) in one_json.as_object().unwrap() {
+            if name.starts_with("logical_") || name.starts_with("boundary_physical_install_order_")
+            {
+                assert_eq!(
+                    total_json[name].as_u64().unwrap(),
+                    value.as_u64().unwrap() * 2,
+                    "{name}"
+                );
+            }
+        }
+        validate_logical_payload_counters(&total, logical_only_mode()).unwrap();
+    }
+
     #[test]
     fn exact_route_cursor_progression() {
         let trace = test_trace(3);
@@ -3818,8 +4485,8 @@ mod tests {
     }
 
     #[test]
-    fn v3_schema_and_predecessor_attempt_contracts_are_frozen() {
-        assert_eq!(SCHEMA, "mer.gpu-native-oracle-scheduled-residency.v3");
+    fn v4_schema_and_predecessor_attempt_contracts_are_frozen() {
+        assert_eq!(SCHEMA, "mer.gpu-native-oracle-scheduled-residency.v4");
         let first = PredecessorFirstAttemptEvidence {
             code_sha: PREDECESSOR_FIRST_ATTEMPT_CODE_SHA,
             result: "FAIL",

--- a/rust-engine/src/gpu_native_oracle_scheduled_residency.rs
+++ b/rust-engine/src/gpu_native_oracle_scheduled_residency.rs
@@ -34,13 +34,14 @@ use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
+use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 
-pub(crate) const SCHEMA: &str = "mer.gpu-native-oracle-scheduled-residency.v2";
+pub(crate) const SCHEMA: &str = "mer.gpu-native-oracle-scheduled-residency.v3";
 pub(crate) const MODE: &str = "qualify-gpu-native-oracle-scheduled-residency";
 const ORACLE_ROUTE_SCHEMA: &str = "mer.gpu-native-oracle-route-trace.v1";
 const ORACLE_ROUTE_COMMAND_SHA: &str = "3576cb893586f5dd3f5c5e7355658762db02b534";
@@ -69,6 +70,11 @@ const FROZEN_MEASURED_RUNS: usize = 3;
 const FROZEN_RAM_CACHE_SLOTS: usize = 384;
 const ORACLE_FUTURE_SOURCE_POOL_SLOTS: usize = EXPECTED_LAYERS * EXPECTED_TOP_K;
 const PREDECESSOR_FIRST_ATTEMPT_CODE_SHA: &str = "d4e34cf302ee7f8d78b45d8e6dd8e7e524e716f3";
+const PREDECESSOR_SECOND_ATTEMPT_CODE_SHA: &str = "34b55715452acc355fd6dcf21e9c084d038efcd9";
+const PREDECESSOR_SECOND_ATTEMPT_REPORT_SHA256: &str =
+    "a80d79457bb0577bc7231d4567db6126fd1b8b0ccf71b0d5ef73af468a04a6a0";
+const PREDECESSOR_SECOND_ATTEMPT_RUNNER_SHA256: &str =
+    "3e11741e4d7efc58f1ad771d58b810668724968571b881aeb505f1dd2f939c9f";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, ValueEnum)]
 #[serde(rename_all = "kebab-case")]
@@ -396,6 +402,11 @@ struct OracleCounters {
     source_prefetch_batches_completed: u64,
     source_prefetch_batches_skipped_inflight: u64,
     source_prefetch_peak_inflight: u64,
+    source_prefetch_read_batches_with_work: u64,
+    source_prefetch_positions_with_multiple_read_batches: u64,
+    source_prefetch_reads_current_inflight: u64,
+    source_prefetch_reads_peak_inflight: u64,
+    source_prefetch_read_inflight_accounting_errors: u64,
     source_ready_before_boundary: u64,
     source_late_at_boundary: u64,
     source_end_of_trace: u64,
@@ -583,6 +594,96 @@ impl Drop for LayerBatchGuard {
     fn drop(&mut self) {
         self.counters.lock().source_prefetch_batches_completed += 1;
     }
+}
+
+struct DirectFutureReadGuard {
+    counters: Arc<Mutex<OracleCounters>>,
+    entered: bool,
+}
+
+impl DirectFutureReadGuard {
+    fn enter(counters: Arc<Mutex<OracleCounters>>) -> Self {
+        let mut values = counters.lock();
+        let entered = match values.source_prefetch_reads_current_inflight.checked_add(1) {
+            Some(current) => {
+                values.source_prefetch_reads_current_inflight = current;
+                values.source_prefetch_reads_peak_inflight =
+                    values.source_prefetch_reads_peak_inflight.max(current);
+                true
+            }
+            None => {
+                values.source_prefetch_read_inflight_accounting_errors = values
+                    .source_prefetch_read_inflight_accounting_errors
+                    .saturating_add(1);
+                false
+            }
+        };
+        drop(values);
+        Self { counters, entered }
+    }
+}
+
+impl Drop for DirectFutureReadGuard {
+    fn drop(&mut self) {
+        if !self.entered {
+            return;
+        }
+        let mut values = self.counters.lock();
+        match values.source_prefetch_reads_current_inflight.checked_sub(1) {
+            Some(current) => values.source_prefetch_reads_current_inflight = current,
+            None => {
+                values.source_prefetch_read_inflight_accounting_errors = values
+                    .source_prefetch_read_inflight_accounting_errors
+                    .saturating_add(1);
+            }
+        }
+    }
+}
+
+async fn run_bounded_layer_tasks<I, F, Fut, T, A, M>(
+    work: I,
+    concurrency: usize,
+    task_factory: F,
+    mut aggregate: A,
+    mut merge: M,
+) -> Result<A, String>
+where
+    I: IntoIterator,
+    I::Item: Send + 'static,
+    F: Fn(I::Item) -> Fut + Clone + Send + 'static,
+    Fut: Future<Output = T> + Send + 'static,
+    T: Send + 'static,
+    M: FnMut(&mut A, T),
+{
+    if concurrency == 0 {
+        return Err("qualification layer-task concurrency must be nonzero".into());
+    }
+
+    let mut work = work.into_iter();
+    let mut tasks = tokio::task::JoinSet::new();
+    for item in work.by_ref().take(concurrency) {
+        let task_factory = task_factory.clone();
+        tasks.spawn(async move { task_factory(item).await });
+    }
+
+    while let Some(joined) = tasks.join_next().await {
+        match joined {
+            Ok(value) => merge(&mut aggregate, value),
+            Err(error) => {
+                // A panic or cancellation is a qualification failure. Abort
+                // and resolve every still-owned task so RAII source leases
+                // and inflight guards are released before returning.
+                tasks.abort_all();
+                while tasks.join_next().await.is_some() {}
+                return Err(format!("independent layer source task failed: {error}"));
+            }
+        }
+        if let Some(item) = work.next() {
+            let task_factory = task_factory.clone();
+            tasks.spawn(async move { task_factory(item).await });
+        }
+    }
+    Ok(aggregate)
 }
 
 #[derive(Default)]
@@ -798,6 +899,7 @@ async fn prefetch_layer_batch(
 ) -> PrefetchOutcome {
     let _guard = LayerBatchGuard::enter(counters.clone());
     let mut outcome = PrefetchOutcome::default();
+    let mut direct_read_started_for_batch = false;
     let manager = match engine.core.gpu_native_residency.as_ref() {
         Some(manager) => manager.clone(),
         None => {
@@ -850,9 +952,16 @@ async fn prefetch_layer_batch(
                     Some("token-boundary-direct has no isolated ORACLE source pool".into());
                 return outcome;
             };
+            if !direct_read_started_for_batch {
+                counters.lock().source_prefetch_read_batches_with_work += 1;
+                direct_read_started_for_batch = true;
+            }
             counters.lock().source_reads_started += 1;
             let started = Instant::now();
-            match read_oracle_future_source(&engine, pool, global_id).await {
+            let read_guard = DirectFutureReadGuard::enter(counters.clone());
+            let read = read_oracle_future_source(&engine, pool, global_id).await;
+            drop(read_guard);
+            match read {
                 Ok((resident, bytes)) => {
                     let pool_snapshot = pool.snapshot();
                     let mut values = counters.lock();
@@ -959,6 +1068,18 @@ async fn prefetch_layer_batch(
     outcome
 }
 
+fn merge_prefetch_outcome(outcome: &mut PrefetchOutcome, mut batch: PrefetchOutcome) {
+    if outcome.fatal_error.is_none() {
+        outcome.fatal_error = batch.fatal_error.take();
+    }
+    outcome.failed_ids.append(&mut batch.failed_ids);
+    outcome.successful_ids.append(&mut batch.successful_ids);
+    outcome
+        .deferred_overlap_ids
+        .append(&mut batch.deferred_overlap_ids);
+    outcome.residents.extend(batch.residents);
+}
+
 async fn prefetch_position(
     engine: Arc<Engine>,
     target_position: usize,
@@ -972,52 +1093,111 @@ async fn prefetch_position(
     readiness: Arc<SourceReadiness>,
 ) -> PrefetchOutcome {
     let started = Instant::now();
-    let semaphore = Arc::new(tokio::sync::Semaphore::new(concurrency));
-    let batches = stream::iter(routes.into_iter().enumerate().map(|(layer_index, ids)| {
-        let engine = engine.clone();
-        let counters = counters.clone();
-        let readiness = readiness.clone();
-        let semaphore = semaphore.clone();
-        let current_route_global_ids = current_route_global_ids.clone();
-        let oracle_source_pool = oracle_source_pool.clone();
-        async move {
-            let permit = semaphore
-                .acquire_owned()
-                .await
-                .expect("qualification semaphore remains open");
-            let result = prefetch_layer_batch(
-                engine,
-                layer_index,
-                ids,
-                mode,
-                current_route_global_ids,
-                oracle_source_pool,
-                counters,
-                readiness,
-            )
-            .await;
-            drop(permit);
-            result
-        }
-    }))
-    .buffer_unordered(concurrency)
-    .collect::<Vec<_>>()
-    .await;
-
-    let mut outcome = PrefetchOutcome {
-        target_position,
-        ..PrefetchOutcome::default()
+    let direct_read_batches_before = if mode == OracleScheduledResidencyMode::TokenBoundaryDirect {
+        counters.lock().source_prefetch_read_batches_with_work
+    } else {
+        0
     };
-    for batch in batches {
-        if outcome.fatal_error.is_none() {
-            outcome.fatal_error = batch.fatal_error;
+    let mut outcome = match mode {
+        OracleScheduledResidencyMode::SourceOnly => {
+            // Preserve the v2 SourceOnly scheduling behavior. Its storage
+            // futures do not use the qualification direct-read path.
+            let semaphore = Arc::new(tokio::sync::Semaphore::new(concurrency));
+            let batches = stream::iter(routes.into_iter().enumerate().map(|(layer_index, ids)| {
+                let engine = engine.clone();
+                let counters = counters.clone();
+                let readiness = readiness.clone();
+                let semaphore = semaphore.clone();
+                let current_route_global_ids = current_route_global_ids.clone();
+                let oracle_source_pool = oracle_source_pool.clone();
+                async move {
+                    let permit = semaphore
+                        .acquire_owned()
+                        .await
+                        .expect("qualification semaphore remains open");
+                    let result = prefetch_layer_batch(
+                        engine,
+                        layer_index,
+                        ids,
+                        mode,
+                        current_route_global_ids,
+                        oracle_source_pool,
+                        counters,
+                        readiness,
+                    )
+                    .await;
+                    drop(permit);
+                    result
+                }
+            }))
+            .buffer_unordered(concurrency)
+            .collect::<Vec<_>>()
+            .await;
+            let mut outcome = PrefetchOutcome {
+                target_position,
+                ..PrefetchOutcome::default()
+            };
+            for batch in batches {
+                merge_prefetch_outcome(&mut outcome, batch);
+            }
+            outcome
         }
-        outcome.failed_ids.extend(batch.failed_ids);
-        outcome.successful_ids.extend(batch.successful_ids);
-        outcome
-            .deferred_overlap_ids
-            .extend(batch.deferred_overlap_ids);
-        outcome.residents.extend(batch.residents);
+        OracleScheduledResidencyMode::TokenBoundaryDirect => {
+            let task_engine = engine.clone();
+            let task_counters = counters.clone();
+            let task_readiness = readiness.clone();
+            let task_current_route_global_ids = current_route_global_ids.clone();
+            let task_oracle_source_pool = oracle_source_pool.clone();
+            let task_factory = move |(layer_index, ids)| {
+                let engine = task_engine.clone();
+                let counters = task_counters.clone();
+                let readiness = task_readiness.clone();
+                let current_route_global_ids = task_current_route_global_ids.clone();
+                let oracle_source_pool = task_oracle_source_pool.clone();
+                async move {
+                    prefetch_layer_batch(
+                        engine,
+                        layer_index,
+                        ids,
+                        OracleScheduledResidencyMode::TokenBoundaryDirect,
+                        current_route_global_ids,
+                        oracle_source_pool,
+                        counters,
+                        readiness,
+                    )
+                    .await
+                }
+            };
+            match run_bounded_layer_tasks(
+                routes.into_iter().enumerate(),
+                concurrency,
+                task_factory,
+                PrefetchOutcome {
+                    target_position,
+                    ..PrefetchOutcome::default()
+                },
+                merge_prefetch_outcome,
+            )
+            .await
+            {
+                Ok(outcome) => outcome,
+                Err(error) => PrefetchOutcome {
+                    target_position,
+                    fatal_error: Some(error),
+                    ..PrefetchOutcome::default()
+                },
+            }
+        }
+    };
+    if mode == OracleScheduledResidencyMode::TokenBoundaryDirect {
+        let mut values = counters.lock();
+        if values
+            .source_prefetch_read_batches_with_work
+            .saturating_sub(direct_read_batches_before)
+            > 1
+        {
+            values.source_prefetch_positions_with_multiple_read_batches += 1;
+        }
     }
     let slots = outcome.residents.len() as u64;
     let bytes = slots.saturating_mul(expert_bytes as u64);
@@ -2245,6 +2425,8 @@ struct PhysicalSlotPlanEvidence {
 struct TreatmentContract {
     source_overlap: bool,
     late_source_policy: LateSourcePolicy,
+    independent_layer_source_tasks: bool,
+    per_layer_storage_batch_read_used: bool,
     host_preparation_overlap: bool,
     token_boundary_h2d: bool,
     demand_fallback: bool,
@@ -2275,6 +2457,11 @@ const fn treatment_contract(mode: OracleScheduledResidencyMode) -> TreatmentCont
     TreatmentContract {
         source_overlap: true,
         late_source_policy: late_source_policy(mode),
+        independent_layer_source_tasks: matches!(
+            mode,
+            OracleScheduledResidencyMode::TokenBoundaryDirect
+        ),
+        per_layer_storage_batch_read_used: false,
         host_preparation_overlap: false,
         token_boundary_h2d: matches!(mode, OracleScheduledResidencyMode::TokenBoundaryDirect),
         demand_fallback: true,
@@ -2324,6 +2511,19 @@ struct PredecessorFirstAttemptEvidence {
     acquired: usize,
     interpretation: &'static str,
     first_attempt_rerun: bool,
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+struct PredecessorSecondAttemptEvidence {
+    code_sha: &'static str,
+    result: &'static str,
+    report_sha256: &'static str,
+    runner_sha256: &'static str,
+    configured_source_concurrency: usize,
+    observed_source_prefetch_peak_inflight: u64,
+    decode_tps: f64,
+    ordinary_residency_misses: u64,
+    second_attempt_rerun: bool,
 }
 
 #[derive(Clone, Copy, Debug, Serialize)]
@@ -2424,6 +2624,7 @@ struct OracleScheduledResidencyReport {
     frozen_controls: FrozenControlReferences,
     frozen_workload: FrozenWorkloadEvidence,
     predecessor_first_attempt: PredecessorFirstAttemptEvidence,
+    predecessor_second_attempt: PredecessorSecondAttemptEvidence,
     source_memory_planes: SourceMemoryPlaneEvidence,
     warmup: OracleRunResult,
     measured: Vec<OracleRunResult>,
@@ -2467,6 +2668,13 @@ fn accumulate_oracle(total: &mut OracleCounters, value: &OracleCounters) {
     total.source_prefetch_peak_inflight = total
         .source_prefetch_peak_inflight
         .max(value.source_prefetch_peak_inflight);
+    add!(source_prefetch_read_batches_with_work);
+    add!(source_prefetch_positions_with_multiple_read_batches);
+    total.source_prefetch_reads_current_inflight = value.source_prefetch_reads_current_inflight;
+    total.source_prefetch_reads_peak_inflight = total
+        .source_prefetch_reads_peak_inflight
+        .max(value.source_prefetch_reads_peak_inflight);
+    add!(source_prefetch_read_inflight_accounting_errors);
     add!(source_ready_before_boundary);
     add!(source_late_at_boundary);
     add!(source_end_of_trace);
@@ -2508,12 +2716,75 @@ fn accumulate_oracle(total: &mut OracleCounters, value: &OracleCounters) {
     add!(background_tasks_drained);
 }
 
+fn validate_source_concurrency_mechanism(
+    counters: &OracleCounters,
+    mode: OracleScheduledResidencyMode,
+    concurrency: usize,
+) -> Result<(), BenchmarkFailure> {
+    if mode == OracleScheduledResidencyMode::SourceOnly {
+        if counters.source_prefetch_read_batches_with_work != 0
+            || counters.source_prefetch_positions_with_multiple_read_batches != 0
+            || counters.source_prefetch_reads_current_inflight != 0
+            || counters.source_prefetch_reads_peak_inflight != 0
+            || counters.source_prefetch_read_inflight_accounting_errors != 0
+        {
+            return Err(BenchmarkFailure::new(
+                "postcondition",
+                "source-only-direct-read-accounting",
+                "SourceOnly recorded TokenBoundaryDirect future-read concurrency evidence",
+            ));
+        }
+        return Ok(());
+    }
+
+    if counters.source_prefetch_batches_started != counters.source_prefetch_batches_completed
+        || counters.source_prefetch_read_batches_with_work
+            > counters.source_prefetch_batches_started
+        || (counters.source_prefetch_positions_with_multiple_read_batches != 0
+            && counters.source_prefetch_read_batches_with_work < 2)
+        || counters.source_prefetch_peak_inflight > concurrency as u64
+        || counters.source_prefetch_reads_peak_inflight > concurrency as u64
+        || counters.source_prefetch_reads_current_inflight != 0
+        || counters.source_prefetch_read_inflight_accounting_errors != 0
+    {
+        return Err(BenchmarkFailure::new(
+            "postcondition",
+            "oracle-direct-source-concurrency-accounting",
+            format!(
+                "direct source task/read concurrency did not reconcile at configured concurrency {concurrency}: {counters:?}"
+            ),
+        ));
+    }
+
+    let enough_independent_read_work =
+        counters.source_prefetch_positions_with_multiple_read_batches > 0;
+    if concurrency > 1
+        && enough_independent_read_work
+        && (counters.source_prefetch_peak_inflight <= 1
+            || counters.source_prefetch_reads_peak_inflight <= 1)
+    {
+        return Err(BenchmarkFailure::new(
+            "postcondition",
+            "oracle-direct-source-concurrency-not-observed",
+            format!(
+                "configured direct source concurrency {concurrency} had {} layer batches with direct-read work across {} positions with multiple read-bearing batches, but observed layer/read peaks {}/{}",
+                counters.source_prefetch_read_batches_with_work,
+                counters.source_prefetch_positions_with_multiple_read_batches,
+                counters.source_prefetch_peak_inflight,
+                counters.source_prefetch_reads_peak_inflight,
+            ),
+        ));
+    }
+    Ok(())
+}
+
 fn validate_oracle_counters(
     counters: &OracleCounters,
     mode: OracleScheduledResidencyMode,
     concurrency: usize,
     expert_bytes: usize,
 ) -> Result<(), BenchmarkFailure> {
+    validate_source_concurrency_mechanism(counters, mode, concurrency)?;
     let classified_source = counters
         .source_skipped_physical_current
         .saturating_add(counters.source_prefetch_ram_hits)
@@ -3286,6 +3557,17 @@ pub(crate) async fn run_command(args: CommandArgs) -> Result<(), Box<dyn std::er
             interpretation: "future source retained production-primary buffers across foreground demand",
             first_attempt_rerun: false,
         },
+        predecessor_second_attempt: PredecessorSecondAttemptEvidence {
+            code_sha: PREDECESSOR_SECOND_ATTEMPT_CODE_SHA,
+            result: "PASS",
+            report_sha256: PREDECESSOR_SECOND_ATTEMPT_REPORT_SHA256,
+            runner_sha256: PREDECESSOR_SECOND_ATTEMPT_RUNNER_SHA256,
+            configured_source_concurrency: 4,
+            observed_source_prefetch_peak_inflight: 1,
+            decode_tps: 0.8912406378809807,
+            ordinary_residency_misses: 132,
+            second_attempt_rerun: false,
+        },
         source_memory_planes,
         correctness: CorrectnessEvidence {
             warmup_matches_measured: all_measured_outputs_identical,
@@ -3322,7 +3604,7 @@ mod tests {
     use super::*;
     use crate::io_provider::{NvmeStorage, StorageConfig};
     use std::path::PathBuf;
-    use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+    use std::sync::atomic::{AtomicU32, AtomicU64, AtomicUsize, Ordering};
     use std::time::Duration;
 
     struct TempSourceDir {
@@ -3399,6 +3681,18 @@ mod tests {
             source_prefetch_peak_inflight: 4,
             oracle_ready_at_demand: EXPECTED_SELECTED_IDS as u64,
             source_end_of_trace: 1,
+            ..OracleCounters::default()
+        }
+    }
+
+    fn valid_direct_source_mechanism_counters() -> OracleCounters {
+        OracleCounters {
+            source_prefetch_batches_started: 2,
+            source_prefetch_batches_completed: 2,
+            source_prefetch_peak_inflight: 2,
+            source_prefetch_read_batches_with_work: 2,
+            source_prefetch_positions_with_multiple_read_batches: 1,
+            source_prefetch_reads_peak_inflight: 2,
             ..OracleCounters::default()
         }
     }
@@ -3497,6 +3791,8 @@ mod tests {
     #[test]
     fn source_only_contract_never_mutates_physical_residency() {
         let contract = treatment_contract(OracleScheduledResidencyMode::SourceOnly);
+        assert!(!contract.independent_layer_source_tasks);
+        assert!(!contract.per_layer_storage_batch_read_used);
         assert!(!contract.token_boundary_h2d);
         assert!(!contract.production_direct_staging_used);
         assert!(!contract.h2d_compute_overlap_claimed);
@@ -3522,9 +3818,9 @@ mod tests {
     }
 
     #[test]
-    fn v2_schema_and_predecessor_failure_contract_are_frozen() {
-        assert_eq!(SCHEMA, "mer.gpu-native-oracle-scheduled-residency.v2");
-        let predecessor = PredecessorFirstAttemptEvidence {
+    fn v3_schema_and_predecessor_attempt_contracts_are_frozen() {
+        assert_eq!(SCHEMA, "mer.gpu-native-oracle-scheduled-residency.v3");
+        let first = PredecessorFirstAttemptEvidence {
             code_sha: PREDECESSOR_FIRST_ATTEMPT_CODE_SHA,
             result: "FAIL",
             failure: "ProductionBatchPoolUnavailableAfterReservation",
@@ -3534,16 +3830,44 @@ mod tests {
                 "future source retained production-primary buffers across foreground demand",
             first_attempt_rerun: false,
         };
-        let value = serde_json::to_value(predecessor).unwrap();
-        assert_eq!(value["code_sha"], PREDECESSOR_FIRST_ATTEMPT_CODE_SHA);
-        assert_eq!(value["result"], "FAIL");
-        assert_eq!(value["requested"], 8);
-        assert_eq!(value["acquired"], 1);
-        assert_eq!(value["first_attempt_rerun"], false);
+        let first = serde_json::to_value(first).unwrap();
+        assert_eq!(first["code_sha"], PREDECESSOR_FIRST_ATTEMPT_CODE_SHA);
+        assert_eq!(first["result"], "FAIL");
+        assert_eq!(first["requested"], 8);
+        assert_eq!(first["acquired"], 1);
+        assert_eq!(first["first_attempt_rerun"], false);
+
+        let second = serde_json::to_value(PredecessorSecondAttemptEvidence {
+            code_sha: PREDECESSOR_SECOND_ATTEMPT_CODE_SHA,
+            result: "PASS",
+            report_sha256: PREDECESSOR_SECOND_ATTEMPT_REPORT_SHA256,
+            runner_sha256: PREDECESSOR_SECOND_ATTEMPT_RUNNER_SHA256,
+            configured_source_concurrency: 4,
+            observed_source_prefetch_peak_inflight: 1,
+            decode_tps: 0.8912406378809807,
+            ordinary_residency_misses: 132,
+            second_attempt_rerun: false,
+        })
+        .unwrap();
+        assert_eq!(second["code_sha"], PREDECESSOR_SECOND_ATTEMPT_CODE_SHA);
+        assert_eq!(second["result"], "PASS");
+        assert_eq!(
+            second["report_sha256"],
+            PREDECESSOR_SECOND_ATTEMPT_REPORT_SHA256
+        );
+        assert_eq!(
+            second["runner_sha256"],
+            PREDECESSOR_SECOND_ATTEMPT_RUNNER_SHA256
+        );
+        assert_eq!(second["configured_source_concurrency"], 4);
+        assert_eq!(second["observed_source_prefetch_peak_inflight"], 1);
+        assert_eq!(second["decode_tps"], 0.8912406378809807);
+        assert_eq!(second["ordinary_residency_misses"], 132);
+        assert_eq!(second["second_attempt_rerun"], false);
     }
 
     #[test]
-    fn v2_memory_report_distinguishes_production_and_oracle_planes() {
+    fn v3_memory_report_distinguishes_production_and_oracle_planes() {
         let evidence_for = |mode| {
             let isolated = uses_isolated_oracle_source_pool(mode);
             SourceMemoryPlaneEvidence {
@@ -3819,30 +4143,106 @@ mod tests {
         assert_eq!(oracle_pool.current_in_use_slots(), 0);
     }
 
-    #[tokio::test]
-    async fn source_layer_tasks_obey_bounded_concurrency() {
-        let concurrency = 3usize;
-        let semaphore = Arc::new(tokio::sync::Semaphore::new(concurrency));
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn direct_layer_task_helper_overlaps_bounds_joins_and_releases_leases() {
+        let concurrency = 4usize;
         let counters = Arc::new(Mutex::new(OracleCounters::default()));
-        let mut tasks = Vec::new();
-        for _ in 0..12 {
-            let semaphore = semaphore.clone();
+        let barrier = Arc::new(tokio::sync::Barrier::new(concurrency));
+        let pool = Arc::new(OracleFutureSourcePool::new(concurrency, 4096, 4096));
+        let completed = Arc::new(AtomicUsize::new(0));
+        let task_factory = {
             let counters = counters.clone();
-            tasks.push(tokio::spawn(async move {
-                let _permit = semaphore.acquire_owned().await.unwrap();
-                let _guard = LayerBatchGuard::enter(counters);
-                for _ in 0..4 {
-                    tokio::task::yield_now().await;
+            let barrier = barrier.clone();
+            let pool = pool.clone();
+            let completed = completed.clone();
+            move |target_position| {
+                let counters = counters.clone();
+                let barrier = barrier.clone();
+                let pool = pool.clone();
+                let completed = completed.clone();
+                async move {
+                    let _guard = LayerBatchGuard::enter(counters);
+                    let lease = pool.try_acquire().unwrap();
+                    barrier.wait().await;
+                    drop(lease);
+                    completed.fetch_add(1, Ordering::Relaxed);
+                    PrefetchOutcome {
+                        target_position,
+                        ..PrefetchOutcome::default()
+                    }
                 }
-            }));
-        }
-        for task in tasks {
-            task.await.unwrap();
-        }
+            }
+        };
+        let outcomes = run_bounded_layer_tasks(
+            0..8,
+            concurrency,
+            task_factory,
+            Vec::new(),
+            |outcomes, outcome| outcomes.push(outcome),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcomes.len(), 8);
+        assert_eq!(completed.load(Ordering::Relaxed), 8);
         let values = counters.lock();
-        assert_eq!(values.source_prefetch_batches_started, 12);
-        assert_eq!(values.source_prefetch_batches_completed, 12);
+        assert_eq!(values.source_prefetch_batches_started, 8);
+        assert_eq!(values.source_prefetch_batches_completed, 8);
+        assert!(values.source_prefetch_peak_inflight > 1);
         assert!(values.source_prefetch_peak_inflight <= concurrency as u64);
+        drop(values);
+        assert_eq!(pool.current_in_use_slots(), 0);
+        assert_eq!(pool.snapshot().exhaustion_count, 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn direct_layer_task_helper_propagates_failure_and_drains_owned_tasks() {
+        let concurrency = 4usize;
+        let counters = Arc::new(Mutex::new(OracleCounters::default()));
+        let barrier = Arc::new(tokio::sync::Barrier::new(concurrency));
+        let pool = Arc::new(OracleFutureSourcePool::new(concurrency, 4096, 4096));
+        let task_factory = {
+            let counters = counters.clone();
+            let barrier = barrier.clone();
+            let pool = pool.clone();
+            move |layer_index| {
+                let counters = counters.clone();
+                let barrier = barrier.clone();
+                let pool = pool.clone();
+                async move {
+                    let _guard = LayerBatchGuard::enter(counters);
+                    let lease = pool.try_acquire().unwrap();
+                    barrier.wait().await;
+                    if layer_index == 0 {
+                        panic!("deterministic qualification child failure");
+                    }
+                    drop(lease);
+                    PrefetchOutcome::default()
+                }
+            }
+        };
+        let error = run_bounded_layer_tasks(
+            0..8,
+            concurrency,
+            task_factory,
+            Vec::new(),
+            |outcomes, outcome| outcomes.push(outcome),
+        )
+        .await
+        .err()
+        .expect("child panic must fail the scheduling helper");
+
+        assert!(error.contains("independent layer source task failed"));
+        let values = counters.lock();
+        assert_eq!(
+            values.source_prefetch_batches_started,
+            values.source_prefetch_batches_completed
+        );
+        assert!(values.source_prefetch_peak_inflight > 1);
+        assert!(values.source_prefetch_peak_inflight <= concurrency as u64);
+        drop(values);
+        assert_eq!(pool.current_in_use_slots(), 0);
+        assert_eq!(pool.snapshot().exhaustion_count, 0);
     }
 
     #[tokio::test]
@@ -3858,6 +4258,8 @@ mod tests {
     fn treatment_contract_records_distinct_late_source_policies() {
         let source_only = treatment_contract(OracleScheduledResidencyMode::SourceOnly);
         let direct = treatment_contract(OracleScheduledResidencyMode::TokenBoundaryDirect);
+        assert!(!source_only.independent_layer_source_tasks);
+        assert!(!source_only.per_layer_storage_batch_read_used);
         assert_eq!(
             source_only.late_source_policy,
             LateSourcePolicy::NonblockingDemandFallback
@@ -3882,6 +4284,8 @@ mod tests {
             oracle_source_pool_configured_max_slots(OracleScheduledResidencyMode::SourceOnly),
             0
         );
+        assert!(direct.independent_layer_source_tasks);
+        assert!(!direct.per_layer_storage_batch_read_used);
         assert!(!direct.production_predictor_used);
         assert!(!direct.production_speculative_residency_used);
         assert!(direct.future_source_pool_isolated_from_production_primary);
@@ -4346,6 +4750,123 @@ mod tests {
     }
 
     #[test]
+    fn direct_source_concurrency_mechanism_gates_are_fail_closed() {
+        let valid = valid_direct_source_mechanism_counters();
+        assert!(validate_source_concurrency_mechanism(
+            &valid,
+            OracleScheduledResidencyMode::TokenBoundaryDirect,
+            4,
+        )
+        .is_ok());
+
+        let mut layer_peak_one = valid.clone();
+        layer_peak_one.source_prefetch_peak_inflight = 1;
+        assert!(validate_source_concurrency_mechanism(
+            &layer_peak_one,
+            OracleScheduledResidencyMode::TokenBoundaryDirect,
+            4,
+        )
+        .is_err());
+
+        let mut read_peak_one = valid.clone();
+        read_peak_one.source_prefetch_reads_peak_inflight = 1;
+        assert!(validate_source_concurrency_mechanism(
+            &read_peak_one,
+            OracleScheduledResidencyMode::TokenBoundaryDirect,
+            4,
+        )
+        .is_err());
+
+        for peak in 2..=4 {
+            let mut observed = valid.clone();
+            observed.source_prefetch_peak_inflight = peak;
+            observed.source_prefetch_reads_peak_inflight = peak;
+            assert!(validate_source_concurrency_mechanism(
+                &observed,
+                OracleScheduledResidencyMode::TokenBoundaryDirect,
+                4,
+            )
+            .is_ok());
+        }
+
+        let mut layer_over_bound = valid.clone();
+        layer_over_bound.source_prefetch_peak_inflight = 5;
+        assert!(validate_source_concurrency_mechanism(
+            &layer_over_bound,
+            OracleScheduledResidencyMode::TokenBoundaryDirect,
+            4,
+        )
+        .is_err());
+
+        let mut read_over_bound = valid.clone();
+        read_over_bound.source_prefetch_reads_peak_inflight = 5;
+        assert!(validate_source_concurrency_mechanism(
+            &read_over_bound,
+            OracleScheduledResidencyMode::TokenBoundaryDirect,
+            4,
+        )
+        .is_err());
+
+        let mut current_nonzero = valid.clone();
+        current_nonzero.source_prefetch_reads_current_inflight = 1;
+        assert!(validate_source_concurrency_mechanism(
+            &current_nonzero,
+            OracleScheduledResidencyMode::TokenBoundaryDirect,
+            4,
+        )
+        .is_err());
+
+        let mut accounting_error = valid.clone();
+        accounting_error.source_prefetch_read_inflight_accounting_errors = 1;
+        assert!(validate_source_concurrency_mechanism(
+            &accounting_error,
+            OracleScheduledResidencyMode::TokenBoundaryDirect,
+            4,
+        )
+        .is_err());
+
+        let mut incomplete_batch = valid;
+        incomplete_batch.source_prefetch_batches_completed = 1;
+        assert!(validate_source_concurrency_mechanism(
+            &incomplete_batch,
+            OracleScheduledResidencyMode::TokenBoundaryDirect,
+            4,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn source_only_does_not_require_direct_read_concurrency() {
+        let counters = OracleCounters {
+            source_prefetch_batches_started: 1,
+            source_prefetch_batches_completed: 1,
+            source_prefetch_peak_inflight: 1,
+            ..OracleCounters::default()
+        };
+        assert!(validate_source_concurrency_mechanism(
+            &counters,
+            OracleScheduledResidencyMode::SourceOnly,
+            4,
+        )
+        .is_ok());
+        assert!(
+            !treatment_contract(OracleScheduledResidencyMode::SourceOnly)
+                .independent_layer_source_tasks
+        );
+    }
+
+    #[test]
+    fn direct_future_read_guard_records_underflow_as_an_accounting_error() {
+        let counters = Arc::new(Mutex::new(OracleCounters::default()));
+        let guard = DirectFutureReadGuard::enter(counters.clone());
+        counters.lock().source_prefetch_reads_current_inflight = 0;
+        drop(guard);
+        let counters = counters.lock();
+        assert_eq!(counters.source_prefetch_reads_current_inflight, 0);
+        assert_eq!(counters.source_prefetch_read_inflight_accounting_errors, 1);
+    }
+
+    #[test]
     fn source_only_counter_validation_rejects_physical_mutation() {
         let mut counters = valid_source_only_counters();
         counters.boundary_replacement_sets_started = 1;
@@ -4362,6 +4883,8 @@ mod tests {
     #[test]
     fn serialized_h2d_contract_uses_one_ordered_queue_without_flush_submit() {
         let contract = treatment_contract(OracleScheduledResidencyMode::TokenBoundaryDirect);
+        assert!(contract.independent_layer_source_tasks);
+        assert!(!contract.per_layer_storage_batch_read_used);
         assert!(contract.token_boundary_h2d);
         assert!(contract.same_ordered_queue);
         assert!(contract.production_direct_staging_used);

--- a/rust-engine/src/gpu_native_physical_install_staging.rs
+++ b/rust-engine/src/gpu_native_physical_install_staging.rs
@@ -2,6 +2,9 @@
 //! staging. Control explicitly forces the legacy Vec writer; treatment uses
 //! the ordinary production demand-install path in a fresh runtime.
 
+#[path = "gpu_native_physical_zero_fill_production.rs"]
+pub(crate) mod zero_fill_production;
+
 #[path = "gpu_native_q4_route_parallel.rs"]
 pub(crate) mod q4_route_parallel;
 
@@ -333,7 +336,7 @@ struct ConcurrencyTimingDefinitions {
 fn concurrency_timing_definitions() -> ConcurrencyTimingDefinitions {
     ConcurrencyTimingDefinitions {
         common: TimingDefinitions {
-            physical_slot_prepare_us: "sum of qualification-only per-expert canonical validation plus unchanged whole-slot zero/fill time",
+            physical_slot_prepare_us: "sum of qualification-only per-expert canonical validation plus arm-specific physical-slot fill time",
             physical_queue_staging_us: "sum of qualification-only Queue::write_buffer_with view acquisition plus Drop scheduling time",
             mapping_publication_us: "ordered logical mapping Queue::write_buffer time after all treatment staging jobs finish",
             physical_install_total_us: CONCURRENCY_PHYSICAL_INSTALL_TOTAL_DEFINITION,
@@ -847,6 +850,7 @@ fn benchmark_report(prepared: &Prepared) -> BenchmarkReport {
 enum PhysicalInstallQualificationRun {
     Staging(GpuNativePhysicalInstallStagingQualificationArm),
     Concurrency(crate::engine::GpuNativePhysicalInstallConcurrencyQualificationArm),
+    ZeroFillProduction(crate::engine::GpuNativePhysicalInstallConcurrencyQualificationArm),
 }
 
 struct PhysicalInstallArmRun {
@@ -861,10 +865,12 @@ fn concurrency_common_snapshot(
 ) -> GpuNativePhysicalInstallStagingQualificationSnapshot {
     GpuNativePhysicalInstallStagingQualificationSnapshot {
         arm: match source.arm {
-            crate::engine::GpuNativePhysicalInstallConcurrencyQualificationArm::Control => {
+            crate::engine::GpuNativePhysicalInstallConcurrencyQualificationArm::Control
+            | crate::engine::GpuNativePhysicalInstallConcurrencyQualificationArm::ConcurrentFullZeroControl => {
                 GpuNativePhysicalInstallStagingQualificationArm::Control
             }
-            crate::engine::GpuNativePhysicalInstallConcurrencyQualificationArm::Treatment => {
+            crate::engine::GpuNativePhysicalInstallConcurrencyQualificationArm::Treatment
+            | crate::engine::GpuNativePhysicalInstallConcurrencyQualificationArm::ProductionNoZeroFillTreatment => {
                 GpuNativePhysicalInstallStagingQualificationArm::Treatment
             }
         },
@@ -920,29 +926,28 @@ async fn run_physical_install_arm(
     args: &CommandArgs,
     run: PhysicalInstallQualificationRun,
 ) -> Result<PhysicalInstallArmRun, BenchmarkFailure> {
+    use crate::engine::GpuNativePhysicalInstallConcurrencyQualificationArm as ConcurrentArm;
     let (arm_name, arm) = match run {
-        PhysicalInstallQualificationRun::Staging(
-            GpuNativePhysicalInstallStagingQualificationArm::Control,
-        )
-        | PhysicalInstallQualificationRun::Concurrency(
-            crate::engine::GpuNativePhysicalInstallConcurrencyQualificationArm::Control,
-        ) => (
-            "control",
-            GpuNativePhysicalInstallStagingQualificationArm::Control,
-        ),
-        PhysicalInstallQualificationRun::Staging(
-            GpuNativePhysicalInstallStagingQualificationArm::Treatment,
-        )
-        | PhysicalInstallQualificationRun::Concurrency(
-            crate::engine::GpuNativePhysicalInstallConcurrencyQualificationArm::Treatment,
-        ) => (
-            "treatment",
-            GpuNativePhysicalInstallStagingQualificationArm::Treatment,
-        ),
+        PhysicalInstallQualificationRun::Staging(arm) => match arm {
+            GpuNativePhysicalInstallStagingQualificationArm::Control => ("control", arm),
+            GpuNativePhysicalInstallStagingQualificationArm::Treatment => ("treatment", arm),
+        },
+        PhysicalInstallQualificationRun::Concurrency(arm)
+        | PhysicalInstallQualificationRun::ZeroFillProduction(arm) => match arm {
+            ConcurrentArm::Control | ConcurrentArm::ConcurrentFullZeroControl => (
+                "control",
+                GpuNativePhysicalInstallStagingQualificationArm::Control,
+            ),
+            ConcurrentArm::Treatment | ConcurrentArm::ProductionNoZeroFillTreatment => (
+                "treatment",
+                GpuNativePhysicalInstallStagingQualificationArm::Treatment,
+            ),
+        },
     };
     let mode_name = match run {
         PhysicalInstallQualificationRun::Staging(_) => PRODUCTION_MODE,
         PhysicalInstallQualificationRun::Concurrency(_) => CONCURRENCY_MODE,
+        PhysicalInstallQualificationRun::ZeroFillProduction(_) => zero_fill_production::MODE,
     };
     let mut benchmark = benchmark_report(prepared);
     let runtime = crate::gpu_native_real_benchmark::construct_runtime(
@@ -957,7 +962,8 @@ async fn run_physical_install_arm(
         PhysicalInstallQualificationRun::Staging(arm) => runtime
             .engine
             .enable_gpu_native_physical_install_staging_qualification(arm),
-        PhysicalInstallQualificationRun::Concurrency(arm) => runtime
+        PhysicalInstallQualificationRun::Concurrency(arm)
+        | PhysicalInstallQualificationRun::ZeroFillProduction(arm) => runtime
         .engine
             .enable_gpu_native_physical_install_concurrency_qualification(arm),
     };
@@ -1052,7 +1058,8 @@ async fn run_physical_install_arm(
             .engine
             .gpu_native_physical_install_staging_qualification_snapshot();
             }
-            PhysicalInstallQualificationRun::Concurrency(_) => {
+            PhysicalInstallQualificationRun::Concurrency(_)
+            | PhysicalInstallQualificationRun::ZeroFillProduction(_) => {
                 warmup_concurrency = runtime
                     .engine
                     .gpu_native_physical_install_concurrency_qualification_snapshot();
@@ -1156,7 +1163,8 @@ async fn run_physical_install_arm(
                 .gpu_native_physical_install_staging_qualification_snapshot(),
             None,
         ),
-        PhysicalInstallQualificationRun::Concurrency(_) => {
+        PhysicalInstallQualificationRun::Concurrency(_)
+        | PhysicalInstallQualificationRun::ZeroFillProduction(_) => {
             let concurrency = runtime
                 .engine
                 .gpu_native_physical_install_concurrency_qualification_snapshot();
@@ -2316,7 +2324,7 @@ pub(crate) async fn run_concurrency_command(
             logical_expert_bytes: 2_654_208,
             slot_stride_bytes: 2_654_212,
             physical_tail_bytes: 0,
-            destination_fill_zero_unchanged: true,
+            destination_fill_zero_unchanged: false,
         },
         timing_definitions: concurrency_timing_definitions(),
         benchmark_complete: false,

--- a/rust-engine/src/gpu_native_physical_zero_fill_production.rs
+++ b/rust-engine/src/gpu_native_physical_zero_fill_production.rs
@@ -1,0 +1,686 @@
+//! Same-child, same-concurrency qualification of production zero-fill elision.
+//! Reuses physical-install workload, isolated runtime, observation and teardown.
+use super::*;
+use crate::engine::{
+    GpuNativePhysicalInstallConcurrencyQualificationArm as Arm,
+    GpuNativePhysicalInstallConcurrencyQualificationSnapshot as Snapshot,
+};
+
+pub(crate) const SCHEMA: &str = "mer.gpu-native-physical-zero-fill-production.v1";
+pub(crate) const MODE: &str = "qualify-gpu-native-physical-zero-fill-production";
+const LOGICAL_EXPERT_BYTES: u64 = 2_654_208;
+const SLOT_STRIDE_BYTES: u64 = 2_654_212;
+const EPOCH_BYTES: u64 = 4;
+
+const fn qualification_arms() -> (Arm, Arm) {
+    (
+        Arm::ConcurrentFullZeroControl,
+        Arm::ProductionNoZeroFillTreatment,
+    )
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+struct PairMechanismGate {
+    explicit_full_zero_control: bool,
+    ordinary_no_zero_treatment: bool,
+    both_direct_no_vec: bool,
+    install_accounting_exact: bool,
+    full_zero_bytes_equal_staged: bool,
+    no_zero_bytes_zero: bool,
+    epoch_payload_staged_bytes_exact: bool,
+    concurrent_set_widths_and_behavior_exact: bool,
+    physical_install_and_victim_order_exact: bool,
+    source_and_route_streams_exact: bool,
+    failures_and_accounting_errors_zero: bool,
+    timing_accounting_exact: bool,
+    passed: bool,
+}
+
+fn install_accounting_exact(s: &Snapshot, p: &GpuNativeProductionPhysicalInstallSnapshot) -> bool {
+    let installs = s.physical_install_completions;
+    installs > 0
+        && production_concurrency_exercised(p)
+        && s.physical_install_attempts == installs
+        && s.physical_install_experts == installs
+        && s.reservation_attempts == installs
+        && s.reservation_successes == installs
+        && s.physical_stage_attempts == installs
+        && s.physical_stage_completions == installs
+        && s.direct_staging_writes == installs
+        && s.ordered_commit_attempts == installs
+        && s.ordered_commit_completions == installs
+        && s.mapping_publications == installs
+        && s.physical_install_sets == p.physical_install_sets
+        && installs == p.physical_install_experts
+        && installs == p.physical_install_attempts
+        && installs == p.physical_stage_completions
+        && installs == p.ordered_commit_completions
+        && s.parallel_eligible_sets == p.parallel_eligible_sets
+        && s.parallel_staging_sets == p.parallel_staging_sets
+        && s.parallel_staging_experts == p.parallel_staging_experts
+        && s.singleton_staging_sets == p.singleton_staging_sets
+        && s.parallel_staging_sets > 0
+        && s.parallel_staging_sets == s.parallel_eligible_sets
+        && s.parallel_staging_experts == s.parallel_eligible_experts
+        && s.parallel_staging_experts
+            .checked_add(s.singleton_staging_sets)
+            == Some(installs)
+        && s.parallel_staging_sets
+            .checked_add(s.singleton_staging_sets)
+            == Some(s.physical_install_sets)
+        && s.max_in_flight_physical_staging >= 2
+}
+
+fn bytes_exact(s: &Snapshot) -> bool {
+    let installs = s.physical_install_completions;
+    installs.checked_mul(EPOCH_BYTES) == Some(s.physical_slot_epoch_write_bytes)
+        && installs.checked_mul(LOGICAL_EXPERT_BYTES) == Some(s.physical_slot_payload_copy_bytes)
+        && installs.checked_mul(SLOT_STRIDE_BYTES) == Some(s.physical_slot_bytes_staged)
+        && s.physical_bytes_staged == s.physical_slot_bytes_staged
+}
+
+fn failures_zero(s: &Snapshot) -> bool {
+    s.reservation_failures == 0
+        && s.direct_staging_failures == 0
+        && s.physical_stage_failures == 0
+        && s.ordered_commit_failures == 0
+        && s.ordered_commit_violations == 0
+        && s.unpublished_physical_writes_after_failure == 0
+        && s.active_physical_staging == 0
+        && s.evidence_accounting_errors == 0
+        && s.timing_accounting_errors == 0
+        && s.overlapping_demand_sets == 0
+        && s.single_request_stream
+}
+
+fn timing_accounting_exact(s: &Snapshot) -> bool {
+    s.sum_individual_physical_stage_us
+        .checked_add(s.physical_ordered_commit_us)
+        == Some(s.physical_install_total_us)
+        && s.physical_slot_prepare_us
+            .checked_add(s.physical_queue_staging_us)
+            .is_some_and(|parts| parts <= s.sum_individual_physical_stage_us)
+        && s.mapping_publication_us <= s.physical_ordered_commit_us
+}
+
+fn pair_mechanism_gate(
+    c: &Snapshot,
+    t: &Snapshot,
+    cp: &GpuNativeProductionPhysicalInstallSnapshot,
+    tp: &GpuNativeProductionPhysicalInstallSnapshot,
+) -> PairMechanismGate {
+    let mut gate = PairMechanismGate {
+        explicit_full_zero_control: c.arm == qualification_arms().0
+            && !c.production_physical_install_concurrency_changed
+            && !c.control_forces_sequential_direct_staging
+            && !c.treatment_uses_ordinary_production_path,
+        ordinary_no_zero_treatment: t.arm == qualification_arms().1
+            && !t.production_physical_install_concurrency_changed
+            && t.treatment_uses_ordinary_production_path
+            && !t.control_forces_sequential_direct_staging,
+        both_direct_no_vec: c.direct_staging_writes > 0
+            && t.direct_staging_writes > 0
+            && c.full_slot_vec_materializations == 0
+            && t.full_slot_vec_materializations == 0,
+        install_accounting_exact: install_accounting_exact(c, cp)
+            && install_accounting_exact(t, tp)
+            && c.physical_install_completions == t.physical_install_completions,
+        full_zero_bytes_equal_staged: c.physical_slot_zero_fill_bytes > 0
+            && c.physical_slot_zero_fill_bytes == c.physical_slot_bytes_staged,
+        no_zero_bytes_zero: t.physical_slot_zero_fill_bytes == 0,
+        epoch_payload_staged_bytes_exact: bytes_exact(c)
+            && bytes_exact(t)
+            && c.physical_slot_epoch_write_bytes == t.physical_slot_epoch_write_bytes
+            && c.physical_slot_payload_copy_bytes == t.physical_slot_payload_copy_bytes
+            && c.physical_slot_bytes_staged == t.physical_slot_bytes_staged,
+        concurrent_set_widths_and_behavior_exact: c
+            .normal_production_uses_concurrent_physical_staging
+            && t.normal_production_uses_concurrent_physical_staging
+            && c.physical_install_sets == t.physical_install_sets
+            && c.install_set_width_min == t.install_set_width_min
+            && c.install_set_width_max == t.install_set_width_max
+            && c.install_set_width_mean == t.install_set_width_mean
+            && c.parallel_eligible_sets == t.parallel_eligible_sets
+            && c.parallel_eligible_experts == t.parallel_eligible_experts
+            && c.parallel_staging_sets == t.parallel_staging_sets
+            && c.parallel_staging_experts == t.parallel_staging_experts
+            && c.singleton_staging_sets == t.singleton_staging_sets
+            && c.rayon_num_threads >= 2
+            && c.rayon_num_threads == t.rayon_num_threads
+            && c.caller_was_already_rayon_worker == t.caller_was_already_rayon_worker
+            && c.ordered_install_set_behavior_sha256 == t.ordered_install_set_behavior_sha256,
+        physical_install_and_victim_order_exact: c.physical_victim_ids_sha256
+            == t.physical_victim_ids_sha256
+            && c.reservation_identity_sha256 == t.reservation_identity_sha256
+            && c.physical_residency_identity_sha256 == t.physical_residency_identity_sha256
+            && c.mapping_publications == t.mapping_publications
+            && c.mapping_unpublications == t.mapping_unpublications,
+        source_and_route_streams_exact: c.selected_route_ids_sha256 == t.selected_route_ids_sha256
+            && c.physical_missing_ids_sha256 == t.physical_missing_ids_sha256
+            && c.demand_source_request_ids_sha256 == t.demand_source_request_ids_sha256
+            && c.demand_source_requests == t.demand_source_requests
+            && c.source_nvme_reads == t.source_nvme_reads
+            && c.source_nvme_bytes == t.source_nvme_bytes,
+        failures_and_accounting_errors_zero: failures_zero(c) && failures_zero(t),
+        timing_accounting_exact: timing_accounting_exact(c) && timing_accounting_exact(t),
+        passed: false,
+    };
+    gate.passed = gate.explicit_full_zero_control
+        && gate.ordinary_no_zero_treatment
+        && gate.both_direct_no_vec
+        && gate.install_accounting_exact
+        && gate.full_zero_bytes_equal_staged
+        && gate.no_zero_bytes_zero
+        && gate.epoch_payload_staged_bytes_exact
+        && gate.concurrent_set_widths_and_behavior_exact
+        && gate.physical_install_and_victim_order_exact
+        && gate.source_and_route_streams_exact
+        && gate.failures_and_accounting_errors_zero
+        && gate.timing_accounting_exact;
+    gate
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct Gates {
+    behavioral: BehavioralGate,
+    work_equivalence: WorkEquivalenceGate,
+    warmup_mechanism: PairMechanismGate,
+    measured_mechanism: PairMechanismGate,
+    warmup_and_measured_work_exact: bool,
+    token_ids_text_and_routes_exact: bool,
+    stale_generation_and_install_errors_zero: bool,
+    physical_installs_reconcile_with_residency: bool,
+    passed: bool,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct Performance {
+    #[serde(flatten)]
+    physical_install: ConcurrencyPerformanceComparison,
+    mean_time_to_first_token_seconds: MetricComparison,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct Report {
+    schema: &'static str,
+    mode: &'static str,
+    control: Option<ConcurrencyArmReport>,
+    treatment: Option<ConcurrencyArmReport>,
+    control_path: &'static str,
+    treatment_path: &'static str,
+    both_arms_concurrent_direct_staging: bool,
+    source_scheduler_changed: bool,
+    staging_byte_count_changed: bool,
+    queue_ordering_changed: bool,
+    payload_offset_bytes: u64,
+    logical_expert_bytes: u64,
+    slot_stride_bytes: u64,
+    tail_padding_bytes: u64,
+    no_zero_requires_complete_coverage_before_first_write: bool,
+    frozen_workload: FrozenWorkload,
+    provenance: BenchmarkProvenance,
+    timing_definitions: ConcurrencyTimingDefinitions,
+    reconciliation: Option<ProductionReconciliation>,
+    gates: Option<Gates>,
+    performance: Option<Performance>,
+    benchmark_complete: bool,
+    qualification_pass: bool,
+    performance_result: &'static str,
+    failure: Option<BenchmarkFailure>,
+}
+
+fn work_pair_exact(c: &ArmWorkEvidence, t: &ArmWorkEvidence) -> bool {
+    c.gpu_native_residency
+        .logical_admissions_for_physical_misses
+        == t.gpu_native_residency
+            .logical_admissions_for_physical_misses
+        && c.gpu_native_residency.ram_to_vram_installs
+            == t.gpu_native_residency.ram_to_vram_installs
+        && c.gpu_native_residency.physical_evictions == t.gpu_native_residency.physical_evictions
+        && c.gpu_native_residency.physical_reinstalls == t.gpu_native_residency.physical_reinstalls
+        && c.token_loop.residency_miss_attempts == t.token_loop.residency_miss_attempts
+        && c.token_loop.residency_services == t.token_loop.residency_services
+        && recovery_semantics_equal(c.recovery, t.recovery)
+        && c.routed_execution.selected_routed_experts == t.routed_execution.selected_routed_experts
+        && c.engine_storage.ram_hits == t.engine_storage.ram_hits
+        && c.engine_storage.ram_misses == t.engine_storage.ram_misses
+        && c.engine_storage.nvme_read_operations == t.engine_storage.nvme_read_operations
+        && c.engine_storage.nvme_bytes_read == t.engine_storage.nvme_bytes_read
+        && c.token_loop.queue_submissions == t.token_loop.queue_submissions
+        && c.token_loop.boundary_maps == t.token_loop.boundary_maps
+        && c.token_loop.boundary_readbacks == t.token_loop.boundary_readbacks
+}
+
+fn work_errors_zero(w: &ArmWorkEvidence) -> bool {
+    w.gpu_native_residency.stale_generation_rejections == 0
+        && w.token_loop.fatal_failures == 0
+        && w.token_loop.no_progress_failures == 0
+        && w.token_loop.replay_attempts == 0
+        && w.recovery.full_token_replay_attempts == 0
+}
+
+// Performance has no argument and cannot affect correctness/mechanism PASS.
+fn qualification_pass(reconciliation_pass: bool, gates: &Gates) -> bool {
+    reconciliation_pass && gates.passed
+}
+
+pub(crate) async fn run_command(args: CommandArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let prepared = prepare(&args)?;
+    let mut timing_definitions = concurrency_timing_definitions();
+    timing_definitions.common.physical_install_total_us = "both arms: sum of each post-reservation physical stage plus ordered commit service; excludes reservation time";
+    timing_definitions.common.physical_slot_prepare_us = "both arms: validated host preparation; control zeros the full slot, treatment completely overwrites epoch and payload without explicit zero fill";
+    timing_definitions.common.mapping_publication_us =
+        "both arms: ordered logical mapping Queue::write_buffer time after all staging jobs finish";
+    let mut report = Report {
+        schema: SCHEMA,
+        mode: MODE,
+        control: None,
+        treatment: None,
+        control_path: "concurrent direct staging with explicit full-slot zero fill",
+        treatment_path:
+            "ordinary production concurrent direct staging with complete-overwrite no-zero fill",
+        both_arms_concurrent_direct_staging: true,
+        source_scheduler_changed: false,
+        staging_byte_count_changed: false,
+        queue_ordering_changed: false,
+        payload_offset_bytes: EPOCH_BYTES,
+        logical_expert_bytes: LOGICAL_EXPERT_BYTES,
+        slot_stride_bytes: SLOT_STRIDE_BYTES,
+        tail_padding_bytes: 0,
+        no_zero_requires_complete_coverage_before_first_write: true,
+        frozen_workload: frozen_workload(args.expected_adapter_name.clone()),
+        provenance: prepared.provenance.clone(),
+        timing_definitions,
+        reconciliation: None,
+        gates: None,
+        performance: None,
+        benchmark_complete: false,
+        qualification_pass: false,
+        performance_result: "not_measured",
+        failure: None,
+    };
+    let (control_arm, treatment_arm) = qualification_arms();
+    for arm in [control_arm, treatment_arm] {
+        let result = run_physical_install_arm(
+            &prepared,
+            &args,
+            PhysicalInstallQualificationRun::ZeroFillProduction(arm),
+        )
+        .await;
+        let run = match result {
+            Ok(run) => run,
+            Err(failure) => {
+                report.failure = Some(failure.clone());
+                emit_report(&report, &args.report_out)?;
+                return Err(failure.to_string().into());
+            }
+        };
+        let failure = run.common.failure.clone();
+        let arm_report = ConcurrencyArmReport {
+            common: run.common,
+            warmup_mechanism: run.warmup_concurrency,
+            mechanism: run.concurrency,
+        };
+        let snapshots_present = arm_report.common.complete
+            && arm_report.mechanism.is_some()
+            && arm_report.warmup_mechanism.is_some()
+            && arm_report.common.source.is_some()
+            && arm_report.common.warmup_source.is_some()
+            && arm_report.common.work.is_some()
+            && arm_report.common.warmup_work.is_some()
+            && arm_report.common.production.is_some()
+            && arm_report.common.warmup_production.is_some()
+            && arm_report.common.production_physical_install.is_some()
+            && arm_report
+                .common
+                .warmup_production_physical_install
+                .is_some();
+        if arm == control_arm {
+            report.control = Some(arm_report);
+        } else {
+            report.treatment = Some(arm_report);
+        }
+        if let Some(failure) = failure.or_else(|| {
+            (!snapshots_present).then(|| {
+                BenchmarkFailure::new(
+                    "postcondition",
+                    "missing-zero-fill-arm-evidence",
+                    "complete warmup and measured evidence is required",
+                )
+            })
+        }) {
+            report.failure = Some(failure.clone());
+            emit_report(&report, &args.report_out)?;
+            return Err(failure.to_string().into());
+        }
+    }
+    let c = report.control.as_ref().expect("stored control");
+    let t = report.treatment.as_ref().expect("stored treatment");
+    let reconciliation =
+        production_reconciliation(reconcile(&c.common, &t.common), &c.common, &t.common);
+    let (behavioral, work_equivalence) = common_gates(&reconciliation.common);
+    let warmup_mechanism = pair_mechanism_gate(
+        c.warmup_mechanism.as_ref().unwrap(),
+        t.warmup_mechanism.as_ref().unwrap(),
+        c.common
+            .warmup_production_physical_install
+            .as_ref()
+            .unwrap(),
+        t.common
+            .warmup_production_physical_install
+            .as_ref()
+            .unwrap(),
+    );
+    let measured_mechanism = pair_mechanism_gate(
+        c.mechanism.as_ref().unwrap(),
+        t.mechanism.as_ref().unwrap(),
+        c.common.production_physical_install.as_ref().unwrap(),
+        t.common.production_physical_install.as_ref().unwrap(),
+    );
+    let cw = c.common.warmup_work.as_ref().unwrap();
+    let tw = t.common.warmup_work.as_ref().unwrap();
+    let cm = c.common.work.as_ref().unwrap();
+    let tm = t.common.work.as_ref().unwrap();
+    let warmup_and_measured_work_exact = work_pair_exact(cw, tw) && work_pair_exact(cm, tm);
+    let stale_generation_and_install_errors_zero =
+        [cw, tw, cm, tm].into_iter().all(work_errors_zero);
+    let physical_installs_reconcile_with_residency = [
+        (cw, c.warmup_mechanism.as_ref().unwrap()),
+        (tw, t.warmup_mechanism.as_ref().unwrap()),
+        (cm, c.mechanism.as_ref().unwrap()),
+        (tm, t.mechanism.as_ref().unwrap()),
+    ]
+    .into_iter()
+    .all(|(work, mechanism)| {
+        work.gpu_native_residency.ram_to_vram_installs == mechanism.physical_install_completions
+    });
+    let token_ids_text_and_routes_exact = c.common.warmup_results.len() == FROZEN_WARMUP_RUNS
+        && t.common.warmup_results.len() == FROZEN_WARMUP_RUNS
+        && generated_results(&c.common).len() == FROZEN_MEASURED_RUNS
+        && generated_results(&t.common).len() == FROZEN_MEASURED_RUNS
+        && c.common
+            .warmup_results
+            .iter()
+            .zip(&t.common.warmup_results)
+            .all(|(a, b)| {
+                a.generated_tokens == FROZEN_OUTPUT_TOKENS
+                    && b.generated_tokens == FROZEN_OUTPUT_TOKENS
+                    && a.generated_text_sha256 == b.generated_text_sha256
+                    && a.generated_token_ids_sha256 == b.generated_token_ids_sha256
+            })
+        && generated_results(&c.common)
+            .iter()
+            .zip(generated_results(&t.common))
+            .all(|(a, b)| {
+                a.generated_tokens == FROZEN_OUTPUT_TOKENS
+                    && b.generated_tokens == FROZEN_OUTPUT_TOKENS
+                    && a.generated_text_sha256 == b.generated_text_sha256
+                    && a.generated_token_ids_sha256 == b.generated_token_ids_sha256
+            })
+        && warmup_mechanism.source_and_route_streams_exact
+        && measured_mechanism.source_and_route_streams_exact;
+    let passed = behavioral.passed
+        && work_equivalence.passed
+        && warmup_mechanism.passed
+        && measured_mechanism.passed
+        && warmup_and_measured_work_exact
+        && token_ids_text_and_routes_exact
+        && stale_generation_and_install_errors_zero
+        && physical_installs_reconcile_with_residency;
+    let gates = Gates {
+        behavioral,
+        work_equivalence,
+        warmup_mechanism,
+        measured_mechanism,
+        warmup_and_measured_work_exact,
+        token_ids_text_and_routes_exact,
+        stale_generation_and_install_errors_zero,
+        physical_installs_reconcile_with_residency,
+        passed,
+    };
+    let performance = concurrency_performance(c, t).map(|physical_install| Performance {
+        physical_install,
+        mean_time_to_first_token_seconds: comparison(
+            generated_results(&c.common)
+                .iter()
+                .map(|r| r.timing.time_to_first_token_seconds)
+                .sum::<f64>()
+                / FROZEN_MEASURED_RUNS as f64,
+            generated_results(&t.common)
+                .iter()
+                .map(|r| r.timing.time_to_first_token_seconds)
+                .sum::<f64>()
+                / FROZEN_MEASURED_RUNS as f64,
+        ),
+    });
+    report.qualification_pass = qualification_pass(reconciliation.all_invariants_pass, &gates);
+    report.reconciliation = Some(reconciliation);
+    report.gates = Some(gates);
+    match performance {
+        Ok(performance) => {
+            report.benchmark_complete = true;
+            report.performance_result = performance.physical_install.common.performance_result;
+            report.performance = Some(performance);
+        }
+        Err(failure) => {
+            report.qualification_pass = false;
+            report.failure = Some(failure.clone());
+            emit_report(&report, &args.report_out)?;
+            return Err(failure.to_string().into());
+        }
+    }
+    emit_report(&report, &args.report_out)?;
+    if report.qualification_pass {
+        Ok(())
+    } else {
+        Err("physical zero-fill production qualification gates did not all pass; see emitted report".into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture(arm: Arm) -> (Snapshot, GpuNativeProductionPhysicalInstallSnapshot) {
+        let mut s = crate::engine::empty_physical_zero_fill_test_snapshot(arm);
+        s.physical_install_attempts = 3;
+        s.physical_install_completions = 3;
+        s.physical_install_experts = 3;
+        s.direct_staging_writes = 3;
+        s.reservation_attempts = 3;
+        s.reservation_successes = 3;
+        s.physical_stage_attempts = 3;
+        s.physical_stage_completions = 3;
+        s.ordered_commit_attempts = 3;
+        s.ordered_commit_completions = 3;
+        s.mapping_publications = 3;
+        s.physical_slot_bytes_staged = 3 * SLOT_STRIDE_BYTES;
+        s.physical_bytes_staged = s.physical_slot_bytes_staged;
+        s.physical_slot_zero_fill_bytes = if arm == Arm::ProductionNoZeroFillTreatment {
+            0
+        } else {
+            s.physical_slot_bytes_staged
+        };
+        s.physical_slot_epoch_write_bytes = 3 * EPOCH_BYTES;
+        s.physical_slot_payload_copy_bytes = 3 * LOGICAL_EXPERT_BYTES;
+        s.physical_install_sets = 1;
+        s.install_set_width_min = 3;
+        s.install_set_width_max = 3;
+        s.install_set_width_mean = 3.0;
+        s.parallel_eligible_sets = 1;
+        s.parallel_eligible_experts = 3;
+        s.parallel_staging_sets = 1;
+        s.parallel_staging_experts = 3;
+        s.max_in_flight_physical_staging = 3;
+        s.rayon_num_threads = 4;
+        s.physical_slot_prepare_us = 10;
+        s.physical_queue_staging_us = 5;
+        s.sum_individual_physical_stage_us = 30;
+        s.physical_ordered_commit_us = 9;
+        s.mapping_publication_us = 3;
+        s.physical_install_total_us = 39;
+        let p = GpuNativeProductionPhysicalInstallSnapshot {
+            physical_install_sets: 1,
+            physical_install_experts: 3,
+            parallel_eligible_sets: 1,
+            parallel_staging_sets: 1,
+            parallel_staging_experts: 3,
+            reservation_attempts: 3,
+            reservation_successes: 3,
+            physical_install_attempts: 3,
+            physical_stage_attempts: 3,
+            physical_stage_completions: 3,
+            direct_staging_successes: 3,
+            ordered_commit_attempts: 3,
+            ordered_commit_completions: 3,
+            max_in_flight_physical_staging: 3,
+            ..GpuNativeProductionPhysicalInstallSnapshot::default()
+        };
+        (s, p)
+    }
+
+    #[test]
+    fn zero_fill_production_frozen_contract_selects_only_concurrent_control_and_production() {
+        assert_eq!(SCHEMA, "mer.gpu-native-physical-zero-fill-production.v1");
+        assert_eq!(MODE, "qualify-gpu-native-physical-zero-fill-production");
+        assert_ne!(SCHEMA, CONCURRENCY_SCHEMA);
+        assert_eq!(
+            qualification_arms(),
+            (
+                Arm::ConcurrentFullZeroControl,
+                Arm::ProductionNoZeroFillTreatment
+            )
+        );
+        assert_eq!(
+            FROZEN_PROMPT,
+            "Write a Rust function that adds two i32 values and returns the result."
+        );
+        assert_eq!(
+            (
+                FROZEN_OUTPUT_TOKENS,
+                FROZEN_WARMUP_RUNS,
+                FROZEN_MEASURED_RUNS
+            ),
+            (128, 1, 3)
+        );
+        assert_eq!(
+            FROZEN_CONFIG_PATH,
+            "/home/randyap8/slice11-qwen3-coder-gpu-native.toml"
+        );
+        assert_eq!(
+            FROZEN_CONFIG_SHA256,
+            "33d7cf96328d9c68b0ff45448d91d597d2e3a757cb99e6e61c72998ceabdd056"
+        );
+        let workload = frozen_workload("NVIDIA L4".into());
+        assert_eq!(workload.cache_reset, "keep");
+        assert_eq!(workload.sampling, "greedy");
+        assert_eq!(EPOCH_BYTES + LOGICAL_EXPERT_BYTES, SLOT_STRIDE_BYTES);
+    }
+
+    #[test]
+    fn zero_fill_production_accepts_exact_bytes_and_concurrent_identity() {
+        let (c, cp) = fixture(qualification_arms().0);
+        let (t, tp) = fixture(qualification_arms().1);
+        let gate = pair_mechanism_gate(&c, &t, &cp, &tp);
+        assert!(gate.passed, "{gate:?}");
+        // Timing magnitudes and performance gains cannot rescue or defeat a
+        // valid mechanism; timing decomposition still must reconcile.
+        let mut slow = t.clone();
+        slow.sum_individual_physical_stage_us = 300_000;
+        slow.physical_install_total_us = 300_009;
+        assert!(pair_mechanism_gate(&c, &slow, &cp, &tp).passed);
+    }
+
+    #[test]
+    fn zero_fill_production_rejects_wrong_fill_bytes_counts_order_and_failures() {
+        let (c, cp) = fixture(qualification_arms().0);
+        let (t, tp) = fixture(qualification_arms().1);
+        let corruptions: &[fn(&mut Snapshot)] = &[
+            |s| s.physical_slot_zero_fill_bytes = 1,
+            |s| s.physical_slot_epoch_write_bytes -= 1,
+            |s| s.physical_slot_payload_copy_bytes -= 1,
+            |s| s.physical_slot_bytes_staged -= 1,
+            |s| s.physical_bytes_staged -= 1,
+            |s| s.physical_install_completions -= 1,
+            |s| s.direct_staging_writes = 0,
+            |s| s.full_slot_vec_materializations = 1,
+            |s| s.physical_install_attempts += 1,
+            |s| s.reservation_attempts += 1,
+            |s| s.reservation_successes -= 1,
+            |s| s.reservation_failures = 1,
+            |s| s.physical_stage_attempts += 1,
+            |s| s.physical_stage_completions -= 1,
+            |s| s.physical_stage_failures = 1,
+            |s| s.direct_staging_failures = 1,
+            |s| s.ordered_commit_attempts += 1,
+            |s| s.ordered_commit_completions -= 1,
+            |s| s.ordered_commit_failures = 1,
+            |s| s.ordered_commit_violations = 1,
+            |s| s.mapping_publications -= 1,
+            |s| s.mapping_unpublications += 1,
+            |s| s.unpublished_physical_writes_after_failure = 1,
+            |s| s.active_physical_staging = 1,
+            |s| s.evidence_accounting_errors = 1,
+            |s| s.timing_accounting_errors = 1,
+            |s| s.physical_install_total_us += 1,
+            |s| s.physical_slot_prepare_us = 1_000,
+            |s| s.mapping_publication_us = 1_000,
+            |s| s.overlapping_demand_sets = 1,
+            |s| s.physical_install_sets += 1,
+            |s| s.install_set_width_min = 1,
+            |s| s.install_set_width_max = 8,
+            |s| s.install_set_width_mean = f64::NAN,
+            |s| s.parallel_staging_sets = 0,
+            |s| s.parallel_eligible_sets += 1,
+            |s| s.parallel_staging_experts -= 1,
+            |s| s.parallel_eligible_experts += 1,
+            |s| s.singleton_staging_sets = 1,
+            |s| s.max_in_flight_physical_staging = 1,
+            |s| s.rayon_num_threads = 1,
+            |s| s.caller_was_already_rayon_worker = true,
+            |s| s.ordered_install_set_behavior_sha256.push('x'),
+            |s| s.physical_victim_ids_sha256.push('x'),
+            |s| s.physical_residency_identity_sha256.push('x'),
+            |s| s.reservation_identity_sha256.push('x'),
+            |s| s.selected_route_ids_sha256.push('x'),
+            |s| s.physical_missing_ids_sha256.push('x'),
+            |s| s.demand_source_request_ids_sha256.push('x'),
+            |s| s.demand_source_requests += 1,
+            |s| s.source_nvme_reads += 1,
+            |s| s.source_nvme_bytes += 1,
+        ];
+        for (index, corrupt) in corruptions.iter().enumerate() {
+            let mut bad = t.clone();
+            corrupt(&mut bad);
+            assert!(
+                !pair_mechanism_gate(&c, &bad, &cp, &tp).passed,
+                "corruption {index}"
+            );
+        }
+        for bytes in [0, c.physical_slot_bytes_staged - 1] {
+            let mut bad_control = c.clone();
+            bad_control.physical_slot_zero_fill_bytes = bytes;
+            assert!(!pair_mechanism_gate(&bad_control, &t, &cp, &tp).passed);
+        }
+        let mut sequential_control = c.clone();
+        sequential_control.arm = Arm::Control;
+        assert!(!pair_mechanism_gate(&sequential_control, &t, &cp, &tp).passed);
+        let mut bad_production = tp;
+        bad_production.physical_install_failures = 1;
+        assert!(!pair_mechanism_gate(&c, &t, &cp, &bad_production).passed);
+        bad_production = tp;
+        bad_production.direct_staging_allocation_fallbacks = 1;
+        assert!(!pair_mechanism_gate(&c, &t, &cp, &bad_production).passed);
+    }
+
+    #[test]
+    fn zero_fill_production_rejects_absent_work_and_byte_overflow() {
+        let c = crate::engine::empty_physical_zero_fill_test_snapshot(qualification_arms().0);
+        let t = crate::engine::empty_physical_zero_fill_test_snapshot(qualification_arms().1);
+        let p = GpuNativeProductionPhysicalInstallSnapshot::default();
+        assert!(!pair_mechanism_gate(&c, &t, &p, &p).passed);
+        let (mut huge, _) = fixture(qualification_arms().1);
+        huge.physical_install_completions = u64::MAX;
+        assert!(!bytes_exact(&huge));
+    }
+}

--- a/rust-engine/src/gpu_native_real_benchmark.rs
+++ b/rust-engine/src/gpu_native_real_benchmark.rs
@@ -1363,7 +1363,7 @@ fn next_ordinary_step(
 }
 
 #[derive(Clone, Debug)]
-struct RequestSnapshotStart {
+pub(crate) struct RequestSnapshotStart {
     token_loop: GpuNativeTokenLoopSnapshot,
     recovery: GpuNativeRecoverySnapshot,
     routed: RoutedExpertExecutionSnapshot,
@@ -1375,7 +1375,7 @@ struct RequestSnapshotStart {
 }
 
 impl RequestSnapshotStart {
-    fn capture(runtime: &crate::BenchRealRuntime) -> Result<Self, BenchmarkFailure> {
+    pub(crate) fn capture(runtime: &crate::BenchRealRuntime) -> Result<Self, BenchmarkFailure> {
         let token_loop = runtime.gpu_native_token_loop.as_ref().ok_or_else(|| {
             BenchmarkFailure::new(
                 "startup",
@@ -1415,7 +1415,7 @@ impl RequestSnapshotStart {
         })
     }
 
-    fn finish(
+    pub(crate) fn finish(
         self,
         runtime: &crate::BenchRealRuntime,
     ) -> Result<RequestSnapshots, BenchmarkFailure> {
@@ -2904,68 +2904,84 @@ mod tests {
 
     #[test]
     fn cli_parses_required_gpu_native_benchmark_surface() {
-        use clap::Parser as _;
+        std::thread::Builder::new()
+            .name("gpu-native-real-cli-parse".into())
+            .stack_size(8 * 1024 * 1024)
+            .spawn(|| {
+                use clap::Parser as _;
 
-        let cli = crate::Cli::try_parse_from([
-            "micro-expert-router",
-            "bench-gpu-native-real",
-            "--config",
-            "config.toml",
-            "--prompt",
-            "hello",
-            "--output-tokens",
-            "8",
-            "--warmup-runs",
-            "2",
-            "--measured-runs",
-            "3",
-            "--cache-reset",
-            "fresh-runtime",
-            "--greedy",
-            "--expected-adapter-name",
-            "NVIDIA L4",
-            "--report-out",
-            "report.json",
-        ])
-        .unwrap();
-        let crate::Cmd::BenchGpuNativeReal {
-            output_tokens,
-            warmup_runs,
-            measured_runs,
-            cache_reset,
-            greedy,
-            expected_adapter_name,
-            report_out,
-            ..
-        } = cli.cmd
-        else {
-            panic!("expected bench-gpu-native-real command")
-        };
-        assert_eq!(output_tokens, Some(8));
-        assert_eq!(warmup_runs, 2);
-        assert_eq!(measured_runs, 3);
-        assert_eq!(cache_reset, crate::BenchRealCacheReset::FreshRuntime);
-        assert!(greedy);
-        assert_eq!(expected_adapter_name, "NVIDIA L4");
-        assert_eq!(report_out, Some(PathBuf::from("report.json")));
+                let cli = crate::Cli::try_parse_from([
+                    "micro-expert-router",
+                    "bench-gpu-native-real",
+                    "--config",
+                    "config.toml",
+                    "--prompt",
+                    "hello",
+                    "--output-tokens",
+                    "8",
+                    "--warmup-runs",
+                    "2",
+                    "--measured-runs",
+                    "3",
+                    "--cache-reset",
+                    "fresh-runtime",
+                    "--greedy",
+                    "--expected-adapter-name",
+                    "NVIDIA L4",
+                    "--report-out",
+                    "report.json",
+                ])
+                .unwrap();
+                let crate::Cmd::BenchGpuNativeReal {
+                    output_tokens,
+                    warmup_runs,
+                    measured_runs,
+                    cache_reset,
+                    greedy,
+                    expected_adapter_name,
+                    report_out,
+                    ..
+                } = cli.cmd
+                else {
+                    panic!("expected bench-gpu-native-real command")
+                };
+                assert_eq!(output_tokens, Some(8));
+                assert_eq!(warmup_runs, 2);
+                assert_eq!(measured_runs, 3);
+                assert_eq!(cache_reset, crate::BenchRealCacheReset::FreshRuntime);
+                assert!(greedy);
+                assert_eq!(expected_adapter_name, "NVIDIA L4");
+                assert_eq!(report_out, Some(PathBuf::from("report.json")));
+            })
+            .unwrap()
+            .join()
+            .unwrap();
     }
 
     #[test]
     fn cli_rejects_missing_required_greedy_flag() {
-        use clap::Parser as _;
+        std::thread::Builder::new()
+            .name("gpu-native-real-cli-parse".into())
+            .stack_size(8 * 1024 * 1024)
+            .spawn(|| {
+                use clap::Parser as _;
 
-        let error = crate::Cli::try_parse_from([
-            "micro-expert-router",
-            "bench-gpu-native-real",
-            "--config",
-            "config.toml",
-            "--prompt",
-            "hello",
-            "--expected-adapter-name",
-            "NVIDIA L4",
-        ])
-        .unwrap_err();
-        assert!(error.to_string().contains("--greedy"));
+                let error = crate::Cli::try_parse_from([
+                    "micro-expert-router",
+                    "bench-gpu-native-real",
+                    "--config",
+                    "config.toml",
+                    "--prompt",
+                    "hello",
+                    "--expected-adapter-name",
+                    "NVIDIA L4",
+                ])
+                .unwrap_err();
+                assert!(error.to_string().contains("--greedy"));
+            })
+            .unwrap()
+            .join()
+            .unwrap();
     }
 
     #[test]

--- a/rust-engine/src/gpu_native_residency.rs
+++ b/rust-engine/src/gpu_native_residency.rs
@@ -9,9 +9,10 @@
 
 use crate::backend::gpu_native::{
     GpuNativeBootstrapError, GpuNativeExecutorContext, GpuNativePhysicalInstallEvidence,
-    GpuNativeProductionPhysicalInstallSnapshot, GpuNativeQ4ExpertAcquire, GpuNativeQ4ExpertArena,
-    GpuNativeQ4ExpertGeometry, GpuNativeQ4ExpertKey, GpuNativeQ4ExpertPreparedInstall,
-    GpuNativeQ4ExpertResidency, GpuNativeQ4ExpertRetire, GpuNativeQ4ExpertVramPlan,
+    GpuNativePhysicalSlotFillPolicy, GpuNativeProductionPhysicalInstallSnapshot,
+    GpuNativeQ4ExpertAcquire, GpuNativeQ4ExpertArena, GpuNativeQ4ExpertGeometry,
+    GpuNativeQ4ExpertKey, GpuNativeQ4ExpertPreparedInstall, GpuNativeQ4ExpertResidency,
+    GpuNativeQ4ExpertRetire, GpuNativeQ4ExpertVramPlan,
 };
 use crate::expert_cache::{ExpertResident, GpuAdmission, GpuExpertCache};
 use lru::LruCache;
@@ -362,6 +363,7 @@ pub(crate) enum GpuNativeResidencyPriority {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum DemandPhysicalInstallPath {
     ProductionConcurrentDirectStaging,
+    QualificationConcurrentDirectStagingNoZeroFill,
     SequentialDirectStagingControl,
     LegacyFullSlotVecControl,
 }
@@ -370,8 +372,17 @@ const fn ordinary_demand_install_path() -> DemandPhysicalInstallPath {
     DemandPhysicalInstallPath::ProductionConcurrentDirectStaging
 }
 
-const fn oracle_safe_boundary_install_path() -> DemandPhysicalInstallPath {
-    DemandPhysicalInstallPath::ProductionConcurrentDirectStaging
+const fn oracle_safe_boundary_install_path(
+    fill_policy: GpuNativePhysicalSlotFillPolicy,
+) -> DemandPhysicalInstallPath {
+    match fill_policy {
+        GpuNativePhysicalSlotFillPolicy::FullSlotZero => {
+            DemandPhysicalInstallPath::ProductionConcurrentDirectStaging
+        }
+        GpuNativePhysicalSlotFillPolicy::QualificationNoZeroFill => {
+            DemandPhysicalInstallPath::QualificationConcurrentDirectStagingNoZeroFill
+        }
+    }
 }
 
 const fn production_concurrency_control_path() -> DemandPhysicalInstallPath {
@@ -821,8 +832,9 @@ impl GpuNativeTieredResidencyManager {
     /// ORACLE-0B-S qualification-only destructive replacement. The caller
     /// must present the non-cloneable witness minted by the token loop after
     /// the previous token's successful boundary readback. Physical staging is
-    /// exactly the ordinary production concurrent direct-staging path; only
-    /// the demand-request counter is kept separate. The resulting queue writes
+    /// the ordinary production concurrent direct-staging path for full-zero
+    /// control, or the same transaction with qualification no-zero fill.
+    /// The demand-request counter is kept separate. The resulting queue writes
     /// are deliberately left pending: next-token mapping writes follow them,
     /// then the next token's one normal command-buffer submit orders both sets
     /// of writes before compute. No extra empty submit is used to flush H2D.
@@ -831,6 +843,7 @@ impl GpuNativeTieredResidencyManager {
         boundary: &mut crate::gpu_native_token_loop::GpuNativeSafeTokenBoundary,
         layer_index: usize,
         demands: &[GpuNativeDemandExpert],
+        fill_policy: GpuNativePhysicalSlotFillPolicy,
         observer: &dyn GpuNativePhysicalInstallObserver,
     ) -> Result<Vec<GpuNativeQ4ExpertResidency>, GpuNativeTieredResidencyError> {
         boundary
@@ -845,7 +858,7 @@ impl GpuNativeTieredResidencyManager {
             GpuNativeResidencyPriority::OracleSafeBoundary,
             layer_index,
             demands,
-            oracle_safe_boundary_install_path(),
+            oracle_safe_boundary_install_path(fill_policy),
             Some(observer),
         )
     }
@@ -962,15 +975,29 @@ impl GpuNativeTieredResidencyManager {
         if matches!(
             install_path,
             DemandPhysicalInstallPath::ProductionConcurrentDirectStaging
+                | DemandPhysicalInstallPath::QualificationConcurrentDirectStagingNoZeroFill
         ) {
-            self.install_parallel_physical_misses_locked::<OBSERVE>(
-                demands,
-                &misses,
-                layer,
-                &mut state,
-                &mut resolved,
-                observer,
-            )?;
+            if install_path
+                == DemandPhysicalInstallPath::QualificationConcurrentDirectStagingNoZeroFill
+            {
+                self.install_parallel_physical_misses_locked::<true, true>(
+                    demands,
+                    &misses,
+                    layer,
+                    &mut state,
+                    &mut resolved,
+                    observer,
+                )?;
+            } else {
+                self.install_parallel_physical_misses_locked::<OBSERVE, false>(
+                    demands,
+                    &misses,
+                    layer,
+                    &mut state,
+                    &mut resolved,
+                    observer,
+                )?;
+            }
         } else {
             let transaction_started = (OBSERVE && !misses.is_empty()).then(Instant::now);
             if OBSERVE && !misses.is_empty() {
@@ -1020,7 +1047,11 @@ impl GpuNativeTieredResidencyManager {
             .collect()
     }
 
-    fn install_parallel_physical_misses_locked<'a, const OBSERVE: bool>(
+    fn install_parallel_physical_misses_locked<
+        'a,
+        const OBSERVE: bool,
+        const NO_ZERO_FILL: bool,
+    >(
         &self,
         demands: &[GpuNativeDemandExpert],
         misses: &[usize],
@@ -1201,7 +1232,13 @@ impl GpuNativeTieredResidencyManager {
                     .record_physical_stage_started();
             }
             let stage_started = OBSERVE.then(Instant::now);
-            let result = if OBSERVE {
+            let result = if NO_ZERO_FILL {
+                self.executor
+                    .stage_q4_expert_residency_qualification_no_zero_fill(
+                        reserved.permit,
+                        reserved.resident.data(),
+                    )
+            } else if OBSERVE {
                 self.executor.stage_q4_expert_residency_production_observed(
                     reserved.permit,
                     reserved.resident.data(),
@@ -1212,9 +1249,10 @@ impl GpuNativeTieredResidencyManager {
                     .map(|prepared| (prepared, GpuNativePhysicalInstallEvidence::default()))
             };
             match result {
-                Ok((prepared, evidence)) => {
+                Ok((prepared, mut evidence)) => {
                     let individual_stage_us = stage_started.map_or(0, qualification_elapsed_us);
                     if OBSERVE {
+                        evidence.individual_physical_stage_us = individual_stage_us;
                         observer
                             .expect("observed production install has an observer")
                             .record_physical_stage_completed(evidence, individual_stage_us);
@@ -1644,7 +1682,8 @@ impl GpuNativeTieredResidencyManager {
                         DemandPhysicalInstallPath::LegacyFullSlotVecControl => self
                             .executor
                             .install_q4_expert_residency_legacy_observed(permit, resident.data()),
-                        DemandPhysicalInstallPath::ProductionConcurrentDirectStaging => {
+                        DemandPhysicalInstallPath::ProductionConcurrentDirectStaging
+                        | DemandPhysicalInstallPath::QualificationConcurrentDirectStagingNoZeroFill => {
                             unreachable!("ordinary production installs use the split transaction")
                         }
                     };
@@ -1676,7 +1715,8 @@ impl GpuNativeTieredResidencyManager {
                         DemandPhysicalInstallPath::SequentialDirectStagingControl => {
                             unreachable!("sequential control is qualifier-only")
                         }
-                        DemandPhysicalInstallPath::ProductionConcurrentDirectStaging => {
+                        DemandPhysicalInstallPath::ProductionConcurrentDirectStaging
+                        | DemandPhysicalInstallPath::QualificationConcurrentDirectStagingNoZeroFill => {
                             unreachable!("ordinary production installs use the split transaction")
                         }
                     };
@@ -1799,7 +1839,7 @@ mod tests {
             DemandPhysicalInstallPath::ProductionConcurrentDirectStaging
         );
         assert_eq!(
-            oracle_safe_boundary_install_path(),
+            oracle_safe_boundary_install_path(GpuNativePhysicalSlotFillPolicy::FullSlotZero),
             DemandPhysicalInstallPath::ProductionConcurrentDirectStaging
         );
         assert_eq!(
@@ -1815,7 +1855,7 @@ mod tests {
             speculative_install_path()
         );
         assert_ne!(
-            oracle_safe_boundary_install_path(),
+            oracle_safe_boundary_install_path(GpuNativePhysicalSlotFillPolicy::FullSlotZero),
             speculative_install_path()
         );
     }
@@ -1823,11 +1863,11 @@ mod tests {
     #[test]
     fn oracle_direct_staging_uses_the_production_direct_path() {
         assert_eq!(
-            oracle_safe_boundary_install_path(),
+            oracle_safe_boundary_install_path(GpuNativePhysicalSlotFillPolicy::FullSlotZero),
             ordinary_demand_install_path()
         );
         assert_eq!(
-            oracle_safe_boundary_install_path(),
+            oracle_safe_boundary_install_path(GpuNativePhysicalSlotFillPolicy::FullSlotZero),
             DemandPhysicalInstallPath::ProductionConcurrentDirectStaging
         );
     }
@@ -1835,9 +1875,58 @@ mod tests {
     #[test]
     fn oracle_direct_staging_never_uses_legacy_full_slot_vec_control() {
         assert_ne!(
-            oracle_safe_boundary_install_path(),
+            oracle_safe_boundary_install_path(GpuNativePhysicalSlotFillPolicy::FullSlotZero),
             speculative_install_path()
         );
+    }
+
+    #[test]
+    fn oracle_no_zero_fill_is_a_qualification_only_concurrent_path() {
+        let treatment = oracle_safe_boundary_install_path(
+            GpuNativePhysicalSlotFillPolicy::QualificationNoZeroFill,
+        );
+        assert_eq!(
+            treatment,
+            DemandPhysicalInstallPath::QualificationConcurrentDirectStagingNoZeroFill
+        );
+        assert_ne!(treatment, ordinary_demand_install_path());
+        assert_ne!(treatment, production_concurrency_control_path());
+        assert_ne!(treatment, speculative_install_path());
+        // The production wrappers must keep the full-zero specialization;
+        // only the named qualification wrapper may specialize it to true.
+        let backend = include_str!("backend/gpu_native.rs");
+        for (wrapper, specialization) in [
+            (
+                "stage_q4_expert_residency_production<'a>",
+                "::<false, true, false>",
+            ),
+            (
+                "stage_q4_expert_residency_production_observed<'a>",
+                "::<true, true, false>",
+            ),
+            (
+                "stage_q4_expert_residency_qualification<'a>",
+                "::<true, false, false>",
+            ),
+            (
+                "stage_q4_expert_residency_qualification_no_zero_fill<'a>",
+                "::<true, true, true>",
+            ),
+        ] {
+            let body = backend
+                .split(&format!("pub(crate) fn {wrapper}"))
+                .nth(1)
+                .unwrap()
+                .split("\n    }")
+                .next()
+                .unwrap();
+            assert!(
+                body.contains(&format!(
+                    "stage_q4_expert_residency_inner{specialization}(permit, payload)"
+                )),
+                "{wrapper}"
+            );
+        }
     }
 
     #[test]
@@ -2029,8 +2118,8 @@ mod tests {
 
     #[test]
     fn qualification_logical_only_physical_stage_source_witness() {
-        // Both actual production stage calls consume the ExpertResident field
-        // of ReservedPhysicalInstall. Pin this narrow source-selection contract
+        // Both production calls and the new qualification call consume the
+        // ExpertResident field of ReservedPhysicalInstall. Pin this contract
         // without changing the frozen engine/hash witnesses or requiring a GPU.
         let source = include_str!("gpu_native_residency.rs");
         let stage = source
@@ -2040,7 +2129,10 @@ mod tests {
             .split("let parallel_stage_started =")
             .next()
             .unwrap();
-        assert_eq!(stage.matches("reserved.resident.data()").count(), 2);
+        assert_eq!(stage.matches("reserved.resident.data()").count(), 3);
+        let production = stage.split("} else if OBSERVE {").nth(1).unwrap();
+        assert_eq!(production.matches("reserved.resident.data()").count(), 2);
+        assert!(stage.contains("stage_q4_expert_residency_qualification_no_zero_fill("));
         assert!(stage.contains("stage_q4_expert_residency_production_observed("));
         assert!(stage.contains(".stage_q4_expert_residency_production("));
         assert!(!stage.contains("admission.resident()"));

--- a/rust-engine/src/gpu_native_residency.rs
+++ b/rust-engine/src/gpu_native_residency.rs
@@ -362,7 +362,8 @@ pub(crate) enum GpuNativeResidencyPriority {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum DemandPhysicalInstallPath {
-    ProductionConcurrentDirectStaging,
+    ProductionConcurrentDirectStaging, // Complete overwrite, no explicit zero fill.
+    QualificationConcurrentDirectStagingFullZero,
     QualificationConcurrentDirectStagingNoZeroFill,
     SequentialDirectStagingControl,
     LegacyFullSlotVecControl,
@@ -377,7 +378,7 @@ const fn oracle_safe_boundary_install_path(
 ) -> DemandPhysicalInstallPath {
     match fill_policy {
         GpuNativePhysicalSlotFillPolicy::FullSlotZero => {
-            DemandPhysicalInstallPath::ProductionConcurrentDirectStaging
+            DemandPhysicalInstallPath::QualificationConcurrentDirectStagingFullZero
         }
         GpuNativePhysicalSlotFillPolicy::QualificationNoZeroFill => {
             DemandPhysicalInstallPath::QualificationConcurrentDirectStagingNoZeroFill
@@ -829,11 +830,29 @@ impl GpuNativeTieredResidencyManager {
         )
     }
 
+    /// Same concurrent reserve/stage/commit transaction as production, with
+    /// explicit full-slot zero writes for the zero-fill production qualifier.
+    pub(crate) fn ensure_demand_set_full_zero_control_observed(
+        &self,
+        priority: GpuNativeResidencyPriority,
+        layer_index: usize,
+        demands: &[GpuNativeDemandExpert],
+        observer: &dyn GpuNativePhysicalInstallObserver,
+    ) -> Result<Vec<GpuNativeQ4ExpertResidency>, GpuNativeTieredResidencyError> {
+        self.ensure_demand_set_inner::<true>(
+            priority,
+            layer_index,
+            demands,
+            DemandPhysicalInstallPath::QualificationConcurrentDirectStagingFullZero,
+            Some(observer),
+        )
+    }
+
     /// ORACLE-0B-S qualification-only destructive replacement. The caller
     /// must present the non-cloneable witness minted by the token loop after
     /// the previous token's successful boundary readback. Physical staging is
-    /// the ordinary production concurrent direct-staging path for full-zero
-    /// control, or the same transaction with qualification no-zero fill.
+    /// the shared concurrent direct-staging transaction with an explicit
+    /// full-zero control or historical qualification no-zero fill.
     /// The demand-request counter is kept separate. The resulting queue writes
     /// are deliberately left pending: next-token mapping writes follow them,
     /// then the next token's one normal command-buffer submit orders both sets
@@ -975,10 +994,11 @@ impl GpuNativeTieredResidencyManager {
         if matches!(
             install_path,
             DemandPhysicalInstallPath::ProductionConcurrentDirectStaging
+                | DemandPhysicalInstallPath::QualificationConcurrentDirectStagingFullZero
                 | DemandPhysicalInstallPath::QualificationConcurrentDirectStagingNoZeroFill
         ) {
             if install_path
-                == DemandPhysicalInstallPath::QualificationConcurrentDirectStagingNoZeroFill
+                == DemandPhysicalInstallPath::QualificationConcurrentDirectStagingFullZero
             {
                 self.install_parallel_physical_misses_locked::<true, true>(
                     demands,
@@ -1050,7 +1070,7 @@ impl GpuNativeTieredResidencyManager {
     fn install_parallel_physical_misses_locked<
         'a,
         const OBSERVE: bool,
-        const NO_ZERO_FILL: bool,
+        const FULL_ZERO_CONTROL: bool,
     >(
         &self,
         demands: &[GpuNativeDemandExpert],
@@ -1232,9 +1252,9 @@ impl GpuNativeTieredResidencyManager {
                     .record_physical_stage_started();
             }
             let stage_started = OBSERVE.then(Instant::now);
-            let result = if NO_ZERO_FILL {
+            let result = if FULL_ZERO_CONTROL {
                 self.executor
-                    .stage_q4_expert_residency_qualification_no_zero_fill(
+                    .stage_q4_expert_residency_full_zero_control_observed(
                         reserved.permit,
                         reserved.resident.data(),
                     )
@@ -1683,6 +1703,7 @@ impl GpuNativeTieredResidencyManager {
                             .executor
                             .install_q4_expert_residency_legacy_observed(permit, resident.data()),
                         DemandPhysicalInstallPath::ProductionConcurrentDirectStaging
+                        | DemandPhysicalInstallPath::QualificationConcurrentDirectStagingFullZero
                         | DemandPhysicalInstallPath::QualificationConcurrentDirectStagingNoZeroFill => {
                             unreachable!("ordinary production installs use the split transaction")
                         }
@@ -1716,6 +1737,7 @@ impl GpuNativeTieredResidencyManager {
                             unreachable!("sequential control is qualifier-only")
                         }
                         DemandPhysicalInstallPath::ProductionConcurrentDirectStaging
+                        | DemandPhysicalInstallPath::QualificationConcurrentDirectStagingFullZero
                         | DemandPhysicalInstallPath::QualificationConcurrentDirectStagingNoZeroFill => {
                             unreachable!("ordinary production installs use the split transaction")
                         }
@@ -1840,7 +1862,7 @@ mod tests {
         );
         assert_eq!(
             oracle_safe_boundary_install_path(GpuNativePhysicalSlotFillPolicy::FullSlotZero),
-            DemandPhysicalInstallPath::ProductionConcurrentDirectStaging
+            DemandPhysicalInstallPath::QualificationConcurrentDirectStagingFullZero
         );
         assert_eq!(
             production_concurrency_control_path(),
@@ -1861,14 +1883,14 @@ mod tests {
     }
 
     #[test]
-    fn oracle_direct_staging_uses_the_production_direct_path() {
-        assert_eq!(
+    fn oracle_full_zero_control_is_explicit_and_concurrent() {
+        assert_ne!(
             oracle_safe_boundary_install_path(GpuNativePhysicalSlotFillPolicy::FullSlotZero),
             ordinary_demand_install_path()
         );
         assert_eq!(
             oracle_safe_boundary_install_path(GpuNativePhysicalSlotFillPolicy::FullSlotZero),
-            DemandPhysicalInstallPath::ProductionConcurrentDirectStaging
+            DemandPhysicalInstallPath::QualificationConcurrentDirectStagingFullZero
         );
     }
 
@@ -1892,16 +1914,20 @@ mod tests {
         assert_ne!(treatment, ordinary_demand_install_path());
         assert_ne!(treatment, production_concurrency_control_path());
         assert_ne!(treatment, speculative_install_path());
-        // The production wrappers must keep the full-zero specialization;
-        // only the named qualification wrapper may specialize it to true.
+        // Production and historical treatment share checked no-zero staging;
+        // the concurrent control alone explicitly selects full zero fill.
         let backend = include_str!("backend/gpu_native.rs");
         for (wrapper, specialization) in [
             (
                 "stage_q4_expert_residency_production<'a>",
-                "::<false, true, false>",
+                "::<false, true, true>",
             ),
             (
                 "stage_q4_expert_residency_production_observed<'a>",
+                "::<true, true, true>",
+            ),
+            (
+                "stage_q4_expert_residency_full_zero_control_observed<'a>",
                 "::<true, true, false>",
             ),
             (
@@ -2132,7 +2158,7 @@ mod tests {
         assert_eq!(stage.matches("reserved.resident.data()").count(), 3);
         let production = stage.split("} else if OBSERVE {").nth(1).unwrap();
         assert_eq!(production.matches("reserved.resident.data()").count(), 2);
-        assert!(stage.contains("stage_q4_expert_residency_qualification_no_zero_fill("));
+        assert!(stage.contains("stage_q4_expert_residency_full_zero_control_observed("));
         assert!(stage.contains("stage_q4_expert_residency_production_observed("));
         assert!(stage.contains(".stage_q4_expert_residency_production("));
         assert!(!stage.contains("admission.resident()"));

--- a/rust-engine/src/gpu_native_residency.rs
+++ b/rust-engine/src/gpu_native_residency.rs
@@ -99,6 +99,10 @@ pub(crate) enum GpuNativeTieredResidencyError {
     PhysicalIdentityCorrupt {
         global_id: u32,
     },
+    UnsafeOracleBoundary {
+        layer_index: usize,
+        detail: String,
+    },
     ResidencyPriorityMismatch,
     Backend(GpuNativeBootstrapError),
 }
@@ -125,6 +129,7 @@ impl fmt::Display for GpuNativeTieredResidencyError {
             Self::NoEvictablePhysicalSlot { layer_index } => write!(f, "layer {layer_index} has no physical victim outside the protected demand set"),
             Self::StalePhysicalRequester { global_id, generation } => write!(f, "stale physical requester for global expert {global_id} generation {generation}"),
             Self::PhysicalIdentityCorrupt { global_id } => write!(f, "GPU-native physical metadata disagrees with the authoritative arena for global expert {global_id}"),
+            Self::UnsafeOracleBoundary { layer_index, detail } => write!(f, "ORACLE-0B-S safe-boundary authorization failed for layer {layer_index}: {detail}"),
             Self::ResidencyPriorityMismatch => f.write_str("residency request used the wrong demand/speculative priority"),
             Self::Backend(error) => write!(f, "GPU-native residency backend error: {error}"),
         }
@@ -350,6 +355,7 @@ impl GpuNativeModelExpertVramPlan {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) enum GpuNativeResidencyPriority {
     Demand,
+    OracleSafeBoundary,
     Speculative { score: f64 },
 }
 
@@ -361,6 +367,10 @@ enum DemandPhysicalInstallPath {
 }
 
 const fn ordinary_demand_install_path() -> DemandPhysicalInstallPath {
+    DemandPhysicalInstallPath::ProductionConcurrentDirectStaging
+}
+
+const fn oracle_safe_boundary_install_path() -> DemandPhysicalInstallPath {
     DemandPhysicalInstallPath::ProductionConcurrentDirectStaging
 }
 
@@ -808,6 +818,38 @@ impl GpuNativeTieredResidencyManager {
         )
     }
 
+    /// ORACLE-0B-S qualification-only destructive replacement. The caller
+    /// must present the non-cloneable witness minted by the token loop after
+    /// the previous token's successful boundary readback. Physical staging is
+    /// exactly the ordinary production concurrent direct-staging path; only
+    /// the demand-request counter is kept separate. The resulting queue writes
+    /// are deliberately left pending: next-token mapping writes follow them,
+    /// then the next token's one normal command-buffer submit orders both sets
+    /// of writes before compute. No extra empty submit is used to flush H2D.
+    pub(crate) fn ensure_oracle_future_set_at_safe_boundary(
+        &self,
+        boundary: &mut crate::gpu_native_token_loop::GpuNativeSafeTokenBoundary,
+        layer_index: usize,
+        demands: &[GpuNativeDemandExpert],
+        observer: &dyn GpuNativePhysicalInstallObserver,
+    ) -> Result<Vec<GpuNativeQ4ExpertResidency>, GpuNativeTieredResidencyError> {
+        boundary
+            .authorize_layer_once(layer_index)
+            .map_err(
+                |detail| GpuNativeTieredResidencyError::UnsafeOracleBoundary {
+                    layer_index,
+                    detail: detail.to_string(),
+                },
+            )?;
+        self.ensure_demand_set_inner::<true>(
+            GpuNativeResidencyPriority::OracleSafeBoundary,
+            layer_index,
+            demands,
+            oracle_safe_boundary_install_path(),
+            Some(observer),
+        )
+    }
+
     /// PR2-B-B.1 control: the exact pre-B-B sequential production direct-
     /// staging path, observed only by the dedicated production qualifier.
     pub(crate) fn ensure_demand_set_physical_install_concurrency_control(
@@ -834,7 +876,10 @@ impl GpuNativeTieredResidencyManager {
         install_path: DemandPhysicalInstallPath,
         observer: Option<&dyn GpuNativePhysicalInstallObserver>,
     ) -> Result<Vec<GpuNativeQ4ExpertResidency>, GpuNativeTieredResidencyError> {
-        if !matches!(priority, GpuNativeResidencyPriority::Demand) {
+        if !matches!(
+            priority,
+            GpuNativeResidencyPriority::Demand | GpuNativeResidencyPriority::OracleSafeBoundary
+        ) {
             return Err(GpuNativeTieredResidencyError::ResidencyPriorityMismatch);
         }
         let layer =
@@ -876,9 +921,11 @@ impl GpuNativeTieredResidencyManager {
             }
         }
 
-        self.counters
-            .demand_requests
-            .fetch_add(demands.len() as u64, Ordering::Relaxed);
+        if matches!(priority, GpuNativeResidencyPriority::Demand) {
+            self.counters
+                .demand_requests
+                .fetch_add(demands.len() as u64, Ordering::Relaxed);
+        }
         let mut state = layer.state.lock();
         let mut resolved = vec![None; demands.len()];
         let mut misses = Vec::new();
@@ -1742,6 +1789,10 @@ mod tests {
             DemandPhysicalInstallPath::ProductionConcurrentDirectStaging
         );
         assert_eq!(
+            oracle_safe_boundary_install_path(),
+            DemandPhysicalInstallPath::ProductionConcurrentDirectStaging
+        );
+        assert_eq!(
             production_concurrency_control_path(),
             DemandPhysicalInstallPath::SequentialDirectStagingControl
         );
@@ -1751,6 +1802,30 @@ mod tests {
         );
         assert_ne!(
             production_concurrency_control_path(),
+            speculative_install_path()
+        );
+        assert_ne!(
+            oracle_safe_boundary_install_path(),
+            speculative_install_path()
+        );
+    }
+
+    #[test]
+    fn oracle_direct_staging_uses_the_production_direct_path() {
+        assert_eq!(
+            oracle_safe_boundary_install_path(),
+            ordinary_demand_install_path()
+        );
+        assert_eq!(
+            oracle_safe_boundary_install_path(),
+            DemandPhysicalInstallPath::ProductionConcurrentDirectStaging
+        );
+    }
+
+    #[test]
+    fn oracle_direct_staging_never_uses_legacy_full_slot_vec_control() {
+        assert_ne!(
+            oracle_safe_boundary_install_path(),
             speculative_install_path()
         );
     }

--- a/rust-engine/src/gpu_native_residency.rs
+++ b/rust-engine/src/gpu_native_residency.rs
@@ -670,6 +670,23 @@ impl GpuNativeTieredResidencyManager {
         &self.plan
     }
 
+    /// Re-run the production model-wide slot planner for an alternate expert
+    /// budget without allocating buffers or mutating residency. Qualification
+    /// analyzers use the authoritative executor limits rather than guessing
+    /// per-layer capacities from the budget.
+    pub(crate) fn plan_for_budget(
+        &self,
+        total_expert_budget_bytes: u64,
+    ) -> Result<GpuNativeModelExpertVramPlan, GpuNativeTieredResidencyError> {
+        let limits = self.executor.device_limits()?;
+        GpuNativeModelExpertVramPlan::try_new(
+            self.plan.num_layers(),
+            self.plan.geometry(),
+            total_expert_budget_bytes,
+            &limits,
+        )
+    }
+
     pub(crate) fn arena(&self, layer_index: usize) -> Option<&Arc<GpuNativeQ4ExpertArena>> {
         self.layers.get(layer_index).map(|layer| &layer.arena)
     }

--- a/rust-engine/src/gpu_native_residency.rs
+++ b/rust-engine/src/gpu_native_residency.rs
@@ -1763,6 +1763,16 @@ fn oldest_unprotected<T>(cache: &LruCache<u32, T>, protected: &HashSet<u32>) -> 
 }
 
 #[cfg(test)]
+pub(crate) fn validate_qualification_physical_source_for_test(
+    gpu_cache: &GpuExpertCache,
+    global_id: u32,
+    resident: &Arc<ExpertResident>,
+    admission: &GpuAdmission,
+) -> Result<(), GpuNativeTieredResidencyError> {
+    validate_physical_install_source(gpu_cache, global_id, resident, admission)
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::buffer_pool::BufferPool;
@@ -1963,6 +1973,85 @@ mod tests {
                 generation: admission.generation(),
             })
         );
+    }
+
+    #[test]
+    fn qualification_logical_only_physical_validation_uses_real_source_and_rejects_stale_or_wrong_ids(
+    ) {
+        let cache = GpuExpertCache::new(8, 0.0, 0);
+        let audit = Arc::new(AtomicU64::new(0));
+        let pool = BufferPool::new_qualification_oracle_future_source(2, 8, 4);
+        let mut buffer = pool.try_acquire().unwrap();
+        buffer
+            .as_mut_slice()
+            .copy_from_slice(&[1, 2, 3, 4, 5, 6, 7, 8]);
+        let resident = Arc::new(ExpertResident::new(7, buffer));
+        cache
+            .demand_admit_lru(Arc::new(GpuResident::new_qualification_logical_only(
+                7,
+                resident.data().len(),
+                crate::inference::WeightDtype::Q4_0,
+                audit.clone(),
+            )))
+            .unwrap();
+        let admission = cache.current_admission(7).unwrap();
+        assert_eq!(
+            validate_physical_install_source(&cache, 7, &resident, &admission),
+            Ok(())
+        );
+        let demand = GpuNativeDemandExpert::install(7, resident.clone(), admission.clone());
+        match &demand {
+            GpuNativeDemandExpert::Install {
+                resident: source,
+                admission: logical,
+                ..
+            } => {
+                assert!(Arc::ptr_eq(source, &resident));
+                assert_eq!(source.data(), &[1, 2, 3, 4, 5, 6, 7, 8]);
+                assert_eq!(logical.generation(), admission.generation());
+            }
+            _ => panic!("install must carry the real source"),
+        }
+        let wrong = Arc::new(ExpertResident::new(8, pool.try_acquire().unwrap()));
+        assert_eq!(
+            validate_physical_install_source(&cache, 7, &wrong, &admission),
+            Err(GpuNativeTieredResidencyError::DemandSourceIdentityMismatch { global_id: 7 })
+        );
+        cache
+            .demand_admit_lru(Arc::new(GpuResident::new(8, vec![0; 8])))
+            .unwrap();
+        assert!(matches!(
+            validate_physical_install_source(&cache, 7, &resident, &admission),
+            Err(GpuNativeTieredResidencyError::LogicalAdmissionStale { .. })
+        ));
+        assert_eq!(audit.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn qualification_logical_only_physical_stage_source_witness() {
+        // Both actual production stage calls consume the ExpertResident field
+        // of ReservedPhysicalInstall. Pin this narrow source-selection contract
+        // without changing the frozen engine/hash witnesses or requiring a GPU.
+        let source = include_str!("gpu_native_residency.rs");
+        let stage = source
+            .split("let stage_one = |reserved:")
+            .nth(1)
+            .unwrap()
+            .split("let parallel_stage_started =")
+            .next()
+            .unwrap();
+        assert_eq!(stage.matches("reserved.resident.data()").count(), 2);
+        assert!(stage.contains("stage_q4_expert_residency_production_observed("));
+        assert!(stage.contains(".stage_q4_expert_residency_production("));
+        assert!(!stage.contains("admission.resident()"));
+        let owners = source
+            .split("struct ReservedPhysicalInstall<'a> {")
+            .nth(1)
+            .unwrap()
+            .split('}')
+            .next()
+            .unwrap();
+        assert!(owners.contains("resident: Arc<ExpertResident>"));
     }
 
     #[test]

--- a/rust-engine/src/gpu_native_token_loop.rs
+++ b/rust-engine/src/gpu_native_token_loop.rs
@@ -2399,7 +2399,7 @@ impl GpuNativeTokenLoop {
                     .fetch_add(1, Ordering::Relaxed);
             }
 
-            engine.record_gpu_native_actual_routes(&report.selected_ids);
+            engine.record_gpu_native_actual_routes(position, &report.selected_ids);
 
             return Ok(GpuNativeStepOutput {
                 sampled_token: if sample {

--- a/rust-engine/src/gpu_native_token_loop.rs
+++ b/rust-engine/src/gpu_native_token_loop.rs
@@ -10,7 +10,9 @@ use crate::gpu_native_physical_install_staging::q4_route_parallel::{
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::fmt;
+use std::future::Future;
 use std::ops::Range;
+use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
@@ -131,6 +133,80 @@ fn saturating_micros(start: Instant) -> u64 {
     u64::try_from(start.elapsed().as_micros()).unwrap_or(u64::MAX)
 }
 
+/// Qualification-only handoff for ORACLE-0B-S. Ordinary token execution
+/// always passes `None`, so no serving path observes this interface.
+pub(crate) trait GpuNativeOracleScheduleHook: Send + Sync {
+    /// Called immediately after the normal command buffer is submitted. The
+    /// hook may start CPU/source work, but it must not mutate physical VRAM.
+    fn on_token_submitted(&self, position: usize);
+
+    /// Called only after the boundary map completed, `Maintain::Wait`
+    /// returned, the report parsed, and the completed token status is clean.
+    fn on_safe_token_boundary<'a>(
+        &'a self,
+        engine: &'a Arc<Engine>,
+        boundary: GpuNativeSafeTokenBoundary,
+        actual_routes: &'a [Vec<u32>],
+    ) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + 'a>>;
+}
+
+fn notify_oracle_token_submitted(hook: Option<&dyn GpuNativeOracleScheduleHook>, position: usize) {
+    if let Some(hook) = hook {
+        hook.on_token_submitted(position);
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(not(test), allow(dead_code))]
+enum GpuNativeTokenCompletionState {
+    SubmissionInFlight,
+    BoundaryMapParsedAfterPoll,
+}
+
+/// Non-cloneable proof that the current token submission has completed and
+/// destructive qualification-only residency mutation is safe. Its fields and
+/// constructor remain private to this module, so callers cannot manufacture a
+/// boundary merely because `Queue::submit` returned.
+pub(crate) struct GpuNativeSafeTokenBoundary {
+    position: usize,
+    authorized_layers: HashSet<usize>,
+}
+
+impl GpuNativeSafeTokenBoundary {
+    fn after_successful_report(position: usize) -> Self {
+        Self {
+            position,
+            authorized_layers: HashSet::new(),
+        }
+    }
+
+    pub(crate) const fn position(&self) -> usize {
+        self.position
+    }
+
+    pub(crate) fn authorize_layer_once(&mut self, layer_index: usize) -> Result<(), &'static str> {
+        if self.authorized_layers.insert(layer_index) {
+            Ok(())
+        } else {
+            Err("safe-boundary witness was reused for the same layer")
+        }
+    }
+}
+
+fn issue_oracle_safe_boundary(
+    position: usize,
+    completion: GpuNativeTokenCompletionState,
+) -> Result<GpuNativeSafeTokenBoundary, &'static str> {
+    match completion {
+        GpuNativeTokenCompletionState::SubmissionInFlight => {
+            Err("current token submission has not reached its proven completion boundary")
+        }
+        GpuNativeTokenCompletionState::BoundaryMapParsedAfterPoll => Ok(
+            GpuNativeSafeTokenBoundary::after_successful_report(position),
+        ),
+    }
+}
+
 impl GpuNativeTokenLoopCounters {
     fn snapshot(&self) -> GpuNativeTokenLoopSnapshot {
         GpuNativeTokenLoopSnapshot {
@@ -199,6 +275,7 @@ pub enum GpuNativeTokenLoopError {
         actual: usize,
     },
     MapFailed(String),
+    OracleScheduleFailed(String),
 }
 
 impl fmt::Display for GpuNativeTokenLoopError {
@@ -274,6 +351,9 @@ impl fmt::Display for GpuNativeTokenLoopError {
                 "selected expert count mismatch: expected {expected}, got {actual}"
             ),
             Self::MapFailed(detail) => write!(f, "staging buffer map failed: {detail}"),
+            Self::OracleScheduleFailed(detail) => {
+                write!(f, "ORACLE-0B-S scheduling failed: {detail}")
+            }
         }
     }
 }
@@ -1553,8 +1633,10 @@ impl GpuNativeTokenLoop {
         let prefix_count = prompt_ids.len().saturating_sub(1);
         for &token_id in &prompt_ids[..prefix_count] {
             let pos = request.committed_position;
-            self.step_token_unified_inner(engine, request, token_id, pos, false, None, None, None)
-                .await?;
+            self.step_token_unified_inner(
+                engine, request, token_id, pos, false, None, None, None, None,
+            )
+            .await?;
         }
 
         // Final prompt token: evaluate LM-head and sample first completion token
@@ -1567,6 +1649,7 @@ impl GpuNativeTokenLoop {
                 final_prompt,
                 final_prompt_pos,
                 true,
+                None,
                 None,
                 None,
                 None,
@@ -1587,7 +1670,9 @@ impl GpuNativeTokenLoop {
                 break;
             }
             let next_token = self
-                .step_token_unified_inner(engine, request, last_token, pos, true, None, None, None)
+                .step_token_unified_inner(
+                    engine, request, last_token, pos, true, None, None, None, None,
+                )
                 .await?
                 .sampled_token
                 .ok_or_else(|| GpuNativeTokenLoopError::InvalidBoundaryReport {
@@ -1612,7 +1697,35 @@ impl GpuNativeTokenLoop {
         let _guard = self.execution_guard.lock().await;
         let out = self
             .step_token_unified_inner(
-                engine, request, token_id, position, sample, None, None, None,
+                engine, request, token_id, position, sample, None, None, None, None,
+            )
+            .await?;
+        Ok(out.sampled_token)
+    }
+
+    /// ORACLE-0B-S-only token step. The ordinary public step above remains
+    /// byte-for-byte on the no-hook branch.
+    pub(crate) async fn step_token_oracle_scheduled(
+        &self,
+        engine: &Arc<Engine>,
+        request: &mut GpuNativeRequestState,
+        token_id: u32,
+        position: usize,
+        sample: bool,
+        oracle_hook: &dyn GpuNativeOracleScheduleHook,
+    ) -> Result<Option<u32>, GpuNativeTokenLoopError> {
+        let _guard = self.execution_guard.lock().await;
+        let out = self
+            .step_token_unified_inner(
+                engine,
+                request,
+                token_id,
+                position,
+                sample,
+                None,
+                None,
+                None,
+                Some(oracle_hook),
             )
             .await?;
         Ok(out.sampled_token)
@@ -1644,6 +1757,7 @@ impl GpuNativeTokenLoop {
                 position,
                 sample,
                 Some((trace_layout, diagnostic_staging_buffer)),
+                None,
                 None,
                 None,
             )
@@ -1684,6 +1798,7 @@ impl GpuNativeTokenLoop {
                 true,
                 None,
                 Some((trace_layout, diagnostic_staging_buffer)),
+                None,
                 None,
             )
             .await?;
@@ -1734,6 +1849,7 @@ impl GpuNativeTokenLoop {
                     diagnostic_staging_buffer,
                     None,
                 )),
+                None,
             )
             .await?;
         let trace =
@@ -1783,6 +1899,7 @@ impl GpuNativeTokenLoop {
                     diagnostic_staging_buffer,
                     None,
                 )),
+                None,
             )
             .await?;
         let trace = out.semantic_corpus_trace.ok_or_else(|| {
@@ -1836,6 +1953,7 @@ impl GpuNativeTokenLoop {
                     semantic_trace_staging_buffer,
                     None,
                 )),
+                None,
             )
             .await?;
         let full_trace =
@@ -1908,6 +2026,7 @@ impl GpuNativeTokenLoop {
                     diagnostic_staging_buffer,
                     Some(&stage_scratch),
                 )),
+                None,
             )
             .await?;
         let trace = out.q4_expert_stage_trace.ok_or_else(|| {
@@ -2178,6 +2297,7 @@ impl GpuNativeTokenLoop {
             &wgpu::Buffer,
             Option<&GpuNativeScratch>,
         )>,
+        oracle_hook: Option<&dyn GpuNativeOracleScheduleHook>,
     ) -> Result<GpuNativeStepOutput, GpuNativeTokenLoopError> {
         let max_attempts = gpu_native_attempt_bound(self.layers.len())?;
         let mut attempts = 0usize;
@@ -2223,6 +2343,7 @@ impl GpuNativeTokenLoop {
                     sink.as_ref(),
                     router_rank_sink.as_ref(),
                     semantic_sink.as_ref(),
+                    oracle_hook,
                 )?
             } else {
                 self.execute_token_segment_unified(
@@ -2235,6 +2356,7 @@ impl GpuNativeTokenLoop {
                     sink.as_ref(),
                     router_rank_sink.as_ref(),
                     semantic_sink.as_ref(),
+                    oracle_hook,
                 )?
             };
             attempts += 1;
@@ -2401,6 +2523,17 @@ impl GpuNativeTokenLoop {
 
             engine.record_gpu_native_actual_routes(position, &report.selected_ids);
 
+            if let Some(hook) = oracle_hook {
+                let boundary = issue_oracle_safe_boundary(
+                    position,
+                    GpuNativeTokenCompletionState::BoundaryMapParsedAfterPoll,
+                )
+                .expect("successful parsed boundary after Maintain::Wait is a completion proof");
+                hook.on_safe_token_boundary(engine, boundary, &report.selected_ids)
+                    .await
+                    .map_err(GpuNativeTokenLoopError::OracleScheduleFailed)?;
+            }
+
             return Ok(GpuNativeStepOutput {
                 sampled_token: if sample {
                     Some(report.sampled_token)
@@ -2427,7 +2560,7 @@ impl GpuNativeTokenLoop {
         replay: bool,
     ) -> Result<GpuNativeBoundaryReport, GpuNativeTokenLoopError> {
         let output = self.execute_token_attempt_unified(
-            request, token_id, position, sample, replay, None, None, None,
+            request, token_id, position, sample, replay, None, None, None, None,
         )?;
         Ok(output.boundary_report)
     }
@@ -2455,6 +2588,7 @@ impl GpuNativeTokenLoop {
             sample,
             replay,
             Some(&sink),
+            None,
             None,
             None,
         )?;
@@ -2631,6 +2765,7 @@ impl GpuNativeTokenLoop {
         diagnostic_sink: Option<&GpuNativeDiagnosticSink<'_>>,
         router_rank_sink: Option<&GpuNativeRouterRankDiagnosticSink<'_>>,
         semantic_sink: Option<&GpuNativeExpertPermutationSemanticSink<'_>>,
+        oracle_hook: Option<&dyn GpuNativeOracleScheduleHook>,
     ) -> Result<GpuNativeAttemptOutput, GpuNativeTokenLoopError> {
         let segment = GpuNativeExecutionSegment::fresh(self.layers.len())?;
         self.execute_token_segment_unified(
@@ -2643,6 +2778,7 @@ impl GpuNativeTokenLoop {
             diagnostic_sink,
             router_rank_sink,
             semantic_sink,
+            oracle_hook,
         )
     }
 
@@ -2659,6 +2795,7 @@ impl GpuNativeTokenLoop {
         diagnostic_sink: Option<&GpuNativeDiagnosticSink<'_>>,
         router_rank_sink: Option<&GpuNativeRouterRankDiagnosticSink<'_>>,
         semantic_sink: Option<&GpuNativeExpertPermutationSemanticSink<'_>>,
+        oracle_hook: Option<&dyn GpuNativeOracleScheduleHook>,
     ) -> Result<GpuNativeAttemptOutput, GpuNativeTokenLoopError> {
         if position != request.committed_position {
             return Err(GpuNativeTokenLoopError::PositionMismatch {
@@ -3125,6 +3262,10 @@ impl GpuNativeTokenLoop {
         self.counters
             .queue_submissions
             .fetch_add(1, Ordering::Relaxed);
+        // This callback is deliberately after the one normal submit and
+        // before the blocking boundary poll. It may overlap only NVMe/source
+        // work with current-token GPU execution.
+        notify_oracle_token_submitted(oracle_hook, position);
 
         // ONE map/readback for production boundary report
         let slice = request
@@ -4872,5 +5013,57 @@ pub(crate) mod tests {
         assert_eq!(trace1.status, 0);
         assert_eq!(request_state.committed_position, 2);
         assert!(trace1.post_attention_residual.iter().all(|v| v.is_finite()));
+    }
+
+    struct CountingOracleHook(AtomicU64);
+
+    impl GpuNativeOracleScheduleHook for CountingOracleHook {
+        fn on_token_submitted(&self, _position: usize) {
+            self.0.fetch_add(1, Ordering::Relaxed);
+        }
+
+        fn on_safe_token_boundary<'a>(
+            &'a self,
+            _engine: &'a Arc<Engine>,
+            _boundary: GpuNativeSafeTokenBoundary,
+            _actual_routes: &'a [Vec<u32>],
+        ) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + 'a>> {
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    #[test]
+    fn ordinary_token_path_has_no_oracle_behavior_when_hook_is_absent() {
+        let hook = CountingOracleHook(AtomicU64::new(0));
+        notify_oracle_token_submitted(None, 7);
+        assert_eq!(hook.0.load(Ordering::Relaxed), 0);
+        notify_oracle_token_submitted(Some(&hook), 7);
+        assert_eq!(hook.0.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn destructive_boundary_cannot_be_issued_while_submission_is_in_flight() {
+        assert!(
+            issue_oracle_safe_boundary(7, GpuNativeTokenCompletionState::SubmissionInFlight)
+                .is_err()
+        );
+        let boundary = issue_oracle_safe_boundary(
+            7,
+            GpuNativeTokenCompletionState::BoundaryMapParsedAfterPoll,
+        )
+        .unwrap();
+        assert_eq!(boundary.position(), 7);
+    }
+
+    #[test]
+    fn safe_boundary_witness_cannot_be_reused_for_one_layer() {
+        let mut boundary = issue_oracle_safe_boundary(
+            3,
+            GpuNativeTokenCompletionState::BoundaryMapParsedAfterPoll,
+        )
+        .unwrap();
+        assert_eq!(boundary.authorize_layer_once(4), Ok(()));
+        assert!(boundary.authorize_layer_once(4).is_err());
+        assert_eq!(boundary.authorize_layer_once(5), Ok(()));
     }
 }

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -150,6 +150,7 @@ pub(crate) mod gpu_native_physical_install_staging;
 pub(crate) mod gpu_native_q4_expert_stage_attribution;
 pub(crate) mod gpu_native_demand_source_concurrency;
 pub(crate) mod gpu_native_oracle_routes;
+pub(crate) mod gpu_native_oracle_scheduled_residency;
 pub(crate) mod gpu_native_real_benchmark;
 pub(crate) mod gpu_native_router_rank_diagnostics;
 pub(crate) mod gpu_native_semantic_parity_corpus;
@@ -924,6 +925,28 @@ enum Cmd {
         #[arg(long)]
         request_json: PathBuf,
         /// Required destination for the versioned diagnostic JSON artifact.
+        #[arg(long)]
+        report_out: PathBuf,
+    },
+
+    /// ORACLE-0B-S perfect-future source scheduling with either source-only
+    /// treatment or serialized same-queue H2D at a proven token boundary.
+    #[command(name = "qualify-gpu-native-oracle-scheduled-residency")]
+    QualifyGpuNativeOracleScheduledResidency {
+        /// Path to the strict production GPU-native TOML config.
+        #[arg(long)]
+        config: PathBuf,
+        /// Immutable ORACLE-0A v1 route-trace report used as future truth.
+        #[arg(long)]
+        oracle_trace: PathBuf,
+        /// Qualification treatment arm.
+        #[arg(long, value_enum)]
+        treatment_mode:
+            crate::gpu_native_oracle_scheduled_residency::OracleScheduledResidencyMode,
+        /// Maximum concurrent layer-level source batches.
+        #[arg(long, default_value_t = 4)]
+        oracle_source_concurrency: usize,
+        /// Required destination for the versioned ORACLE-0B-S report.
         #[arg(long)]
         report_out: PathBuf,
     },
@@ -1950,6 +1973,7 @@ fn startup_config_path(cmd: &Cmd) -> Option<&Path> {
         | Cmd::BenchReal { config, .. }
         | Cmd::BenchGpuNativeReal { config, .. }
         | Cmd::TraceGpuNativeOracleRoutes { config, .. }
+        | Cmd::QualifyGpuNativeOracleScheduledResidency { config, .. }
         | Cmd::QualifyGpuNativeDemandSourceConcurrencyProduction { config, .. }
         | Cmd::QualifyGpuNativeQ4RouteParallelProduction { config, .. }
         | Cmd::QualifyGpuNativeOutOfCore { config, .. }
@@ -2397,6 +2421,29 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     progress_watchdog,
                 },
             ))
+        }
+        Cmd::QualifyGpuNativeOracleScheduledResidency {
+            config,
+            oracle_trace,
+            treatment_mode,
+            oracle_source_concurrency,
+            report_out,
+        } => {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()?;
+            rt.block_on(
+                crate::gpu_native_oracle_scheduled_residency::run_command(
+                    crate::gpu_native_oracle_scheduled_residency::CommandArgs {
+                        config,
+                        oracle_trace,
+                        treatment_mode,
+                        oracle_source_concurrency,
+                        report_out,
+                        progress_watchdog,
+                    },
+                ),
+            )
         }
         Cmd::QualifyGpuNativeDemandSourceConcurrencyProduction {
             config,

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -1022,6 +1022,18 @@ enum Cmd {
         report_out: PathBuf,
     },
 
+    /// Production zero-fill qualification: concurrent full-zero control versus
+    /// ordinary production concurrent complete overwrite with no explicit zero.
+    #[command(name = "qualify-gpu-native-physical-zero-fill-production")]
+    QualifyGpuNativePhysicalZeroFillProduction {
+        #[arg(long)]
+        config: PathBuf,
+        #[arg(long)]
+        expected_adapter_name: String,
+        #[arg(long)]
+        report_out: PathBuf,
+    },
+
     /// Qualify strict real-checkpoint inference with CPU dense/attention/KV/
     /// router/head planes and native-Q4_0 routed experts on a hardware GPU.
     QualifyHybridQ4 {
@@ -1979,6 +1991,7 @@ fn startup_config_path(cmd: &Cmd) -> Option<&Path> {
         | Cmd::QualifyGpuNativeOutOfCore { config, .. }
         | Cmd::QualifyGpuNativePhysicalInstallStagingProduction { config, .. }
         | Cmd::QualifyGpuNativePhysicalInstallConcurrencyProduction { config, .. }
+        | Cmd::QualifyGpuNativePhysicalZeroFillProduction { config, .. }
         | Cmd::QualifyHybridQ4 { config, .. }
         | Cmd::QualifyHybridQ4Parity { config, .. }
         | Cmd::QualifyHybridQ4GreedyParity { config, .. }
@@ -2525,6 +2538,25 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .build()?;
             rt.block_on(
                 crate::gpu_native_physical_install_staging::run_concurrency_command(
+                    crate::gpu_native_physical_install_staging::CommandArgs {
+                        config,
+                        expected_adapter_name,
+                        report_out,
+                        progress_watchdog,
+                    },
+                ),
+            )
+        }
+        Cmd::QualifyGpuNativePhysicalZeroFillProduction {
+            config,
+            expected_adapter_name,
+            report_out,
+        } => {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()?;
+            rt.block_on(
+                crate::gpu_native_physical_install_staging::zero_fill_production::run_command(
                     crate::gpu_native_physical_install_staging::CommandArgs {
                         config,
                         expected_adapter_name,
@@ -16598,6 +16630,46 @@ mod tests {
                 );
                 assert_eq!(expected_adapter_name, "NVIDIA L4");
                 assert_eq!(report_out, &PathBuf::from("pr2bb-report.json"));
+            }
+            _ => panic!("unexpected command variant"),
+        }
+        assert_eq!(
+            super::startup_config_path(&cli.cmd),
+            Some(Path::new(
+                "/home/randyap8/slice11-qwen3-coder-gpu-native.toml"
+            ))
+        );
+    }
+
+    #[test]
+    fn gpu_native_physical_zero_fill_production_cli_parses_qualified_command() {
+        let cli = <Cli as clap::Parser>::try_parse_from([
+            "micro-expert-router",
+            "qualify-gpu-native-physical-zero-fill-production",
+            "--config",
+            "/home/randyap8/slice11-qwen3-coder-gpu-native.toml",
+            "--expected-adapter-name",
+            "NVIDIA L4",
+            "--report-out",
+            "physical-zero-fill-production-report.json",
+        ])
+        .unwrap();
+
+        match &cli.cmd {
+            Cmd::QualifyGpuNativePhysicalZeroFillProduction {
+                config,
+                expected_adapter_name,
+                report_out,
+            } => {
+                assert_eq!(
+                    config,
+                    &PathBuf::from("/home/randyap8/slice11-qwen3-coder-gpu-native.toml")
+                );
+                assert_eq!(expected_adapter_name, "NVIDIA L4");
+                assert_eq!(
+                    report_out,
+                    &PathBuf::from("physical-zero-fill-production-report.json")
+                );
             }
             _ => panic!("unexpected command variant"),
         }

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -149,6 +149,7 @@ pub(crate) mod gpu_native_out_of_core;
 pub(crate) mod gpu_native_physical_install_staging;
 pub(crate) mod gpu_native_q4_expert_stage_attribution;
 pub(crate) mod gpu_native_demand_source_concurrency;
+pub(crate) mod gpu_native_oracle_routes;
 pub(crate) mod gpu_native_real_benchmark;
 pub(crate) mod gpu_native_router_rank_diagnostics;
 pub(crate) mod gpu_native_semantic_parity_corpus;
@@ -908,6 +909,23 @@ enum Cmd {
         /// Write the typed JSON benchmark report here instead of stdout.
         #[arg(long)]
         report_out: Option<PathBuf>,
+    },
+
+    /// Capture authoritative ordered route truth from the ordinary production
+    /// GPU-native token loop and run offline capacity/replacement analysis.
+    #[command(name = "trace-gpu-native-oracle-routes")]
+    TraceGpuNativeOracleRoutes {
+        /// Path to the strict production GPU-native TOML config.
+        #[arg(long)]
+        config: PathBuf,
+        /// OpenAI-style request JSON containing `prompt` or chat `messages`
+        /// and the exact requested output-token count. Decoding is always
+        /// greedy and the runtime is always restricted to NVIDIA L4.
+        #[arg(long)]
+        request_json: PathBuf,
+        /// Required destination for the versioned diagnostic JSON artifact.
+        #[arg(long)]
+        report_out: PathBuf,
     },
 
     /// Production-path PR2-A.2 control/treatment qualification. Control
@@ -1931,6 +1949,7 @@ fn startup_config_path(cmd: &Cmd) -> Option<&Path> {
         Cmd::Serve { config }
         | Cmd::BenchReal { config, .. }
         | Cmd::BenchGpuNativeReal { config, .. }
+        | Cmd::TraceGpuNativeOracleRoutes { config, .. }
         | Cmd::QualifyGpuNativeDemandSourceConcurrencyProduction { config, .. }
         | Cmd::QualifyGpuNativeQ4RouteParallelProduction { config, .. }
         | Cmd::QualifyGpuNativeOutOfCore { config, .. }
@@ -2357,6 +2376,23 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     cache_reset,
                     greedy,
                     expected_adapter_name,
+                    report_out,
+                    progress_watchdog,
+                },
+            ))
+        }
+        Cmd::TraceGpuNativeOracleRoutes {
+            config,
+            request_json,
+            report_out,
+        } => {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()?;
+            rt.block_on(crate::gpu_native_oracle_routes::run_command(
+                crate::gpu_native_oracle_routes::CommandArgs {
+                    config,
+                    request_json,
                     report_out,
                     progress_watchdog,
                 },

--- a/rust-engine/src/server.rs
+++ b/rust-engine/src/server.rs
@@ -566,7 +566,10 @@ pub(crate) fn map_gpu_native_token_loop_error(
         | GpuNativeTokenLoopError::InvalidSelectedExpertId { .. }
         | GpuNativeTokenLoopError::DuplicateSelectedExpertId { .. }
         | GpuNativeTokenLoopError::InvalidTopKCount { .. }
-        | GpuNativeTokenLoopError::MapFailed(_) => GenerateError::Inference(err.to_string()),
+        | GpuNativeTokenLoopError::MapFailed(_)
+        | GpuNativeTokenLoopError::OracleScheduleFailed(_) => {
+            GenerateError::Inference(err.to_string())
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Preserve the qualified ORACLE/performance lineage and productionize the exact safe physical-slot zero-fill elision mechanism for ordinary GPU-native demand installs.

The branch is an exact descendant of `main` (`7ab35f10d2798faf3d997e0d90f51f3e6519529e`), ahead by 10 and behind by 0. This PR intentionally preserves that evidence ancestry; merge with a merge commit, not squash/rebase.

## Production mechanism

Ordinary production concurrent direct staging now uses the checked complete-overwrite path that omits the redundant full-slot zero fill only after proving:

- destination length equals the exact slot stride;
- epoch + payload cover the complete destination before the first write;
- frozen Qwen3-Coder Q4 geometry is 4-byte epoch + 2,654,208-byte payload = 2,654,212-byte slot;
- no trailing padding exists.

The explicit concurrent full-zero qualification control remains available. Queue ordering, staging byte count/H2D bytes, source acquisition, predictor/prefetch, io_uring, routing/Q4 math, VRAM policy, logical admission/LRU/generation, mapping publication ordering and recovery semantics are unchanged by the productionization child.

## Review

Reviewed cumulative `main..ae681ae6` ancestry and final production child. Earlier commits add/fix qualification-only ORACLE route/residency analysis and isolated source-plane evidence; shared hooks are observational/guarded when qualification observers are absent. Production `GpuResident` constructors retain materialized ownership semantics. ORACLE-specific buffer-pool origin accounting is isolated from production primary/shadow pools. No unrelated product feature change found.

Final reviewed child:

- HEAD `ae681ae60f362a1b33521eb7fe54323d2aaa79ce`
- parent `e4b954e04fb0c8a6607101e76d5a4449cef3c7c2`
- tree `112b2d4a9176f43d314ee97270aef3997cee247f`

## Linux/L4 preflight

PASS on `instance-20260715-025109`, NVIDIA L4/Vulkan, frozen config/model.

- canonical build: `cargo build --release --features tokenizer`
- binary SHA-256 `9af076122516ecc34eddd3f5e8965d12961916d3fff5917705b26dc4b037919a`
- exact Git object identity and seven-file productionization scope PASS
- tokenizer/backend/residency/physical-install/zero-fill/ORACLE-v5/concurrency-CLI portable checks PASS
- `validate-data` PASS
- 12 GiB external cgroup / zero-swap capability PASS

## FIRST immutable production A/B

Pair `physical-zero-fill-production-v1-ae681ae6-first`
Schema `mer.gpu-native-physical-zero-fill-production.v1`

Control: concurrent direct staging with explicit full-slot zero fill.
Treatment: ordinary production concurrent direct staging with complete-overwrite no-zero fill.

Correctness / causal gates:

- `qualification_pass=true`
- behavioral gate PASS
- work-equivalence gate PASS
- warmup mechanism PASS
- measured mechanism PASS
- exact token IDs/text/routes PASS
- exact source/install/victim identity PASS
- `CROSS_ARM_CAUSAL_IDENTITY=PASS`
- 12 GiB zero-swap envelope PASS

Performance:

- decode TPS `1.102281921 -> 1.110298999` (**+0.7273%**)
- E2E generated TPS `0.993043728 -> 1.000227017` (**+0.7234%**)
- mean request wall `128.897933s -> 127.971578s` (**-0.7187%**)
- TTFT `13.681156s -> 13.587433s` (**-0.6851%**)
- physical demand install **-31.9006%**
- slot preparation **-40.7694%**
- physical parallel-stage wall **-33.6535%**
- individual physical-stage sum **-39.7983%**
- physical-install total **-39.7111%**
- install transaction **-33.0101%**

Exact work correspondence:

- physical installs: `90,717` in both arms
- staged bytes: `240,782,150,004` in both arms
- source NVMe reads: `88,029` in both arms
- source NVMe bytes: `234,007,842,816` in both arms
- explicit zero-fill bytes: `240,782,150,004 -> 0`
- epoch bytes: `362,868` in both arms
- payload-copy bytes: `240,781,787,136` in both arms

Evidence hashes:

- report SHA-256 `a6b957f9824b128b743d6435470c4c7ce5270a837d2be9dbe6ae5f3b3634bcf9`
- A/B summary SHA-256 `bdd8fb4ceb14d5abe79ed3917e104421fb962657fe356bd5431a1bc4dfcb85a4`
- qualifier log SHA-256 `648c0771213bc3c92084e64a9c7d46f7495e573d5340251e2b29b93c002a7110`

## Decision

KEEP / MERGE. Do not rerun the immutable FIRST pair.

Next performance lane after merge: isolate payload-copy/staging-memory cost; do not optimize `Queue::write_buffer_with` view acquisition first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added GPU-native route-trace diagnostics with versioned JSON reports and validation.
  - Added qualification workflows for scheduled residency and physical slot zero-fill performance.
  - Added safe-boundary scheduling for future expert residency and budget-based residency planning.
  - Added detailed staging, routing, timing, and storage evidence to qualification reports.

- **Bug Fixes**
  - Improved inference error reporting when GPU-native scheduling fails.
  - Added validation to reject unsafe residency boundaries and incomplete physical-slot coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->