### PR TITLE
Attribute GPU-native staging payload copy cost

### DIFF
--- a/docs/benchmarks/gpu-native-staging-payload-copy-diagnostic.md
+++ b/docs/benchmarks/gpu-native-staging-payload-copy-diagnostic.md
@@ -1,0 +1,115 @@
+# GPU-native physical staging payload-copy attribution
+
+`diagnose-gpu-native-physical-staging-payload-copy` emits
+`mer.gpu-native-physical-staging-payload-copy.v1`. It measures host preparation
+and describes a discriminator; decode TPS is never a diagnostic pass/fail gate.
+No hardware result is implied by the portable tests.
+
+Build from the reviewed, clean branch on Linux with the canonical command:
+
+```sh
+cd rust-engine
+cargo build --release --features tokenizer
+```
+
+After code review and explicit authorization for the authoritative L4 inference
+run, invoke the combined standalone and one-arm real-inference diagnostic:
+
+```sh
+./target/release/micro-expert-router diagnose-gpu-native-physical-staging-payload-copy \
+  --config /home/randyap8/slice11-qwen3-coder-gpu-native.toml \
+  --expected-adapter-name 'NVIDIA L4' \
+  --warmup-iterations 3 \
+  --iterations 20 \
+  --report-out /home/randyap8/staging-payload-copy-attribution-v1.json
+```
+
+To run only the bounded RAM/WGPU experiment, without loading a model, add
+`--standalone-only`. This mode also accepts another exact adapter name for
+non-authoritative portable GPU investigation. Full real inference requires
+Linux, NVIDIA L4/Vulkan, the existing frozen config path/hash, and 2048 MiB
+managed expert VRAM. It reuses the existing physical-install workload runner:
+the fixed Rust-addition prompt, greedy, 128 output tokens, one warmup, three
+measured runs, cache reset `keep`, and the frozen disabled predictor contract.
+It selects only `ProductionNoZeroFillTreatment`; it does not run a comparison
+inference arm or change inference configuration.
+
+The standalone `--iterations` range is 1–1000; `--warmup-iterations` is 1–100.
+They do not change inference warmup or measured counts. Fewer than ten measured
+pairs per width produces `no-clear-discriminator`. Widths are always 1, 2, 4, 8.
+
+## JSON contents and timing definitions
+
+- `build_provenance` and `executable_identity` identify the binary. `tree_sha`
+  is null because the existing embedded build provenance does not supply one.
+  The real arm additionally carries existing model, config, artifacts, runtime
+  adapter, and executable provenance.
+- `geometry` is payload offset 4, payload 2,654,208 B, stride 2,654,212 B,
+  tail 0. `standalone.source_payload_sha256` identifies the deterministic
+  versioned source pattern, independent of model data.
+- `standalone.ram` and `standalone.wgpu_staging` each contain four width cases,
+  including every measured batch, checked operations/bytes, exclusive copy
+  time, host batch wall time, both throughputs, epoch/coverage time, observed
+  job concurrency, failures and accounting errors. WGPU acquisition, view
+  drop/scheduling, and submit/drain are separately reported.
+- Host batch wall includes Rayon dispatch/join and each job's work. WGPU
+  submit/drain and RAM verification are outside wall and copy timers. Decimal
+  GB/s is `bytes / nanoseconds`; it is host-copy throughput, not DMA bandwidth.
+  Width 1 is inline; wider jobs use MER's existing shared Rayon pool. Actual
+  concurrency is reported even when the pool cannot exercise the full width.
+- The same validated complete-overwrite helper measures both destination
+  types. RAM destinations are preallocated and reused; full payload hashes
+  are checked outside timing after every RAM phase. WGPU views are never read.
+  The isolated queue submits and waits after every WGPU batch, including
+  warmups/failures. At most N writes are pending for width N, bounded at
+  21,233,696 B for width 8. These submits/polls never enter ordinary inference.
+- `real_inference.warmup_attribution` and
+  `real_inference.measured_production_attribution` separate the phases and
+  report install counts, epoch/payload/staged bytes, validation, epoch write,
+  payload copy, broad preparation, queue staging, checked residual, copy GB/s,
+  copy share, residual share and accounting validity. Full observer and
+  workload evidence remains in `real_inference.production_arm`.
+- Production `physical_slot_validation_us` includes the existing pre-view
+  checked-writer work plus the shared destination coverage check. The broad
+  historical `physical_slot_prepare_us` still measures original checked-writer
+  preparation plus outer view fill. Residual is the checked difference between
+  broad prepare and the three subphases. Overflow, underflow or missing
+  observation counts fail accounting; they cannot silently disappear.
+- Production retains integer microseconds per install. Sub-microsecond epoch
+  writes can truncate to zero, and residual includes quantization and timer
+  overhead. Standalone retains nanoseconds and reports fractional microseconds.
+  A zero epoch total does not establish zero epoch-write cost.
+
+`complete` means the requested diagnostic phases completed and their accounting
+is valid. It is not performance qualification. Failures produce an incomplete
+report and nonzero exit. Standalone-only reports have `real_inference: null`.
+
+The final `diagnostic_classification` follows documented conservative rules:
+
+1. `staging-view-memory-slower-than-ram`: WGPU/RAM summed-copy throughput ratio
+   and paired p90 are both at most 0.90 at three or more widths.
+2. `concurrency-amortization-dominant`: all aggregate and paired p10/p90 copy
+   ratios are within 0.90–1.10, and both destinations gain at least 25% in
+   aggregate wall throughput from width 1 to width 8, with observed concurrency.
+3. `host-memcpy-bandwidth-dominant`: copy ratios satisfy the same similarity
+   requirement and valid real production evidence attributes at least 80% of
+   broad preparation to payload copy.
+4. Otherwise, `no-clear-discriminator`.
+
+All classifications require at least ten paired samples at every width and no
+standalone failures. Raw batches, ratios and production attribution remain
+authoritative. These descriptive labels do not prove a WGPU memory type,
+transfer causality, or a production optimization.
+
+## Production isolation
+
+Normal staging remains `stage_q4_expert_residency_inner::<false, true, true>`.
+It calls the ordinary no-zero helper, with no new timers. The measured
+specialization alone calls the observed equivalent. Both share the checked
+coverage contract, validate before the first write, and write the same epoch
+and payload bytes. Production source work, concurrency, slot policy,
+publication, queue ordering/submission count, and recovery are unchanged.
+
+Portable focused checks use `cargo test --features tokenizer payload_copy`.
+When libtest needs a larger thread stack, set `RUST_MIN_STACK=8388608` for tests
+only. The runtime does not require that environment variable.

--- a/rust-engine/src/backend/gpu_native.rs
+++ b/rust-engine/src/backend/gpu_native.rs
@@ -2268,6 +2268,12 @@ pub(crate) struct GpuNativePhysicalInstallEvidence {
     pub(crate) physical_slot_epoch_write_bytes: u64,
     pub(crate) physical_slot_payload_copy_bytes: u64,
     pub(crate) physical_slot_prepare_us: u64,
+    pub(crate) physical_slot_validation_us: u64,
+    pub(crate) physical_slot_epoch_write_us: u64,
+    pub(crate) physical_slot_payload_copy_us: u64,
+    pub(crate) physical_slot_prepare_residual_us: u64,
+    pub(crate) physical_slot_subphase_observations: u64,
+    pub(crate) physical_slot_timing_accounting_errors: u64,
     pub(crate) physical_queue_staging_us: u64,
     pub(crate) mapping_publication_us: u64,
     /// Existing residency stage timer, carried to the completion observer.
@@ -2275,6 +2281,28 @@ pub(crate) struct GpuNativePhysicalInstallEvidence {
 }
 
 impl GpuNativePhysicalInstallEvidence {
+    /// A failed decomposition is retained as an accounting error, never hidden
+    /// by a saturating subtraction or allowed to change install recovery.
+    fn observe_no_zero(&mut self, outer_validation_us: u64, observed: PhysicalSlotObservation) {
+        self.physical_slot_subphase_observations = 1;
+        let validation = observed
+            .validation_us()
+            .and_then(|v| outer_validation_us.checked_add(v));
+        let epoch = observed.epoch_write_us();
+        let payload = observed.payload_copy_us();
+        self.physical_slot_validation_us = validation.unwrap_or(u64::MAX);
+        self.physical_slot_epoch_write_us = epoch.unwrap_or(u64::MAX);
+        self.physical_slot_payload_copy_us = payload.unwrap_or(u64::MAX);
+        match validation
+            .and_then(|v| v.checked_add(epoch?))
+            .and_then(|v| v.checked_add(payload?))
+            .and_then(|parts| self.physical_slot_prepare_us.checked_sub(parts))
+        {
+            Some(residual) => self.physical_slot_prepare_residual_us = residual,
+            None => self.physical_slot_timing_accounting_errors = 1,
+        }
+    }
+
     fn direct_stage<const NO_ZERO_FILL: bool>(
         geometry: GpuNativeQ4ExpertGeometry,
         prepare_us: u64,
@@ -2683,14 +2711,33 @@ fn fill_physical_q4_expert_slot(
     CheckedPhysicalQ4ExpertSlot::new(geometry, logical_id, slot_epoch, payload)?.fill(destination)
 }
 
-struct CheckedPhysicalQ4ExpertSlot<'a> {
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct PhysicalSlotObservation {
+    pub(crate) validation: std::time::Duration,
+    pub(crate) epoch_write: std::time::Duration,
+    pub(crate) payload_copy: std::time::Duration,
+}
+
+impl PhysicalSlotObservation {
+    fn validation_us(self) -> Option<u64> {
+        u64::try_from(self.validation.as_micros()).ok()
+    }
+    fn epoch_write_us(self) -> Option<u64> {
+        u64::try_from(self.epoch_write.as_micros()).ok()
+    }
+    fn payload_copy_us(self) -> Option<u64> {
+        u64::try_from(self.payload_copy.as_micros()).ok()
+    }
+}
+
+pub(crate) struct CheckedPhysicalQ4ExpertSlot<'a> {
     geometry: GpuNativeQ4ExpertGeometry,
     slot_epoch: u32,
     payload: &'a [u8],
 }
 
 impl<'a> CheckedPhysicalQ4ExpertSlot<'a> {
-    fn new(
+    pub(crate) fn new(
         geometry: GpuNativeQ4ExpertGeometry,
         logical_id: u32,
         slot_epoch: u32,
@@ -2730,18 +2777,17 @@ impl<'a> CheckedPhysicalQ4ExpertSlot<'a> {
         Ok(())
     }
 
-    /// Shared production/qualification complete overwrite. Reuse the validated
-    /// payload/epoch and require complete destination coverage before writing
-    /// even the first epoch byte. Future padded slots must use full-zero fill.
-    fn fill_complete_overwrite_no_zero(
-        self,
-        destination: &mut [u8],
-    ) -> Result<(), GpuNativeBootstrapError> {
-        if destination.len() != self.geometry.slot_stride_bytes {
+    /// The same checked coverage contract is used by ordinary and observed
+    /// complete overwrite. All checks finish before the first destination write.
+    fn complete_overwrite_range(
+        &self,
+        destination_len: usize,
+    ) -> Result<std::ops::Range<usize>, GpuNativeBootstrapError> {
+        if destination_len != self.geometry.slot_stride_bytes {
             return Err(
                 GpuNativeBootstrapError::ExpertPhysicalSlotDestinationLength {
                     expected: self.geometry.slot_stride_bytes,
-                    actual: destination.len(),
+                    actual: destination_len,
                 },
             );
         }
@@ -2749,19 +2795,49 @@ impl<'a> CheckedPhysicalQ4ExpertSlot<'a> {
         let payload_end = payload_start
             .checked_add(self.geometry.logical_expert_bytes)
             .ok_or(GpuNativeBootstrapError::ExpertArenaBudgetOverflow)?;
-        if payload_end != destination.len() {
+        if payload_end != destination_len {
             return Err(
                 GpuNativeBootstrapError::ExpertPhysicalSlotDestinationLength {
                     expected: payload_end,
-                    actual: destination.len(),
+                    actual: destination_len,
                 },
             );
         }
+        Ok(payload_start..payload_end)
+    }
+
+    fn fill_complete_overwrite_no_zero(
+        self,
+        destination: &mut [u8],
+    ) -> Result<(), GpuNativeBootstrapError> {
+        let range = self.complete_overwrite_range(destination.len())?;
         destination[..GPU_NATIVE_EXPERT_SLOT_EPOCH_BYTES]
             .copy_from_slice(&self.slot_epoch.to_le_bytes());
-        destination[payload_start..payload_end]
-            .copy_from_slice(&self.payload[..self.geometry.logical_expert_bytes]);
+        destination[range].copy_from_slice(&self.payload[..self.geometry.logical_expert_bytes]);
         Ok(())
+    }
+
+    /// Only the MEASURE=true specialization and the standalone diagnostic call
+    /// this observed equivalent. No allocation, submission, poll, or readback.
+    pub(crate) fn fill_complete_overwrite_no_zero_observed(
+        self,
+        destination: &mut [u8],
+    ) -> Result<PhysicalSlotObservation, GpuNativeBootstrapError> {
+        let started = Instant::now();
+        let range = self.complete_overwrite_range(destination.len())?;
+        let validation = started.elapsed();
+        let started = Instant::now();
+        destination[..GPU_NATIVE_EXPERT_SLOT_EPOCH_BYTES]
+            .copy_from_slice(&self.slot_epoch.to_le_bytes());
+        let epoch_write = started.elapsed();
+        let started = Instant::now();
+        destination[range].copy_from_slice(&self.payload[..self.geometry.logical_expert_bytes]);
+        let payload_copy = started.elapsed();
+        Ok(PhysicalSlotObservation {
+            validation,
+            epoch_write,
+            payload_copy,
+        })
     }
 }
 
@@ -7611,6 +7687,7 @@ impl GpuNativeExecutorContext {
                 physical_queue_staging_us: queue_staging_us.get(),
                 mapping_publication_us: mapping_us.get(),
                 individual_physical_stage_us: 0,
+                ..GpuNativePhysicalInstallEvidence::default()
             },
         ))
     }
@@ -7711,11 +7788,14 @@ impl GpuNativeExecutorContext {
         let arena = permit.arena;
         let upload_bytes = arena.geometry.slot_stride_bytes as u64;
         let prepare_us = std::cell::Cell::new(0u64);
+        let outer_validation_us = std::cell::Cell::new(0u64);
+        let observation = std::cell::Cell::new(PhysicalSlotObservation::default());
         let queue_staging_us = std::cell::Cell::new(0u64);
         let validate_started = MEASURE.then(Instant::now);
         let result = permit.stage_with_checked_physical_writer(payload, |bank, offset, checked| {
             if let Some(started) = validate_started {
                 prepare_us.set(elapsed_us(started));
+                outer_validation_us.set(prepare_us.get());
             }
             let size = wgpu::BufferSize::new(upload_bytes)
                 .expect("validated physical expert slot is nonempty");
@@ -7735,7 +7815,12 @@ impl GpuNativeExecutorContext {
             }
             let fill_started = MEASURE.then(Instant::now);
             if NO_ZERO_FILL {
-                checked.fill_complete_overwrite_no_zero(view.as_mut())?;
+                if MEASURE {
+                    observation
+                        .set(checked.fill_complete_overwrite_no_zero_observed(view.as_mut())?);
+                } else {
+                    checked.fill_complete_overwrite_no_zero(view.as_mut())?;
+                }
             } else {
                 checked.fill(view.as_mut())?;
             }
@@ -7754,14 +7839,15 @@ impl GpuNativeExecutorContext {
                 if let Some(stage_guard) = stage_guard {
                     stage_guard.succeed();
                 }
-                Ok((
-                    prepared,
-                    GpuNativePhysicalInstallEvidence::direct_stage::<NO_ZERO_FILL>(
-                        arena.geometry,
-                        prepare_us.get(),
-                        queue_staging_us.get(),
-                    ),
-                ))
+                let mut evidence = GpuNativePhysicalInstallEvidence::direct_stage::<NO_ZERO_FILL>(
+                    arena.geometry,
+                    prepare_us.get(),
+                    queue_staging_us.get(),
+                );
+                if MEASURE && NO_ZERO_FILL {
+                    evidence.observe_no_zero(outer_validation_us.get(), observation.get());
+                }
+                Ok((prepared, evidence))
             }
             Err(error) => {
                 if RECORD_PRODUCTION
@@ -7952,6 +8038,7 @@ impl GpuNativeExecutorContext {
                 physical_queue_staging_us: queue_staging_us.get(),
                 mapping_publication_us: mapping_us.get(),
                 individual_physical_stage_us: 0,
+                ..GpuNativePhysicalInstallEvidence::default()
             },
         ))
     }
@@ -11321,6 +11408,121 @@ pub(crate) mod tests {
                 }
             )
         );
+    }
+
+    #[test]
+    fn payload_copy_observed_no_zero_matches_ordinary_frozen_geometry() {
+        let geometry = GpuNativeQ4ExpertGeometry::try_new(2048, 768, 128, 8).unwrap();
+        assert_eq!(
+            (
+                geometry.payload_offset_bytes(),
+                geometry.logical_expert_bytes(),
+                geometry.slot_stride_bytes()
+            ),
+            (4, 2_654_208, 2_654_212)
+        );
+        let payload: Vec<u8> = (0..geometry.logical_expert_bytes())
+            .map(|i| (i % 251) as u8)
+            .collect();
+        for epoch in [1, 0x12345678, u32::MAX] {
+            let mut ordinary = vec![0xa5; geometry.slot_stride_bytes()];
+            let mut observed = ordinary.clone();
+            CheckedPhysicalQ4ExpertSlot::new(geometry, 0, epoch, &payload)
+                .unwrap()
+                .fill_complete_overwrite_no_zero(&mut ordinary)
+                .unwrap();
+            let started = Instant::now();
+            let times = CheckedPhysicalQ4ExpertSlot::new(geometry, 0, epoch, &payload)
+                .unwrap()
+                .fill_complete_overwrite_no_zero_observed(&mut observed)
+                .unwrap();
+            assert!(times.validation + times.epoch_write + times.payload_copy <= started.elapsed());
+            assert_eq!(observed, ordinary);
+            assert_eq!(&observed[..4], &epoch.to_le_bytes());
+            assert_eq!(&observed[4..], payload.as_slice());
+        }
+    }
+
+    #[test]
+    fn payload_copy_observed_rejects_all_incomplete_coverage_before_writing() {
+        let geometry = GpuNativeQ4ExpertGeometry::try_new(2048, 768, 128, 8).unwrap();
+        let payload = vec![0x37; geometry.logical_expert_bytes()];
+        let padded = GpuNativeQ4ExpertGeometry {
+            slot_stride_bytes: geometry.slot_stride_bytes() + 4,
+            ..geometry
+        };
+        for (g, length) in [
+            (geometry, geometry.slot_stride_bytes() - 4),
+            (geometry, geometry.slot_stride_bytes() + 4),
+            (padded, padded.slot_stride_bytes()),
+        ] {
+            let mut destination = vec![0xa5; length];
+            assert!(CheckedPhysicalQ4ExpertSlot::new(g, 0, 1, &payload)
+                .unwrap()
+                .fill_complete_overwrite_no_zero_observed(&mut destination)
+                .is_err());
+            assert!(destination.iter().all(|b| *b == 0xa5));
+        }
+    }
+
+    #[test]
+    fn payload_copy_evidence_residual_is_checked_and_overflow_is_visible() {
+        let geometry = GpuNativeQ4ExpertGeometry::try_new(2048, 768, 128, 8).unwrap();
+        let observed = PhysicalSlotObservation {
+            validation: std::time::Duration::from_micros(2),
+            epoch_write: std::time::Duration::from_micros(1),
+            payload_copy: std::time::Duration::from_micros(5),
+        };
+        let mut valid = GpuNativePhysicalInstallEvidence::direct_stage::<true>(geometry, 12, 3);
+        valid.observe_no_zero(2, observed);
+        assert_eq!(valid.physical_slot_validation_us, 4);
+        assert_eq!(valid.physical_slot_prepare_residual_us, 2);
+        assert_eq!(valid.physical_slot_timing_accounting_errors, 0);
+        for (outer, broad) in [(0, 7), (u64::MAX, u64::MAX)] {
+            let mut invalid =
+                GpuNativePhysicalInstallEvidence::direct_stage::<true>(geometry, broad, 0);
+            invalid.observe_no_zero(outer, observed);
+            assert_eq!(invalid.physical_slot_timing_accounting_errors, 1);
+        }
+    }
+
+    #[test]
+    fn payload_copy_normal_path_has_no_subphase_timers_or_queue_behavior_hooks() {
+        let source = include_str!("gpu_native.rs");
+        let ordinary = source
+            .split("    fn fill_complete_overwrite_no_zero(\n")
+            .nth(1)
+            .unwrap()
+            .split("    pub(crate) fn fill_complete_overwrite_no_zero_observed")
+            .next()
+            .unwrap();
+        assert!(!ordinary.contains("Instant::"));
+        assert!(!ordinary.contains("elapsed("));
+        assert!(!ordinary.contains("Vec::"));
+        let production = source
+            .split("    pub(crate) fn stage_q4_expert_residency_production<'a>(")
+            .nth(1)
+            .unwrap()
+            .split("    pub(crate) fn")
+            .next()
+            .unwrap();
+        assert!(production.contains("stage_q4_expert_residency_inner::<false, true, true>"));
+        let stage = source
+            .split("    fn stage_q4_expert_residency_inner<\n")
+            .nth(1)
+            .unwrap()
+            .split("    pub(crate) fn commit_q4_expert_residency_production")
+            .next()
+            .unwrap();
+        assert!(stage
+            .split_whitespace()
+            .collect::<String>()
+            .contains("ifMEASURE{observation.set("));
+        assert_eq!(stage.matches(".write_buffer_with(").count(), 1);
+        assert_eq!(stage.matches("drop(view)").count(), 1);
+        for forbidden in [".submit(", ".poll(", "map_async", "payload_copy::"] {
+            assert!(!stage.contains(forbidden));
+        }
     }
 
     #[test]

--- a/rust-engine/src/engine.rs
+++ b/rust-engine/src/engine.rs
@@ -575,6 +575,11 @@ pub(crate) struct GpuNativePhysicalInstallStagingQualificationSnapshot {
     pub(crate) mapping_publications: u64,
     pub(crate) mapping_unpublications: u64,
     pub(crate) physical_slot_prepare_us: u64,
+    pub(crate) physical_slot_validation_us: u64,
+    pub(crate) physical_slot_epoch_write_us: u64,
+    pub(crate) physical_slot_payload_copy_us: u64,
+    pub(crate) physical_slot_prepare_residual_us: u64,
+    pub(crate) physical_slot_subphase_observations: u64,
     pub(crate) physical_queue_staging_us: u64,
     pub(crate) mapping_publication_us: u64,
     pub(crate) physical_install_total_us: u64,
@@ -631,6 +636,11 @@ pub(crate) struct GpuNativePhysicalInstallConcurrencyQualificationSnapshot {
     pub(crate) mapping_publications: u64,
     pub(crate) mapping_unpublications: u64,
     pub(crate) physical_slot_prepare_us: u64,
+    pub(crate) physical_slot_validation_us: u64,
+    pub(crate) physical_slot_epoch_write_us: u64,
+    pub(crate) physical_slot_payload_copy_us: u64,
+    pub(crate) physical_slot_prepare_residual_us: u64,
+    pub(crate) physical_slot_subphase_observations: u64,
     pub(crate) physical_queue_staging_us: u64,
     pub(crate) mapping_publication_us: u64,
     pub(crate) physical_install_total_us: u64,
@@ -1039,6 +1049,11 @@ struct GpuNativeDemandSourceQualification {
     mapping_publications: AtomicU64,
     mapping_unpublications: AtomicU64,
     physical_slot_prepare_us: AtomicU64,
+    physical_slot_validation_us: AtomicU64,
+    physical_slot_epoch_write_us: AtomicU64,
+    physical_slot_payload_copy_us: AtomicU64,
+    physical_slot_prepare_residual_us: AtomicU64,
+    physical_slot_subphase_observations: AtomicU64,
     physical_queue_staging_us: AtomicU64,
     mapping_publication_us: AtomicU64,
     physical_install_total_us: AtomicU64,
@@ -1140,6 +1155,11 @@ impl GpuNativeDemandSourceQualification {
             mapping_publications: AtomicU64::new(0),
             mapping_unpublications: AtomicU64::new(0),
             physical_slot_prepare_us: AtomicU64::new(0),
+            physical_slot_validation_us: AtomicU64::new(0),
+            physical_slot_epoch_write_us: AtomicU64::new(0),
+            physical_slot_payload_copy_us: AtomicU64::new(0),
+            physical_slot_prepare_residual_us: AtomicU64::new(0),
+            physical_slot_subphase_observations: AtomicU64::new(0),
             physical_queue_staging_us: AtomicU64::new(0),
             mapping_publication_us: AtomicU64::new(0),
             physical_install_total_us: AtomicU64::new(0),
@@ -1361,6 +1381,17 @@ impl GpuNativeDemandSourceQualification {
             mapping_publications: self.mapping_publications.load(Ordering::Relaxed),
             mapping_unpublications: self.mapping_unpublications.load(Ordering::Relaxed),
             physical_slot_prepare_us: self.physical_slot_prepare_us.load(Ordering::Relaxed),
+            physical_slot_validation_us: self.physical_slot_validation_us.load(Ordering::Relaxed),
+            physical_slot_epoch_write_us: self.physical_slot_epoch_write_us.load(Ordering::Relaxed),
+            physical_slot_payload_copy_us: self
+                .physical_slot_payload_copy_us
+                .load(Ordering::Relaxed),
+            physical_slot_prepare_residual_us: self
+                .physical_slot_prepare_residual_us
+                .load(Ordering::Relaxed),
+            physical_slot_subphase_observations: self
+                .physical_slot_subphase_observations
+                .load(Ordering::Relaxed),
             physical_queue_staging_us: self.physical_queue_staging_us.load(Ordering::Relaxed),
             mapping_publication_us: self.mapping_publication_us.load(Ordering::Relaxed),
             physical_install_total_us: self.physical_install_total_us.load(Ordering::Relaxed),
@@ -1444,6 +1475,11 @@ impl GpuNativeDemandSourceQualification {
             mapping_publications: self.mapping_publications.load(Ordering::Relaxed),
             mapping_unpublications: self.mapping_unpublications.load(Ordering::Relaxed),
             physical_slot_prepare_us: self.physical_slot_prepare_us.load(Ordering::Relaxed),
+            physical_slot_validation_us: self.physical_slot_validation_us.load(Ordering::Relaxed),
+            physical_slot_epoch_write_us: self.physical_slot_epoch_write_us.load(Ordering::Relaxed),
+            physical_slot_payload_copy_us: self.physical_slot_payload_copy_us.load(Ordering::Relaxed),
+            physical_slot_prepare_residual_us: self.physical_slot_prepare_residual_us.load(Ordering::Relaxed),
+            physical_slot_subphase_observations: self.physical_slot_subphase_observations.load(Ordering::Relaxed),
             physical_queue_staging_us: self.physical_queue_staging_us.load(Ordering::Relaxed),
             mapping_publication_us: self.mapping_publication_us.load(Ordering::Relaxed),
             physical_install_total_us: self.physical_install_total_us.load(Ordering::Relaxed),
@@ -1509,6 +1545,96 @@ pub(crate) fn empty_physical_zero_fill_test_snapshot(
         .physical_install_concurrency_snapshot()
 }
 
+impl GpuNativeDemandSourceQualification {
+    fn record_slot_attribution(&self, evidence: GpuNativePhysicalInstallEvidence) {
+        for (counter, bytes) in [
+            (
+                &self.physical_slot_bytes_staged,
+                evidence.physical_slot_bytes_staged,
+            ),
+            (
+                &self.physical_slot_zero_fill_bytes,
+                evidence.physical_slot_zero_fill_bytes,
+            ),
+            (
+                &self.physical_slot_epoch_write_bytes,
+                evidence.physical_slot_epoch_write_bytes,
+            ),
+            (
+                &self.physical_slot_payload_copy_bytes,
+                evidence.physical_slot_payload_copy_bytes,
+            ),
+        ] {
+            if counter
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |total| {
+                    total.checked_add(bytes)
+                })
+                .is_err()
+            {
+                self.evidence_accounting_errors
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+        }
+        let observed = evidence.physical_slot_subphase_observations;
+        let parts = evidence
+            .physical_slot_validation_us
+            .checked_add(evidence.physical_slot_epoch_write_us)
+            .and_then(|v| v.checked_add(evidence.physical_slot_payload_copy_us));
+        let decomposition_valid = if observed == 1 {
+            evidence.direct_staging_writes == 1
+                && evidence.physical_slot_zero_fill_bytes == 0
+                && parts.and_then(|v| v.checked_add(evidence.physical_slot_prepare_residual_us))
+                    == Some(evidence.physical_slot_prepare_us)
+        } else {
+            observed == 0 && parts == Some(0) && evidence.physical_slot_prepare_residual_us == 0
+        };
+        if !decomposition_valid || evidence.physical_slot_timing_accounting_errors != 0 {
+            self.timing_accounting_errors
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        for (counter, value) in [
+            (
+                &self.physical_slot_validation_us,
+                evidence.physical_slot_validation_us,
+            ),
+            (
+                &self.physical_slot_epoch_write_us,
+                evidence.physical_slot_epoch_write_us,
+            ),
+            (
+                &self.physical_slot_payload_copy_us,
+                evidence.physical_slot_payload_copy_us,
+            ),
+            (
+                &self.physical_slot_prepare_residual_us,
+                evidence.physical_slot_prepare_residual_us,
+            ),
+            (
+                &self.physical_slot_subphase_observations,
+                evidence.physical_slot_subphase_observations,
+            ),
+            (
+                &self.physical_slot_prepare_us,
+                evidence.physical_slot_prepare_us,
+            ),
+            (
+                &self.physical_queue_staging_us,
+                evidence.physical_queue_staging_us,
+            ),
+        ] {
+            if counter
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |total| {
+                    total.checked_add(value)
+                })
+                .is_err()
+            {
+                self.timing_accounting_errors
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
+}
+
 impl GpuNativePhysicalInstallObserver for GpuNativeDemandSourceQualification {
     fn record_physical_victim(&self, global_id: u32) {
         self.physical_victim_ids.lock().record_id(global_id);
@@ -1556,37 +1682,8 @@ impl GpuNativePhysicalInstallObserver for GpuNativeDemandSourceQualification {
             .fetch_add(evidence.full_slot_vec_materializations, Ordering::Relaxed);
         self.direct_staging_writes
             .fetch_add(evidence.direct_staging_writes, Ordering::Relaxed);
-        self.physical_slot_bytes_staged
-            .fetch_add(evidence.physical_slot_bytes_staged, Ordering::Relaxed);
-        for (counter, bytes) in [
-            (
-                &self.physical_slot_zero_fill_bytes,
-                evidence.physical_slot_zero_fill_bytes,
-            ),
-            (
-                &self.physical_slot_epoch_write_bytes,
-                evidence.physical_slot_epoch_write_bytes,
-            ),
-            (
-                &self.physical_slot_payload_copy_bytes,
-                evidence.physical_slot_payload_copy_bytes,
-            ),
-        ] {
-            if counter
-                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |total| {
-                    total.checked_add(bytes)
-                })
-                .is_err()
-            {
-                self.evidence_accounting_errors
-                    .fetch_add(1, Ordering::Relaxed);
-            }
-        }
         self.mapping_publications.fetch_add(1, Ordering::Relaxed);
-        self.physical_slot_prepare_us
-            .fetch_add(evidence.physical_slot_prepare_us, Ordering::Relaxed);
-        self.physical_queue_staging_us
-            .fetch_add(evidence.physical_queue_staging_us, Ordering::Relaxed);
+        self.record_slot_attribution(evidence);
         self.mapping_publication_us
             .fetch_add(evidence.mapping_publication_us, Ordering::Relaxed);
         self.physical_install_total_us
@@ -9254,6 +9351,71 @@ mod tests {
         fn drop(&mut self) {
             let _ = std::fs::remove_dir_all(&self.path);
         }
+    }
+
+    #[test]
+    fn payload_copy_observer_aggregates_bytes_timings_and_detects_mismatch_and_overflow() {
+        let state = GpuNativeDemandSourceQualification::new_physical_install_concurrency(
+            GpuNativePhysicalInstallConcurrencyQualificationArm::ProductionNoZeroFillTreatment,
+            385,
+            0,
+        );
+        let evidence = GpuNativePhysicalInstallEvidence {
+            direct_staging_writes: 1,
+            physical_slot_bytes_staged: 2_654_212,
+            physical_slot_epoch_write_bytes: 4,
+            physical_slot_payload_copy_bytes: 2_654_208,
+            physical_slot_validation_us: 2,
+            physical_slot_epoch_write_us: 1,
+            physical_slot_payload_copy_us: 5,
+            physical_slot_prepare_residual_us: 2,
+            physical_slot_prepare_us: 10,
+            physical_queue_staging_us: 3,
+            physical_slot_subphase_observations: 1,
+            ..Default::default()
+        };
+        for _ in 0..3 {
+            state.record_slot_attribution(evidence);
+        }
+        let s = state.physical_install_concurrency_snapshot();
+        assert_eq!(s.physical_slot_subphase_observations, 3);
+        assert_eq!(s.physical_slot_epoch_write_bytes, 3 * 4);
+        assert_eq!(s.physical_slot_payload_copy_bytes, 3 * 2_654_208);
+        assert_eq!(s.physical_slot_bytes_staged, 3 * 2_654_212);
+        assert_eq!(
+            (
+                s.physical_slot_validation_us,
+                s.physical_slot_epoch_write_us,
+                s.physical_slot_payload_copy_us,
+                s.physical_slot_prepare_residual_us,
+                s.physical_slot_prepare_us,
+                s.physical_queue_staging_us
+            ),
+            (6, 3, 15, 6, 30, 9)
+        );
+        assert_eq!(s.timing_accounting_errors, 0);
+        state.record_slot_attribution(GpuNativePhysicalInstallEvidence {
+            physical_slot_prepare_residual_us: 1,
+            ..evidence
+        });
+        assert_eq!(
+            state
+                .physical_install_concurrency_snapshot()
+                .timing_accounting_errors,
+            1
+        );
+        state
+            .physical_slot_payload_copy_us
+            .store(u64::MAX, Ordering::Relaxed);
+        state
+            .physical_slot_payload_copy_bytes
+            .store(u64::MAX, Ordering::Relaxed);
+        state.record_slot_attribution(evidence);
+        let s = state.physical_install_concurrency_snapshot();
+        assert_eq!(s.timing_accounting_errors, 2);
+        assert_eq!(s.evidence_accounting_errors, 1);
+        assert_eq!(s.physical_slot_payload_copy_us, u64::MAX);
+        assert_eq!(s.physical_slot_payload_copy_bytes, u64::MAX);
     }
 
     #[test]

--- a/rust-engine/src/gpu_native_physical_install_staging.rs
+++ b/rust-engine/src/gpu_native_physical_install_staging.rs
@@ -2,6 +2,9 @@
 //! staging. Control explicitly forces the legacy Vec writer; treatment uses
 //! the ordinary production demand-install path in a fresh runtime.
 
+#[path = "gpu_native_physical_staging_payload_copy.rs"]
+pub(crate) mod payload_copy;
+
 #[path = "gpu_native_physical_zero_fill_production.rs"]
 pub(crate) mod zero_fill_production;
 
@@ -915,6 +918,11 @@ fn concurrency_common_snapshot(
         mapping_publications: source.mapping_publications,
         mapping_unpublications: source.mapping_unpublications,
         physical_slot_prepare_us: source.physical_slot_prepare_us,
+        physical_slot_validation_us: source.physical_slot_validation_us,
+        physical_slot_epoch_write_us: source.physical_slot_epoch_write_us,
+        physical_slot_payload_copy_us: source.physical_slot_payload_copy_us,
+        physical_slot_prepare_residual_us: source.physical_slot_prepare_residual_us,
+        physical_slot_subphase_observations: source.physical_slot_subphase_observations,
         physical_queue_staging_us: source.physical_queue_staging_us,
         mapping_publication_us: source.mapping_publication_us,
         physical_install_total_us: source.physical_install_total_us,
@@ -925,6 +933,15 @@ async fn run_physical_install_arm(
     prepared: &Prepared,
     args: &CommandArgs,
     run: PhysicalInstallQualificationRun,
+) -> Result<PhysicalInstallArmRun, BenchmarkFailure> {
+    run_physical_install_arm_inner(prepared, args, run, None).await
+}
+
+async fn run_physical_install_arm_inner(
+    prepared: &Prepared,
+    args: &CommandArgs,
+    run: PhysicalInstallQualificationRun,
+    diagnostic_mode: Option<&'static str>,
 ) -> Result<PhysicalInstallArmRun, BenchmarkFailure> {
     use crate::engine::GpuNativePhysicalInstallConcurrencyQualificationArm as ConcurrentArm;
     let (arm_name, arm) = match run {
@@ -944,11 +961,11 @@ async fn run_physical_install_arm(
             ),
         },
     };
-    let mode_name = match run {
+    let mode_name = diagnostic_mode.unwrap_or(match run {
         PhysicalInstallQualificationRun::Staging(_) => PRODUCTION_MODE,
         PhysicalInstallQualificationRun::Concurrency(_) => CONCURRENCY_MODE,
         PhysicalInstallQualificationRun::ZeroFillProduction(_) => zero_fill_production::MODE,
-    };
+    });
     let mut benchmark = benchmark_report(prepared);
     let runtime = crate::gpu_native_real_benchmark::construct_runtime(
         &prepared.spec,

--- a/rust-engine/src/gpu_native_physical_staging_payload_copy.rs
+++ b/rust-engine/src/gpu_native_physical_staging_payload_copy.rs
@@ -1,0 +1,1067 @@
+//! Diagnostic-only host-copy discriminator and one-arm production attribution.
+//! GPU resources here are isolated from inference; every bounded staging batch
+//! is submitted and drained outside its wall/copy timers before the next batch.
+use super::*;
+use crate::backend::gpu_native::{
+    CheckedPhysicalQ4ExpertSlot, GpuNativeQ4ExpertGeometry, PhysicalSlotObservation,
+};
+use crate::engine::GpuNativePhysicalInstallConcurrencyQualificationSnapshot as Snapshot;
+use rayon::prelude::*;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+
+pub(crate) const SCHEMA: &str = "mer.gpu-native-physical-staging-payload-copy.v1";
+pub(crate) const MODE: &str = "diagnose-gpu-native-physical-staging-payload-copy";
+const WIDTHS: [usize; 4] = [1, 2, 4, 8];
+const PAYLOAD: usize = 2_654_208;
+const STRIDE: usize = 2_654_212;
+const OFFSET: usize = 4;
+const MATERIALITY: f64 = 0.10;
+const MAX_ITERATIONS: usize = 1000;
+
+type DiagnosticResult<T> = Result<T, String>;
+
+#[derive(Clone, Debug)]
+pub(crate) struct Args {
+    pub(crate) common: CommandArgs,
+    pub(crate) standalone_only: bool,
+    pub(crate) iterations: usize,
+    pub(crate) warmup_iterations: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct Geometry {
+    payload_offset_bytes: usize,
+    payload_bytes: usize,
+    slot_stride_bytes: usize,
+    tail_padding_bytes: usize,
+}
+
+fn geometry() -> DiagnosticResult<(GpuNativeQ4ExpertGeometry, Geometry)> {
+    let g = GpuNativeQ4ExpertGeometry::try_new(2048, 768, 128, 8).map_err(|e| e.to_string())?;
+    let end = g
+        .payload_offset_bytes()
+        .checked_add(g.logical_expert_bytes())
+        .ok_or("geometry overflow")?;
+    let tail = g
+        .slot_stride_bytes()
+        .checked_sub(end)
+        .ok_or("geometry coverage underflow")?;
+    if (
+        g.payload_offset_bytes(),
+        g.logical_expert_bytes(),
+        g.slot_stride_bytes(),
+        tail,
+    ) != (OFFSET, PAYLOAD, STRIDE, 0)
+    {
+        return Err("frozen geometry mismatch".into());
+    }
+    Ok((
+        g,
+        Geometry {
+            payload_offset_bytes: OFFSET,
+            payload_bytes: PAYLOAD,
+            slot_stride_bytes: STRIDE,
+            tail_padding_bytes: tail,
+        },
+    ))
+}
+
+/// Versioned, platform-independent byte sequence; no randomness or model data.
+fn payload() -> Vec<u8> {
+    (0..PAYLOAD)
+        .map(|i| ((i as u64 * 131 + (i as u64 >> 8) * 17 + 29) & 255) as u8)
+        .collect()
+}
+
+fn add(a: u64, b: u64) -> DiagnosticResult<u64> {
+    a.checked_add(b)
+        .ok_or_else(|| "timing/byte accounting overflow".into())
+}
+fn ns(d: Duration) -> DiagnosticResult<u64> {
+    u64::try_from(d.as_nanos()).map_err(|_| "duration overflow".into())
+}
+fn gbps(bytes: u64, nanos: u64) -> Option<f64> {
+    (nanos != 0).then(|| bytes as f64 / nanos as f64)
+}
+fn ratio(a: f64, b: f64) -> Option<f64> {
+    (a.is_finite() && b.is_finite() && b > 0.0).then(|| a / b)
+}
+
+#[derive(Default)]
+struct Active {
+    jobs: AtomicUsize,
+    max: AtomicUsize,
+}
+struct Job<'a>(&'a Active);
+impl Active {
+    fn enter(&self) -> Job<'_> {
+        let n = self.jobs.fetch_add(1, Ordering::AcqRel) + 1;
+        self.max.fetch_max(n, Ordering::Relaxed);
+        Job(self)
+    }
+}
+impl Drop for Job<'_> {
+    fn drop(&mut self) {
+        self.0.jobs.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct JobTimes {
+    copy_ns: u64,
+    validation_ns: u64,
+    epoch_ns: u64,
+    acquire_ns: u64,
+    drop_ns: u64,
+}
+impl JobTimes {
+    fn observed(o: PhysicalSlotObservation) -> DiagnosticResult<Self> {
+        Ok(Self {
+            copy_ns: ns(o.payload_copy)?,
+            validation_ns: ns(o.validation)?,
+            epoch_ns: ns(o.epoch_write)?,
+            ..Self::default()
+        })
+    }
+}
+
+/// Destination storage is supplied by the caller. There are no allocations in
+/// the observed fill or its timed copy; the exact production coverage check is
+/// shared. black_box is outside all subphase timers.
+fn ram_copy(
+    g: GpuNativeQ4ExpertGeometry,
+    source: &[u8],
+    destination: &mut [u8],
+) -> DiagnosticResult<JobTimes> {
+    let checked = CheckedPhysicalQ4ExpertSlot::new(g, 0, 1, source).map_err(|e| e.to_string())?;
+    let observed = checked
+        .fill_complete_overwrite_no_zero_observed(destination)
+        .map_err(|e| e.to_string())?;
+    std::hint::black_box(destination);
+    JobTimes::observed(observed)
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct Batch {
+    iteration: usize,
+    operations: u64,
+    payload_bytes: u64,
+    sum_individual_copy_ns: u64,
+    sum_individual_copy_us: f64,
+    validation_us: f64,
+    epoch_write_us: f64,
+    wall_ns: u64,
+    wall_us: f64,
+    view_acquisition_us: f64,
+    view_drop_scheduling_us: f64,
+    submit_and_drain_us: f64,
+    max_simultaneous_jobs_observed: usize,
+    failures: Vec<String>,
+    accounting_errors: Vec<String>,
+}
+
+/// Exactly one job per supplied destination; inline singleton and shared
+/// process-wide Rayon for wider batches, matching physical staging's style.
+fn batch<T: Send, F>(iteration: usize, destinations: &mut [T], job: F) -> Batch
+where
+    F: Fn(usize, &mut T) -> DiagnosticResult<JobTimes> + Sync + Send,
+{
+    let active = Active::default();
+    let run = |(i, destination): (usize, &mut T)| {
+        let _guard = active.enter();
+        job(i, destination)
+    };
+    let started = Instant::now();
+    let results: Vec<_> = if destinations.len() == 1 {
+        destinations.iter_mut().enumerate().map(run).collect()
+    } else {
+        destinations.par_iter_mut().enumerate().map(run).collect()
+    };
+    let wall = started.elapsed();
+    let mut b = Batch {
+        iteration,
+        operations: 0,
+        payload_bytes: 0,
+        sum_individual_copy_ns: 0,
+        sum_individual_copy_us: 0.0,
+        validation_us: 0.0,
+        epoch_write_us: 0.0,
+        wall_ns: 0,
+        wall_us: 0.0,
+        view_acquisition_us: 0.0,
+        view_drop_scheduling_us: 0.0,
+        submit_and_drain_us: 0.0,
+        max_simultaneous_jobs_observed: active.max.load(Ordering::Relaxed),
+        failures: vec![],
+        accounting_errors: vec![],
+    };
+    let mut validation = 0;
+    let mut epoch = 0;
+    let mut acquire = 0;
+    let mut drop_time = 0;
+    let accounting = (|| -> DiagnosticResult<()> {
+        b.wall_ns = ns(wall)?;
+        for result in results {
+            match result {
+                Err(e) => b.failures.push(e),
+                Ok(t) => {
+                    b.operations = add(b.operations, 1)?;
+                    b.payload_bytes = add(b.payload_bytes, PAYLOAD as u64)?;
+                    b.sum_individual_copy_ns = add(b.sum_individual_copy_ns, t.copy_ns)?;
+                    validation = add(validation, t.validation_ns)?;
+                    epoch = add(epoch, t.epoch_ns)?;
+                    acquire = add(acquire, t.acquire_ns)?;
+                    drop_time = add(drop_time, t.drop_ns)?;
+                }
+            }
+        }
+        if active.jobs.load(Ordering::Relaxed) != 0
+            || b.max_simultaneous_jobs_observed > destinations.len()
+        {
+            return Err("active staging jobs exceeded requested width or leaked".into());
+        }
+        Ok(())
+    })();
+    if let Err(e) = accounting {
+        b.accounting_errors.push(e);
+    }
+    b.wall_us = b.wall_ns as f64 / 1000.0;
+    b.sum_individual_copy_us = b.sum_individual_copy_ns as f64 / 1000.0;
+    b.validation_us = validation as f64 / 1000.0;
+    b.epoch_write_us = epoch as f64 / 1000.0;
+    b.view_acquisition_us = acquire as f64 / 1000.0;
+    b.view_drop_scheduling_us = drop_time as f64 / 1000.0;
+    b
+}
+
+#[derive(Debug, Serialize)]
+struct Case {
+    destination: &'static str,
+    width: usize,
+    operations: u64,
+    bytes_per_operation: usize,
+    total_payload_bytes: u64,
+    sum_individual_copy_us: f64,
+    batch_iteration_wall_us: f64,
+    effective_aggregate_gbps_from_wall: Option<f64>,
+    effective_summed_copy_gbps: Option<f64>,
+    view_acquisition_us: Option<f64>,
+    view_drop_scheduling_us: Option<f64>,
+    epoch_write_us: f64,
+    validation_us: f64,
+    submit_and_drain_us: Option<f64>,
+    max_simultaneous_jobs_observed: usize,
+    failures: Vec<String>,
+    accounting_errors: Vec<String>,
+    destination_payload_sha256: Option<String>,
+    batches: Vec<Batch>,
+}
+
+fn summarize(
+    destination: &'static str,
+    width: usize,
+    batches: Vec<Batch>,
+    checksum: Option<String>,
+) -> DiagnosticResult<Case> {
+    let mut ops = 0;
+    let mut bytes = 0;
+    let mut copy = 0;
+    let mut wall = 0;
+    for b in &batches {
+        ops = add(ops, b.operations)?;
+        bytes = add(bytes, b.payload_bytes)?;
+        copy = add(copy, b.sum_individual_copy_ns)?;
+        wall = add(wall, b.wall_ns)?;
+    }
+    let staging = destination == "wgpu-staging-view";
+    let mut c = Case {
+        destination,
+        width,
+        operations: ops,
+        bytes_per_operation: PAYLOAD,
+        total_payload_bytes: bytes,
+        sum_individual_copy_us: copy as f64 / 1000.0,
+        batch_iteration_wall_us: wall as f64 / 1000.0,
+        effective_aggregate_gbps_from_wall: gbps(bytes, wall),
+        effective_summed_copy_gbps: gbps(bytes, copy),
+        view_acquisition_us: staging.then(|| batches.iter().map(|b| b.view_acquisition_us).sum()),
+        view_drop_scheduling_us: staging
+            .then(|| batches.iter().map(|b| b.view_drop_scheduling_us).sum()),
+        epoch_write_us: batches.iter().map(|b| b.epoch_write_us).sum(),
+        validation_us: batches.iter().map(|b| b.validation_us).sum(),
+        submit_and_drain_us: staging.then(|| batches.iter().map(|b| b.submit_and_drain_us).sum()),
+        max_simultaneous_jobs_observed: batches
+            .iter()
+            .map(|b| b.max_simultaneous_jobs_observed)
+            .max()
+            .unwrap_or(0),
+        failures: batches.iter().flat_map(|b| b.failures.clone()).collect(),
+        accounting_errors: batches
+            .iter()
+            .flat_map(|b| b.accounting_errors.clone())
+            .collect(),
+        destination_payload_sha256: checksum,
+        batches,
+    };
+    if (width as u64).checked_mul(c.batches.len() as u64) != Some(ops)
+        || ops.checked_mul(PAYLOAD as u64) != Some(bytes)
+        || c.max_simultaneous_jobs_observed > width
+    {
+        c.accounting_errors
+            .push("operations/bytes/width mismatch".into());
+    }
+    if copy == 0 || wall == 0 {
+        c.accounting_errors
+            .push("zero elapsed time cannot define throughput".into());
+    }
+    Ok(c)
+}
+
+#[derive(Debug, Serialize)]
+struct WidthComparison {
+    width: usize,
+    wgpu_to_ram_summed_copy_gbps_ratio: Option<f64>,
+    wgpu_to_ram_wall_gbps_ratio: Option<f64>,
+    paired_copy_gbps_ratios: Vec<f64>,
+    paired_ratio_p10: Option<f64>,
+    paired_ratio_p90: Option<f64>,
+}
+fn comparison_for(r: &Case, w: &Case) -> WidthComparison {
+    let ratios: Vec<f64> = r
+        .batches
+        .iter()
+        .zip(&w.batches)
+        .filter_map(|(r, w)| {
+            if r.operations != w.operations || !r.failures.is_empty() || !w.failures.is_empty() {
+                return None;
+            }
+            ratio(
+                gbps(w.payload_bytes, w.sum_individual_copy_ns)?,
+                gbps(r.payload_bytes, r.sum_individual_copy_ns)?,
+            )
+        })
+        .collect();
+    let mut sorted = ratios.clone();
+    sorted.sort_by(f64::total_cmp);
+    let percentile = |p: f64| {
+        (!sorted.is_empty()).then(|| sorted[((sorted.len() - 1) as f64 * p).ceil() as usize])
+    };
+    WidthComparison {
+        width: r.width,
+        wgpu_to_ram_summed_copy_gbps_ratio: w
+            .effective_summed_copy_gbps
+            .zip(r.effective_summed_copy_gbps)
+            .and_then(|(a, b)| ratio(a, b)),
+        wgpu_to_ram_wall_gbps_ratio: w
+            .effective_aggregate_gbps_from_wall
+            .zip(r.effective_aggregate_gbps_from_wall)
+            .and_then(|(a, b)| ratio(a, b)),
+        paired_ratio_p10: percentile(0.1),
+        paired_ratio_p90: percentile(0.9),
+        paired_copy_gbps_ratios: ratios,
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct AdapterIdentity {
+    name: String,
+    vendor: u32,
+    device: u32,
+    device_type: String,
+    backend: String,
+    driver: String,
+    driver_info: String,
+}
+#[derive(Debug, Serialize)]
+struct Standalone {
+    adapter: AdapterIdentity,
+    authoritative_l4: bool,
+    rayon_num_threads: usize,
+    max_pending_staging_writes: usize,
+    max_pending_staging_bytes: usize,
+    source_pattern: &'static str,
+    source_payload_sha256: String,
+    warmup_iterations_per_width_and_destination: usize,
+    measured_iterations_per_width_and_destination: usize,
+    order: &'static str,
+    wall_definition: &'static str,
+    ram: Vec<Case>,
+    wgpu_staging: Vec<Case>,
+    comparisons: Vec<WidthComparison>,
+}
+
+async fn standalone(args: &Args) -> DiagnosticResult<Standalone> {
+    let (g, _) = geometry()?;
+    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+        backends: if args.common.expected_adapter_name == "NVIDIA L4" {
+            wgpu::Backends::VULKAN
+        } else {
+            wgpu::Backends::all()
+        },
+        ..Default::default()
+    });
+    let adapter = instance
+        .enumerate_adapters(wgpu::Backends::all())
+        .into_iter()
+        .find(|a| a.get_info().name == args.common.expected_adapter_name)
+        .ok_or_else(|| {
+            format!(
+                "expected adapter {:?} unavailable",
+                args.common.expected_adapter_name
+            )
+        })?;
+    let info = adapter.get_info();
+    let authoritative_l4 = cfg!(target_os = "linux")
+        && info.name == "NVIDIA L4"
+        && info.vendor == 0x10de
+        && info.device_type == wgpu::DeviceType::DiscreteGpu
+        && info.backend == wgpu::Backend::Vulkan;
+    if !args.standalone_only && !authoritative_l4 {
+        return Err("real inference attribution requires Linux NVIDIA L4/Vulkan".into());
+    }
+    let (device, queue) = adapter
+        .request_device(
+            &wgpu::DeviceDescriptor {
+                label: Some(MODE),
+                required_features: wgpu::Features::empty(),
+                required_limits: wgpu::Limits::default(),
+            },
+            None,
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+    let gpu_errors = Arc::new(parking_lot::Mutex::new(Vec::<String>::new()));
+    let errors = gpu_errors.clone();
+    device.on_uncaptured_error(Box::new(move |error| errors.lock().push(error.to_string())));
+    let source = payload();
+    let source_hash = crate::greedy_parity::sha256_hex(&source);
+    let max_bytes = STRIDE
+        .checked_mul(*WIDTHS.last().unwrap())
+        .ok_or("bounded memory overflow")?;
+    let target = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("payload-copy-diagnostic-only"),
+        size: u64::try_from(max_bytes).map_err(|_| "buffer size overflow")?,
+        usage: wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+    let mut result = Standalone {
+        adapter: AdapterIdentity { name: info.name, vendor: info.vendor, device: info.device, device_type: format!("{:?}", info.device_type), backend: format!("{:?}", info.backend), driver: info.driver, driver_info: info.driver_info },
+        authoritative_l4, rayon_num_threads: rayon::current_num_threads(), max_pending_staging_writes: 8,
+        max_pending_staging_bytes: max_bytes, source_pattern: "v1: byte[i] = (i*131 + (i>>8)*17 + 29) mod 256",
+        source_payload_sha256: source_hash.clone(), warmup_iterations_per_width_and_destination: args.warmup_iterations,
+        measured_iterations_per_width_and_destination: args.iterations,
+        order: "alternate RAM-first and WGPU-first by iteration at each ascending width; warmups excluded",
+        wall_definition: "host job dispatch/join plus validation, epoch, copy and (WGPU only) acquisition/drop; excludes buffer allocation, checksum, submit and drain; GB/s is decimal host throughput, not DMA bandwidth",
+        ram: vec![], wgpu_staging: vec![], comparisons: vec![],
+    };
+    for width in WIDTHS {
+        let mut ram = vec![vec![0xa5; STRIDE]; width];
+        let mut slots = vec![(); width];
+        let mut ram_batches = Vec::with_capacity(args.iterations);
+        let mut wgpu_batches = Vec::with_capacity(args.iterations);
+        let iterations = args
+            .warmup_iterations
+            .checked_add(args.iterations)
+            .ok_or("iteration overflow")?;
+        for iteration in 0..iterations {
+            for ram_first in if iteration % 2 == 0 {
+                [true, false]
+            } else {
+                [false, true]
+            } {
+                let mut b = if ram_first {
+                    batch(iteration, &mut ram, |_, destination| {
+                        ram_copy(g, &source, destination)
+                    })
+                } else {
+                    batch(iteration, &mut slots, |i, _| {
+                        let checked = CheckedPhysicalQ4ExpertSlot::new(g, 0, 1, &source)
+                            .map_err(|e| e.to_string())?;
+                        let offset = i
+                            .checked_mul(STRIDE)
+                            .and_then(|v| u64::try_from(v).ok())
+                            .ok_or("offset overflow")?;
+                        let started = Instant::now();
+                        let mut view = queue
+                            .write_buffer_with(
+                                &target,
+                                offset,
+                                wgpu::BufferSize::new(STRIDE as u64).unwrap(),
+                            )
+                            .ok_or("write_buffer_with unavailable")?;
+                        let acquire_ns = ns(started.elapsed())?;
+                        let observed =
+                            checked.fill_complete_overwrite_no_zero_observed(view.as_mut());
+                        let started = Instant::now();
+                        drop(view);
+                        let drop_ns = ns(started.elapsed())?;
+                        let mut times = JobTimes::observed(observed.map_err(|e| e.to_string())?)?;
+                        times.acquire_ns = acquire_ns;
+                        times.drop_ns = drop_ns;
+                        Ok(times)
+                    })
+                };
+                if ram_first {
+                    // Observable, full byte-level check after every RAM phase,
+                    // outside the wall and copy timers, without a GPU readback.
+                    for destination in &ram {
+                        if &destination[..OFFSET] != 1u32.to_le_bytes().as_slice()
+                            || crate::greedy_parity::sha256_hex(&destination[OFFSET..])
+                                != source_hash
+                        {
+                            b.failures.push("RAM destination content mismatch".into());
+                        }
+                    }
+                } else {
+                    // This isolated queue holds <= width scheduled writes. Drain
+                    // every batch, including failed/warmup batches, before reuse.
+                    let started = Instant::now();
+                    let submission = queue.submit(std::iter::empty());
+                    device.poll(wgpu::Maintain::WaitForSubmissionIndex(submission));
+                    b.submit_and_drain_us = ns(started.elapsed())? as f64 / 1000.0;
+                    b.failures.extend(gpu_errors.lock().drain(..));
+                }
+                if iteration < args.warmup_iterations {
+                    if !b.failures.is_empty() || !b.accounting_errors.is_empty() {
+                        return Err(format!(
+                            "warmup failed: {:?} {:?}",
+                            b.failures, b.accounting_errors
+                        ));
+                    }
+                } else if ram_first {
+                    ram_batches.push(b);
+                } else {
+                    wgpu_batches.push(b);
+                }
+            }
+        }
+        let r = summarize("plain-ram", width, ram_batches, Some(source_hash.clone()))?;
+        let w = summarize("wgpu-staging-view", width, wgpu_batches, None)?;
+        result.comparisons.push(comparison_for(&r, &w));
+        result.ram.push(r);
+        result.wgpu_staging.push(w);
+    }
+    Ok(result)
+}
+
+#[derive(Debug, Serialize)]
+struct ProductionTotals {
+    install_count: u64,
+    payload_bytes_copied: u64,
+    epoch_bytes_written: u64,
+    staged_bytes: u64,
+    physical_slot_validation_us: u64,
+    physical_slot_epoch_write_us: u64,
+    physical_slot_payload_copy_us: u64,
+    physical_slot_prepare_us: u64,
+    physical_queue_staging_us: u64,
+    physical_slot_prepare_residual_us: u64,
+    payload_copy_effective_gbps: Option<f64>,
+    payload_copy_share_of_prepare: Option<f64>,
+    residual_share_of_prepare: Option<f64>,
+    subphase_observations: u64,
+    accounting_valid: bool,
+}
+fn production_totals(s: &Snapshot) -> ProductionTotals {
+    let parts = s
+        .physical_slot_validation_us
+        .checked_add(s.physical_slot_epoch_write_us)
+        .and_then(|v| v.checked_add(s.physical_slot_payload_copy_us));
+    ProductionTotals {
+        install_count: s.physical_install_completions,
+        payload_bytes_copied: s.physical_slot_payload_copy_bytes,
+        epoch_bytes_written: s.physical_slot_epoch_write_bytes,
+        staged_bytes: s.physical_slot_bytes_staged,
+        physical_slot_validation_us: s.physical_slot_validation_us,
+        physical_slot_epoch_write_us: s.physical_slot_epoch_write_us,
+        physical_slot_payload_copy_us: s.physical_slot_payload_copy_us,
+        physical_slot_prepare_us: s.physical_slot_prepare_us,
+        physical_queue_staging_us: s.physical_queue_staging_us,
+        physical_slot_prepare_residual_us: s.physical_slot_prepare_residual_us,
+        payload_copy_effective_gbps: ratio(
+            s.physical_slot_payload_copy_bytes as f64,
+            s.physical_slot_payload_copy_us as f64 * 1000.0,
+        ),
+        payload_copy_share_of_prepare: ratio(
+            s.physical_slot_payload_copy_us as f64,
+            s.physical_slot_prepare_us as f64,
+        ),
+        residual_share_of_prepare: ratio(
+            s.physical_slot_prepare_residual_us as f64,
+            s.physical_slot_prepare_us as f64,
+        ),
+        subphase_observations: s.physical_slot_subphase_observations,
+        accounting_valid: s.physical_install_completions > 0
+            && s.physical_slot_subphase_observations == s.physical_install_completions
+            && zero_fill_production::bytes_exact(s)
+            && zero_fill_production::failures_zero(s)
+            && zero_fill_production::timing_accounting_exact(s)
+            && parts.and_then(|v| v.checked_add(s.physical_slot_prepare_residual_us))
+                == Some(s.physical_slot_prepare_us),
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct RealInference {
+    frozen_workload: FrozenWorkload,
+    provenance: BenchmarkProvenance,
+    production_arm: ConcurrencyArmReport,
+    warmup_attribution: Option<ProductionTotals>,
+    measured_production_attribution: Option<ProductionTotals>,
+    accounting_valid: bool,
+}
+fn phase_valid(
+    s: Option<&Snapshot>,
+    p: Option<&GpuNativeProductionPhysicalInstallSnapshot>,
+    w: Option<&ArmWorkEvidence>,
+    source: Option<&ProductionDemandSourceSnapshot>,
+) -> bool {
+    match (s, p, w, source) {
+        (Some(s), Some(p), Some(w), Some(source)) => production_totals(s).accounting_valid
+            && s.arm == crate::engine::GpuNativePhysicalInstallConcurrencyQualificationArm::ProductionNoZeroFillTreatment
+            && s.treatment_uses_ordinary_production_path && s.physical_slot_zero_fill_bytes == 0
+            && s.full_slot_vec_materializations == 0
+            && zero_fill_production::install_accounting_exact(s, p)
+            && zero_fill_production::work_errors_zero(w) && production_safety_zero(source)
+            && s.physical_install_completions == w.gpu_native_residency.ram_to_vram_installs,
+        _ => false,
+    }
+}
+async fn real_inference(args: &Args) -> Result<RealInference, Box<dyn std::error::Error>> {
+    if args.common.expected_adapter_name != "NVIDIA L4" || !cfg!(target_os = "linux") {
+        return Err("frozen real attribution requires Linux and exact NVIDIA L4".into());
+    }
+    let prepared = prepare(&args.common)?;
+    if prepared.spec.cfg.gpu_cache.vram_capacity_mb != 2048 {
+        return Err("frozen real attribution requires 2 GiB managed expert VRAM".into());
+    }
+    let run = run_physical_install_arm_inner(
+        &prepared,
+        &args.common,
+        PhysicalInstallQualificationRun::ZeroFillProduction(
+            crate::engine::GpuNativePhysicalInstallConcurrencyQualificationArm::ProductionNoZeroFillTreatment,
+        ),
+        Some(MODE),
+    )
+    .await?;
+    let production_arm = ConcurrencyArmReport {
+        common: run.common,
+        warmup_mechanism: run.warmup_concurrency,
+        mechanism: run.concurrency,
+    };
+    let warmup_attribution = production_arm
+        .warmup_mechanism
+        .as_ref()
+        .map(production_totals);
+    let measured_production_attribution = production_arm.mechanism.as_ref().map(production_totals);
+    let c = &production_arm.common;
+    let accounting_valid = c.complete
+        && c.failure.is_none()
+        && c.warmup_results.len() == FROZEN_WARMUP_RUNS
+        && c.warmup_results
+            .iter()
+            .all(|r| r.generated_tokens == FROZEN_OUTPUT_TOKENS)
+        && generated_results(c).len() == FROZEN_MEASURED_RUNS
+        && generated_results(c)
+            .iter()
+            .all(|r| r.generated_tokens == FROZEN_OUTPUT_TOKENS)
+        && phase_valid(
+            production_arm.warmup_mechanism.as_ref(),
+            c.warmup_production_physical_install.as_ref(),
+            c.warmup_work.as_ref(),
+            c.warmup_production.as_ref(),
+        )
+        && phase_valid(
+            production_arm.mechanism.as_ref(),
+            c.production_physical_install.as_ref(),
+            c.work.as_ref(),
+            c.production.as_ref(),
+        );
+    Ok(RealInference {
+        frozen_workload: frozen_workload(args.common.expected_adapter_name.clone()),
+        provenance: prepared.provenance,
+        production_arm,
+        warmup_attribution,
+        measured_production_attribution,
+        accounting_valid,
+    })
+}
+
+fn classify(s: &Standalone, real: Option<&ProductionTotals>) -> &'static str {
+    if s.ram
+        .iter()
+        .chain(&s.wgpu_staging)
+        .any(|c| !c.failures.is_empty() || !c.accounting_errors.is_empty())
+    {
+        return "no-clear-discriminator";
+    }
+    if s.comparisons.len() != WIDTHS.len()
+        || s.comparisons
+            .iter()
+            .any(|c| c.paired_copy_gbps_ratios.len() < 10)
+    {
+        return "no-clear-discriminator";
+    }
+    // Demand a >=10% difference even at paired p90, at >=3 of 4 widths,
+    // with at least 10 paired iterations. Raw batches remain authoritative.
+    if s.comparisons
+        .iter()
+        .filter(|c| {
+            c.paired_copy_gbps_ratios.len() >= 10
+                && c.paired_ratio_p90.is_some_and(|r| r <= 1.0 - MATERIALITY)
+                && c.wgpu_to_ram_summed_copy_gbps_ratio
+                    .is_some_and(|r| r <= 1.0 - MATERIALITY)
+        })
+        .count()
+        >= 3
+    {
+        return "staging-view-memory-slower-than-ram";
+    }
+    let similar = s.comparisons.iter().all(|c| {
+        c.paired_ratio_p10.is_some_and(|r| r >= 1.0 - MATERIALITY)
+            && c.paired_ratio_p90.is_some_and(|r| r <= 1.0 + MATERIALITY)
+            && c.wgpu_to_ram_summed_copy_gbps_ratio
+                .is_some_and(|r| (1.0 - MATERIALITY..=1.0 + MATERIALITY).contains(&r))
+    });
+    let scaling = |cases: &[Case]| {
+        cases.first().zip(cases.last()).and_then(|(a, b)| {
+            ratio(
+                b.effective_aggregate_gbps_from_wall?,
+                a.effective_aggregate_gbps_from_wall?,
+            )
+        })
+    };
+    if similar
+        && s.wgpu_staging
+            .last()
+            .is_some_and(|c| c.max_simultaneous_jobs_observed >= 2)
+        && scaling(&s.wgpu_staging).is_some_and(|r| r >= 1.25)
+        && scaling(&s.ram).is_some_and(|r| r >= 1.25)
+    {
+        return "concurrency-amortization-dominant";
+    }
+    if similar
+        && real.is_some_and(|r| {
+            r.accounting_valid && r.payload_copy_share_of_prepare.is_some_and(|r| r >= 0.8)
+        })
+    {
+        return "host-memcpy-bandwidth-dominant";
+    }
+    "no-clear-discriminator"
+}
+
+#[derive(Debug, Serialize)]
+struct Report {
+    schema: &'static str,
+    mode: &'static str,
+    diagnostic_only: bool,
+    build_provenance: BuildProvenance,
+    tree_sha: Option<String>,
+    tree_sha_note: &'static str,
+    executable_identity: Option<(PathBuf, String)>,
+    geometry: Option<Geometry>,
+    requested_widths: [usize; 4],
+    standalone_only: bool,
+    materiality_threshold_fraction: f64,
+    classification_rule: &'static str,
+    timing_definition: &'static str,
+    standalone: Option<Standalone>,
+    real_inference: Option<RealInference>,
+    complete: bool,
+    failures: Vec<String>,
+    diagnostic_classification: &'static str,
+}
+
+pub(crate) async fn run_command(args: Args) -> Result<(), Box<dyn std::error::Error>> {
+    let mut report = Report {
+        schema: SCHEMA, mode: MODE, diagnostic_only: true, build_provenance: BuildProvenance::embedded(),
+        tree_sha: None, tree_sha_note: "existing embedded build provenance does not supply a tree SHA",
+        executable_identity: None, geometry: None, requested_widths: WIDTHS, standalone_only: args.standalone_only,
+        materiality_threshold_fraction: MATERIALITY,
+        classification_rule: "priority: staging slower if aggregate ratio and paired p90 <=0.90 at >=3 widths with >=10 pairs; all classifications need >=10 pairs per width; else concurrency if all aggregate and paired p10/p90 copy ratios in [0.90,1.10] and both width8/width1 wall throughputs >=1.25; else host memcpy if ratios similar and valid real copy share >=0.80; else unclear. This is descriptive evidence, not proof of memory type or an optimization recommendation; raw measurements are authoritative.",
+        timing_definition: "production validation includes original checked-writer pre-view preparation plus shared coverage validation; prepare retains historical outer timing. residual=prepare-(validation+epoch+payload), checked; accounting error on underflow/overflow. Production integer microseconds truncate each install subphase (especially epoch); residual includes timer overhead and truncation. Standalone retains nanoseconds and reports fractional microseconds. Decode TPS cannot affect diagnostic completeness.",
+        standalone: None, real_inference: None, complete: false, failures: vec![], diagnostic_classification: "no-clear-discriminator",
+    };
+    let result: Result<(), Box<dyn std::error::Error>> = async {
+        if !(1..=MAX_ITERATIONS).contains(&args.iterations) || !(1..=100).contains(&args.warmup_iterations) {
+            return Err("iterations must be 1..=1000 and warmup-iterations 1..=100".into());
+        }
+        report.geometry = Some(geometry()?.1);
+        report.executable_identity = Some(crate::current_executable_identity()?);
+        report.standalone = Some(standalone(&args).await?);
+        if report.standalone.as_ref().unwrap().ram.iter().chain(&report.standalone.as_ref().unwrap().wgpu_staging)
+            .any(|c| !c.failures.is_empty() || !c.accounting_errors.is_empty()) { return Err("standalone copy failures/accounting errors; see cases".into()); }
+        if !args.standalone_only {
+            report.real_inference = Some(real_inference(&args).await?);
+            if !report.real_inference.as_ref().unwrap().accounting_valid { return Err("real production attribution incomplete or accounting invalid; see arm evidence".into()); }
+        }
+        report.diagnostic_classification = classify(report.standalone.as_ref().unwrap(), report.real_inference.as_ref().and_then(|r| r.measured_production_attribution.as_ref()));
+        report.complete = true;
+        Ok(())
+    }.await;
+    if let Err(e) = &result {
+        report.failures.push(e.to_string());
+    }
+    emit_report(&report, &args.common.report_out)?;
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn payload_copy_contract_geometry_payload_identity_and_widths_are_frozen() {
+        assert_eq!(SCHEMA, "mer.gpu-native-physical-staging-payload-copy.v1");
+        assert_eq!(WIDTHS, [1, 2, 4, 8]);
+        let (_, g) = geometry().unwrap();
+        assert_eq!(
+            (
+                g.payload_offset_bytes,
+                g.payload_bytes,
+                g.slot_stride_bytes,
+                g.tail_padding_bytes
+            ),
+            (4, 2_654_208, 2_654_212, 0)
+        );
+        let source = payload();
+        assert_eq!(source.len(), PAYLOAD);
+        assert_eq!(
+            crate::greedy_parity::sha256_hex(&source),
+            "08a90a4f167d260eea22683314fc19b72d06b5420c01188e5c7e765e09219336"
+        );
+    }
+
+    #[test]
+    fn payload_copy_ram_reuses_preallocated_destination_and_copy_has_no_allocator() {
+        let (g, _) = geometry().unwrap();
+        let source = payload();
+        let mut destination = vec![0xa5; STRIDE];
+        let ptr = destination.as_ptr();
+        let capacity = destination.capacity();
+        for _ in 0..3 {
+            ram_copy(g, &source, &mut destination).unwrap();
+            assert_eq!(destination.as_ptr(), ptr);
+            assert_eq!(destination.capacity(), capacity);
+            assert_eq!(&destination[..4], &1u32.to_le_bytes());
+            assert_eq!(&destination[4..], source.as_slice());
+        }
+        let backend = include_str!("backend/gpu_native.rs");
+        let observed = backend
+            .split("    pub(crate) fn fill_complete_overwrite_no_zero_observed(\n")
+            .nth(1)
+            .unwrap()
+            .split("\nfn validate_q4_expert_uploads")
+            .next()
+            .unwrap();
+        for forbidden in ["vec![", "Vec::", ".to_vec(", ".resize(", "alloc("] {
+            assert!(!observed.contains(forbidden));
+        }
+        assert!(observed.contains(".copy_from_slice("));
+    }
+
+    #[test]
+    fn payload_copy_jobs_are_bounded_at_every_width_and_failures_join() {
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(8)
+            .build()
+            .unwrap();
+        for width in WIDTHS {
+            let mut destinations = vec![0; width];
+            let b = pool.install(|| {
+                batch(0, &mut destinations, |i, d| {
+                    *d = i + 1;
+                    std::thread::yield_now();
+                    Ok(JobTimes {
+                        copy_ns: 100,
+                        ..Default::default()
+                    })
+                })
+            });
+            assert_eq!(b.operations, width as u64);
+            assert!((1..=width).contains(&b.max_simultaneous_jobs_observed));
+            assert_eq!(destinations, (1..=width).collect::<Vec<_>>());
+            assert!(b.accounting_errors.is_empty());
+            let failed = pool.install(|| {
+                batch(1, &mut destinations, |i, _| {
+                    if i == 0 {
+                        Err("injected acquisition failure".into())
+                    } else {
+                        Ok(JobTimes::default())
+                    }
+                })
+            });
+            assert_eq!(failed.failures, ["injected acquisition failure"]);
+            assert_eq!(failed.operations, width as u64 - 1);
+            assert!(failed.max_simultaneous_jobs_observed <= width);
+        }
+    }
+
+    #[test]
+    fn payload_copy_aggregation_reports_overflow_and_work_mismatch() {
+        let mut slots = vec![(); 2];
+        let b = batch(0, &mut slots, |_, _| {
+            Ok(JobTimes {
+                copy_ns: u64::MAX,
+                ..Default::default()
+            })
+        });
+        assert!(!b.accounting_errors.is_empty());
+        let c = summarize("plain-ram", 4, vec![b], None).unwrap();
+        assert!(c
+            .accounting_errors
+            .iter()
+            .any(|e| e.contains("operations/bytes/width")));
+        assert!(add(u64::MAX, 1).is_err());
+        assert_eq!(gbps(2_654_208, 1_000_000), Some(2.654208));
+        assert!(gbps(1, 0).is_none());
+    }
+
+    fn production_fixture() -> Snapshot {
+        let mut s = crate::engine::empty_physical_zero_fill_test_snapshot(
+            crate::engine::GpuNativePhysicalInstallConcurrencyQualificationArm::ProductionNoZeroFillTreatment);
+        s.physical_install_completions = 3;
+        s.physical_slot_subphase_observations = 3;
+        s.physical_slot_epoch_write_bytes = 12;
+        s.physical_slot_payload_copy_bytes = 3 * PAYLOAD as u64;
+        s.physical_slot_bytes_staged = 3 * STRIDE as u64;
+        s.physical_bytes_staged = s.physical_slot_bytes_staged;
+        s.physical_slot_validation_us = 3;
+        s.physical_slot_epoch_write_us = 1;
+        s.physical_slot_payload_copy_us = 90;
+        s.physical_slot_prepare_residual_us = 6;
+        s.physical_slot_prepare_us = 100;
+        s.physical_queue_staging_us = 10;
+        s.sum_individual_physical_stage_us = 120;
+        s.physical_ordered_commit_us = 5;
+        s.physical_install_total_us = 125;
+        s
+    }
+
+    #[test]
+    fn payload_copy_production_totals_fail_closed_on_every_accounting_corruption() {
+        let s = production_fixture();
+        let totals = production_totals(&s);
+        assert!(totals.accounting_valid);
+        assert_eq!(totals.payload_copy_share_of_prepare, Some(0.9));
+        assert_eq!(totals.residual_share_of_prepare, Some(0.06));
+        for corrupt in [
+            (|s: &mut Snapshot| s.physical_slot_epoch_write_bytes += 1) as fn(&mut Snapshot),
+            |s| s.physical_slot_payload_copy_bytes += 1,
+            |s| s.physical_slot_bytes_staged += 1,
+            |s| s.physical_slot_subphase_observations -= 1,
+            |s| s.physical_slot_prepare_residual_us -= 1,
+            |s| s.physical_slot_payload_copy_us = u64::MAX,
+            |s| s.physical_install_completions = u64::MAX,
+            |s| s.timing_accounting_errors = 1,
+            |s| s.evidence_accounting_errors = 1,
+            |s| s.physical_slot_prepare_us = 1,
+        ] {
+            let mut bad = s.clone();
+            corrupt(&mut bad);
+            assert!(!production_totals(&bad).accounting_valid);
+        }
+    }
+
+    fn fixture(copy_ratio: f64, scaling: bool) -> Standalone {
+        let case = |width: usize, staging: bool| {
+            let copy = (1_000_000.0 * width as f64 / if staging { copy_ratio } else { 1.0 }) as u64;
+            let wall = if scaling {
+                2_000_000
+            } else {
+                2_000_000 * width as u64
+            };
+            let batches = (0..20)
+                .map(|iteration| Batch {
+                    iteration,
+                    operations: width as u64,
+                    payload_bytes: PAYLOAD as u64 * width as u64,
+                    sum_individual_copy_ns: copy,
+                    sum_individual_copy_us: copy as f64 / 1000.0,
+                    validation_us: 0.0,
+                    epoch_write_us: 0.0,
+                    wall_ns: wall,
+                    wall_us: wall as f64 / 1000.0,
+                    view_acquisition_us: 0.0,
+                    view_drop_scheduling_us: 0.0,
+                    submit_and_drain_us: 0.0,
+                    max_simultaneous_jobs_observed: width,
+                    failures: vec![],
+                    accounting_errors: vec![],
+                })
+                .collect();
+            summarize(
+                if staging {
+                    "wgpu-staging-view"
+                } else {
+                    "plain-ram"
+                },
+                width,
+                batches,
+                None,
+            )
+            .unwrap()
+        };
+        let ram: Vec<_> = WIDTHS.into_iter().map(|w| case(w, false)).collect();
+        let wgpu_staging: Vec<_> = WIDTHS.into_iter().map(|w| case(w, true)).collect();
+        let comparisons = ram
+            .iter()
+            .zip(&wgpu_staging)
+            .map(|(r, w)| comparison_for(r, w))
+            .collect();
+        Standalone {
+            adapter: AdapterIdentity {
+                name: "synthetic".into(),
+                vendor: 0,
+                device: 0,
+                device_type: "synthetic".into(),
+                backend: "synthetic".into(),
+                driver: "".into(),
+                driver_info: "".into(),
+            },
+            authoritative_l4: false,
+            rayon_num_threads: 8,
+            max_pending_staging_writes: 8,
+            max_pending_staging_bytes: STRIDE * 8,
+            source_pattern: "synthetic",
+            source_payload_sha256: "".into(),
+            warmup_iterations_per_width_and_destination: 3,
+            measured_iterations_per_width_and_destination: 20,
+            order: "synthetic",
+            wall_definition: "synthetic",
+            ram,
+            wgpu_staging,
+            comparisons,
+        }
+    }
+
+    #[test]
+    fn payload_copy_classification_is_material_conservative_and_failure_sensitive() {
+        assert_eq!(
+            classify(&fixture(0.8, false), None),
+            "staging-view-memory-slower-than-ram"
+        );
+        assert_eq!(
+            classify(&fixture(0.95, false), None),
+            "no-clear-discriminator"
+        );
+        assert_eq!(
+            classify(&fixture(1.0, true), None),
+            "concurrency-amortization-dominant"
+        );
+        let totals = production_totals(&production_fixture());
+        assert_eq!(
+            classify(&fixture(1.0, false), Some(&totals)),
+            "host-memcpy-bandwidth-dominant"
+        );
+        let mut failed = fixture(0.8, false);
+        failed.wgpu_staging[0].failures.push("injected".into());
+        assert_eq!(classify(&failed, Some(&totals)), "no-clear-discriminator");
+        let mut noisy = fixture(0.8, false);
+        for c in &mut noisy.comparisons {
+            c.paired_ratio_p90 = Some(1.01);
+        }
+        assert_eq!(classify(&noisy, None), "no-clear-discriminator");
+    }
+}

--- a/rust-engine/src/gpu_native_physical_zero_fill_production.rs
+++ b/rust-engine/src/gpu_native_physical_zero_fill_production.rs
@@ -36,7 +36,10 @@ struct PairMechanismGate {
     passed: bool,
 }
 
-fn install_accounting_exact(s: &Snapshot, p: &GpuNativeProductionPhysicalInstallSnapshot) -> bool {
+pub(super) fn install_accounting_exact(
+    s: &Snapshot,
+    p: &GpuNativeProductionPhysicalInstallSnapshot,
+) -> bool {
     let installs = s.physical_install_completions;
     installs > 0
         && production_concurrency_exercised(p)
@@ -71,7 +74,7 @@ fn install_accounting_exact(s: &Snapshot, p: &GpuNativeProductionPhysicalInstall
         && s.max_in_flight_physical_staging >= 2
 }
 
-fn bytes_exact(s: &Snapshot) -> bool {
+pub(super) fn bytes_exact(s: &Snapshot) -> bool {
     let installs = s.physical_install_completions;
     installs.checked_mul(EPOCH_BYTES) == Some(s.physical_slot_epoch_write_bytes)
         && installs.checked_mul(LOGICAL_EXPERT_BYTES) == Some(s.physical_slot_payload_copy_bytes)
@@ -79,7 +82,7 @@ fn bytes_exact(s: &Snapshot) -> bool {
         && s.physical_bytes_staged == s.physical_slot_bytes_staged
 }
 
-fn failures_zero(s: &Snapshot) -> bool {
+pub(super) fn failures_zero(s: &Snapshot) -> bool {
     s.reservation_failures == 0
         && s.direct_staging_failures == 0
         && s.physical_stage_failures == 0
@@ -93,7 +96,7 @@ fn failures_zero(s: &Snapshot) -> bool {
         && s.single_request_stream
 }
 
-fn timing_accounting_exact(s: &Snapshot) -> bool {
+pub(super) fn timing_accounting_exact(s: &Snapshot) -> bool {
     s.sum_individual_physical_stage_us
         .checked_add(s.physical_ordered_commit_us)
         == Some(s.physical_install_total_us)
@@ -251,7 +254,7 @@ fn work_pair_exact(c: &ArmWorkEvidence, t: &ArmWorkEvidence) -> bool {
         && c.token_loop.boundary_readbacks == t.token_loop.boundary_readbacks
 }
 
-fn work_errors_zero(w: &ArmWorkEvidence) -> bool {
+pub(super) fn work_errors_zero(w: &ArmWorkEvidence) -> bool {
     w.gpu_native_residency.stale_generation_rejections == 0
         && w.token_loop.fatal_failures == 0
         && w.token_loop.no_progress_failures == 0

--- a/rust-engine/src/gpu_native_q4_route_parallel.rs
+++ b/rust-engine/src/gpu_native_q4_route_parallel.rs
@@ -1122,11 +1122,11 @@ mod tests {
         for (source, expected) in [
             (
                 include_str!("engine.rs"),
-                "842f1ff0027b66292a8c429379710ee81d703ae3c455c725275647231ddc4409",
+                "28fd6cfdec0f42d232a7e02c6f2a8b0dd50ccc3a00f926f25a650c7eff8230c5",
             ),
             (
                 include_str!("gpu_native_residency.rs"),
-                "2cb1d408f795b76a48298f47a56393d12b7228e8b8ca9d03172baaa81371f30e",
+                "a918fe46cbe488374e5534bb2b9a32c9341a66f5460480298b84368b6483c261",
             ),
             (
                 include_str!("config.rs"),
@@ -1134,7 +1134,7 @@ mod tests {
             ),
             (
                 include_str!("gpu_native_physical_install_staging.rs"),
-                "bd74830366047f26ab43e1be4a53bad225c7db3331857e2c56b83a5fde06f0bb",
+                "3654bef7035faec3981c30733dad9dc09956b84fed4b88cee547137754d49c06",
             ),
         ] {
             assert_eq!(

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -1034,6 +1034,27 @@ enum Cmd {
         report_out: PathBuf,
     },
 
+    /// Diagnostic host-copy discriminator plus frozen one-arm production attribution.
+    #[command(name = "diagnose-gpu-native-physical-staging-payload-copy")]
+    DiagnoseGpuNativePhysicalStagingPayloadCopy {
+        #[arg(
+            long,
+            default_value = "/home/randyap8/slice11-qwen3-coder-gpu-native.toml"
+        )]
+        config: PathBuf,
+        #[arg(long, default_value = "NVIDIA L4")]
+        expected_adapter_name: String,
+        #[arg(long)]
+        report_out: PathBuf,
+        /// Run only the standalone RAM/WGPU discriminator, without loading a model.
+        #[arg(long)]
+        standalone_only: bool,
+        #[arg(long, default_value_t = 20)]
+        iterations: usize,
+        #[arg(long, default_value_t = 3)]
+        warmup_iterations: usize,
+    },
+
     /// Qualify strict real-checkpoint inference with CPU dense/attention/KV/
     /// router/head planes and native-Q4_0 routed experts on a hardware GPU.
     QualifyHybridQ4 {
@@ -1981,6 +2002,11 @@ fn parse_autotune_probe_output(
 
 fn startup_config_path(cmd: &Cmd) -> Option<&Path> {
     match cmd {
+        Cmd::DiagnoseGpuNativePhysicalStagingPayloadCopy {
+            config,
+            standalone_only: false,
+            ..
+        } => Some(config.as_path()),
         Cmd::Serve { config }
         | Cmd::BenchReal { config, .. }
         | Cmd::BenchGpuNativeReal { config, .. }
@@ -2562,6 +2588,33 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         expected_adapter_name,
                         report_out,
                         progress_watchdog,
+                    },
+                ),
+            )
+        }
+        Cmd::DiagnoseGpuNativePhysicalStagingPayloadCopy {
+            config,
+            expected_adapter_name,
+            report_out,
+            standalone_only,
+            iterations,
+            warmup_iterations,
+        } => {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()?;
+            rt.block_on(
+                crate::gpu_native_physical_install_staging::payload_copy::run_command(
+                    crate::gpu_native_physical_install_staging::payload_copy::Args {
+                        common: crate::gpu_native_physical_install_staging::CommandArgs {
+                            config,
+                            expected_adapter_name,
+                            report_out,
+                            progress_watchdog,
+                        },
+                        standalone_only,
+                        iterations,
+                        warmup_iterations,
                     },
                 ),
             )
@@ -16638,6 +16691,50 @@ mod tests {
             Some(Path::new(
                 "/home/randyap8/slice11-qwen3-coder-gpu-native.toml"
             ))
+        );
+    }
+
+    #[test]
+    fn payload_copy_cli_is_explicit_and_standalone_skips_model_config() {
+        let cli = Cli::try_parse_from([
+            "mer",
+            "diagnose-gpu-native-physical-staging-payload-copy",
+            "--report-out",
+            "report.json",
+        ])
+        .unwrap();
+        assert_eq!(
+            startup_config_path(&cli.cmd),
+            Some(Path::new(
+                "/home/randyap8/slice11-qwen3-coder-gpu-native.toml"
+            ))
+        );
+        match cli.cmd {
+            Cmd::DiagnoseGpuNativePhysicalStagingPayloadCopy {
+                standalone_only,
+                iterations,
+                warmup_iterations,
+                expected_adapter_name,
+                ..
+            } => {
+                assert!(!standalone_only);
+                assert_eq!((iterations, warmup_iterations), (20, 3));
+                assert_eq!(expected_adapter_name, "NVIDIA L4");
+            }
+            _ => panic!("wrong command"),
+        }
+        let cli = Cli::try_parse_from([
+            "mer",
+            "diagnose-gpu-native-physical-staging-payload-copy",
+            "--standalone-only",
+            "--report-out",
+            "report.json",
+        ])
+        .unwrap();
+        assert!(startup_config_path(&cli.cmd).is_none());
+        assert!(
+            Cli::try_parse_from(["mer", "diagnose-gpu-native-physical-staging-payload-copy"])
+                .is_err()
         );
     }
 


### PR DESCRIPTION
## Scope

Adds the diagnostic-only GPU-native physical staging payload-copy attribution path and the measured specialization needed to decompose production slot preparation without changing ordinary production behavior.

Qualified head: `84600aee97ce11c9e471b66f7991980b4734c819`
Parent / current main: `4ec88c248232ac987307b9766d50c831137afcbf`
Tree: `c08808d0f62d89a1139f4d1c873fd35720fd3436`

## Validation

- Frozen witness: 1 passed
- Payload-copy tests: 12 passed
- Full suite: 1,526 passed, 0 failed, 15 ignored
- `cargo check --tests --features tokenizer`: passed
- canonical release build: passed on macOS and Linux/L4 preflight

## Immutable FIRST L4 evidence

- FIRST result: PASS
- report SHA-256: `7e3a8445bf92d0e74956560ef9f1564f615a7773cfbbd000f32ebf536aa62f8f`
- diagnostic log SHA-256: `e5546c29a2528cb681a59cdae633136a6e5e1109d58b817a9bda090c32770d79`
- frozen Linux binary SHA-256: `912cf3a5b27b1273dc70898544e398a4e5f37c78e9f0f461eedcdd46849ef3df`
- config SHA-256: `33d7cf96328d9c68b0ff45448d91d597d2e3a757cb99e6e61c72998ceabdd056`
- NVIDIA L4 / Vulkan, 12 GiB memory cap, zero swap, zero OOM

Production attribution: 90,717 installs, 240,781,787,136 payload bytes copied; payload copy consumed 47,450,917 us of 47,522,048 us total slot preparation (99.8503%), with accounting valid. Diagnostic classification remained conservatively `no-clear-discriminator`; raw measurements are authoritative.

## Merge policy

Use a normal merge commit only. Do not squash or rebase: preserve the exact hardware-qualified commit `84600aee97ce11c9e471b66f7991980b4734c819` in ancestry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a GPU-native physical staging payload-copy diagnostic CLI command.
  - Supports standalone benchmarking and optional production inference attribution.
  - Produces versioned JSON reports with copy timings, accounting details, and bottleneck classification.
  - Adds configurable iteration, warmup, adapter, configuration, and report-output options.

- **Documentation**
  - Added usage guidance covering build commands, supported modes, report contents, timing definitions, classifications, and production-isolation guarantees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->