### PR TITLE
Productionize GPU-native source-to-upload copy elision

### DIFF
--- a/rust-engine/src/backend/gpu_native.rs
+++ b/rust-engine/src/backend/gpu_native.rs
@@ -89,6 +89,9 @@ fn elapsed_us(started: Instant) -> u64 {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum GpuNativeBootstrapError {
     GpuBackendUnavailable,
+    QualificationSourceUpload {
+        detail: String,
+    },
     DeviceLost {
         detail: String,
     },
@@ -520,6 +523,7 @@ pub(crate) enum GpuNativeBootstrapError {
 impl fmt::Display for GpuNativeBootstrapError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::QualificationSourceUpload { detail } => write!(f, "source/upload qualification: {detail}"),
             Self::GpuBackendUnavailable => write!(
                 f,
                 "GPU-native execution requires the authoritative production GPU backend"
@@ -7863,6 +7867,84 @@ impl GpuNativeExecutorContext {
                 Err(error)
             }
         }
+    }
+
+    pub(crate) fn stage_q4_expert_source_upload<'a>(
+        &self,
+        permit: GpuNativeQ4ExpertInstallPermit<'a>,
+        payload: &[u8],
+        lease: crate::gpu_native_source_upload::Lease,
+        copies: &crate::gpu_native_source_upload::CopySet<'_>,
+    ) -> Result<
+        (
+            GpuNativeQ4ExpertPreparedInstall<'a>,
+            GpuNativePhysicalInstallEvidence,
+        ),
+        GpuNativeBootstrapError,
+    > {
+        use crate::gpu_native_source_upload::PAYLOAD;
+        let started = Instant::now();
+        let gpu = self.authoritative_gpu()?;
+        let arena = permit.arena;
+        if arena.context_id != self.context_id || lease.context_id() != self.context_id {
+            return Err(GpuNativeBootstrapError::ForeignExpertArena);
+        }
+        let geometry = arena.geometry;
+        if geometry.d_model() != 2048
+            || geometry.d_ff() != 768
+            || geometry.num_experts() != 128
+            || geometry.top_k() != 8
+            || geometry.logical_expert_bytes != PAYLOAD
+            || geometry.payload_offset_bytes() != 4
+            || geometry.slot_stride_bytes != PAYLOAD + 4
+        {
+            return Err(GpuNativeBootstrapError::QualificationSourceUpload {
+                detail: "fused physical Q4 geometry mismatch".into(),
+            });
+        }
+        let stage = self.production_physical_install.begin_stage();
+        let mut lease = Some(lease);
+        let prepared =
+            permit.stage_with_checked_physical_writer(payload, |bank, offset, checked| {
+                let destination = arena.banks.get(bank as usize).ok_or_else(|| {
+                    GpuNativeBootstrapError::QualificationSourceUpload {
+                        detail: "invalid destination bank".into(),
+                    }
+                })?;
+                let lease = lease.take().expect("one checked writer invocation");
+                lease.copy_source_offset().map_err(|detail| {
+                    GpuNativeBootstrapError::QualificationSourceUpload { detail }
+                })?;
+                let payload_offset = offset
+                    .checked_add(4)
+                    .ok_or(GpuNativeBootstrapError::ExpertArenaBudgetOverflow)?;
+                if payload_offset
+                    .checked_add(PAYLOAD as u64)
+                    .is_none_or(|end| end > destination.size())
+                {
+                    return Err(GpuNativeBootstrapError::QualificationSourceUpload {
+                        detail: "invalid physical upload slot range".into(),
+                    });
+                }
+                // Only the exact epoch goes through queue staging. The payload is
+                // encoded from the authoritative, already-unmapped source lease.
+                gpu.queue
+                    .write_buffer(destination, offset, &checked.slot_epoch.to_le_bytes());
+                copies
+                    .encode(lease, &gpu.device, destination, payload_offset)
+                    .map_err(|detail| GpuNativeBootstrapError::QualificationSourceUpload { detail })
+            })?;
+        stage.succeed();
+        Ok((
+            prepared,
+            GpuNativePhysicalInstallEvidence {
+                physical_slot_bytes_staged: (PAYLOAD + 4) as u64,
+                physical_slot_epoch_write_bytes: 4,
+                physical_slot_prepare_us: elapsed_us(started),
+                // CPU payload-copy bytes and direct queue payload writes are zero.
+                ..GpuNativePhysicalInstallEvidence::default()
+            },
+        ))
     }
 
     pub(crate) fn commit_q4_expert_residency_production(

--- a/rust-engine/src/engine.rs
+++ b/rust-engine/src/engine.rs
@@ -31,6 +31,7 @@ use crate::gpu_native_residency::{
     GpuNativeSpeculativeInstall, GpuNativeSpeculativeProbe, GpuNativeTieredResidencyError,
     GpuNativeTieredResidencyManager, GpuNativeTieredResidencySnapshot,
 };
+use crate::gpu_native_source_upload::{Arm as SourceUploadArm, State as SourceUploadState};
 use crate::inference::{
     combine_outputs, run_inference_bf16, run_inference_f16, run_inference_int8,
     run_inference_mixed_quant, run_inference_mxfp4, run_inference_q4_0, run_inference_q4_0_qmm,
@@ -522,6 +523,8 @@ pub(crate) enum GpuNativePhysicalInstallConcurrencyQualificationArm {
     ConcurrentFullZeroControl,
     /// Zero-fill qualifier: observe ordinary production, with no zero fill.
     ProductionNoZeroFillTreatment,
+    SourceToUploadControl,
+    SourceToUploadTreatment,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -529,6 +532,7 @@ enum GpuNativeQualificationPurpose {
     DemandSource(GpuNativeDemandSourceQualificationArm),
     PhysicalInstallStaging(GpuNativePhysicalInstallStagingQualificationArm),
     PhysicalInstallConcurrency(GpuNativePhysicalInstallConcurrencyQualificationArm),
+    SourceToUpload(SourceUploadArm),
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -1003,6 +1007,7 @@ fn qualification_order_completed_residents(
 
 struct GpuNativeDemandSourceQualification {
     purpose: GpuNativeQualificationPurpose,
+    source_upload: Option<Arc<SourceUploadState>>,
     primary_pool_capacity: usize,
     shadow_pool_capacity: usize,
     active_demand_set: AtomicBool,
@@ -1099,6 +1104,7 @@ impl GpuNativeDemandSourceQualification {
     ) -> Self {
         Self {
             purpose: GpuNativeQualificationPurpose::DemandSource(arm),
+            source_upload: None,
             primary_pool_capacity,
             shadow_pool_capacity,
             active_demand_set: AtomicBool::new(false),
@@ -1223,6 +1229,17 @@ impl GpuNativeDemandSourceQualification {
             shadow_pool_capacity,
         );
         state.purpose = GpuNativeQualificationPurpose::PhysicalInstallConcurrency(arm);
+        state
+    }
+
+    fn new_source_upload(upload: Arc<SourceUploadState>, primary: usize, shadow: usize) -> Self {
+        let mut state = Self::new(
+            GpuNativeDemandSourceQualificationArm::Treatment,
+            primary,
+            shadow,
+        );
+        state.purpose = GpuNativeQualificationPurpose::SourceToUpload(upload.arm);
+        state.source_upload = Some(upload);
         state
     }
 
@@ -1401,8 +1418,17 @@ impl GpuNativeDemandSourceQualification {
     fn physical_install_concurrency_snapshot(
         &self,
     ) -> GpuNativePhysicalInstallConcurrencyQualificationSnapshot {
-        let GpuNativeQualificationPurpose::PhysicalInstallConcurrency(arm) = self.purpose else {
-            unreachable!("physical-install concurrency snapshot requested for another qualifier")
+        let arm = match self.purpose {
+            GpuNativeQualificationPurpose::PhysicalInstallConcurrency(arm) => arm,
+            GpuNativeQualificationPurpose::SourceToUpload(SourceUploadArm::Control) => {
+                GpuNativePhysicalInstallConcurrencyQualificationArm::SourceToUploadControl
+            }
+            GpuNativeQualificationPurpose::SourceToUpload(SourceUploadArm::Treatment) => {
+                GpuNativePhysicalInstallConcurrencyQualificationArm::SourceToUploadTreatment
+            }
+            _ => unreachable!(
+                "physical-install concurrency snapshot requested for another qualifier"
+            ),
         };
         let sets = self.physical_install_sets.load(Ordering::Relaxed);
         let width_min = self.install_set_width_min.load(Ordering::Relaxed);
@@ -1422,7 +1448,7 @@ impl GpuNativeDemandSourceQualification {
                 arm,
                 GpuNativePhysicalInstallConcurrencyQualificationArm::Treatment
                     | GpuNativePhysicalInstallConcurrencyQualificationArm::ProductionNoZeroFillTreatment
-            ),
+            ) && !matches!(self.purpose, GpuNativeQualificationPurpose::SourceToUpload(SourceUploadArm::Treatment)),
             single_request_stream: self.overlapping_demand_sets.load(Ordering::Relaxed) == 0,
             overlapping_demand_sets: self.overlapping_demand_sets.load(Ordering::Relaxed),
             primary_pool_capacity: self.primary_pool_capacity,
@@ -1636,6 +1662,10 @@ impl GpuNativeDemandSourceQualification {
 }
 
 impl GpuNativePhysicalInstallObserver for GpuNativeDemandSourceQualification {
+    fn source_upload_state(&self) -> Option<&SourceUploadState> {
+        self.source_upload.as_deref()
+    }
+
     fn record_physical_victim(&self, global_id: u32) {
         self.physical_victim_ids.lock().record_id(global_id);
         self.mapping_unpublications
@@ -1678,6 +1708,35 @@ impl GpuNativePhysicalInstallObserver for GpuNativeDemandSourceQualification {
     ) {
         self.physical_install_completions
             .fetch_add(1, Ordering::Relaxed);
+        if let Some(upload) = &self.source_upload {
+            upload.add(
+                |m| &mut m.total_payload_bytes_staged,
+                evidence.physical_slot_bytes_staged - evidence.physical_slot_epoch_write_bytes,
+            );
+            upload.add(
+                |m| &mut m.physical_cpu_payload_copy_bytes,
+                evidence.physical_slot_payload_copy_bytes,
+            );
+            if upload.arm == SourceUploadArm::Treatment {
+                if evidence.direct_staging_writes == 0 {
+                    upload.add(|m| &mut m.fused_installs, 1);
+                    upload.add(
+                        |m| &mut m.fused_gpu_copy_bytes,
+                        crate::gpu_native_source_upload::PAYLOAD as u64,
+                    );
+                } else {
+                    upload.add(|m| &mut m.fallback_installs, 1);
+                    upload.add(
+                        |m| &mut m.fallback_payload_copy_bytes,
+                        evidence.physical_slot_payload_copy_bytes,
+                    );
+                    upload.add(
+                        |m| &mut m.fallback_payload_copy_us,
+                        evidence.physical_slot_payload_copy_us,
+                    );
+                }
+            }
+        }
         self.full_slot_vec_materializations
             .fetch_add(evidence.full_slot_vec_materializations, Ordering::Relaxed);
         self.direct_staging_writes
@@ -1726,6 +1785,7 @@ impl GpuNativePhysicalInstallObserver for GpuNativeDemandSourceQualification {
         if !matches!(
             self.purpose,
             GpuNativeQualificationPurpose::PhysicalInstallConcurrency(_)
+                | GpuNativeQualificationPurpose::SourceToUpload(_)
         ) {
             return;
         }
@@ -1770,6 +1830,7 @@ impl GpuNativePhysicalInstallObserver for GpuNativeDemandSourceQualification {
         if matches!(
             self.purpose,
             GpuNativeQualificationPurpose::PhysicalInstallConcurrency(_)
+                | GpuNativeQualificationPurpose::SourceToUpload(_)
         ) {
             self.reservation_attempts.fetch_add(1, Ordering::Relaxed);
         }
@@ -1784,6 +1845,7 @@ impl GpuNativePhysicalInstallObserver for GpuNativeDemandSourceQualification {
         if matches!(
             self.purpose,
             GpuNativeQualificationPurpose::PhysicalInstallConcurrency(_)
+                | GpuNativeQualificationPurpose::SourceToUpload(_)
         ) {
             self.reservation_successes.fetch_add(1, Ordering::Relaxed);
             self.reservation_identities
@@ -1796,6 +1858,7 @@ impl GpuNativePhysicalInstallObserver for GpuNativeDemandSourceQualification {
         if matches!(
             self.purpose,
             GpuNativeQualificationPurpose::PhysicalInstallConcurrency(_)
+                | GpuNativeQualificationPurpose::SourceToUpload(_)
         ) {
             self.reservation_failures.fetch_add(1, Ordering::Relaxed);
         }
@@ -1809,6 +1872,7 @@ impl GpuNativePhysicalInstallObserver for GpuNativeDemandSourceQualification {
                     | GpuNativePhysicalInstallConcurrencyQualificationArm::ConcurrentFullZeroControl
                     | GpuNativePhysicalInstallConcurrencyQualificationArm::ProductionNoZeroFillTreatment
             )
+                | GpuNativeQualificationPurpose::SourceToUpload(_)
         ) {
             return;
         }
@@ -1833,14 +1897,26 @@ impl GpuNativePhysicalInstallObserver for GpuNativeDemandSourceQualification {
                     | GpuNativePhysicalInstallConcurrencyQualificationArm::ConcurrentFullZeroControl
                     | GpuNativePhysicalInstallConcurrencyQualificationArm::ProductionNoZeroFillTreatment
             )
+                | GpuNativeQualificationPurpose::SourceToUpload(_)
         ) {
             return;
         }
+        let fused = self
+            .source_upload
+            .as_ref()
+            .is_some_and(|u| u.arm == SourceUploadArm::Treatment)
+            && evidence.direct_staging_writes == 0;
+        let payload_bytes = if fused {
+            crate::gpu_native_source_upload::PAYLOAD as u64
+        } else {
+            evidence.physical_slot_payload_copy_bytes
+        };
         if evidence
             .physical_slot_epoch_write_bytes
-            .checked_add(evidence.physical_slot_payload_copy_bytes)
+            .checked_add(payload_bytes)
             != Some(evidence.physical_slot_bytes_staged)
-            || evidence.direct_staging_writes != 1
+            || (!fused && evidence.direct_staging_writes != 1)
+            || (fused && evidence.physical_slot_payload_copy_bytes != 0)
             || evidence.full_slot_vec_materializations != 0
         {
             self.evidence_accounting_errors
@@ -1872,6 +1948,7 @@ impl GpuNativePhysicalInstallObserver for GpuNativeDemandSourceQualification {
                     | GpuNativePhysicalInstallConcurrencyQualificationArm::ConcurrentFullZeroControl
                     | GpuNativePhysicalInstallConcurrencyQualificationArm::ProductionNoZeroFillTreatment
             )
+                | GpuNativeQualificationPurpose::SourceToUpload(_)
         ) {
             self.physical_stage_failures.fetch_add(1, Ordering::Relaxed);
             self.active_physical_staging.fetch_sub(1, Ordering::AcqRel);
@@ -1886,6 +1963,7 @@ impl GpuNativePhysicalInstallObserver for GpuNativeDemandSourceQualification {
                     | GpuNativePhysicalInstallConcurrencyQualificationArm::ConcurrentFullZeroControl
                     | GpuNativePhysicalInstallConcurrencyQualificationArm::ProductionNoZeroFillTreatment
             )
+                | GpuNativeQualificationPurpose::SourceToUpload(_)
         ) {
             self.physical_parallel_stage_wall_us
                 .fetch_add(wall_us, Ordering::Relaxed);
@@ -1900,6 +1978,7 @@ impl GpuNativePhysicalInstallObserver for GpuNativeDemandSourceQualification {
                     | GpuNativePhysicalInstallConcurrencyQualificationArm::ConcurrentFullZeroControl
                     | GpuNativePhysicalInstallConcurrencyQualificationArm::ProductionNoZeroFillTreatment
             )
+                | GpuNativeQualificationPurpose::SourceToUpload(_)
         ) {
             self.ordered_commit_attempts.fetch_add(1, Ordering::Relaxed);
         }
@@ -1913,6 +1992,7 @@ impl GpuNativePhysicalInstallObserver for GpuNativeDemandSourceQualification {
                     | GpuNativePhysicalInstallConcurrencyQualificationArm::ConcurrentFullZeroControl
                     | GpuNativePhysicalInstallConcurrencyQualificationArm::ProductionNoZeroFillTreatment
             )
+                | GpuNativeQualificationPurpose::SourceToUpload(_)
         ) {
             self.ordered_commit_completions
                 .fetch_add(1, Ordering::Relaxed);
@@ -1925,6 +2005,7 @@ impl GpuNativePhysicalInstallObserver for GpuNativeDemandSourceQualification {
         if matches!(
             self.purpose,
             GpuNativeQualificationPurpose::PhysicalInstallConcurrency(_)
+                | GpuNativeQualificationPurpose::SourceToUpload(_)
         ) {
             self.ordered_commit_failures.fetch_add(1, Ordering::Relaxed);
             if violation {
@@ -1938,6 +2019,7 @@ impl GpuNativePhysicalInstallObserver for GpuNativeDemandSourceQualification {
         if matches!(
             self.purpose,
             GpuNativeQualificationPurpose::PhysicalInstallConcurrency(_)
+                | GpuNativeQualificationPurpose::SourceToUpload(_)
         ) {
             self.physical_reservation_us
                 .fetch_add(wall_us, Ordering::Relaxed);
@@ -1948,6 +2030,7 @@ impl GpuNativePhysicalInstallObserver for GpuNativeDemandSourceQualification {
         if matches!(
             self.purpose,
             GpuNativeQualificationPurpose::PhysicalInstallConcurrency(_)
+                | GpuNativeQualificationPurpose::SourceToUpload(_)
         ) {
             self.physical_install_transaction_us
                 .fetch_add(wall_us, Ordering::Relaxed);
@@ -1958,6 +2041,7 @@ impl GpuNativePhysicalInstallObserver for GpuNativeDemandSourceQualification {
         if matches!(
             self.purpose,
             GpuNativeQualificationPurpose::PhysicalInstallConcurrency(_)
+                | GpuNativeQualificationPurpose::SourceToUpload(_)
         ) {
             self.unpublished_physical_writes_after_failure
                 .fetch_add(count, Ordering::Relaxed);
@@ -2011,6 +2095,9 @@ impl QualificationDemandServiceGuard {
 
 impl Drop for QualificationDemandServiceGuard {
     fn drop(&mut self) {
+        if let Some(upload) = &self.state.source_upload {
+            upload.abandon_pending();
+        }
         self.state
             .total_residency_service_us
             .fetch_add(qualification_elapsed_us(self.started), Ordering::Relaxed);
@@ -4747,7 +4834,18 @@ impl Engine {
         let purpose = current.purpose;
         let primary_pool_capacity = current.primary_pool_capacity;
         let shadow_pool_capacity = current.shadow_pool_capacity;
+        let source_upload = current.source_upload.clone();
+        if let Some(upload) = &source_upload {
+            upload.reset()?;
+        }
         *slot = Some(Arc::new(match purpose {
+            GpuNativeQualificationPurpose::SourceToUpload(_) => {
+                GpuNativeDemandSourceQualification::new_source_upload(
+                    source_upload.expect("upload state"),
+                    primary_pool_capacity,
+                    shadow_pool_capacity,
+                )
+            }
             GpuNativeQualificationPurpose::DemandSource(arm) => {
                 GpuNativeDemandSourceQualification::new(
                     arm,
@@ -4775,6 +4873,7 @@ impl Engine {
             purpose,
             GpuNativeQualificationPurpose::PhysicalInstallStaging(_)
                 | GpuNativeQualificationPurpose::PhysicalInstallConcurrency(_)
+                | GpuNativeQualificationPurpose::SourceToUpload(_)
         ) {
             if let Some(manager) = self.core.gpu_native_residency.as_ref() {
                 manager.reset_production_physical_install_telemetry();
@@ -4848,6 +4947,15 @@ impl Engine {
         &self,
         arm: GpuNativePhysicalInstallConcurrencyQualificationArm,
     ) -> Result<(), String> {
+        if matches!(
+            arm,
+            GpuNativePhysicalInstallConcurrencyQualificationArm::SourceToUploadControl
+                | GpuNativePhysicalInstallConcurrencyQualificationArm::SourceToUploadTreatment
+        ) {
+            return Err(
+                "source/upload arms require the dedicated qualification constructor".into(),
+            );
+        }
         if !self.core.in_flight.is_empty() || self.core.cache.reserved_slots() != 0 {
             return Err(
                 "cannot enable physical-install concurrency qualification with active singleflight entries or cache reservations"
@@ -4882,9 +4990,46 @@ impl Engine {
                 matches!(
                     state.purpose,
                     GpuNativeQualificationPurpose::PhysicalInstallConcurrency(_)
+                        | GpuNativeQualificationPurpose::SourceToUpload(_)
                 )
                 .then(|| state.physical_install_concurrency_snapshot())
             })
+    }
+
+    pub(crate) fn enable_gpu_native_source_upload_qualification(
+        &self,
+        arm: SourceUploadArm,
+    ) -> Result<(), String> {
+        if !self.core.in_flight.is_empty() || self.core.cache.reserved_slots() != 0 {
+            return Err("source/upload qualification requires an idle isolated runtime".into());
+        }
+        let mut slot = self.gpu_native_demand_source_qualification.write();
+        if slot.is_some() {
+            return Err("a residency qualification is already enabled".into());
+        }
+        let manager = self
+            .core
+            .gpu_native_residency
+            .as_ref()
+            .ok_or("missing physical manager")?;
+        let upload = SourceUploadState::new(arm, manager.executor().clone())?;
+        *slot = Some(Arc::new(
+            GpuNativeDemandSourceQualification::new_source_upload(
+                upload,
+                self.core.pool.capacity(),
+                self.core.pool.shadow_capacity(),
+            ),
+        ));
+        self.production_demand_source.reset();
+        manager.reset_production_physical_install_telemetry();
+        Ok(())
+    }
+
+    pub(crate) fn gpu_native_source_upload_snapshot(
+        &self,
+    ) -> Option<crate::gpu_native_source_upload::Snapshot> {
+        self.gpu_native_demand_source_qualification()
+            .and_then(|s| s.source_upload.as_ref().map(|u| u.snapshot()))
     }
 
     pub(crate) fn production_demand_source_snapshot(&self) -> ProductionDemandSourceSnapshot {
@@ -6063,7 +6208,10 @@ impl Engine {
                 GpuNativeDemandSourceQualificationArm::Treatment,
             ))
             | Some(GpuNativeQualificationPurpose::PhysicalInstallStaging(_))
-            | Some(GpuNativeQualificationPurpose::PhysicalInstallConcurrency(_))
+            | Some(
+                GpuNativeQualificationPurpose::PhysicalInstallConcurrency(_)
+                | GpuNativeQualificationPurpose::SourceToUpload(_),
+            )
             | None => {
                 self.gpu_native_production_source_physical_missing_set(global_ids, residents)
                     .await
@@ -6280,16 +6428,48 @@ impl Engine {
         }
 
         let batch_started = Instant::now();
-        let mut refs = buffers.iter_mut().collect::<Vec<_>>();
+        let upload = self
+            .gpu_native_demand_source_qualification()
+            .and_then(|s| s.source_upload.clone());
+        let mut fused_residents = None;
+        let expected_bytes = buffers.iter().map(|buffer| buffer.len()).sum::<usize>();
         let _foreground = self.core.governor.foreground_guard();
-        let read_result = self
-            .core
-            .storage
-            .read_experts_batch(&unresolved, &mut refs)
-            .await;
+        let read_result = if let Some(upload) = upload
+            .as_ref()
+            .filter(|u| u.arm == SourceUploadArm::Treatment)
+        {
+            match upload
+                .read_source(
+                    &self.core.storage,
+                    &unresolved,
+                    std::mem::take(&mut buffers),
+                    self.execution_context().gpu_expert_cache(),
+                )
+                .await
+            {
+                Ok(residents) => {
+                    fused_residents = Some(residents);
+                    Ok(expected_bytes)
+                }
+                Err(error) => Err(std::io::Error::other(error)),
+            }
+        } else {
+            let mut refs = buffers.iter_mut().collect::<Vec<_>>();
+            self.core
+                .storage
+                .read_experts_batch(&unresolved, &mut refs)
+                .await
+        };
         drop(_foreground);
         let batch_wall_us = qualification_elapsed_us(batch_started);
-        let expected_bytes = buffers.iter().map(|buffer| buffer.len()).sum::<usize>();
+        if read_result.is_err() {
+            if let Some(upload) = upload
+                .as_ref()
+                .filter(|u| u.arm == SourceUploadArm::Control)
+            {
+                upload.add(|m| &mut m.source_failures, 1);
+            }
+        }
         let read_bytes = match read_result {
             Ok(read_bytes) if read_bytes == expected_bytes => read_bytes,
             result => {
@@ -6311,6 +6491,9 @@ impl Engine {
             }
         };
 
+        if let Some(upload) = &upload {
+            upload.record_nvme(&unresolved);
+        }
         if let Some(qualification) = self.gpu_native_demand_source_qualification() {
             for &global_id in &unresolved {
                 qualification.record_source_request(global_id);
@@ -6332,21 +6515,29 @@ impl Engine {
         let _ = self.metrics.io_hist.lock().record(batch_wall_us.max(1));
 
         let block_align = self.core.storage.config().block_align;
-        let completed = unresolved
-            .iter()
-            .copied()
-            .zip(buffers)
-            .map(|(global_id, buffer)| {
-                (
-                    global_id,
-                    Arc::new(ExpertResident::new_with_block_align(
+        let completed = if let Some(residents) = fused_residents {
+            unresolved
+                .iter()
+                .copied()
+                .zip(residents)
+                .collect::<HashMap<_, _>>()
+        } else {
+            unresolved
+                .iter()
+                .copied()
+                .zip(buffers)
+                .map(|(global_id, buffer)| {
+                    (
                         global_id,
-                        buffer,
-                        block_align,
-                    )),
-                )
-            })
-            .collect::<HashMap<_, _>>();
+                        Arc::new(ExpertResident::new_with_block_align(
+                            global_id,
+                            buffer,
+                            block_align,
+                        )),
+                    )
+                })
+                .collect::<HashMap<_, _>>()
+        };
         let staged = qualification_order_completed_residents(&unresolved, completed)?;
         for (global_id, resident) in staged {
             if cache_reservation.commit(resident.clone()).is_err() {
@@ -6374,6 +6565,18 @@ impl Engine {
     ) -> Result<(Vec<GpuAdmission>, usize), GpuNativeDemandResidencyError> {
         let gpu = self.execution_context().gpu_expert_cache();
         let mut payloads = HashMap::with_capacity(global_ids.len());
+        let upload = self
+            .gpu_native_demand_source_qualification()
+            .and_then(|s| s.source_upload.clone());
+        let new_ids = if upload.is_some() {
+            global_ids
+                .iter()
+                .copied()
+                .filter(|id| gpu.current_admission(*id).is_none())
+                .collect::<Vec<_>>()
+        } else {
+            Vec::new()
+        };
         for attempt in 1..=GPU_NATIVE_LOGICAL_DEMAND_SET_ATTEMPTS {
             match gpu.demand_admit_set(global_ids, &payloads)? {
                 GpuDemandSetAdmission::Ready {
@@ -6385,6 +6588,19 @@ impl Engine {
                             prom.record_promotions(newly_admitted as u64);
                             prom.set_vram_used_bytes(gpu.used_bytes());
                         }
+                    }
+                    if let Some(upload) = &upload {
+                        if new_ids.len() != newly_admitted {
+                            upload.add(|m| &mut m.accounting_errors, 1);
+                        }
+                        upload.record_logical(
+                            global_ids,
+                            &admissions
+                                .iter()
+                                .map(GpuAdmission::generation)
+                                .collect::<Vec<_>>(),
+                            &new_ids,
+                        );
                     }
                     return Ok((admissions, newly_admitted));
                 }
@@ -6401,14 +6617,54 @@ impl Engine {
                 GpuDemandSetAdmission::PayloadRequired(missing) => {
                     for global_id in missing {
                         let resident = self.gpu_native_demand_source(global_id, residents).await?;
-                        payloads.insert(
-                            global_id,
-                            Arc::new(GpuResident::new_with_dtype(
+                        let payload = if let Some(upload) = upload
+                            .as_ref()
+                            .filter(|u| u.arm == SourceUploadArm::Treatment)
+                        {
+                            let shared = if upload.has_pending(global_id) {
+                                resident
+                                    .qualification_shared_payload()
+                                    .expect("fused resident has materialized shared bytes")
+                                    .clone()
+                            } else {
+                                // A RAM-hit readmission performs the same logical
+                                // materialization as production. No NVMe is issued.
+                                let start = Instant::now();
+                                let shared: Arc<[u8]> = Arc::from(resident.data());
+                                upload.add(|m| &mut m.logical_materialization_operations, 1);
+                                upload.add(
+                                    |m| &mut m.logical_materialization_bytes,
+                                    shared.len() as u64,
+                                );
+                                upload.add(
+                                    |m| &mut m.logical_materialization_us,
+                                    qualification_elapsed_us(start),
+                                );
+                                upload.add(|m| &mut m.shared_payload_constructions, 1);
+                                shared
+                            };
+                            GpuResident::new_qualification_shared(
                                 global_id,
-                                resident.data().to_vec(),
+                                shared,
                                 self.core.options.dtype,
-                            )),
-                        );
+                            )
+                        } else {
+                            let start = upload.as_ref().map(|_| Instant::now());
+                            let bytes = resident.data().to_vec();
+                            if let Some(upload) = &upload {
+                                upload.add(|m| &mut m.logical_materialization_operations, 1);
+                                upload.add(
+                                    |m| &mut m.logical_materialization_bytes,
+                                    bytes.len() as u64,
+                                );
+                                upload.add(
+                                    |m| &mut m.logical_materialization_us,
+                                    qualification_elapsed_us(start.unwrap()),
+                                );
+                            }
+                            GpuResident::new_with_dtype(global_id, bytes, self.core.options.dtype)
+                        };
+                        payloads.insert(global_id, Arc::new(payload));
                     }
                 }
             }
@@ -6576,6 +6832,9 @@ impl Engine {
                         .as_ref()
                         .expect("physical-install concurrency qualification state is present");
                     match arm {
+                        GpuNativePhysicalInstallConcurrencyQualificationArm::SourceToUploadControl | GpuNativePhysicalInstallConcurrencyQualificationArm::SourceToUploadTreatment => {
+                            unreachable!("source/upload arms require their dedicated purpose")
+                        }
                         GpuNativePhysicalInstallConcurrencyQualificationArm::Control => manager
                             .ensure_demand_set_physical_install_concurrency_control(
                                 GpuNativeResidencyPriority::Demand,
@@ -6600,6 +6859,16 @@ impl Engine {
                             ),
                     }
                 }
+                Some(GpuNativeQualificationPurpose::SourceToUpload(_)) => manager
+                    .ensure_demand_set_production_observed(
+                        GpuNativeResidencyPriority::Demand,
+                        layer_index,
+                        &demands,
+                        qualification
+                            .as_ref()
+                            .expect("source/upload qualification")
+                            .as_ref(),
+                    ),
                 Some(GpuNativeQualificationPurpose::DemandSource(_)) | None => manager
                     .ensure_demand_set(GpuNativeResidencyPriority::Demand, layer_index, &demands),
             };
@@ -6610,7 +6879,15 @@ impl Engine {
                 );
             }
             match physical_install_result {
-                Ok(residencies) => return Ok(residencies),
+                Ok(residencies) => {
+                    if let Some(upload) = qualification
+                        .as_ref()
+                        .and_then(|s| s.source_upload.as_ref())
+                    {
+                        upload.finish_request().map_err(|source| GpuNativeDemandResidencyError::ProductionBatchReadFailedAfterReservation { global_ids: global_ids.to_vec(), source })?;
+                    }
+                    return Ok(residencies);
+                }
                 Err(GpuNativeTieredResidencyError::DemandSourceMissing { global_id: _ })
                     if gpu_native_physical_demand_recovery_allowed(recovery_attempts) =>
                 {
@@ -6663,15 +6940,48 @@ impl Engine {
                 drop(evicted);
             }
         }
-        let mut buf = self.core.pool.acquire().await;
+        let buf = self.core.pool.acquire().await;
         // Tier 4: mark this as a foreground (token-blocking) read for the
         // duration of the device I/O so the governor throttles
         // speculation that would otherwise queue ahead of it. No-op when
         // the governor is disabled.
         let _fg = self.core.governor.foreground_guard();
-        let read_result = self.core.storage.read_expert(id, &mut buf).await;
+        let source_bytes = buf.len();
+        let upload = self
+            .gpu_native_demand_source_qualification()
+            .and_then(|s| s.source_upload.clone());
+        let mut ordinary_buffer = Some(buf);
+        let mut fused_resident = None;
+        let read_result = if let Some(upload) = upload
+            .as_ref()
+            .filter(|u| u.arm == SourceUploadArm::Treatment)
+        {
+            match upload
+                .read_source(
+                    &self.core.storage,
+                    &[id],
+                    vec![ordinary_buffer.take().expect("capacity lease")],
+                    self.execution_context().gpu_expert_cache(),
+                )
+                .await
+            {
+                Ok(mut residents) => {
+                    fused_resident = residents.pop();
+                    Ok(source_bytes)
+                }
+                Err(error) => Err(std::io::Error::other(error)),
+            }
+        } else {
+            self.core
+                .storage
+                .read_expert(id, ordinary_buffer.as_mut().expect("production buffer"))
+                .await
+        };
         match read_result {
             Ok(_) => {
+                if let Some(upload) = &upload {
+                    upload.record_nvme(&[id]);
+                }
                 let io_us = io_start.elapsed().as_micros() as u64;
                 let _ = self.metrics.io_hist.lock().record(io_us.max(1));
                 if let Some(qualification) = self.gpu_native_demand_source_qualification() {
@@ -6680,7 +6990,7 @@ impl Engine {
                         .fetch_add(1, Ordering::Relaxed);
                     qualification
                         .source_nvme_bytes
-                        .fetch_add(buf.len() as u64, Ordering::Relaxed);
+                        .fetch_add(source_bytes as u64, Ordering::Relaxed);
                 }
                 // Track every byte the engine actually pulls off the
                 // SSD — including `fetch_with_retry`'s leader path,
@@ -6694,12 +7004,14 @@ impl Engine {
                 self.metrics
                     .counters
                     .bytes_read
-                    .fetch_add(buf.len() as u64, Ordering::Relaxed);
-                let resident = Arc::new(ExpertResident::new_with_block_align(
-                    id,
-                    buf,
-                    self.core.storage.config().block_align,
-                ));
+                    .fetch_add(source_bytes as u64, Ordering::Relaxed);
+                let resident = fused_resident.unwrap_or_else(|| {
+                    Arc::new(ExpertResident::new_with_block_align(
+                        id,
+                        ordinary_buffer.expect("production source buffer"),
+                        self.core.storage.config().block_align,
+                    ))
+                });
                 match self.core.cache.insert(resident.clone()) {
                     Ok(Some(evicted)) => {
                         if let Some(qualification) =
@@ -6736,6 +7048,12 @@ impl Engine {
                 Ok(resident)
             }
             Err(e) => {
+                if let Some(upload) = upload
+                    .as_ref()
+                    .filter(|u| u.arm == SourceUploadArm::Control)
+                {
+                    upload.add(|m| &mut m.source_failures, 1);
+                }
                 // The buffer is returned to the pool when `buf` is dropped.
                 Err(FetchOnceError::Io(e.to_string()))
             }
@@ -13070,6 +13388,68 @@ mod tests {
                 }
             }
         }
+    }
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn source_upload_ram_hit_never_acquires_an_upload_slot_or_reads_nvme() {
+        let dir = TempDir::new("upload-ram-hit");
+        let engine = build_engine(&dir.path, 4, 8, 8, 4, 2, 0, 123);
+        let resident = engine.fetch_with_retry(0).await.unwrap();
+        let before = engine.report().bytes_read;
+        let upload = SourceUploadState::cpu_test_state(SourceUploadArm::Treatment);
+        *engine.gpu_native_demand_source_qualification.write() = Some(Arc::new(
+            GpuNativeDemandSourceQualification::new_source_upload(
+                upload.clone(),
+                engine.core.pool.capacity(),
+                0,
+            ),
+        ));
+        let mut residents = HashMap::new();
+        engine
+            .gpu_native_source_physical_missing_set(&[0], &mut residents)
+            .await
+            .unwrap();
+        assert!(Arc::ptr_eq(&resident, &residents[&0]));
+        assert_eq!(engine.report().bytes_read, before);
+        assert!(upload.take_lease(0, &resident).unwrap().is_none());
+        let metrics = upload.snapshot().metrics;
+        assert_eq!(metrics.acquisition_attempts, 0);
+        assert_eq!(metrics.direct_source_reads, 0);
+    }
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn source_upload_control_keeps_single_read_batch_and_request_order() {
+        let dir = TempDir::new("upload-control");
+        let engine = build_engine(&dir.path, 4, 8, 8, 4, 2, 0, 124);
+        assert!(engine.gpu_native_demand_source_qualification().is_none());
+        let upload = SourceUploadState::cpu_test_state(SourceUploadArm::Control);
+        *engine.gpu_native_demand_source_qualification.write() = Some(Arc::new(
+            GpuNativeDemandSourceQualification::new_source_upload(
+                upload.clone(),
+                engine.core.pool.capacity(),
+                0,
+            ),
+        ));
+        let mut residents = HashMap::new();
+        engine
+            .gpu_native_source_physical_missing_set(&[2, 0], &mut residents)
+            .await
+            .unwrap();
+        assert_eq!(
+            engine.report().bytes_read,
+            2 * engine.core.storage.config().expert_size as u64
+        );
+        assert_eq!(
+            engine
+                .production_demand_source_snapshot()
+                .production_batch_successes,
+            1
+        );
+        assert_eq!(upload.snapshot().metrics.leases_created, 0);
+        let expected = SourceUploadState::cpu_test_state(SourceUploadArm::Control);
+        expected.record_nvme(&[2, 0]);
+        assert_eq!(
+            upload.snapshot().ordered_nvme_ids_sha256,
+            expected.snapshot().ordered_nvme_ids_sha256
+        );
     }
 }
 // end mod engine::tests

--- a/rust-engine/src/engine.rs
+++ b/rust-engine/src/engine.rs
@@ -2133,6 +2133,7 @@ fn gpu_native_physical_missing_ids(global_ids: &[u32], physical_current: &[bool]
 pub(crate) enum GpuNativeResidencyInstallError {
     LegacyPhysicalExpertPlaneActive,
     LogicalCacheMismatch,
+    SourceUploadInitializationFailed,
     AlreadyInstalled,
 }
 
@@ -2144,6 +2145,9 @@ impl std::fmt::Display for GpuNativeResidencyInstallError {
             ),
             Self::LogicalCacheMismatch => f.write_str(
                 "GPU-native residency manager does not share the execution context's logical GpuExpertCache",
+            ),
+            Self::SourceUploadInitializationFailed => f.write_str(
+                "GPU-native source-upload production state initialization failed",
             ),
             Self::AlreadyInstalled => {
                 f.write_str("GPU-native tiered residency manager is already installed")
@@ -3545,6 +3549,7 @@ pub struct Engine {
         parking_lot::RwLock<Option<Arc<dyn GpuNativeActualRouteObserver>>>,
     gpu_native_demand_source_qualification:
         parking_lot::RwLock<Option<Arc<GpuNativeDemandSourceQualification>>>,
+    gpu_native_source_upload_production: Option<Arc<SourceUploadState>>,
     production_demand_source: Arc<ProductionDemandSourceTelemetry>,
     #[cfg(test)]
     production_batch_test_hooks: parking_lot::Mutex<ProductionBatchTestHooks>,
@@ -3926,6 +3931,7 @@ impl Engine {
             gpu_native_actual_route_observer_armed: AtomicBool::new(false),
             gpu_native_actual_route_observer: parking_lot::RwLock::new(None),
             gpu_native_demand_source_qualification: parking_lot::RwLock::new(None),
+            gpu_native_source_upload_production: None,
             production_demand_source,
             #[cfg(test)]
             production_batch_test_hooks: parking_lot::Mutex::new(
@@ -4720,6 +4726,24 @@ impl Engine {
     /// activation of the legacy routed-expert GPU registry: Slice 10 may
     /// compose the GPU-native token loop, but it must never double-consume one
     /// request's configured expert capacity across both physical planes.
+    fn gpu_native_source_upload_production_supported(
+        &self,
+        manager: &GpuNativeTieredResidencyManager,
+    ) -> bool {
+        let expected_geometry =
+            crate::backend::gpu_native::GpuNativeQ4ExpertGeometry::try_new(2048, 768, 128, 8)
+                .expect("frozen Qwen source/upload geometry is valid");
+        let storage = self.core.storage.config();
+        cfg!(target_os = "linux")
+            && self.core.options.dtype == WeightDtype::Q4_0
+            && manager.plan().num_layers() == 48
+            && manager.plan().geometry() == expected_geometry
+            && storage.expert_size == crate::gpu_native_source_upload::FULL
+            && storage.block_align == crate::gpu_native_source_upload::ALIGN
+            && storage.use_direct_io
+            && !self.core.storage.is_packed()
+    }
+
     pub(crate) fn install_gpu_native_residency_manager(
         &mut self,
         manager: Arc<GpuNativeTieredResidencyManager>,
@@ -4738,8 +4762,17 @@ impl Engine {
         ) {
             return Err(GpuNativeResidencyInstallError::LogicalCacheMismatch);
         }
+        let source_upload = if self.gpu_native_source_upload_production_supported(&manager) {
+            Some(
+                SourceUploadState::new_production(manager.executor().clone())
+                    .map_err(|_| GpuNativeResidencyInstallError::SourceUploadInitializationFailed)?,
+            )
+        } else {
+            None
+        };
         self.core.gpu_cache = Some(manager.gpu_cache().clone());
         self.core.gpu_native_residency = Some(manager);
+        self.gpu_native_source_upload_production = source_upload;
         Ok(())
     }
 
@@ -5012,7 +5045,20 @@ impl Engine {
             .gpu_native_residency
             .as_ref()
             .ok_or("missing physical manager")?;
-        let upload = SourceUploadState::new(arm, manager.executor().clone())?;
+        let upload = match arm {
+            SourceUploadArm::Control => {
+                SourceUploadState::new(SourceUploadArm::Control, manager.executor().clone())?
+            }
+            SourceUploadArm::Treatment => {
+                let upload = self
+                    .gpu_native_source_upload_production
+                    .as_ref()
+                    .cloned()
+                    .ok_or("ordinary production source/upload state is unavailable")?;
+                upload.reset()?;
+                upload
+            }
+        };
         *slot = Some(Arc::new(
             GpuNativeDemandSourceQualification::new_source_upload(
                 upload,
@@ -5028,8 +5074,13 @@ impl Engine {
     pub(crate) fn gpu_native_source_upload_snapshot(
         &self,
     ) -> Option<crate::gpu_native_source_upload::Snapshot> {
-        self.gpu_native_demand_source_qualification()
-            .and_then(|s| s.source_upload.as_ref().map(|u| u.snapshot()))
+        match self.gpu_native_demand_source_qualification() {
+            Some(state) => state.source_upload.as_ref().map(|upload| upload.snapshot()),
+            None => self
+                .gpu_native_source_upload_production
+                .as_ref()
+                .map(|upload| upload.snapshot()),
+        }
     }
 
     pub(crate) fn production_demand_source_snapshot(&self) -> ProductionDemandSourceSnapshot {
@@ -6021,6 +6072,14 @@ impl Engine {
         self: &Arc<Self>,
         id: u32,
     ) -> Result<Arc<ExpertResident>, ExpertReadError> {
+        self.fetch_with_retry_inner(id, None).await
+    }
+
+    async fn fetch_with_retry_inner(
+        self: &Arc<Self>,
+        id: u32,
+        source_upload: Option<Arc<SourceUploadState>>,
+    ) -> Result<Arc<ExpertResident>, ExpertReadError> {
         // Fast path: already cached — no singleflight needed. We
         // deliberately do *not* bump the `hits` counter here: the
         // upstream `moe_step` path already increments hits/misses
@@ -6109,7 +6168,7 @@ impl Engine {
             const MAX_ATTEMPTS: usize = 3;
             let mut last_err: Option<String> = None;
             for attempt in 0..MAX_ATTEMPTS {
-                match self.fetch_once(id).await {
+                match self.fetch_once(id, source_upload.clone()).await {
                     Ok(r) => {
                         if attempt > 0 {
                             info!(expert = id, attempt, "expert fetch recovered after retry");
@@ -6161,6 +6220,7 @@ impl Engine {
         self: &Arc<Self>,
         global_id: u32,
         residents: &mut HashMap<u32, Arc<ExpertResident>>,
+        source_upload: Option<Arc<SourceUploadState>>,
     ) -> Result<Arc<ExpertResident>, GpuNativeDemandResidencyError> {
         let qualification = self.gpu_native_demand_source_qualification();
         if let Some(state) = qualification.as_ref() {
@@ -6180,7 +6240,7 @@ impl Engine {
                 if let Some(state) = qualification.as_ref() {
                     state.source_ram_misses.fetch_add(1, Ordering::Relaxed);
                 }
-                self.fetch_with_retry(global_id).await?
+                self.fetch_with_retry_inner(global_id, source_upload.clone()).await?
             }
         };
         residents.insert(global_id, resident.clone());
@@ -6191,6 +6251,7 @@ impl Engine {
         self: &Arc<Self>,
         global_ids: &[u32],
         residents: &mut HashMap<u32, Arc<ExpertResident>>,
+        source_upload: Option<Arc<SourceUploadState>>,
     ) -> Result<(), GpuNativeDemandResidencyError> {
         let qualification = self.gpu_native_demand_source_qualification();
         if let Some(state) = qualification.as_ref() {
@@ -6201,7 +6262,11 @@ impl Engine {
             Some(GpuNativeQualificationPurpose::DemandSource(
                 GpuNativeDemandSourceQualificationArm::Control,
             )) => {
-                self.gpu_native_sequential_source_physical_missing_set(global_ids, residents)
+                self.gpu_native_sequential_source_physical_missing_set(
+                    global_ids,
+                    residents,
+                    source_upload.clone(),
+                )
                     .await
             }
             Some(GpuNativeQualificationPurpose::DemandSource(
@@ -6213,7 +6278,11 @@ impl Engine {
                 | GpuNativeQualificationPurpose::SourceToUpload(_),
             )
             | None => {
-                self.gpu_native_production_source_physical_missing_set(global_ids, residents)
+                self.gpu_native_production_source_physical_missing_set(
+                    global_ids,
+                    residents,
+                    source_upload.clone(),
+                )
                     .await
             }
         };
@@ -6233,6 +6302,7 @@ impl Engine {
         self: &Arc<Self>,
         global_ids: &[u32],
         residents: &mut HashMap<u32, Arc<ExpertResident>>,
+        source_upload: Option<Arc<SourceUploadState>>,
     ) -> Result<(), GpuNativeDemandResidencyError> {
         for &global_id in global_ids {
             if residents.contains_key(&global_id) {
@@ -6240,7 +6310,7 @@ impl Engine {
             }
             let individual_started = Instant::now();
             let source_result = self
-                .gpu_native_demand_source(global_id, residents)
+                .gpu_native_demand_source(global_id, residents, source_upload.clone())
                 .await
                 .map(|_| ());
             if let Some(state) = self.gpu_native_demand_source_qualification() {
@@ -6265,6 +6335,7 @@ impl Engine {
         self: &Arc<Self>,
         global_ids: &[u32],
         residents: &mut HashMap<u32, Arc<ExpertResident>>,
+        source_upload: Option<Arc<SourceUploadState>>,
     ) -> Result<(), GpuNativeDemandResidencyError> {
         let telemetry = self.production_demand_source.clone();
         telemetry.source_sets.fetch_add(1, Ordering::Relaxed);
@@ -6279,7 +6350,11 @@ impl Engine {
                 .fallback_single_item
                 .fetch_add(1, Ordering::Relaxed);
             return self
-                .gpu_native_sequential_source_physical_missing_set(global_ids, residents)
+                .gpu_native_sequential_source_physical_missing_set(
+                    global_ids,
+                    residents,
+                    source_upload.clone(),
+                )
                 .await;
         }
 
@@ -6292,7 +6367,11 @@ impl Engine {
         {
             telemetry.fallback_mixed_ram.fetch_add(1, Ordering::Relaxed);
             return self
-                .gpu_native_sequential_source_physical_missing_set(global_ids, residents)
+                .gpu_native_sequential_source_physical_missing_set(
+                    global_ids,
+                    residents,
+                    source_upload.clone(),
+                )
                 .await;
         }
         telemetry
@@ -6337,7 +6416,11 @@ impl Engine {
                         }
                     }
                     return self
-                        .gpu_native_sequential_source_physical_missing_set(global_ids, residents)
+                        .gpu_native_sequential_source_physical_missing_set(
+                            global_ids,
+                            residents,
+                            source_upload.clone(),
+                        )
                         .await;
                 }
             }
@@ -6362,7 +6445,11 @@ impl Engine {
             telemetry.fallback_mixed_ram.fetch_add(1, Ordering::Relaxed);
             drop(leadership);
             return self
-                .gpu_native_sequential_source_physical_missing_set(global_ids, residents)
+                .gpu_native_sequential_source_physical_missing_set(
+                    global_ids,
+                    residents,
+                    source_upload.clone(),
+                )
                 .await;
         }
 
@@ -6375,7 +6462,11 @@ impl Engine {
                         .fetch_add(1, Ordering::Relaxed);
                     drop(leadership);
                     return self
-                        .gpu_native_sequential_source_physical_missing_set(global_ids, residents)
+                        .gpu_native_sequential_source_physical_missing_set(
+                            global_ids,
+                            residents,
+                            source_upload.clone(),
+                        )
                         .await;
                 }
             };
@@ -6428,16 +6519,30 @@ impl Engine {
         }
 
         let batch_started = Instant::now();
-        let upload = self
-            .gpu_native_demand_source_qualification()
-            .and_then(|s| s.source_upload.clone());
+        let upload = source_upload.clone();
+        let production_fusion_eligible = upload.as_ref().is_some_and(|state| {
+            state.arm == SourceUploadArm::Treatment
+                && (!state.is_production_owned()
+                    || state.can_fuse_source_set(
+                        &unresolved,
+                        self.execution_context().gpu_expert_cache(),
+                    ))
+        });
+        if upload.as_ref().is_some_and(|state| {
+            state.arm == SourceUploadArm::Treatment
+                && state.is_production_owned()
+                && !production_fusion_eligible
+        }) {
+            upload
+                .as_ref()
+                .expect("production upload state")
+                .add(|m| &mut m.source_fallback_reads, unresolved.len() as u64);
+        }
         let mut fused_residents = None;
         let expected_bytes = buffers.iter().map(|buffer| buffer.len()).sum::<usize>();
         let _foreground = self.core.governor.foreground_guard();
-        let read_result = if let Some(upload) = upload
-            .as_ref()
-            .filter(|u| u.arm == SourceUploadArm::Treatment)
-        {
+        let read_result = if production_fusion_eligible {
+            let upload = upload.as_ref().expect("eligible upload state");
             match upload
                 .read_source(
                     &self.core.storage,
@@ -6562,12 +6667,11 @@ impl Engine {
         self: &Arc<Self>,
         global_ids: &[u32],
         residents: &mut HashMap<u32, Arc<ExpertResident>>,
+        source_upload: Option<Arc<SourceUploadState>>,
     ) -> Result<(Vec<GpuAdmission>, usize), GpuNativeDemandResidencyError> {
         let gpu = self.execution_context().gpu_expert_cache();
         let mut payloads = HashMap::with_capacity(global_ids.len());
-        let upload = self
-            .gpu_native_demand_source_qualification()
-            .and_then(|s| s.source_upload.clone());
+        let upload = source_upload.clone();
         let new_ids = if upload.is_some() {
             global_ids
                 .iter()
@@ -6616,7 +6720,13 @@ impl Engine {
                 }
                 GpuDemandSetAdmission::PayloadRequired(missing) => {
                     for global_id in missing {
-                        let resident = self.gpu_native_demand_source(global_id, residents).await?;
+                        let resident = self
+                            .gpu_native_demand_source(
+                                global_id,
+                                residents,
+                                source_upload.clone(),
+                            )
+                            .await?;
                         let payload = if let Some(upload) = upload
                             .as_ref()
                             .filter(|u| u.arm == SourceUploadArm::Treatment)
@@ -6698,6 +6808,21 @@ impl Engine {
             .cloned()
             .map(QualificationDemandServiceGuard::enter)
             .transpose()?;
+        let production_upload_guard = if qualification.is_none() {
+            self.gpu_native_source_upload_production
+                .as_ref()
+                .and_then(|upload| upload.try_begin_production_demand())
+        } else {
+            None
+        };
+        let source_upload = qualification
+            .as_ref()
+            .and_then(|state| state.source_upload.clone())
+            .or_else(|| {
+                production_upload_guard
+                    .as_ref()
+                    .map(|guard| guard.state().clone())
+            });
         let num_layers = manager.plan().num_layers();
         let experts_per_layer = manager.plan().geometry().num_experts() as u32;
         let mut seen = HashSet::with_capacity(global_ids.len());
@@ -6761,11 +6886,19 @@ impl Engine {
                         manager.record_physical_source_acquisition();
                     }
                 }
-                self.gpu_native_source_physical_missing_set(&physical_missing, &mut residents)
-                    .await?;
+                self.gpu_native_source_physical_missing_set(
+                    &physical_missing,
+                    &mut residents,
+                    source_upload.clone(),
+                )
+                .await?;
                 let logical_admission_started = Instant::now();
                 let (admissions, newly_admitted) = self
-                    .ensure_gpu_native_logical_demand_set(&physical_missing, &mut residents)
+                    .ensure_gpu_native_logical_demand_set(
+                        &physical_missing,
+                        &mut residents,
+                        source_upload.clone(),
+                    )
                     .await?;
                 if let Some(state) = qualification.as_ref() {
                     state.logical_demand_admission_us.fetch_add(
@@ -6859,18 +6992,49 @@ impl Engine {
                             ),
                     }
                 }
-                Some(GpuNativeQualificationPurpose::SourceToUpload(_)) => manager
-                    .ensure_demand_set_production_observed(
-                        GpuNativeResidencyPriority::Demand,
-                        layer_index,
-                        &demands,
-                        qualification
-                            .as_ref()
-                            .expect("source/upload qualification")
-                            .as_ref(),
-                    ),
-                Some(GpuNativeQualificationPurpose::DemandSource(_)) | None => manager
+                Some(GpuNativeQualificationPurpose::SourceToUpload(arm)) => {
+                    let observer = qualification
+                        .as_ref()
+                        .expect("source/upload qualification");
+                    match arm {
+                        SourceUploadArm::Control => manager.ensure_demand_set_production_observed(
+                            GpuNativeResidencyPriority::Demand,
+                            layer_index,
+                            &demands,
+                            observer.as_ref(),
+                        ),
+                        SourceUploadArm::Treatment => {
+                            let upload = source_upload
+                                .as_ref()
+                                .expect("treatment uses production-owned upload state");
+                            manager.ensure_demand_set_source_upload_observed(
+                                GpuNativeResidencyPriority::Demand,
+                                layer_index,
+                                &demands,
+                                upload.as_ref(),
+                                observer.as_ref(),
+                            )
+                        }
+                    }
+                }
+                Some(GpuNativeQualificationPurpose::DemandSource(_)) => manager
                     .ensure_demand_set(GpuNativeResidencyPriority::Demand, layer_index, &demands),
+                None => {
+                    if let Some(upload) = source_upload.as_ref() {
+                        manager.ensure_demand_set_source_upload(
+                            GpuNativeResidencyPriority::Demand,
+                            layer_index,
+                            &demands,
+                            upload.as_ref(),
+                        )
+                    } else {
+                        manager.ensure_demand_set(
+                            GpuNativeResidencyPriority::Demand,
+                            layer_index,
+                            &demands,
+                        )
+                    }
+                }
             };
             if let Some(state) = qualification.as_ref() {
                 state.physical_demand_install_us.fetch_add(
@@ -6880,11 +7044,13 @@ impl Engine {
             }
             match physical_install_result {
                 Ok(residencies) => {
-                    if let Some(upload) = qualification
-                        .as_ref()
-                        .and_then(|s| s.source_upload.as_ref())
-                    {
-                        upload.finish_request().map_err(|source| GpuNativeDemandResidencyError::ProductionBatchReadFailedAfterReservation { global_ids: global_ids.to_vec(), source })?;
+                    if let Some(upload) = source_upload.as_ref() {
+                        upload.finish_request().map_err(|source| {
+                            GpuNativeDemandResidencyError::ProductionBatchReadFailedAfterReservation {
+                                global_ids: global_ids.to_vec(),
+                                source,
+                            }
+                        })?;
                     }
                     return Ok(residencies);
                 }
@@ -6913,7 +7079,11 @@ impl Engine {
     /// if the pool is under pressure), issues the read, and either
     /// installs the resident in the cache or surfaces the I/O error
     /// to the retry loop.
-    async fn fetch_once(self: &Arc<Self>, id: u32) -> Result<Arc<ExpertResident>, FetchOnceError> {
+    async fn fetch_once(
+        self: &Arc<Self>,
+        id: u32,
+        source_upload: Option<Arc<SourceUploadState>>,
+    ) -> Result<Arc<ExpertResident>, FetchOnceError> {
         let io_start = Instant::now();
         // Acquire-with-eviction: evict an LRU entry if the cache is at
         // capacity (which releases its `PooledBuffer` on `Arc` drop),
@@ -6947,15 +7117,29 @@ impl Engine {
         // the governor is disabled.
         let _fg = self.core.governor.foreground_guard();
         let source_bytes = buf.len();
-        let upload = self
-            .gpu_native_demand_source_qualification()
-            .and_then(|s| s.source_upload.clone());
+        let upload = source_upload.clone();
+        let production_fusion_eligible = upload.as_ref().is_some_and(|state| {
+            state.arm == SourceUploadArm::Treatment
+                && (!state.is_production_owned()
+                    || state.can_fuse_source_set(
+                        &[id],
+                        self.execution_context().gpu_expert_cache(),
+                    ))
+        });
+        if upload.as_ref().is_some_and(|state| {
+            state.arm == SourceUploadArm::Treatment
+                && state.is_production_owned()
+                && !production_fusion_eligible
+        }) {
+            upload
+                .as_ref()
+                .expect("production upload state")
+                .add(|m| &mut m.source_fallback_reads, 1);
+        }
         let mut ordinary_buffer = Some(buf);
         let mut fused_resident = None;
-        let read_result = if let Some(upload) = upload
-            .as_ref()
-            .filter(|u| u.arm == SourceUploadArm::Treatment)
-        {
+        let read_result = if production_fusion_eligible {
+            let upload = upload.as_ref().expect("eligible upload state");
             match upload
                 .read_source(
                     &self.core.storage,
@@ -9954,7 +10138,7 @@ mod tests {
 
         let mut first_request = HashMap::new();
         let first = engine
-            .gpu_native_demand_source(0, &mut first_request)
+            .gpu_native_demand_source(0, &mut first_request, None)
             .await
             .unwrap();
         let after_nvme = engine.report().bytes_read;
@@ -9962,14 +10146,14 @@ mod tests {
 
         let mut second_request = HashMap::new();
         let ram_hit = engine
-            .gpu_native_demand_source(0, &mut second_request)
+            .gpu_native_demand_source(0, &mut second_request, None)
             .await
             .unwrap();
         assert!(Arc::ptr_eq(&first, &ram_hit));
         assert_eq!(engine.report().bytes_read, after_nvme);
 
         let same_request = engine
-            .gpu_native_demand_source(0, &mut second_request)
+            .gpu_native_demand_source(0, &mut second_request, None)
             .await
             .unwrap();
         assert!(Arc::ptr_eq(&ram_hit, &same_request));
@@ -10104,7 +10288,7 @@ mod tests {
     ) -> Result<HashMap<u32, Arc<ExpertResident>>, GpuNativeDemandResidencyError> {
         let mut residents = HashMap::new();
         engine
-            .gpu_native_source_physical_missing_set(&ids, &mut residents)
+            .gpu_native_source_physical_missing_set(&ids, &mut residents, None)
             .await?;
         Ok(residents)
     }
@@ -10182,7 +10366,7 @@ mod tests {
         let mut priming = HashMap::new();
         for id in 0..6 {
             engine
-                .gpu_native_demand_source(id, &mut priming)
+                .gpu_native_demand_source(id, &mut priming, None)
                 .await
                 .unwrap();
         }
@@ -10266,7 +10450,7 @@ mod tests {
         let engine = build_engine(&dir.path, 4, 8, 8, 4, 2, 0, 21);
         let mut priming = HashMap::new();
         let retained = engine
-            .gpu_native_demand_source(0, &mut priming)
+            .gpu_native_demand_source(0, &mut priming, None)
             .await
             .unwrap();
         drop(priming);
@@ -10301,7 +10485,7 @@ mod tests {
         let mut priming = HashMap::new();
         for id in 0..4 {
             engine
-                .gpu_native_demand_source(id, &mut priming)
+                .gpu_native_demand_source(id, &mut priming, None)
                 .await
                 .unwrap();
         }
@@ -10314,7 +10498,7 @@ mod tests {
             .unwrap();
         let mut residents = HashMap::new();
         let error = engine
-            .gpu_native_source_physical_missing_set(&[4, 5], &mut residents)
+            .gpu_native_source_physical_missing_set(&[4, 5], &mut residents, None)
             .await
             .unwrap_err();
         assert!(matches!(
@@ -10348,7 +10532,7 @@ mod tests {
         let mut retained = HashMap::new();
         for id in [0, 1] {
             engine
-                .gpu_native_demand_source(id, &mut retained)
+                .gpu_native_demand_source(id, &mut retained, None)
                 .await
                 .unwrap();
         }
@@ -10358,7 +10542,7 @@ mod tests {
         // can be acquired, forcing the post-reservation fail-closed path.
         let mut residents = HashMap::new();
         let error = engine
-            .gpu_native_source_physical_missing_set(&[2, 3], &mut residents)
+            .gpu_native_source_physical_missing_set(&[2, 3], &mut residents, None)
             .await
             .unwrap_err();
         assert!(matches!(
@@ -10494,7 +10678,7 @@ mod tests {
         let mut priming = HashMap::new();
         for id in [0, 1] {
             engine
-                .gpu_native_demand_source(id, &mut priming)
+                .gpu_native_demand_source(id, &mut priming, None)
                 .await
                 .unwrap();
         }
@@ -13389,6 +13573,30 @@ mod tests {
             }
         }
     }
+    #[test]
+    fn source_upload_production_wiring_is_demand_scoped_and_preserves_qualification_override() {
+        let source = include_str!("engine.rs");
+        let demand = source
+            .split("pub(crate) async fn ensure_gpu_native_demand_residency(")
+            .nth(1)
+            .unwrap()
+            .split("/// One single fetch attempt.")
+            .next()
+            .unwrap();
+        assert!(demand.contains("try_begin_production_demand()"));
+        assert!(demand.contains("ensure_demand_set_source_upload("));
+        assert!(demand.contains("ensure_demand_set_source_upload_observed("));
+        let ordinary_fetch = source
+            .split("pub async fn fetch_with_retry(")
+            .nth(1)
+            .unwrap()
+            .split("async fn gpu_native_demand_source(")
+            .next()
+            .unwrap();
+        assert!(ordinary_fetch.contains("self.fetch_with_retry_inner(id, None).await"));
+        assert!(!ordinary_fetch.contains("gpu_native_source_upload_production.as_ref()"));
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn source_upload_ram_hit_never_acquires_an_upload_slot_or_reads_nvme() {
         let dir = TempDir::new("upload-ram-hit");
@@ -13405,7 +13613,7 @@ mod tests {
         ));
         let mut residents = HashMap::new();
         engine
-            .gpu_native_source_physical_missing_set(&[0], &mut residents)
+            .gpu_native_source_physical_missing_set(&[0], &mut residents, Some(upload.clone()))
             .await
             .unwrap();
         assert!(Arc::ptr_eq(&resident, &residents[&0]));
@@ -13430,7 +13638,7 @@ mod tests {
         ));
         let mut residents = HashMap::new();
         engine
-            .gpu_native_source_physical_missing_set(&[2, 0], &mut residents)
+            .gpu_native_source_physical_missing_set(&[2, 0], &mut residents, Some(upload.clone()))
             .await
             .unwrap();
         assert_eq!(

--- a/rust-engine/src/expert_cache.rs
+++ b/rust-engine/src/expert_cache.rs
@@ -55,6 +55,10 @@ fn store_heat_f64(a: &AtomicU64, v: f64) {
 pub struct ExpertResident {
     pub id: u32,
     pub buffer: PooledBuffer,
+    /// Qualification-only bytes. The ordinary pool lease is retained solely
+    /// for identical source capacity/backpressure and is never a byte source
+    /// for this representation. Production constructors leave this absent.
+    qualification_shared_payload: Option<Arc<[u8]>>,
     /// Byte offset within `buffer` at which the bare weight payload
     /// begins. `0` for legacy blobs and synthetic fixtures (no UTH);
     /// `UTH_BYTES + page padding` for `gguf-convert` blobs.
@@ -128,6 +132,7 @@ impl ExpertResident {
         Self {
             id,
             buffer,
+            qualification_shared_payload: None,
             payload_offset,
             mixed_layout,
             hits: AtomicU64::new(0),
@@ -137,6 +142,33 @@ impl ExpertResident {
             heat_bits: AtomicU64::new(0.0f64.to_bits()),
             heat_last_epoch: AtomicU64::new(0),
         }
+    }
+
+    pub(crate) fn new_qualification_shared(
+        id: u32,
+        capacity_lease: PooledBuffer,
+        payload: Arc<[u8]>,
+    ) -> Self {
+        assert!(!payload.is_empty());
+        // Do not parse the unused capacity lease as a source file.
+        RESIDENT_EXPERT_BUFFER_BYTES.fetch_add(capacity_lease.len() as u64, Ordering::Relaxed);
+        Self {
+            id,
+            buffer: capacity_lease,
+            qualification_shared_payload: Some(payload),
+            payload_offset: 0,
+            mixed_layout: None,
+            hits: AtomicU64::new(0),
+            q4_0_padded: OnceCell::new(),
+            #[cfg(feature = "q8-candle-reference")]
+            q8_0_qmm: OnceCell::new(),
+            heat_bits: AtomicU64::new(0.0f64.to_bits()),
+            heat_last_epoch: AtomicU64::new(0),
+        }
+    }
+
+    pub(crate) fn qualification_shared_payload(&self) -> Option<&Arc<[u8]>> {
+        self.qualification_shared_payload.as_ref()
     }
 
     /// Parsed UTH2 layout for mixed-projection experts.
@@ -197,8 +229,12 @@ impl ExpertResident {
     /// resident. Qualification code uses this to fail closed if a future
     /// position accidentally retains a production PRIMARY resident.
     #[inline]
-    pub(crate) fn buffer_pool_origin(&self) -> crate::buffer_pool::BufferPoolOrigin {
-        self.buffer.pool_origin()
+    pub(crate) fn buffer_pool_origin(&self) -> Option<crate::buffer_pool::BufferPoolOrigin> {
+        // None is the distinct materialized shared source backing. In
+        // particular it cannot satisfy ORACLE's future-source pool witness.
+        self.qualification_shared_payload
+            .is_none()
+            .then(|| self.buffer.pool_origin())
     }
 
     /// Bare weight bytes — i.e. the buffer with any leading Unified
@@ -208,6 +244,9 @@ impl ExpertResident {
     /// so the UTH is **not** reparsed on each call.
     #[inline]
     pub fn data(&self) -> &[u8] {
+        if let Some(payload) = self.qualification_shared_payload.as_ref() {
+            return payload;
+        }
         &self.buffer.as_slice()[self.payload_offset..]
     }
 
@@ -670,6 +709,7 @@ impl ExpertCache {
 /// cannot retain expert bytes, an ExpertResident, or a source-pool lease.
 enum GpuResidentHostPayload {
     Materialized(Vec<u8>),
+    QualificationShared(Arc<[u8]>),
     QualificationLogicalOnly {
         charged_bytes: usize,
         data_accesses: Arc<AtomicU64>,
@@ -686,6 +726,25 @@ pub struct GpuResident {
 }
 
 impl GpuResident {
+    pub(crate) fn new_qualification_shared(
+        id: u32,
+        bytes: Arc<[u8]>,
+        dtype: crate::inference::WeightDtype,
+    ) -> Self {
+        Self {
+            id,
+            payload: GpuResidentHostPayload::QualificationShared(bytes),
+            dtype,
+        }
+    }
+
+    pub(crate) fn qualification_shared_payload(&self) -> Option<&Arc<[u8]>> {
+        match &self.payload {
+            GpuResidentHostPayload::QualificationShared(bytes) => Some(bytes),
+            _ => None,
+        }
+    }
+
     pub fn new(id: u32, bytes: Vec<u8>) -> Self {
         Self {
             id,
@@ -735,6 +794,7 @@ impl GpuResident {
     pub fn data(&self) -> &[u8] {
         match &self.payload {
             GpuResidentHostPayload::Materialized(bytes) => bytes,
+            GpuResidentHostPayload::QualificationShared(bytes) => bytes,
             GpuResidentHostPayload::QualificationLogicalOnly { data_accesses, .. } => {
                 data_accesses.fetch_add(1, Ordering::Relaxed);
                 panic!("qualification logical-only GpuResident has no payload bytes; physical staging must use ExpertResident::data()");
@@ -752,6 +812,7 @@ impl GpuResident {
     pub fn byte_len(&self) -> usize {
         match &self.payload {
             GpuResidentHostPayload::Materialized(bytes) => bytes.len(),
+            GpuResidentHostPayload::QualificationShared(bytes) => bytes.len(),
             GpuResidentHostPayload::QualificationLogicalOnly { charged_bytes, .. } => {
                 *charged_bytes
             }
@@ -3156,5 +3217,113 @@ mod tests {
         );
         assert!(cache.promote_sync(gpu_res(7, 8)));
         assert!(cache.contains(7));
+    }
+    #[test]
+    fn source_upload_shared_host_and_logical_residents_own_exact_same_bytes() {
+        let pool = BufferPool::new(2, 4096, 4096);
+        let shared: Arc<[u8]> = Arc::from([3u8, 1, 4, 1, 5].as_slice());
+        let host = ExpertResident::new_qualification_shared(
+            17,
+            pool.try_acquire().unwrap(),
+            shared.clone(),
+        );
+        let logical = GpuResident::new_qualification_shared(
+            17,
+            shared.clone(),
+            crate::inference::WeightDtype::Q4_0,
+        );
+        assert_eq!(host.id, 17);
+        assert_eq!(host.payload_offset, 0);
+        assert_eq!(host.data(), shared.as_ref());
+        assert_eq!(logical.data(), shared.as_ref());
+        assert!(Arc::ptr_eq(
+            host.qualification_shared_payload().unwrap(),
+            logical.qualification_shared_payload().unwrap()
+        ));
+        assert_eq!(logical.byte_len(), 5);
+        assert_eq!(logical.dtype(), crate::inference::WeightDtype::Q4_0);
+        assert_eq!(host.buffer_pool_origin(), None);
+        assert_eq!(pool.primary_available(), 1);
+        drop(host);
+        assert_eq!(pool.primary_available(), 2);
+        assert_eq!(logical.data(), &[3, 1, 4, 1, 5]);
+    }
+    #[test]
+    fn source_upload_ordinary_pool_and_vec_representations_are_unchanged() {
+        let pool = BufferPool::new(1, 4096, 4096);
+        let mut buffer = pool.try_acquire().unwrap();
+        buffer.as_mut_slice().fill(23);
+        let ptr = buffer.as_slice().as_ptr();
+        let host = ExpertResident::new(2, buffer);
+        assert!(host.qualification_shared_payload().is_none());
+        assert_eq!(host.data().as_ptr(), ptr);
+        assert_eq!(
+            host.buffer_pool_origin(),
+            Some(crate::buffer_pool::BufferPoolOrigin::Production)
+        );
+        let bytes = vec![9, 8, 7];
+        let ptr = bytes.as_ptr();
+        let gpu = GpuResident::new(2, bytes);
+        assert!(matches!(
+            gpu.payload,
+            GpuResidentHostPayload::Materialized(_)
+        ));
+        assert_eq!(gpu.data().as_ptr(), ptr);
+        assert!(gpu.qualification_shared_payload().is_none());
+        drop(host);
+        assert_eq!(pool.primary_available(), 1);
+    }
+    #[test]
+    fn source_upload_shared_cache_has_identical_insert_victim_and_pool_lifecycle() {
+        fn run(shared: bool) -> (Vec<u32>, Vec<u32>, usize) {
+            let pool = BufferPool::new(4, 4096, 4096);
+            let cache = ExpertCache::new(2);
+            let mut victims = vec![];
+            for id in [0, 1, 2, 0, 3] {
+                let buffer = pool.try_acquire().unwrap();
+                let resident = Arc::new(if shared {
+                    ExpertResident::new_qualification_shared(
+                        id,
+                        buffer,
+                        Arc::from([id as u8; 8].as_slice()),
+                    )
+                } else {
+                    ExpertResident::new(id, buffer)
+                });
+                if let Some(victim) = cache.insert(resident).ok().unwrap() {
+                    victims.push(victim.id);
+                }
+                if id == 1 {
+                    cache.get(0);
+                }
+            }
+            (victims, cache.resident_ids(), pool.primary_available())
+        }
+        assert_eq!(run(false), run(true));
+    }
+    #[test]
+    fn source_upload_shared_logical_admission_charges_payload_and_keeps_generation() {
+        let cache = GpuExpertCache::new(32, 0.0, 0);
+        let bytes: Arc<[u8]> = Arc::from([1u8; 8].as_slice());
+        let resident = Arc::new(GpuResident::new_qualification_shared(
+            2,
+            bytes.clone(),
+            crate::inference::WeightDtype::Q4_0,
+        ));
+        let mut payloads = HashMap::new();
+        payloads.insert(2, resident);
+        let GpuDemandSetAdmission::Ready { admissions, .. } =
+            cache.demand_admit_set(&[2], &payloads).unwrap()
+        else {
+            panic!("admission")
+        };
+        assert_eq!(cache.used_bytes(), 8);
+        assert_eq!(admissions[0].byte_len(), 8);
+        let current = cache.current_admission(2).unwrap();
+        assert_eq!(current.generation(), admissions[0].generation());
+        assert!(Arc::ptr_eq(
+            current.resident().qualification_shared_payload().unwrap(),
+            &bytes
+        ));
     }
 }

--- a/rust-engine/src/gpu_native_oracle_scheduled_residency.rs
+++ b/rust-engine/src/gpu_native_oracle_scheduled_residency.rs
@@ -617,7 +617,7 @@ async fn read_oracle_future_source_from_storage(
         buffer,
         storage.config().block_align,
     ));
-    if resident.buffer_pool_origin() != BufferPoolOrigin::QualificationOracleFutureSource {
+    if resident.buffer_pool_origin() != Some(BufferPoolOrigin::QualificationOracleFutureSource) {
         return Err(OracleSourceReadError::Fatal(
             "ORACLE future-source read returned a production-backed resident".into(),
         ));
@@ -773,7 +773,7 @@ fn validate_retained_source_origins(
         | OracleScheduledResidencyMode::TokenBoundaryDirectLogicalOnlyNoZeroFill => {
             for (&global_id, resident) in &outcome.residents {
                 if resident.buffer_pool_origin()
-                    != BufferPoolOrigin::QualificationOracleFutureSource
+                    != Some(BufferPoolOrigin::QualificationOracleFutureSource)
                 {
                     return Err(format!(
                         "token-boundary-direct retained production-backed future expert {global_id}"
@@ -5228,7 +5228,7 @@ mod tests {
         assert_eq!(bytes, EXPERT_SIZE);
         assert_eq!(
             resident.buffer_pool_origin(),
-            BufferPoolOrigin::QualificationOracleFutureSource
+            Some(BufferPoolOrigin::QualificationOracleFutureSource)
         );
         assert_eq!(production_pool.primary_available(), production_available);
         assert_eq!(production_cache.len(), 0);

--- a/rust-engine/src/gpu_native_physical_install_staging.rs
+++ b/rust-engine/src/gpu_native_physical_install_staging.rs
@@ -8,6 +8,9 @@ pub(crate) mod payload_copy;
 #[path = "gpu_native_physical_zero_fill_production.rs"]
 pub(crate) mod zero_fill_production;
 
+#[path = "gpu_native_source_to_upload_copy_elision_production.rs"]
+pub(crate) mod source_to_upload_production;
+
 #[path = "gpu_native_q4_route_parallel.rs"]
 pub(crate) mod q4_route_parallel;
 
@@ -854,10 +857,13 @@ enum PhysicalInstallQualificationRun {
     Staging(GpuNativePhysicalInstallStagingQualificationArm),
     Concurrency(crate::engine::GpuNativePhysicalInstallConcurrencyQualificationArm),
     ZeroFillProduction(crate::engine::GpuNativePhysicalInstallConcurrencyQualificationArm),
+    SourceToUpload(crate::gpu_native_source_upload::Arm),
 }
 
 struct PhysicalInstallArmRun {
     common: ArmReport,
+    warmup_upload: Option<crate::gpu_native_source_upload::Snapshot>,
+    upload: Option<crate::gpu_native_source_upload::Snapshot>,
     warmup_concurrency:
         Option<crate::engine::GpuNativePhysicalInstallConcurrencyQualificationSnapshot>,
     concurrency: Option<crate::engine::GpuNativePhysicalInstallConcurrencyQualificationSnapshot>,
@@ -869,11 +875,13 @@ fn concurrency_common_snapshot(
     GpuNativePhysicalInstallStagingQualificationSnapshot {
         arm: match source.arm {
             crate::engine::GpuNativePhysicalInstallConcurrencyQualificationArm::Control
-            | crate::engine::GpuNativePhysicalInstallConcurrencyQualificationArm::ConcurrentFullZeroControl => {
+            | crate::engine::GpuNativePhysicalInstallConcurrencyQualificationArm::ConcurrentFullZeroControl
+            | crate::engine::GpuNativePhysicalInstallConcurrencyQualificationArm::SourceToUploadControl => {
                 GpuNativePhysicalInstallStagingQualificationArm::Control
             }
             crate::engine::GpuNativePhysicalInstallConcurrencyQualificationArm::Treatment
-            | crate::engine::GpuNativePhysicalInstallConcurrencyQualificationArm::ProductionNoZeroFillTreatment => {
+            | crate::engine::GpuNativePhysicalInstallConcurrencyQualificationArm::ProductionNoZeroFillTreatment
+            | crate::engine::GpuNativePhysicalInstallConcurrencyQualificationArm::SourceToUploadTreatment => {
                 GpuNativePhysicalInstallStagingQualificationArm::Treatment
             }
         },
@@ -945,17 +953,31 @@ async fn run_physical_install_arm_inner(
 ) -> Result<PhysicalInstallArmRun, BenchmarkFailure> {
     use crate::engine::GpuNativePhysicalInstallConcurrencyQualificationArm as ConcurrentArm;
     let (arm_name, arm) = match run {
+        PhysicalInstallQualificationRun::SourceToUpload(arm) => match arm {
+            crate::gpu_native_source_upload::Arm::Control => (
+                "control",
+                GpuNativePhysicalInstallStagingQualificationArm::Control,
+            ),
+            crate::gpu_native_source_upload::Arm::Treatment => (
+                "treatment",
+                GpuNativePhysicalInstallStagingQualificationArm::Treatment,
+            ),
+        },
         PhysicalInstallQualificationRun::Staging(arm) => match arm {
             GpuNativePhysicalInstallStagingQualificationArm::Control => ("control", arm),
             GpuNativePhysicalInstallStagingQualificationArm::Treatment => ("treatment", arm),
         },
         PhysicalInstallQualificationRun::Concurrency(arm)
         | PhysicalInstallQualificationRun::ZeroFillProduction(arm) => match arm {
-            ConcurrentArm::Control | ConcurrentArm::ConcurrentFullZeroControl => (
+            ConcurrentArm::Control
+            | ConcurrentArm::ConcurrentFullZeroControl
+            | ConcurrentArm::SourceToUploadControl => (
                 "control",
                 GpuNativePhysicalInstallStagingQualificationArm::Control,
             ),
-            ConcurrentArm::Treatment | ConcurrentArm::ProductionNoZeroFillTreatment => (
+            ConcurrentArm::Treatment
+            | ConcurrentArm::ProductionNoZeroFillTreatment
+            | ConcurrentArm::SourceToUploadTreatment => (
                 "treatment",
                 GpuNativePhysicalInstallStagingQualificationArm::Treatment,
             ),
@@ -965,6 +987,7 @@ async fn run_physical_install_arm_inner(
         PhysicalInstallQualificationRun::Staging(_) => PRODUCTION_MODE,
         PhysicalInstallQualificationRun::Concurrency(_) => CONCURRENCY_MODE,
         PhysicalInstallQualificationRun::ZeroFillProduction(_) => zero_fill_production::MODE,
+        PhysicalInstallQualificationRun::SourceToUpload(_) => source_to_upload_production::MODE,
     });
     let mut benchmark = benchmark_report(prepared);
     let runtime = crate::gpu_native_real_benchmark::construct_runtime(
@@ -976,6 +999,9 @@ async fn run_physical_install_arm_inner(
     )
     .await?;
     let enable_result = match run {
+        PhysicalInstallQualificationRun::SourceToUpload(arm) => runtime
+            .engine
+            .enable_gpu_native_source_upload_qualification(arm),
         PhysicalInstallQualificationRun::Staging(arm) => runtime
             .engine
             .enable_gpu_native_physical_install_staging_qualification(arm),
@@ -1062,6 +1088,7 @@ async fn run_physical_install_arm_inner(
         }
     }
 
+    let warmup_upload = runtime.engine.gpu_native_source_upload_snapshot();
     let mut warmup_source = None;
     let mut warmup_concurrency = None;
     let mut warmup_production_physical_install = None;
@@ -1076,7 +1103,8 @@ async fn run_physical_install_arm_inner(
             .gpu_native_physical_install_staging_qualification_snapshot();
             }
             PhysicalInstallQualificationRun::Concurrency(_)
-            | PhysicalInstallQualificationRun::ZeroFillProduction(_) => {
+            | PhysicalInstallQualificationRun::ZeroFillProduction(_)
+            | PhysicalInstallQualificationRun::SourceToUpload(_) => {
                 warmup_concurrency = runtime
                     .engine
                     .gpu_native_physical_install_concurrency_qualification_snapshot();
@@ -1181,7 +1209,8 @@ async fn run_physical_install_arm_inner(
             None,
         ),
         PhysicalInstallQualificationRun::Concurrency(_)
-        | PhysicalInstallQualificationRun::ZeroFillProduction(_) => {
+        | PhysicalInstallQualificationRun::ZeroFillProduction(_)
+        | PhysicalInstallQualificationRun::SourceToUpload(_) => {
             let concurrency = runtime
                 .engine
                 .gpu_native_physical_install_concurrency_qualification_snapshot();
@@ -1191,6 +1220,7 @@ async fn run_physical_install_arm_inner(
             )
         }
     };
+    let upload = runtime.engine.gpu_native_source_upload_snapshot();
     let production_physical_install = runtime.engine.production_physical_install_snapshot();
     if execution_failure.is_none() && production_physical_install.is_none() {
         execution_failure = Some(BenchmarkFailure::new(
@@ -1235,6 +1265,8 @@ async fn run_physical_install_arm_inner(
         benchmark.fail(failure.clone());
     }
     Ok(PhysicalInstallArmRun {
+        warmup_upload,
+        upload,
         common: ArmReport {
         arm,
         complete: execution_failure.is_none(),

--- a/rust-engine/src/gpu_native_q4_route_parallel.rs
+++ b/rust-engine/src/gpu_native_q4_route_parallel.rs
@@ -1122,11 +1122,11 @@ mod tests {
         for (source, expected) in [
             (
                 include_str!("engine.rs"),
-                "28fd6cfdec0f42d232a7e02c6f2a8b0dd50ccc3a00f926f25a650c7eff8230c5",
+                "df78f271e19ff9528e8a8a670e24044e530e867481688e80bc5b3e04c94656cc",
             ),
             (
                 include_str!("gpu_native_residency.rs"),
-                "a918fe46cbe488374e5534bb2b9a32c9341a66f5460480298b84368b6483c261",
+                "de408213f4ae97fa5651d5e240c3cf6fb1d16f812b289ad5bf1ac0047fa1b2c8",
             ),
             (
                 include_str!("config.rs"),
@@ -1134,7 +1134,7 @@ mod tests {
             ),
             (
                 include_str!("gpu_native_physical_install_staging.rs"),
-                "3654bef7035faec3981c30733dad9dc09956b84fed4b88cee547137754d49c06",
+                "6f65b3704f5e64a8dc22a696251b9a0d284a7780fd57c42996e807998249cc52",
             ),
         ] {
             assert_eq!(

--- a/rust-engine/src/gpu_native_q4_route_parallel.rs
+++ b/rust-engine/src/gpu_native_q4_route_parallel.rs
@@ -1122,11 +1122,11 @@ mod tests {
         for (source, expected) in [
             (
                 include_str!("engine.rs"),
-                "df78f271e19ff9528e8a8a670e24044e530e867481688e80bc5b3e04c94656cc",
+                "7814eb2d76f4f0425ce78fbeadbf5cd4581488fcdab3011eb0f4aad5c48b5083",
             ),
             (
                 include_str!("gpu_native_residency.rs"),
-                "de408213f4ae97fa5651d5e240c3cf6fb1d16f812b289ad5bf1ac0047fa1b2c8",
+                "662feee8293175a06a26ee3a400fdff23ce245513d1ebaa44a51b3cc9f601cbe",
             ),
             (
                 include_str!("config.rs"),

--- a/rust-engine/src/gpu_native_residency.rs
+++ b/rust-engine/src/gpu_native_residency.rs
@@ -398,6 +398,9 @@ const fn speculative_install_path() -> DemandPhysicalInstallPath {
 /// already-committed physical events in their production order, except that a
 /// direct-staging unavailability is recorded explicitly before failing.
 pub(crate) trait GpuNativePhysicalInstallObserver: Send + Sync {
+    fn source_upload_state(&self) -> Option<&crate::gpu_native_source_upload::State> {
+        None
+    }
     fn record_physical_victim(&self, global_id: u32);
     fn record_physical_install_attempt(&self);
     fn record_direct_staging_failure(&self);
@@ -1245,6 +1248,21 @@ impl GpuNativeTieredResidencyManager {
                 ));
         }
 
+        let upload = if OBSERVE {
+            observer.and_then(|o| o.source_upload_state())
+        } else {
+            None
+        };
+        if let Some(upload) =
+            upload.filter(|u| u.arm == crate::gpu_native_source_upload::Arm::Treatment)
+        {
+            if reserved.iter().any(|r| upload.has_pending(r.global_id)) {
+                upload.add(|m| &mut m.fused_install_sets, 1);
+            }
+        }
+        let copies = upload
+            .filter(|u| u.arm == crate::gpu_native_source_upload::Arm::Treatment)
+            .map(crate::gpu_native_source_upload::CopySet::new);
         let stage_one = |reserved: ReservedPhysicalInstall<'a>| {
             if OBSERVE {
                 observer
@@ -1252,7 +1270,14 @@ impl GpuNativeTieredResidencyManager {
                     .record_physical_stage_started();
             }
             let stage_started = OBSERVE.then(Instant::now);
-            let result = if FULL_ZERO_CONTROL {
+            let lease = upload
+                .map(|u| u.take_lease(reserved.global_id, &reserved.resident))
+                .transpose();
+            let result = match lease {
+                Err(detail) => Err(crate::backend::gpu_native::GpuNativeBootstrapError::QualificationSourceUpload { detail }),
+                Ok(Some(Some(lease))) => self.executor.stage_q4_expert_source_upload(
+                    reserved.permit, reserved.resident.data(), lease, copies.as_ref().expect("treatment copy set")),
+                _ => if FULL_ZERO_CONTROL {
                 self.executor
                     .stage_q4_expert_residency_full_zero_control_observed(
                         reserved.permit,
@@ -1267,7 +1292,7 @@ impl GpuNativeTieredResidencyManager {
                 self.executor
                     .stage_q4_expert_residency_production(reserved.permit, reserved.resident.data())
                     .map(|prepared| (prepared, GpuNativePhysicalInstallEvidence::default()))
-            };
+            }};
             match result {
                 Ok((prepared, mut evidence)) => {
                     let individual_stage_us = stage_started.map_or(0, qualification_elapsed_us);
@@ -1307,6 +1332,15 @@ impl GpuNativeTieredResidencyManager {
                 ));
         }
 
+        // Queue submission is deliberately separate from token compute and
+        // precedes every executable mapping publication, including a prefix
+        // retained by the existing ordered failure semantics.
+        if let Some(copies) = &copies {
+            copies.submit(&self.executor).map_err(|detail| {
+                upload.expect("copy audit").add(|m| &mut m.copy_failures, 1);
+                GpuNativeTieredResidencyError::from(crate::backend::gpu_native::GpuNativeBootstrapError::QualificationSourceUpload { detail })
+            })?;
+        }
         let first_stage_failure = staged.iter().position(Result::is_err);
         let mut remaining_successful = staged.iter().filter(|result| result.is_ok()).count() as u64;
         for (position, staged_result) in staged.into_iter().enumerate() {
@@ -2144,7 +2178,7 @@ mod tests {
 
     #[test]
     fn qualification_logical_only_physical_stage_source_witness() {
-        // Both production calls and the new qualification call consume the
+        // Both production calls and both qualification calls validate the
         // ExpertResident field of ReservedPhysicalInstall. Pin this contract
         // without changing the frozen engine/hash witnesses or requiring a GPU.
         let source = include_str!("gpu_native_residency.rs");
@@ -2155,7 +2189,8 @@ mod tests {
             .split("let parallel_stage_started =")
             .next()
             .unwrap();
-        assert_eq!(stage.matches("reserved.resident.data()").count(), 3);
+        assert_eq!(stage.matches("reserved.resident.data()").count(), 4);
+        assert_eq!(stage.matches("stage_q4_expert_source_upload(").count(), 1);
         let production = stage.split("} else if OBSERVE {").nth(1).unwrap();
         assert_eq!(production.matches("reserved.resident.data()").count(), 2);
         assert!(stage.contains("stage_q4_expert_residency_full_zero_control_observed("));

--- a/rust-engine/src/gpu_native_residency.rs
+++ b/rust-engine/src/gpu_native_residency.rs
@@ -801,6 +801,59 @@ impl GpuNativeTieredResidencyManager {
         )
     }
 
+    pub(crate) fn ensure_demand_set_source_upload(
+        &self,
+        priority: GpuNativeResidencyPriority,
+        layer_index: usize,
+        demands: &[GpuNativeDemandExpert],
+        source_upload: &crate::gpu_native_source_upload::State,
+    ) -> Result<Vec<GpuNativeQ4ExpertResidency>, GpuNativeTieredResidencyError> {
+        if source_upload.arm != crate::gpu_native_source_upload::Arm::Treatment {
+            return Err(GpuNativeTieredResidencyError::Backend(
+                GpuNativeBootstrapError::QualificationSourceUpload {
+                    detail: "ordinary production source/upload state must use treatment".into(),
+                },
+            ));
+        }
+        self.ensure_demand_set_inner_with_source_upload::<false>(
+            priority,
+            layer_index,
+            demands,
+            ordinary_demand_install_path(),
+            None,
+            Some(source_upload),
+        )
+    }
+
+    pub(crate) fn ensure_demand_set_source_upload_observed(
+        &self,
+        priority: GpuNativeResidencyPriority,
+        layer_index: usize,
+        demands: &[GpuNativeDemandExpert],
+        source_upload: &crate::gpu_native_source_upload::State,
+        observer: &dyn GpuNativePhysicalInstallObserver,
+    ) -> Result<Vec<GpuNativeQ4ExpertResidency>, GpuNativeTieredResidencyError> {
+        if source_upload.arm != crate::gpu_native_source_upload::Arm::Treatment
+            || observer
+                .source_upload_state()
+                .is_none_or(|observed| !std::ptr::eq(observed, source_upload))
+        {
+            return Err(GpuNativeTieredResidencyError::Backend(
+                GpuNativeBootstrapError::QualificationSourceUpload {
+                    detail: "observed source/upload state must be the production-owned treatment state".into(),
+                },
+            ));
+        }
+        self.ensure_demand_set_inner_with_source_upload::<true>(
+            priority,
+            layer_index,
+            demands,
+            ordinary_demand_install_path(),
+            Some(observer),
+            Some(source_upload),
+        )
+    }
+
     pub(crate) fn ensure_demand_set_legacy_control(
         &self,
         priority: GpuNativeResidencyPriority,
@@ -911,6 +964,25 @@ impl GpuNativeTieredResidencyManager {
         install_path: DemandPhysicalInstallPath,
         observer: Option<&dyn GpuNativePhysicalInstallObserver>,
     ) -> Result<Vec<GpuNativeQ4ExpertResidency>, GpuNativeTieredResidencyError> {
+        self.ensure_demand_set_inner_with_source_upload::<OBSERVE>(
+            priority,
+            layer_index,
+            demands,
+            install_path,
+            observer,
+            None,
+        )
+    }
+
+    fn ensure_demand_set_inner_with_source_upload<const OBSERVE: bool>(
+        &self,
+        priority: GpuNativeResidencyPriority,
+        layer_index: usize,
+        demands: &[GpuNativeDemandExpert],
+        install_path: DemandPhysicalInstallPath,
+        observer: Option<&dyn GpuNativePhysicalInstallObserver>,
+        production_source_upload: Option<&crate::gpu_native_source_upload::State>,
+    ) -> Result<Vec<GpuNativeQ4ExpertResidency>, GpuNativeTieredResidencyError> {
         if !matches!(
             priority,
             GpuNativeResidencyPriority::Demand | GpuNativeResidencyPriority::OracleSafeBoundary
@@ -1010,6 +1082,7 @@ impl GpuNativeTieredResidencyManager {
                     &mut state,
                     &mut resolved,
                     observer,
+                    production_source_upload,
                 )?;
             } else {
                 self.install_parallel_physical_misses_locked::<OBSERVE, false>(
@@ -1019,6 +1092,7 @@ impl GpuNativeTieredResidencyManager {
                     &mut state,
                     &mut resolved,
                     observer,
+                    production_source_upload,
                 )?;
             }
         } else {
@@ -1082,6 +1156,7 @@ impl GpuNativeTieredResidencyManager {
         state: &mut MutexGuard<'_, LayerResidencyState>,
         resolved: &mut [Option<GpuNativeQ4ExpertResidency>],
         observer: Option<&dyn GpuNativePhysicalInstallObserver>,
+        production_source_upload: Option<&crate::gpu_native_source_upload::State>,
     ) -> Result<(), GpuNativeTieredResidencyError> {
         if misses.is_empty() {
             return Ok(());
@@ -1248,7 +1323,21 @@ impl GpuNativeTieredResidencyManager {
                 ));
         }
 
-        let upload = if OBSERVE {
+        let upload = if let Some(production_source_upload) = production_source_upload {
+            if OBSERVE
+                && observer
+                    .and_then(|o| o.source_upload_state())
+                    .is_none_or(|observed| !std::ptr::eq(observed, production_source_upload))
+            {
+                return Err(GpuNativeTieredResidencyError::Backend(
+                    GpuNativeBootstrapError::QualificationSourceUpload {
+                        detail: "explicit production source/upload state disagrees with observer"
+                            .into(),
+                    },
+                ));
+            }
+            Some(production_source_upload)
+        } else if OBSERVE {
             observer.and_then(|o| o.source_upload_state())
         } else {
             None
@@ -1273,6 +1362,7 @@ impl GpuNativeTieredResidencyManager {
             let lease = upload
                 .map(|u| u.take_lease(reserved.global_id, &reserved.resident))
                 .transpose();
+            let fused_source_upload = matches!(&lease, Ok(Some(Some(_))));
             let result = match lease {
                 Err(detail) => Err(crate::backend::gpu_native::GpuNativeBootstrapError::QualificationSourceUpload { detail }),
                 Ok(Some(Some(lease))) => self.executor.stage_q4_expert_source_upload(
@@ -1296,6 +1386,31 @@ impl GpuNativeTieredResidencyManager {
             match result {
                 Ok((prepared, mut evidence)) => {
                     let individual_stage_us = stage_started.map_or(0, qualification_elapsed_us);
+                    if !OBSERVE {
+                        if let Some(upload) = upload {
+                            upload.add(
+                                |m| &mut m.total_payload_bytes_staged,
+                                crate::gpu_native_source_upload::PAYLOAD as u64,
+                            );
+                            if fused_source_upload {
+                                upload.add(|m| &mut m.fused_installs, 1);
+                                upload.add(
+                                    |m| &mut m.fused_gpu_copy_bytes,
+                                    crate::gpu_native_source_upload::PAYLOAD as u64,
+                                );
+                            } else {
+                                upload.add(|m| &mut m.fallback_installs, 1);
+                                upload.add(
+                                    |m| &mut m.fallback_payload_copy_bytes,
+                                    crate::gpu_native_source_upload::PAYLOAD as u64,
+                                );
+                                upload.add(
+                                    |m| &mut m.physical_cpu_payload_copy_bytes,
+                                    crate::gpu_native_source_upload::PAYLOAD as u64,
+                                );
+                            }
+                        }
+                    }
                     if OBSERVE {
                         evidence.individual_physical_stage_us = individual_stage_us;
                         observer

--- a/rust-engine/src/gpu_native_source_to_upload_copy_elision_production.rs
+++ b/rust-engine/src/gpu_native_source_to_upload_copy_elision_production.rs
@@ -1,0 +1,966 @@
+//! Qualification-only real-inference A/B of single-read source/upload fusion.
+//! Reuses physical-install workload, isolated runtime, observation and teardown.
+use super::*;
+use crate::engine::GpuNativePhysicalInstallConcurrencyQualificationSnapshot as Snapshot;
+
+pub(crate) const SCHEMA: &str = "mer.gpu-native-source-to-upload-copy-elision-production.v1";
+pub(crate) const MODE: &str = "qualify-gpu-native-source-to-upload-copy-elision-production";
+const LOGICAL_EXPERT_BYTES: u64 = 2_654_208;
+const SLOT_STRIDE_BYTES: u64 = 2_654_212;
+const EPOCH_BYTES: u64 = 4;
+use crate::gpu_native_source_upload::{Arm, Snapshot as UploadSnapshot, CAPACITY, FULL, PAYLOAD};
+
+const fn qualification_arms() -> (Arm, Arm) {
+    (Arm::Control, Arm::Treatment)
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+struct PairMechanismGate {
+    source_and_route_streams_exact: bool,
+    logical_materialization_and_generations_exact: bool,
+    physical_install_reservation_victim_and_publication_exact: bool,
+    source_scheduler_exact: bool,
+    control_copy_accounting_exact: bool,
+    treatment_fused_and_fallback_bytes_exact: bool,
+    treatment_every_nvme_read_fused: bool,
+    ring_and_submission_accounting_exact: bool,
+    failures_and_accounting_errors_zero: bool,
+    production_install_reconciliation: bool,
+    passed: bool,
+}
+
+fn install_exact(
+    s: &Snapshot,
+    p: &GpuNativeProductionPhysicalInstallSnapshot,
+    u: &UploadSnapshot,
+) -> bool {
+    let n = s.physical_install_completions;
+    n > 0
+        && production_concurrency_exercised(p)
+        && s.physical_install_attempts == n
+        && s.physical_install_experts == n
+        && s.reservation_attempts == n
+        && s.reservation_successes == n
+        && s.physical_stage_attempts == n
+        && s.physical_stage_completions == n
+        && s.direct_staging_writes
+            .checked_add(u.metrics.fused_installs)
+            == Some(n)
+        && s.ordered_commit_attempts == n
+        && s.ordered_commit_completions == n
+        && s.mapping_publications == n
+        && s.physical_install_sets == p.physical_install_sets
+        && n == p.physical_install_experts
+        && n == p.physical_install_attempts
+        && n == p.physical_stage_completions
+        && n == p.ordered_commit_completions
+        && s.parallel_eligible_sets == p.parallel_eligible_sets
+        && s.parallel_staging_sets == p.parallel_staging_sets
+        && s.parallel_staging_experts == p.parallel_staging_experts
+        && s.singleton_staging_sets == p.singleton_staging_sets
+        && s.max_in_flight_physical_staging >= 2
+        && s.parallel_staging_sets > 0
+        && s.parallel_staging_sets == s.parallel_eligible_sets
+        && s.parallel_staging_experts == s.parallel_eligible_experts
+        && s.parallel_staging_experts
+            .checked_add(s.singleton_staging_sets)
+            == Some(n)
+        && s.parallel_staging_sets
+            .checked_add(s.singleton_staging_sets)
+            == Some(s.physical_install_sets)
+        && n.checked_mul(EPOCH_BYTES) == Some(s.physical_slot_epoch_write_bytes)
+        && n.checked_mul(SLOT_STRIDE_BYTES) == Some(s.physical_slot_bytes_staged)
+        && s.physical_bytes_staged == s.physical_slot_bytes_staged
+        && s.physical_slot_zero_fill_bytes == 0
+        && s.full_slot_vec_materializations == 0
+}
+fn upload_errors_zero(u: &UploadSnapshot) -> bool {
+    let m = &u.metrics;
+    m.source_failures == 0
+        && m.source_fallback_reads == 0
+        && m.alignment_failures == 0
+        && m.mapped_direct_io_rejections == 0
+        && m.remap_failures == 0
+        && m.copy_failures == 0
+        && m.accounting_errors == 0
+        && m.leases_dropped_unconsumed == 0
+        && m.non_shared_logical_fallbacks == 0
+        && m.non_shared_logical_rejections == 0
+        && u.active_leases == 0
+        && u.pending_leases == 0
+}
+fn ring_exact(c: &UploadSnapshot, t: &UploadSnapshot) -> bool {
+    let (c, ring_capacity, active, m) = (&c.metrics, t.ring_capacity, t.active_leases, &t.metrics);
+    [
+        c.acquisition_attempts,
+        c.acquisition_waits,
+        c.acquisition_wait_us,
+        c.high_water,
+        c.map_attempts,
+        c.map_completions,
+        c.map_wait_us,
+        c.unmaps,
+        c.remap_attempts,
+        c.remap_completions,
+        c.remap_wait_us,
+        c.leases_consumed,
+        c.leases_released,
+        c.odirect_observations,
+        c.direct_payload_bytes,
+        c.copied_experts,
+        c.copied_bytes,
+        c.fused_install_sets,
+        c.fallback_installs,
+        c.fallback_payload_copy_bytes,
+    ]
+    .iter()
+    .all(|v| *v == 0)
+        && c.copy_submissions == 0
+        && c.copy_command_buffers == 0
+        && c.leases_created == 0
+        && c.direct_source_reads == 0
+        && c.direct_source_bytes == 0
+        && c.fused_installs == 0
+        && c.fused_gpu_copy_bytes == 0
+        && ring_capacity == CAPACITY
+        && active == 0
+        && m.high_water > 0
+        && m.high_water <= CAPACITY as u64
+        && m.acquisition_attempts == m.leases_created
+        && m.leases_created == m.direct_source_reads
+        && m.leases_consumed == m.leases_created
+        && m.leases_released == m.leases_created
+        && m.leases_consumed == m.fused_installs
+        && m.map_attempts == m.map_completions
+        && m.map_completions == m.leases_created
+        && m.unmaps == m.map_completions
+        && m.remap_attempts == m.remap_completions
+        && m.remap_completions <= m.map_completions
+        && m.copy_submissions > 0
+        && m.copy_submissions == m.copy_command_buffers
+        && m.copy_submissions == m.fused_install_sets
+        && m.copied_experts == m.fused_installs
+        && m.copied_bytes == m.fused_gpu_copy_bytes
+}
+fn pair_mechanism_gate(
+    c: &Snapshot,
+    t: &Snapshot,
+    cp: &GpuNativeProductionPhysicalInstallSnapshot,
+    tp: &GpuNativeProductionPhysicalInstallSnapshot,
+    cu: &UploadSnapshot,
+    tu: &UploadSnapshot,
+    cs: &ProductionDemandSourceSnapshot,
+    ts: &ProductionDemandSourceSnapshot,
+) -> PairMechanismGate {
+    let (cm, tm) = (&cu.metrics, &tu.metrics);
+    let total = t
+        .physical_install_completions
+        .checked_mul(LOGICAL_EXPERT_BYTES);
+    let source_and_route_streams_exact = c.selected_route_ids_sha256 == t.selected_route_ids_sha256
+        && c.physical_missing_ids_sha256 == t.physical_missing_ids_sha256
+        && c.physical_missing_experts == t.physical_missing_experts
+        && c.demand_source_request_ids_sha256 == t.demand_source_request_ids_sha256
+        && c.demand_source_requests == t.demand_source_requests
+        && c.source_ram_hits == t.source_ram_hits
+        && c.source_ram_misses == t.source_ram_misses
+        && c.source_nvme_reads == t.source_nvme_reads
+        && c.source_nvme_bytes == t.source_nvme_bytes
+        && cu.ordered_nvme_ids_sha256 == tu.ordered_nvme_ids_sha256
+        && c.ram_cache_inserts == t.ram_cache_inserts
+        && c.ram_cache_evictions == t.ram_cache_evictions
+        && c.demand_ram_insert_ids_sha256 == t.demand_ram_insert_ids_sha256
+        && c.demand_ram_eviction_ids_sha256 == t.demand_ram_eviction_ids_sha256;
+    let logical_materialization_and_generations_exact = cm.logical_admissions
+        == tm.logical_admissions
+        && cm.logical_generation_observations == tm.logical_generation_observations
+        && cu.logical_admission_ids_sha256 == tu.logical_admission_ids_sha256
+        && cu.logical_generation_ids_sha256 == tu.logical_generation_ids_sha256
+        && cm.logical_materialization_operations == tm.logical_materialization_operations
+        && cm.logical_materialization_bytes == tm.logical_materialization_bytes
+        && cm
+            .logical_materialization_operations
+            .checked_mul(LOGICAL_EXPERT_BYTES)
+            == Some(cm.logical_materialization_bytes)
+        && tm.logical_materialization_operations == tm.shared_payload_constructions
+        && cm.shared_payload_constructions == 0;
+    let physical_install_reservation_victim_and_publication_exact = c.physical_install_completions
+        == t.physical_install_completions
+        && c.physical_install_sets == t.physical_install_sets
+        && c.reservation_identity_sha256 == t.reservation_identity_sha256
+        && c.physical_victim_ids_sha256 == t.physical_victim_ids_sha256
+        && c.physical_residency_identity_sha256 == t.physical_residency_identity_sha256
+        && c.mapping_publications == t.mapping_publications
+        && c.mapping_unpublications == t.mapping_unpublications
+        && c.physical_slot_bytes_staged == t.physical_slot_bytes_staged
+        && c.ordered_install_set_behavior_sha256 == t.ordered_install_set_behavior_sha256
+        && c.install_set_width_min == t.install_set_width_min
+        && c.install_set_width_max == t.install_set_width_max
+        && c.install_set_width_mean == t.install_set_width_mean
+        && c.parallel_eligible_sets == t.parallel_eligible_sets
+        && c.parallel_eligible_experts == t.parallel_eligible_experts
+        && c.parallel_staging_sets == t.parallel_staging_sets
+        && c.parallel_staging_experts == t.parallel_staging_experts
+        && c.singleton_staging_sets == t.singleton_staging_sets
+        && c.rayon_num_threads >= 2
+        && c.rayon_num_threads == t.rayon_num_threads
+        && c.caller_was_already_rayon_worker == t.caller_was_already_rayon_worker;
+    let source_scheduler_exact = match (serde_json::to_value(cs), serde_json::to_value(ts)) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => false,
+    };
+    let control_copy_accounting_exact = cu.arm == Arm::Control
+        && cu.ring_capacity == 0
+        && c.physical_install_completions
+            .checked_mul(LOGICAL_EXPERT_BYTES)
+            == Some(cm.physical_cpu_payload_copy_bytes)
+        && cm.physical_cpu_payload_copy_bytes == c.physical_slot_payload_copy_bytes
+        && c.direct_staging_writes == c.physical_install_completions
+        && cm.total_payload_bytes_staged == cm.physical_cpu_payload_copy_bytes;
+    let treatment_fused_and_fallback_bytes_exact = tu.arm == Arm::Treatment
+        && tm.fused_installs.checked_add(tm.fallback_installs)
+            == Some(t.physical_install_completions)
+        && tm.fused_installs.checked_mul(LOGICAL_EXPERT_BYTES) == Some(tm.fused_gpu_copy_bytes)
+        && tm.fallback_installs.checked_mul(LOGICAL_EXPERT_BYTES)
+            == Some(tm.fallback_payload_copy_bytes)
+        && tm
+            .fused_gpu_copy_bytes
+            .checked_add(tm.fallback_payload_copy_bytes)
+            == total
+        && tm.physical_cpu_payload_copy_bytes == tm.fallback_payload_copy_bytes
+        && tm.physical_cpu_payload_copy_bytes == t.physical_slot_payload_copy_bytes
+        && tm.fallback_installs == t.direct_staging_writes
+        && Some(tm.total_payload_bytes_staged) == total;
+    let treatment_every_nvme_read_fused = tm.direct_source_reads > 0
+        && tm.direct_source_reads == t.source_nvme_reads
+        && tm.direct_source_bytes == t.source_nvme_bytes
+        && tm.direct_source_reads.checked_mul(FULL as u64) == Some(tm.direct_source_bytes)
+        && tm.direct_source_reads.checked_mul(PAYLOAD as u64) == Some(tm.direct_payload_bytes)
+        && tm.odirect_observations == tm.direct_source_reads;
+    let ring_and_submission_accounting_exact = ring_exact(cu, tu);
+    let failures_and_accounting_errors_zero = upload_errors_zero(cu)
+        && upload_errors_zero(tu)
+        && zero_fill_production::failures_zero(c)
+        && zero_fill_production::failures_zero(t)
+        && zero_fill_production::timing_accounting_exact(c)
+        && zero_fill_production::timing_accounting_exact(t);
+    let production_install_reconciliation = install_exact(c, cp, cu) && install_exact(t, tp, tu);
+    let passed = source_and_route_streams_exact
+        && logical_materialization_and_generations_exact
+        && physical_install_reservation_victim_and_publication_exact
+        && source_scheduler_exact
+        && control_copy_accounting_exact
+        && treatment_fused_and_fallback_bytes_exact
+        && treatment_every_nvme_read_fused
+        && ring_and_submission_accounting_exact
+        && failures_and_accounting_errors_zero
+        && production_install_reconciliation;
+    PairMechanismGate {
+        source_and_route_streams_exact,
+        logical_materialization_and_generations_exact,
+        physical_install_reservation_victim_and_publication_exact,
+        source_scheduler_exact,
+        control_copy_accounting_exact,
+        treatment_fused_and_fallback_bytes_exact,
+        treatment_every_nvme_read_fused,
+        ring_and_submission_accounting_exact,
+        failures_and_accounting_errors_zero,
+        production_install_reconciliation,
+        passed,
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct UploadArmReport {
+    #[serde(flatten)]
+    run: ConcurrencyArmReport,
+    warmup_upload: Option<UploadSnapshot>,
+    upload: Option<UploadSnapshot>,
+}
+impl std::ops::Deref for UploadArmReport {
+    type Target = ConcurrencyArmReport;
+    fn deref(&self) -> &Self::Target {
+        &self.run
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct Gates {
+    behavioral: BehavioralGate,
+    work_equivalence: WorkEquivalenceGate,
+    warmup_mechanism: PairMechanismGate,
+    measured_mechanism: PairMechanismGate,
+    warmup_and_measured_work_exact: bool,
+    token_ids_text_and_routes_exact: bool,
+    stale_generation_and_install_errors_zero: bool,
+    physical_installs_reconcile_with_residency: bool,
+    source_bytes_and_logical_admissions_reconcile: bool,
+    passed: bool,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct Performance {
+    #[serde(flatten)]
+    physical_install: ConcurrencyPerformanceComparison,
+    mean_time_to_first_token_seconds: MetricComparison,
+    fused_install_coverage_percent: f64,
+    fused_payload_coverage_percent: f64,
+    control_cpu_physical_payload_copy_bytes: u64,
+    control_cpu_physical_payload_copy_us: u64,
+    treatment_mechanism: crate::gpu_native_source_upload::Metrics,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct Report {
+    schema: &'static str,
+    mode: &'static str,
+    control: Option<UploadArmReport>,
+    treatment: Option<UploadArmReport>,
+    control_path: &'static str,
+    treatment_path: &'static str,
+    both_arms_same_reservation_and_commit: bool,
+    source_scheduler_changed: bool,
+    staging_byte_count_changed: bool,
+    queue_ordering_changed: bool,
+    payload_offset_bytes: u64,
+    logical_expert_bytes: u64,
+    slot_stride_bytes: u64,
+    tail_padding_bytes: u64,
+    no_zero_requires_complete_coverage_before_first_write: bool,
+    frozen_workload: FrozenWorkload,
+    provenance: BenchmarkProvenance,
+    timing_definitions: ConcurrencyTimingDefinitions,
+    logical_materialization_timing_definition: &'static str,
+    reconciliation: Option<ProductionReconciliation>,
+    gates: Option<Gates>,
+    performance: Option<Performance>,
+    benchmark_complete: bool,
+    qualification_pass: bool,
+    performance_result: &'static str,
+    failure: Option<BenchmarkFailure>,
+}
+
+fn work_pair_exact(c: &ArmWorkEvidence, t: &ArmWorkEvidence) -> bool {
+    c.gpu_native_residency
+        .logical_admissions_for_physical_misses
+        == t.gpu_native_residency
+            .logical_admissions_for_physical_misses
+        && c.gpu_native_residency.ram_to_vram_installs
+            == t.gpu_native_residency.ram_to_vram_installs
+        && c.gpu_native_residency.physical_evictions == t.gpu_native_residency.physical_evictions
+        && c.gpu_native_residency.physical_reinstalls == t.gpu_native_residency.physical_reinstalls
+        && c.token_loop.residency_miss_attempts == t.token_loop.residency_miss_attempts
+        && c.token_loop.residency_services == t.token_loop.residency_services
+        && recovery_semantics_equal(c.recovery, t.recovery)
+        && c.routed_execution.selected_routed_experts == t.routed_execution.selected_routed_experts
+        && c.engine_storage.ram_hits == t.engine_storage.ram_hits
+        && c.engine_storage.ram_misses == t.engine_storage.ram_misses
+        && c.engine_storage.nvme_read_operations == t.engine_storage.nvme_read_operations
+        && c.engine_storage.nvme_bytes_read == t.engine_storage.nvme_bytes_read
+        && c.token_loop.queue_submissions == t.token_loop.queue_submissions
+        && c.token_loop.boundary_maps == t.token_loop.boundary_maps
+        && c.token_loop.boundary_readbacks == t.token_loop.boundary_readbacks
+}
+
+pub(super) fn work_errors_zero(w: &ArmWorkEvidence) -> bool {
+    w.gpu_native_residency.stale_generation_rejections == 0
+        && w.token_loop.fatal_failures == 0
+        && w.token_loop.no_progress_failures == 0
+        && w.token_loop.replay_attempts == 0
+        && w.recovery.full_token_replay_attempts == 0
+}
+
+// Performance has no argument and cannot affect correctness/mechanism PASS.
+fn qualification_pass(reconciliation_pass: bool, gates: &Gates) -> bool {
+    reconciliation_pass && gates.passed
+}
+
+pub(crate) async fn run_command(args: CommandArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let prepared = prepare(&args)?;
+    let mut timing_definitions = concurrency_timing_definitions();
+    timing_definitions.common.physical_install_total_us = "both arms: sum of each post-reservation physical stage plus ordered commit service; excludes reservation time";
+    timing_definitions.common.physical_slot_prepare_us = "control and RAM-hit fallback: validated no-zero CPU payload staging; fused treatment: validation, epoch write and GPU copy encoding; copy-set submission separately timed";
+    timing_definitions.common.mapping_publication_us =
+        "both arms: ordered logical mapping Queue::write_buffer time after staging; treatment additionally submits the fused copy set before publication";
+    let mut report = Report {
+        schema: SCHEMA,
+        mode: MODE,
+        control: None,
+        treatment: None,
+        control_path: "ordinary production source and concurrent no-zero Queue::write_buffer_with",
+        treatment_path:
+            "single-read NVMe to bounded mapped upload; shared logical/RAM payload; GPU-copy fused misses; ordinary RAM-hit physical fallback",
+        both_arms_same_reservation_and_commit: true,
+        source_scheduler_changed: false,
+        staging_byte_count_changed: false,
+        queue_ordering_changed: true,
+        payload_offset_bytes: EPOCH_BYTES,
+        logical_expert_bytes: LOGICAL_EXPERT_BYTES,
+        slot_stride_bytes: SLOT_STRIDE_BYTES,
+        tail_padding_bytes: 0,
+        no_zero_requires_complete_coverage_before_first_write: true,
+        frozen_workload: frozen_workload(args.expected_adapter_name.clone()),
+        provenance: prepared.provenance.clone(),
+        timing_definitions,
+        logical_materialization_timing_definition: "logical cache transaction wall is logical_demand_admission_us; treatment fresh shared-host materialization occurs inside source acquisition and is separately counted/timed as logical_materialization_us; RAM-hit readmission materialization occurs inside the logical transaction",
+        reconciliation: None,
+        gates: None,
+        performance: None,
+        benchmark_complete: false,
+        qualification_pass: false,
+        performance_result: "not_measured",
+        failure: None,
+    };
+    let (control_arm, treatment_arm) = qualification_arms();
+    for arm in [control_arm, treatment_arm] {
+        let result = run_physical_install_arm(
+            &prepared,
+            &args,
+            PhysicalInstallQualificationRun::SourceToUpload(arm),
+        )
+        .await;
+        let run = match result {
+            Ok(run) => run,
+            Err(failure) => {
+                report.failure = Some(failure.clone());
+                emit_report(&report, &args.report_out)?;
+                return Err(failure.to_string().into());
+            }
+        };
+        let failure = run.common.failure.clone();
+        let arm_report = UploadArmReport {
+            run: ConcurrencyArmReport {
+                common: run.common,
+                warmup_mechanism: run.warmup_concurrency,
+                mechanism: run.concurrency,
+            },
+            warmup_upload: run.warmup_upload,
+            upload: run.upload,
+        };
+        let snapshots_present = arm_report.upload.is_some()
+            && arm_report.warmup_upload.is_some()
+            && arm_report.common.complete
+            && arm_report.mechanism.is_some()
+            && arm_report.warmup_mechanism.is_some()
+            && arm_report.common.source.is_some()
+            && arm_report.common.warmup_source.is_some()
+            && arm_report.common.work.is_some()
+            && arm_report.common.warmup_work.is_some()
+            && arm_report.common.production.is_some()
+            && arm_report.common.warmup_production.is_some()
+            && arm_report.common.production_physical_install.is_some()
+            && arm_report
+                .common
+                .warmup_production_physical_install
+                .is_some();
+        if arm == control_arm {
+            report.control = Some(arm_report);
+        } else {
+            report.treatment = Some(arm_report);
+        }
+        if let Some(failure) = failure.or_else(|| {
+            (!snapshots_present).then(|| {
+                BenchmarkFailure::new(
+                    "postcondition",
+                    "missing-source-upload-arm-evidence",
+                    "complete warmup and measured evidence is required",
+                )
+            })
+        }) {
+            report.failure = Some(failure.clone());
+            emit_report(&report, &args.report_out)?;
+            return Err(failure.to_string().into());
+        }
+    }
+    let c = report.control.as_ref().expect("stored control");
+    let t = report.treatment.as_ref().expect("stored treatment");
+    let reconciliation =
+        production_reconciliation(reconcile(&c.common, &t.common), &c.common, &t.common);
+    let (behavioral, work_equivalence) = common_gates(&reconciliation.common);
+    let warmup_mechanism = pair_mechanism_gate(
+        c.warmup_mechanism.as_ref().unwrap(),
+        t.warmup_mechanism.as_ref().unwrap(),
+        c.common
+            .warmup_production_physical_install
+            .as_ref()
+            .unwrap(),
+        t.common
+            .warmup_production_physical_install
+            .as_ref()
+            .unwrap(),
+        c.warmup_upload.as_ref().unwrap(),
+        t.warmup_upload.as_ref().unwrap(),
+        c.common.warmup_production.as_ref().unwrap(),
+        t.common.warmup_production.as_ref().unwrap(),
+    );
+    let measured_mechanism = pair_mechanism_gate(
+        c.mechanism.as_ref().unwrap(),
+        t.mechanism.as_ref().unwrap(),
+        c.common.production_physical_install.as_ref().unwrap(),
+        t.common.production_physical_install.as_ref().unwrap(),
+        c.upload.as_ref().unwrap(),
+        t.upload.as_ref().unwrap(),
+        c.common.production.as_ref().unwrap(),
+        t.common.production.as_ref().unwrap(),
+    );
+    let cw = c.common.warmup_work.as_ref().unwrap();
+    let tw = t.common.warmup_work.as_ref().unwrap();
+    let cm = c.common.work.as_ref().unwrap();
+    let tm = t.common.work.as_ref().unwrap();
+    let warmup_and_measured_work_exact = work_pair_exact(cw, tw) && work_pair_exact(cm, tm);
+    let stale_generation_and_install_errors_zero =
+        [cw, tw, cm, tm].into_iter().all(work_errors_zero);
+    let physical_installs_reconcile_with_residency = [
+        (cw, c.warmup_mechanism.as_ref().unwrap()),
+        (tw, t.warmup_mechanism.as_ref().unwrap()),
+        (cm, c.mechanism.as_ref().unwrap()),
+        (tm, t.mechanism.as_ref().unwrap()),
+    ]
+    .into_iter()
+    .all(|(work, mechanism)| {
+        work.gpu_native_residency.ram_to_vram_installs == mechanism.physical_install_completions
+    });
+    let source_bytes_and_logical_admissions_reconcile = [
+        (cw,c.warmup_mechanism.as_ref().unwrap(),c.warmup_upload.as_ref().unwrap(),c.common.warmup_production.as_ref().unwrap()),
+        (tw,t.warmup_mechanism.as_ref().unwrap(),t.warmup_upload.as_ref().unwrap(),t.common.warmup_production.as_ref().unwrap()),
+        (cm,c.mechanism.as_ref().unwrap(),c.upload.as_ref().unwrap(),c.common.production.as_ref().unwrap()),
+        (tm,t.mechanism.as_ref().unwrap(),t.upload.as_ref().unwrap(),t.common.production.as_ref().unwrap()),
+    ].into_iter().all(|(work,source,upload,production)| {
+        work.gpu_native_residency.logical_admissions_for_physical_misses == upload.metrics.logical_admissions
+            && work.engine_storage.nvme_bytes_read == source.source_nvme_bytes
+            // The inherited I/O histogram records one observation per batch,
+            // not one per expert; reconcile its observation count explicitly.
+            && source.source_nvme_reads.checked_sub(production.production_batch_experts)
+                .and_then(|v| v.checked_add(production.production_batch_successes)) == Some(work.engine_storage.nvme_read_operations)
+    });
+    let token_ids_text_and_routes_exact = c.common.warmup_results.len() == FROZEN_WARMUP_RUNS
+        && t.common.warmup_results.len() == FROZEN_WARMUP_RUNS
+        && generated_results(&c.common).len() == FROZEN_MEASURED_RUNS
+        && generated_results(&t.common).len() == FROZEN_MEASURED_RUNS
+        && c.common
+            .warmup_results
+            .iter()
+            .zip(&t.common.warmup_results)
+            .all(|(a, b)| {
+                a.generated_tokens == FROZEN_OUTPUT_TOKENS
+                    && b.generated_tokens == FROZEN_OUTPUT_TOKENS
+                    && a.generated_text_sha256 == b.generated_text_sha256
+                    && a.generated_token_ids_sha256 == b.generated_token_ids_sha256
+            })
+        && generated_results(&c.common)
+            .iter()
+            .zip(generated_results(&t.common))
+            .all(|(a, b)| {
+                a.generated_tokens == FROZEN_OUTPUT_TOKENS
+                    && b.generated_tokens == FROZEN_OUTPUT_TOKENS
+                    && a.generated_text_sha256 == b.generated_text_sha256
+                    && a.generated_token_ids_sha256 == b.generated_token_ids_sha256
+            })
+        && warmup_mechanism.source_and_route_streams_exact
+        && measured_mechanism.source_and_route_streams_exact;
+    let passed = behavioral.passed
+        && work_equivalence.passed
+        && warmup_mechanism.passed
+        && measured_mechanism.passed
+        && warmup_and_measured_work_exact
+        && token_ids_text_and_routes_exact
+        && stale_generation_and_install_errors_zero
+        && physical_installs_reconcile_with_residency
+        && source_bytes_and_logical_admissions_reconcile;
+    let gates = Gates {
+        behavioral,
+        work_equivalence,
+        warmup_mechanism,
+        measured_mechanism,
+        warmup_and_measured_work_exact,
+        token_ids_text_and_routes_exact,
+        stale_generation_and_install_errors_zero,
+        physical_installs_reconcile_with_residency,
+        source_bytes_and_logical_admissions_reconcile,
+        passed,
+    };
+    let performance = concurrency_performance(c, t).map(|physical_install| Performance {
+        fused_install_coverage_percent: t.upload.as_ref().unwrap().metrics.fused_installs as f64
+            / t.mechanism.as_ref().unwrap().physical_install_completions as f64
+            * 100.0,
+        fused_payload_coverage_percent: t.upload.as_ref().unwrap().metrics.fused_gpu_copy_bytes
+            as f64
+            / (t.mechanism.as_ref().unwrap().physical_install_completions * LOGICAL_EXPERT_BYTES)
+                as f64
+            * 100.0,
+        control_cpu_physical_payload_copy_bytes: c
+            .upload
+            .as_ref()
+            .unwrap()
+            .metrics
+            .physical_cpu_payload_copy_bytes,
+        control_cpu_physical_payload_copy_us: c
+            .mechanism
+            .as_ref()
+            .unwrap()
+            .physical_slot_payload_copy_us,
+        treatment_mechanism: t.upload.as_ref().unwrap().metrics.clone(),
+        physical_install,
+        mean_time_to_first_token_seconds: comparison(
+            generated_results(&c.common)
+                .iter()
+                .map(|r| r.timing.time_to_first_token_seconds)
+                .sum::<f64>()
+                / FROZEN_MEASURED_RUNS as f64,
+            generated_results(&t.common)
+                .iter()
+                .map(|r| r.timing.time_to_first_token_seconds)
+                .sum::<f64>()
+                / FROZEN_MEASURED_RUNS as f64,
+        ),
+    });
+    report.qualification_pass = qualification_pass(reconciliation.all_invariants_pass, &gates);
+    report.reconciliation = Some(reconciliation);
+    report.gates = Some(gates);
+    match performance {
+        Ok(performance) => {
+            report.benchmark_complete = true;
+            report.performance_result = performance.physical_install.common.performance_result;
+            report.performance = Some(performance);
+        }
+        Err(failure) => {
+            report.qualification_pass = false;
+            report.failure = Some(failure.clone());
+            emit_report(&report, &args.report_out)?;
+            return Err(failure.to_string().into());
+        }
+    }
+    report.qualification_pass = completed_pass(
+        report.benchmark_complete,
+        report.failure.is_some(),
+        report.qualification_pass,
+    );
+    emit_report(&report, &args.report_out)?;
+    if report.qualification_pass {
+        Ok(())
+    } else {
+        Err(
+            "source-to-upload production qualification gates did not all pass; see emitted report"
+                .into(),
+        )
+    }
+}
+
+fn completed_pass(complete: bool, has_failure: bool, gates_pass: bool) -> bool {
+    complete && !has_failure && gates_pass
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::GpuNativePhysicalInstallConcurrencyQualificationArm as LegacyArm;
+    fn physical_fixture() -> (Snapshot, GpuNativeProductionPhysicalInstallSnapshot) {
+        let mut s = crate::engine::empty_physical_zero_fill_test_snapshot(
+            LegacyArm::ProductionNoZeroFillTreatment,
+        );
+        s.physical_install_attempts = 3;
+        s.physical_install_completions = 3;
+        s.physical_install_experts = 3;
+        s.direct_staging_writes = 3;
+        s.reservation_attempts = 3;
+        s.reservation_successes = 3;
+        s.physical_stage_attempts = 3;
+        s.physical_stage_completions = 3;
+        s.ordered_commit_attempts = 3;
+        s.ordered_commit_completions = 3;
+        s.mapping_publications = 3;
+        s.physical_slot_bytes_staged = 3 * SLOT_STRIDE_BYTES;
+        s.physical_bytes_staged = s.physical_slot_bytes_staged;
+        s.physical_slot_zero_fill_bytes = 0;
+        s.physical_slot_epoch_write_bytes = 3 * EPOCH_BYTES;
+        s.physical_slot_payload_copy_bytes = 3 * LOGICAL_EXPERT_BYTES;
+        s.physical_install_sets = 1;
+        s.install_set_width_min = 3;
+        s.install_set_width_max = 3;
+        s.install_set_width_mean = 3.0;
+        s.parallel_eligible_sets = 1;
+        s.parallel_eligible_experts = 3;
+        s.parallel_staging_sets = 1;
+        s.parallel_staging_experts = 3;
+        s.max_in_flight_physical_staging = 3;
+        s.rayon_num_threads = 4;
+        s.physical_slot_prepare_us = 10;
+        s.physical_queue_staging_us = 5;
+        s.sum_individual_physical_stage_us = 30;
+        s.physical_ordered_commit_us = 9;
+        s.mapping_publication_us = 3;
+        s.physical_install_total_us = 39;
+        let p = GpuNativeProductionPhysicalInstallSnapshot {
+            physical_install_sets: 1,
+            physical_install_experts: 3,
+            parallel_eligible_sets: 1,
+            parallel_staging_sets: 1,
+            parallel_staging_experts: 3,
+            reservation_attempts: 3,
+            reservation_successes: 3,
+            physical_install_attempts: 3,
+            physical_stage_attempts: 3,
+            physical_stage_completions: 3,
+            direct_staging_successes: 3,
+            ordered_commit_attempts: 3,
+            ordered_commit_completions: 3,
+            max_in_flight_physical_staging: 3,
+            ..GpuNativeProductionPhysicalInstallSnapshot::default()
+        };
+        (s, p)
+    }
+
+    fn source_fixture() -> ProductionDemandSourceSnapshot {
+        ProductionDemandSourceSnapshot {
+            ordinary_production_path_exercised: true,
+            production_source_sets: 0,
+            production_batch_eligible_sets: 0,
+            production_batch_attempts: 0,
+            production_batch_successes: 0,
+            production_batch_experts: 0,
+            production_sequential_fallback_mixed_ram: 0,
+            production_sequential_fallback_single_item: 0,
+            production_sequential_fallback_singleflight_contention: 0,
+            production_sequential_fallback_reservation: 0,
+            production_sequential_fallback_pool: 0,
+            production_sequential_fallback_batch_read_error: 0,
+            production_batch_width_min: 0,
+            production_batch_width_max: 0,
+            production_batch_width_mean: 0.0,
+            production_singleflight_ids_claimed: 0,
+            production_singleflight_claim_rollbacks: 0,
+            production_singleflight_followers_observed: 0,
+            production_cache_slots_reserved: 0,
+            production_cache_reservations_consumed: 0,
+            production_cache_reservations_released: 0,
+            production_cache_reservation_leaks: 0,
+            production_batch_commit_violations: 0,
+            stale_singleflight_entries: 0,
+        }
+    }
+
+    fn fixture(
+        arm: Arm,
+    ) -> (
+        Snapshot,
+        GpuNativeProductionPhysicalInstallSnapshot,
+        UploadSnapshot,
+    ) {
+        let (mut s, p) = physical_fixture();
+        s.source_nvme_reads = 2;
+        s.source_nvme_bytes = 2 * FULL as u64;
+        s.source_ram_misses = 2;
+        s.source_ram_hits = 1;
+        let mut u = crate::gpu_native_source_upload::State::cpu_test_state(arm).snapshot();
+        let m = &mut u.metrics;
+        m.logical_admissions = 2;
+        m.logical_generation_observations = 3;
+        m.logical_materialization_operations = 2;
+        m.logical_materialization_bytes = 2 * PAYLOAD as u64;
+        m.total_payload_bytes_staged = 3 * PAYLOAD as u64;
+        if arm == Arm::Control {
+            m.physical_cpu_payload_copy_bytes = 3 * PAYLOAD as u64;
+        } else {
+            u.ring_capacity = 16;
+            s.direct_staging_writes = 1;
+            s.physical_slot_payload_copy_bytes = PAYLOAD as u64;
+            m.physical_cpu_payload_copy_bytes = PAYLOAD as u64;
+            m.fallback_installs = 1;
+            m.fallback_payload_copy_bytes = PAYLOAD as u64;
+            m.fused_installs = 2;
+            m.fused_gpu_copy_bytes = 2 * PAYLOAD as u64;
+            m.shared_payload_constructions = 2;
+            m.acquisition_attempts = 2;
+            m.high_water = 2;
+            m.map_attempts = 2;
+            m.map_completions = 2;
+            m.unmaps = 2;
+            m.leases_created = 2;
+            m.leases_consumed = 2;
+            m.leases_released = 2;
+            m.odirect_observations = 2;
+            m.direct_source_reads = 2;
+            m.direct_source_bytes = 2 * FULL as u64;
+            m.direct_payload_bytes = 2 * PAYLOAD as u64;
+            m.fused_install_sets = 1;
+            m.copy_command_buffers = 1;
+            m.copy_submissions = 1;
+            m.copied_experts = 2;
+            m.copied_bytes = 2 * PAYLOAD as u64;
+        }
+        (s, p, u)
+    }
+    #[test]
+    fn source_upload_pair_accepts_exact_hybrid_copy_accounting_and_extra_submit() {
+        let (c, cp, cu) = fixture(Arm::Control);
+        let (t, tp, tu) = fixture(Arm::Treatment);
+        let source = source_fixture();
+        let gate = pair_mechanism_gate(&c, &t, &cp, &tp, &cu, &tu, &source, &source);
+        assert!(gate.passed, "{gate:?}");
+        assert_ne!(cu.metrics.copy_submissions, tu.metrics.copy_submissions);
+        assert_ne!(tu.metrics.physical_cpu_payload_copy_bytes, 0);
+    }
+    #[test]
+    fn source_upload_pair_rejects_source_identity_logical_and_fallback_corruption() {
+        let (c, cp, cu) = fixture(Arm::Control);
+        let (t, tp, tu) = fixture(Arm::Treatment);
+        let source = source_fixture();
+        let mutations: &[fn(&mut UploadSnapshot)] = &[
+            |s| s.metrics.fused_gpu_copy_bytes += 1,
+            |s| s.metrics.fallback_payload_copy_bytes = 0,
+            |s| s.metrics.physical_cpu_payload_copy_bytes = 0,
+            |s| s.metrics.total_payload_bytes_staged += 1,
+            |s| s.metrics.fused_installs += 1,
+            |s| s.metrics.fallback_installs += 1,
+            |s| s.metrics.direct_source_reads += 1,
+            |s| s.metrics.direct_source_bytes += 1,
+            |s| s.metrics.source_fallback_reads = 1,
+            |s| s.metrics.odirect_observations -= 1,
+            |s| s.metrics.shared_payload_constructions -= 1,
+            |s| s.metrics.logical_materialization_operations -= 1,
+            |s| s.metrics.logical_materialization_bytes -= 1,
+            |s| s.metrics.logical_admissions += 1,
+            |s| s.metrics.logical_generation_observations += 1,
+            |s| s.metrics.non_shared_logical_fallbacks = 1,
+            |s| s.ordered_nvme_ids_sha256.push('x'),
+            |s| s.logical_admission_ids_sha256.push('x'),
+            |s| s.logical_generation_ids_sha256.push('x'),
+            |s| s.metrics.copy_submissions += 1,
+            |s| s.metrics.copy_command_buffers = 0,
+            |s| s.metrics.fused_install_sets += 1,
+            |s| s.metrics.copied_experts += 1,
+            |s| s.metrics.copied_bytes += 1,
+            |s| s.metrics.leases_created += 1,
+            |s| s.metrics.leases_consumed -= 1,
+            |s| s.metrics.leases_released -= 1,
+            |s| s.metrics.leases_dropped_unconsumed = 1,
+            |s| s.metrics.map_attempts += 1,
+            |s| s.metrics.map_completions -= 1,
+            |s| s.metrics.unmaps -= 1,
+            |s| s.metrics.remap_attempts += 1,
+            |s| s.metrics.remap_completions = 3,
+            |s| s.metrics.high_water = 17,
+            |s| s.metrics.alignment_failures = 1,
+            |s| s.metrics.mapped_direct_io_rejections = 1,
+            |s| s.metrics.remap_failures = 1,
+            |s| s.metrics.copy_failures = 1,
+            |s| s.metrics.source_failures = 1,
+            |s| s.metrics.accounting_errors = 1,
+            |s| s.active_leases = 1,
+            |s| s.pending_leases = 1,
+            |s| s.ring_capacity = 17,
+            |s| s.arm = Arm::Control,
+        ];
+        for (i, mutate) in mutations.iter().enumerate() {
+            let mut bad = tu.clone();
+            mutate(&mut bad);
+            assert!(
+                !pair_mechanism_gate(&c, &t, &cp, &tp, &cu, &bad, &source, &source).passed,
+                "mutation {i}"
+            );
+        }
+    }
+    #[test]
+    fn source_upload_pair_rejects_source_cache_physical_identity_and_failures() {
+        let (c, cp, cu) = fixture(Arm::Control);
+        let (t, tp, tu) = fixture(Arm::Treatment);
+        let source = source_fixture();
+        let mutations: &[fn(&mut Snapshot)] = &[
+            |s| s.source_nvme_reads += 1,
+            |s| s.source_nvme_bytes += 1,
+            |s| s.source_ram_hits += 1,
+            |s| s.source_ram_misses += 1,
+            |s| s.demand_source_requests += 1,
+            |s| s.ram_cache_inserts += 1,
+            |s| s.ram_cache_evictions += 1,
+            |s| s.demand_ram_insert_ids_sha256.push('x'),
+            |s| s.demand_ram_eviction_ids_sha256.push('x'),
+            |s| s.physical_missing_ids_sha256.push('x'),
+            |s| s.demand_source_request_ids_sha256.push('x'),
+            |s| s.selected_route_ids_sha256.push('x'),
+            |s| s.reservation_identity_sha256.push('x'),
+            |s| s.physical_victim_ids_sha256.push('x'),
+            |s| s.physical_residency_identity_sha256.push('x'),
+            |s| s.mapping_publications += 1,
+            |s| s.mapping_unpublications += 1,
+            |s| s.physical_install_completions += 1,
+            |s| s.physical_install_sets += 1,
+            |s| s.physical_slot_bytes_staged += 1,
+            |s| s.physical_slot_payload_copy_bytes += 1,
+            |s| s.reservation_failures = 1,
+            |s| s.physical_stage_failures = 1,
+            |s| s.ordered_commit_failures = 1,
+            |s| s.evidence_accounting_errors = 1,
+            |s| s.overlapping_demand_sets = 1,
+        ];
+        for (i, mutate) in mutations.iter().enumerate() {
+            let mut bad = t.clone();
+            mutate(&mut bad);
+            assert!(
+                !pair_mechanism_gate(&c, &bad, &cp, &tp, &cu, &tu, &source, &source).passed,
+                "mutation {i}"
+            );
+        }
+        let mut changed_source = source_fixture();
+        changed_source.production_batch_successes += 1;
+        assert!(!pair_mechanism_gate(&c, &t, &cp, &tp, &cu, &tu, &source, &changed_source).passed);
+    }
+    #[test]
+    fn source_upload_pass_is_independent_of_speed_but_requires_complete_failure_free_run() {
+        let (c, cp, cu) = fixture(Arm::Control);
+        let (mut t, tp, tu) = fixture(Arm::Treatment);
+        let source = source_fixture();
+        t.sum_individual_physical_stage_us = 3_000_000;
+        t.physical_install_total_us = 3_000_009;
+        assert!(pair_mechanism_gate(&c, &t, &cp, &tp, &cu, &tu, &source, &source).passed);
+        assert!(completed_pass(true, false, true));
+        for (complete, failure, gates) in [
+            (false, false, true),
+            (true, true, true),
+            (true, false, false),
+            (false, true, false),
+        ] {
+            assert!(!completed_pass(complete, failure, gates));
+        }
+    }
+    #[test]
+    fn source_upload_cli_schema_and_frozen_workload_have_no_overrides() {
+        use clap::Parser;
+        let args = [
+            "micro-expert-router",
+            MODE,
+            "--config",
+            FROZEN_CONFIG_PATH,
+            "--expected-adapter-name",
+            "NVIDIA L4",
+            "--report-out",
+            "/tmp/qualification-candidate.json",
+        ];
+        let parsed = crate::Cli::try_parse_from(args).unwrap();
+        assert!(matches!(
+            parsed.cmd,
+            crate::Cmd::QualifyGpuNativeSourceToUploadCopyElisionProduction { .. }
+        ));
+        let mut invalid = args.to_vec();
+        invalid.extend(["--output-tokens", "1"]);
+        assert!(crate::Cli::try_parse_from(invalid).is_err());
+        assert_eq!(
+            SCHEMA,
+            "mer.gpu-native-source-to-upload-copy-elision-production.v1"
+        );
+        assert_eq!(
+            (
+                FROZEN_OUTPUT_TOKENS,
+                FROZEN_WARMUP_RUNS,
+                FROZEN_MEASURED_RUNS
+            ),
+            (128, 1, 3)
+        );
+        assert_eq!(
+            FROZEN_PROMPT,
+            "Write a Rust function that adds two i32 values and returns the result."
+        );
+        let workload = frozen_workload("NVIDIA L4".into());
+        assert_eq!(workload.cache_reset, "keep");
+        assert_eq!(workload.sampling, "greedy");
+    }
+}

--- a/rust-engine/src/gpu_native_source_to_upload_copy_elision_production.rs
+++ b/rust-engine/src/gpu_native_source_to_upload_copy_elision_production.rs
@@ -3,7 +3,7 @@
 use super::*;
 use crate::engine::GpuNativePhysicalInstallConcurrencyQualificationSnapshot as Snapshot;
 
-pub(crate) const SCHEMA: &str = "mer.gpu-native-source-to-upload-copy-elision-production.v1";
+pub(crate) const SCHEMA: &str = "mer.gpu-native-source-to-upload-copy-elision-production.v2";
 pub(crate) const MODE: &str = "qualify-gpu-native-source-to-upload-copy-elision-production";
 const LOGICAL_EXPERT_BYTES: u64 = 2_654_208;
 const SLOT_STRIDE_BYTES: u64 = 2_654_212;
@@ -24,6 +24,7 @@ struct PairMechanismGate {
     treatment_fused_and_fallback_bytes_exact: bool,
     treatment_every_nvme_read_fused: bool,
     ring_and_submission_accounting_exact: bool,
+    production_upload_ownership_exact: bool,
     failures_and_accounting_errors_zero: bool,
     production_install_reconciliation: bool,
     passed: bool,
@@ -237,6 +238,7 @@ fn pair_mechanism_gate(
         && tm.direct_source_reads.checked_mul(PAYLOAD as u64) == Some(tm.direct_payload_bytes)
         && tm.odirect_observations == tm.direct_source_reads;
     let ring_and_submission_accounting_exact = ring_exact(cu, tu);
+    let production_upload_ownership_exact = !cu.production_owned && tu.production_owned;
     let failures_and_accounting_errors_zero = upload_errors_zero(cu)
         && upload_errors_zero(tu)
         && zero_fill_production::failures_zero(c)
@@ -252,6 +254,7 @@ fn pair_mechanism_gate(
         && treatment_fused_and_fallback_bytes_exact
         && treatment_every_nvme_read_fused
         && ring_and_submission_accounting_exact
+        && production_upload_ownership_exact
         && failures_and_accounting_errors_zero
         && production_install_reconciliation;
     PairMechanismGate {
@@ -263,6 +266,7 @@ fn pair_mechanism_gate(
         treatment_fused_and_fallback_bytes_exact,
         treatment_every_nvme_read_fused,
         ring_and_submission_accounting_exact,
+        production_upload_ownership_exact,
         failures_and_accounting_errors_zero,
         production_install_reconciliation,
         passed,
@@ -388,7 +392,7 @@ pub(crate) async fn run_command(args: CommandArgs) -> Result<(), Box<dyn std::er
         treatment: None,
         control_path: "ordinary production source and concurrent no-zero Queue::write_buffer_with",
         treatment_path:
-            "single-read NVMe to bounded mapped upload; shared logical/RAM payload; GPU-copy fused misses; ordinary RAM-hit physical fallback",
+            "ordinary production-owned single-read NVMe to bounded mapped upload; shared logical/RAM payload; GPU-copy fused misses; ordinary RAM-hit physical fallback",
         both_arms_same_reservation_and_commit: true,
         source_scheduler_changed: false,
         staging_byte_count_changed: false,
@@ -750,7 +754,11 @@ mod tests {
         s.source_nvme_bytes = 2 * FULL as u64;
         s.source_ram_misses = 2;
         s.source_ram_hits = 1;
-        let mut u = crate::gpu_native_source_upload::State::cpu_test_state(arm).snapshot();
+        let mut u = if arm == Arm::Treatment {
+            crate::gpu_native_source_upload::State::cpu_test_production_state().snapshot()
+        } else {
+            crate::gpu_native_source_upload::State::cpu_test_state(arm).snapshot()
+        };
         let m = &mut u.metrics;
         m.logical_admissions = 2;
         m.logical_generation_observations = 3;
@@ -848,6 +856,7 @@ mod tests {
             |s| s.active_leases = 1,
             |s| s.pending_leases = 1,
             |s| s.ring_capacity = 17,
+            |s| s.production_owned = false,
             |s| s.arm = Arm::Control,
         ];
         for (i, mutate) in mutations.iter().enumerate() {
@@ -945,7 +954,7 @@ mod tests {
         assert!(crate::Cli::try_parse_from(invalid).is_err());
         assert_eq!(
             SCHEMA,
-            "mer.gpu-native-source-to-upload-copy-elision-production.v1"
+            "mer.gpu-native-source-to-upload-copy-elision-production.v2"
         );
         assert_eq!(
             (

--- a/rust-engine/src/gpu_native_source_upload.rs
+++ b/rust-engine/src/gpu_native_source_upload.rs
@@ -12,6 +12,7 @@ use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
 pub(crate) const FULL: usize = 2_658_304;
 pub(crate) const PAYLOAD: usize = 2_654_208;
@@ -93,6 +94,7 @@ impl Metrics {
 #[derive(Clone, Debug, Serialize)]
 pub(crate) struct Snapshot {
     pub(crate) arm: Arm,
+    pub(crate) production_owned: bool,
     pub(crate) ring_capacity: usize,
     pub(crate) active_leases: usize,
     pub(crate) pending_leases: usize,
@@ -141,6 +143,8 @@ struct Ring {
 
 pub(crate) struct State {
     pub(crate) arm: Arm,
+    production_owned: bool,
+    production_demand_gate: Arc<Semaphore>,
     ring: Option<Ring>,
     pub(crate) metrics: Mutex<Metrics>,
     pending: Mutex<HashMap<u32, Lease>>,
@@ -148,17 +152,54 @@ pub(crate) struct State {
     logical_ids: Mutex<Sha256>,
     generations: Mutex<Sha256>,
 }
+
+pub(crate) struct ProductionDemandGuard {
+    state: Arc<State>,
+    _permit: OwnedSemaphorePermit,
+}
+
+impl ProductionDemandGuard {
+    pub(crate) fn state(&self) -> &Arc<State> {
+        &self.state
+    }
+}
+
+impl Drop for ProductionDemandGuard {
+    fn drop(&mut self) {
+        // This guard is the sole production owner of the ring while alive, so
+        // request failure/cancellation can safely clear its pending source leases.
+        self.state.abandon_pending();
+    }
+}
+
 impl State {
     pub(crate) fn new(
         arm: Arm,
         executor: Arc<GpuNativeExecutorContext>,
     ) -> Result<Arc<Self>, String> {
+        Self::new_with_ownership(arm, executor, false)
+    }
+
+    pub(crate) fn new_production(
+        executor: Arc<GpuNativeExecutorContext>,
+    ) -> Result<Arc<Self>, String> {
+        Self::new_with_ownership(Arm::Treatment, executor, true)
+    }
+
+    fn new_with_ownership(
+        arm: Arm,
+        executor: Arc<GpuNativeExecutorContext>,
+        production_owned: bool,
+    ) -> Result<Arc<Self>, String> {
+        if production_owned && arm != Arm::Treatment {
+            return Err("production source/upload state must use the treatment mechanism".into());
+        }
         let ring = if arm == Arm::Treatment {
             let gpu = executor.authoritative_gpu().map_err(|e| e.to_string())?;
             let slots = (0..CAPACITY)
                 .map(|_| Slot {
                     buffer: gpu.device.create_buffer(&wgpu::BufferDescriptor {
-                        label: Some("qualification source-to-upload bounded slot"),
+                        label: Some("source-to-upload bounded slot"),
                         size: UPLOAD_BYTES as u64,
                         usage: wgpu::BufferUsages::MAP_WRITE | wgpu::BufferUsages::COPY_SRC,
                         mapped_at_creation: false,
@@ -173,6 +214,8 @@ impl State {
         };
         Ok(Arc::new(Self {
             arm,
+            production_owned,
+            production_demand_gate: Arc::new(Semaphore::new(1)),
             ring,
             metrics: Mutex::new(Metrics::default()),
             pending: Mutex::new(HashMap::new()),
@@ -181,10 +224,23 @@ impl State {
             generations: Mutex::new(Sha256::new()),
         }))
     }
+
     #[cfg(test)]
     pub(crate) fn cpu_test_state(arm: Arm) -> Arc<Self> {
+        Self::cpu_test_state_with_ownership(arm, false)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn cpu_test_production_state() -> Arc<Self> {
+        Self::cpu_test_state_with_ownership(Arm::Treatment, true)
+    }
+
+    #[cfg(test)]
+    fn cpu_test_state_with_ownership(arm: Arm, production_owned: bool) -> Arc<Self> {
         Arc::new(Self {
             arm,
+            production_owned,
+            production_demand_gate: Arc::new(Semaphore::new(1)),
             ring: None,
             metrics: Mutex::new(Metrics::default()),
             pending: Mutex::new(HashMap::new()),
@@ -194,12 +250,50 @@ impl State {
         })
     }
 
+    pub(crate) fn is_production_owned(&self) -> bool {
+        self.production_owned
+    }
+
+    pub(crate) fn try_begin_production_demand(
+        self: &Arc<Self>,
+    ) -> Option<ProductionDemandGuard> {
+        if !self.production_owned || self.arm != Arm::Treatment {
+            return None;
+        }
+        let permit = self
+            .production_demand_gate
+            .clone()
+            .try_acquire_owned()
+            .ok()?;
+        Some(ProductionDemandGuard {
+            state: self.clone(),
+            _permit: permit,
+        })
+    }
+
+    pub(crate) fn can_fuse_source_set(
+        &self,
+        ids: &[u32],
+        logical: &GpuExpertCache,
+    ) -> bool {
+        self.arm == Arm::Treatment
+            && !ids.is_empty()
+            && ids.len() <= CAPACITY
+            && !ids.iter().any(|id| self.pending.lock().contains_key(id))
+            && ids.iter().all(|id| {
+                logical
+                    .current_admission(*id)
+                    .is_none_or(|a| a.resident().qualification_shared_payload().is_some())
+            })
+    }
+
     pub(crate) fn add(&self, field: fn(&mut Metrics) -> &mut u64, n: u64) {
         self.metrics.lock().add(field, n);
     }
     pub(crate) fn snapshot(&self) -> Snapshot {
         Snapshot {
             arm: self.arm,
+            production_owned: self.production_owned,
             ring_capacity: self.ring.as_ref().map_or(0, |r| r.slots.len()),
             active_leases: self.active_leases(),
             pending_leases: self.pending.lock().len(),
@@ -224,8 +318,11 @@ impl State {
         })
     }
     pub(crate) fn reset(&self) -> Result<(), String> {
-        if self.active_leases() != 0 || !self.pending.lock().is_empty() {
-            return Err("cannot reset upload evidence with outstanding leases".into());
+        if self.active_leases() != 0
+            || !self.pending.lock().is_empty()
+            || (self.production_owned && self.production_demand_gate.available_permits() != 1)
+        {
+            return Err("cannot reset upload evidence with outstanding leases or production demand".into());
         }
         *self.metrics.lock() = Metrics::default();
         *self.nvme_ids.lock() = Sha256::new();
@@ -832,6 +929,23 @@ mod tests {
         assert_eq!(state.snapshot().metrics.leases_created, 0);
         assert_eq!(state.snapshot().metrics.direct_source_reads, 0);
     }
+
+    #[test]
+    fn source_upload_production_demand_gate_is_exclusive_and_owned() {
+        let state = State::cpu_test_production_state();
+        assert!(state.snapshot().production_owned);
+        let guard = state
+            .try_begin_production_demand()
+            .expect("first production demand owns the upload ring");
+        assert!(state.try_begin_production_demand().is_none());
+        drop(guard);
+        assert!(state.try_begin_production_demand().is_some());
+
+        let control = State::cpu_test_state(Arm::Control);
+        assert!(!control.snapshot().production_owned);
+        assert!(control.try_begin_production_demand().is_none());
+    }
+
     #[test]
     fn source_upload_counter_overflow_is_a_visible_accounting_error() {
         let mut metrics = Metrics::default();

--- a/rust-engine/src/gpu_native_source_upload.rs
+++ b/rust-engine/src/gpu_native_source_upload.rs
@@ -1,0 +1,911 @@
+//! Private real-inference source/upload mechanism. No production constructor
+//! creates this state. Source I/O lives here; physical installation receives only
+//! a one-shot, identity-checked unmapped lease, never a storage handle.
+use crate::backend::gpu_native::GpuNativeExecutorContext;
+use crate::buffer_pool::PooledBuffer;
+use crate::expert_cache::{ExpertResident, GpuExpertCache};
+use crate::io_provider::NvmeStorage;
+use crate::tensor_header::{TensorHeader, UthDtypeId};
+use parking_lot::Mutex;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Instant;
+
+pub(crate) const FULL: usize = 2_658_304;
+pub(crate) const PAYLOAD: usize = 2_654_208;
+pub(crate) const ALIGN: usize = 4096;
+pub(crate) const CAPACITY: usize = 16;
+pub(crate) const UPLOAD_BYTES: usize = FULL + ALIGN;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum GpuNativeSourceToUploadCopyElisionQualificationArm {
+    Control,
+    Treatment,
+}
+pub(crate) use GpuNativeSourceToUploadCopyElisionQualificationArm as Arm;
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub(crate) struct Metrics {
+    pub(crate) acquisition_attempts: u64,
+    pub(crate) acquisition_waits: u64,
+    pub(crate) acquisition_wait_us: u64,
+    pub(crate) high_water: u64,
+    pub(crate) map_attempts: u64,
+    pub(crate) map_completions: u64,
+    pub(crate) map_wait_us: u64,
+    pub(crate) unmaps: u64,
+    pub(crate) remap_attempts: u64,
+    pub(crate) remap_completions: u64,
+    pub(crate) remap_failures: u64,
+    pub(crate) remap_wait_us: u64,
+    pub(crate) alignment_failures: u64,
+    pub(crate) leases_created: u64,
+    pub(crate) leases_consumed: u64,
+    pub(crate) leases_released: u64,
+    pub(crate) leases_dropped_unconsumed: u64,
+    pub(crate) mapped_direct_io_rejections: u64,
+    pub(crate) odirect_observations: u64,
+    pub(crate) direct_source_reads: u64,
+    pub(crate) direct_source_bytes: u64,
+    pub(crate) direct_payload_bytes: u64,
+    pub(crate) source_failures: u64,
+    pub(crate) source_fallback_reads: u64,
+    pub(crate) fused_source_us: u64,
+    pub(crate) logical_materialization_operations: u64,
+    pub(crate) logical_materialization_bytes: u64,
+    pub(crate) logical_materialization_us: u64,
+    pub(crate) shared_payload_constructions: u64,
+    pub(crate) shared_payload_reuse: u64,
+    pub(crate) non_shared_logical_fallbacks: u64,
+    pub(crate) non_shared_logical_rejections: u64,
+    pub(crate) logical_admissions: u64,
+    pub(crate) logical_generation_observations: u64,
+    pub(crate) total_payload_bytes_staged: u64,
+    pub(crate) physical_cpu_payload_copy_bytes: u64,
+    pub(crate) fallback_installs: u64,
+    pub(crate) fallback_payload_copy_bytes: u64,
+    pub(crate) fallback_payload_copy_us: u64,
+    pub(crate) fused_installs: u64,
+    pub(crate) fused_gpu_copy_bytes: u64,
+    pub(crate) fused_install_sets: u64,
+    pub(crate) copy_command_buffers: u64,
+    pub(crate) copy_submissions: u64,
+    pub(crate) copied_experts: u64,
+    pub(crate) copied_bytes: u64,
+    pub(crate) copy_encode_us: u64,
+    pub(crate) copy_submit_us: u64,
+    pub(crate) copy_failures: u64,
+    pub(crate) accounting_errors: u64,
+}
+impl Metrics {
+    pub(crate) fn add(&mut self, field: fn(&mut Self) -> &mut u64, n: u64) {
+        let value = field(self);
+        if let Some(sum) = value.checked_add(n) {
+            *value = sum;
+        } else {
+            self.accounting_errors = self.accounting_errors.saturating_add(1);
+        }
+    }
+}
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct Snapshot {
+    pub(crate) arm: Arm,
+    pub(crate) ring_capacity: usize,
+    pub(crate) active_leases: usize,
+    pub(crate) pending_leases: usize,
+    pub(crate) ordered_nvme_ids_sha256: String,
+    pub(crate) logical_admission_ids_sha256: String,
+    pub(crate) logical_generation_ids_sha256: String,
+    #[serde(flatten)]
+    pub(crate) metrics: Metrics,
+}
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SlotState {
+    Available,
+    Mapping,
+    Mapped,
+    Ready,
+    Submitted,
+}
+impl SlotState {
+    fn transition(&mut self, expected: Self, next: Self) -> Result<(), String> {
+        if *self != expected {
+            return Err(format!(
+                "upload state mismatch: expected {expected:?}, got {self:?}"
+            ));
+        }
+        *self = next;
+        Ok(())
+    }
+}
+fn reserve_slot<'a>(states: impl Iterator<Item = &'a Mutex<SlotState>>) -> Option<usize> {
+    states.enumerate().find_map(|(i, s)| {
+        s.lock()
+            .transition(SlotState::Available, SlotState::Mapping)
+            .ok()
+            .map(|_| i)
+    })
+}
+struct Slot {
+    buffer: wgpu::Buffer,
+    state: Mutex<SlotState>,
+    ever_mapped: Mutex<bool>,
+}
+struct Ring {
+    executor: Arc<GpuNativeExecutorContext>,
+    slots: Vec<Slot>,
+}
+
+pub(crate) struct State {
+    pub(crate) arm: Arm,
+    ring: Option<Ring>,
+    pub(crate) metrics: Mutex<Metrics>,
+    pending: Mutex<HashMap<u32, Lease>>,
+    nvme_ids: Mutex<Sha256>,
+    logical_ids: Mutex<Sha256>,
+    generations: Mutex<Sha256>,
+}
+impl State {
+    pub(crate) fn new(
+        arm: Arm,
+        executor: Arc<GpuNativeExecutorContext>,
+    ) -> Result<Arc<Self>, String> {
+        let ring = if arm == Arm::Treatment {
+            let gpu = executor.authoritative_gpu().map_err(|e| e.to_string())?;
+            let slots = (0..CAPACITY)
+                .map(|_| Slot {
+                    buffer: gpu.device.create_buffer(&wgpu::BufferDescriptor {
+                        label: Some("qualification source-to-upload bounded slot"),
+                        size: UPLOAD_BYTES as u64,
+                        usage: wgpu::BufferUsages::MAP_WRITE | wgpu::BufferUsages::COPY_SRC,
+                        mapped_at_creation: false,
+                    }),
+                    state: Mutex::new(SlotState::Available),
+                    ever_mapped: Mutex::new(false),
+                })
+                .collect();
+            Some(Ring { executor, slots })
+        } else {
+            None
+        };
+        Ok(Arc::new(Self {
+            arm,
+            ring,
+            metrics: Mutex::new(Metrics::default()),
+            pending: Mutex::new(HashMap::new()),
+            nvme_ids: Mutex::new(Sha256::new()),
+            logical_ids: Mutex::new(Sha256::new()),
+            generations: Mutex::new(Sha256::new()),
+        }))
+    }
+    #[cfg(test)]
+    pub(crate) fn cpu_test_state(arm: Arm) -> Arc<Self> {
+        Arc::new(Self {
+            arm,
+            ring: None,
+            metrics: Mutex::new(Metrics::default()),
+            pending: Mutex::new(HashMap::new()),
+            nvme_ids: Mutex::new(Sha256::new()),
+            logical_ids: Mutex::new(Sha256::new()),
+            generations: Mutex::new(Sha256::new()),
+        })
+    }
+
+    pub(crate) fn add(&self, field: fn(&mut Metrics) -> &mut u64, n: u64) {
+        self.metrics.lock().add(field, n);
+    }
+    pub(crate) fn snapshot(&self) -> Snapshot {
+        Snapshot {
+            arm: self.arm,
+            ring_capacity: self.ring.as_ref().map_or(0, |r| r.slots.len()),
+            active_leases: self.active_leases(),
+            pending_leases: self.pending.lock().len(),
+            metrics: self.metrics.lock().clone(),
+            ordered_nvme_ids_sha256: format!("{:x}", self.nvme_ids.lock().clone().finalize()),
+            logical_admission_ids_sha256: format!(
+                "{:x}",
+                self.logical_ids.lock().clone().finalize()
+            ),
+            logical_generation_ids_sha256: format!(
+                "{:x}",
+                self.generations.lock().clone().finalize()
+            ),
+        }
+    }
+    fn active_leases(&self) -> usize {
+        self.ring.as_ref().map_or(0, |r| {
+            r.slots
+                .iter()
+                .filter(|s| *s.state.lock() != SlotState::Available)
+                .count()
+        })
+    }
+    pub(crate) fn reset(&self) -> Result<(), String> {
+        if self.active_leases() != 0 || !self.pending.lock().is_empty() {
+            return Err("cannot reset upload evidence with outstanding leases".into());
+        }
+        *self.metrics.lock() = Metrics::default();
+        *self.nvme_ids.lock() = Sha256::new();
+        *self.logical_ids.lock() = Sha256::new();
+        *self.generations.lock() = Sha256::new();
+        Ok(())
+    }
+    pub(crate) fn record_nvme(&self, ids: &[u32]) {
+        let mut h = self.nvme_ids.lock();
+        for id in ids {
+            h.update(id.to_le_bytes());
+        }
+    }
+    pub(crate) fn record_logical(&self, ids: &[u32], generations: &[u64], new_ids: &[u32]) {
+        let mut h = self.generations.lock();
+        for (&id, &generation) in ids.iter().zip(generations) {
+            h.update(id.to_le_bytes());
+            h.update(generation.to_le_bytes());
+        }
+        let mut a = self.logical_ids.lock();
+        for id in new_ids {
+            a.update(id.to_le_bytes());
+        }
+        self.add(|m| &mut m.logical_admissions, new_ids.len() as u64);
+        self.add(|m| &mut m.logical_generation_observations, ids.len() as u64);
+    }
+    fn acquire(self: &Arc<Self>, id: u32) -> Result<Lease, String> {
+        self.add(|m| &mut m.acquisition_attempts, 1);
+        let ring = self
+            .ring
+            .as_ref()
+            .ok_or("control cannot acquire an upload lease")?;
+        let index = reserve_slot(ring.slots.iter().map(|s| &s.state)).ok_or_else(|| {
+            // The frozen single demand stream cannot release an outstanding
+            // source lease while waiting here. Fail closed instead of deadlock
+            // or creating a seventeenth buffer.
+            self.add(|m| &mut m.accounting_errors, 1);
+            "bounded upload ring exhausted".to_string()
+        })?;
+        self.add(|m| &mut m.leases_created, 1);
+        let active = self.active_leases() as u64;
+        let mut metrics = self.metrics.lock();
+        metrics.high_water = metrics.high_water.max(active);
+        drop(metrics);
+        let lease = Lease {
+            state: self.clone(),
+            index,
+            id,
+            offset: 0,
+            payload: None,
+            consumed: false,
+        };
+        let slot = &ring.slots[index];
+        let remap = *slot.ever_mapped.lock();
+        self.add(|m| &mut m.map_attempts, 1);
+        if remap {
+            self.add(|m| &mut m.remap_attempts, 1);
+        }
+        let start = Instant::now();
+        let (tx, rx) = std::sync::mpsc::sync_channel(1);
+        slot.buffer
+            .slice(..)
+            .map_async(wgpu::MapMode::Write, move |r| {
+                let _ = tx.send(r);
+            });
+        let gpu = ring
+            .executor
+            .authoritative_gpu()
+            .map_err(|e| e.to_string())?;
+        gpu.device.poll(wgpu::Maintain::Wait);
+        let result = rx
+            .recv()
+            .map_err(|e| e.to_string())
+            .and_then(|r| r.map_err(|e| e.to_string()));
+        let wait_us = elapsed(start);
+        self.add(|m| &mut m.map_wait_us, wait_us);
+        if remap {
+            self.add(|m| &mut m.remap_wait_us, wait_us);
+        }
+        if let Err(error) = result {
+            if remap {
+                self.add(|m| &mut m.remap_failures, 1);
+            }
+            self.add(|m| &mut m.copy_failures, 1);
+            return Err(error);
+        }
+        slot.state
+            .lock()
+            .transition(SlotState::Mapping, SlotState::Mapped)?;
+        self.add(|m| &mut m.map_completions, 1);
+        if remap {
+            self.add(|m| &mut m.remap_completions, 1);
+        }
+        *slot.ever_mapped.lock() = true;
+        Ok(lease)
+    }
+    pub(crate) async fn read_source(
+        self: &Arc<Self>,
+        storage: &NvmeStorage,
+        ids: &[u32],
+        buffers: Vec<PooledBuffer>,
+        logical: &GpuExpertCache,
+    ) -> Result<Vec<Arc<ExpertResident>>, String> {
+        if self.arm != Arm::Treatment || ids.len() != buffers.len() || ids.len() > CAPACITY {
+            return Err("invalid qualification source set".into());
+        }
+        if ids.iter().any(|id| self.pending.lock().contains_key(id)) {
+            self.add(|m| &mut m.accounting_errors, 1);
+            return Err("second source read while an upload lease exists".into());
+        }
+        // A pre-existing ordinary Vec admission cannot share its allocation.
+        // Reject before I/O rather than silently adding treatment-only copies.
+        for id in ids {
+            if logical
+                .current_admission(*id)
+                .is_some_and(|a| a.resident().qualification_shared_payload().is_none())
+            {
+                self.add(|m| &mut m.non_shared_logical_rejections, 1);
+                return Err("non-shared logical admission prevents source fusion".into());
+            }
+        }
+        let mut leases = ids
+            .iter()
+            .map(|&id| self.acquire(id))
+            .collect::<Result<Vec<_>, _>>()?;
+        let mut views = leases
+            .iter()
+            .map(|l| l.buffer().slice(..).get_mapped_range_mut())
+            .collect::<Vec<_>>();
+        let offsets = views
+            .iter()
+            .map(|v| aligned_offset(v.as_ptr() as usize, v.len()))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| {
+                self.add(|m| &mut m.alignment_failures, 1);
+                e
+            })?;
+        let mut destinations = views
+            .iter_mut()
+            .zip(&offsets)
+            .map(|(v, &o)| &mut v[o..o + FULL])
+            .collect::<Vec<_>>();
+        let started = Instant::now();
+        let result = storage
+            .read_experts_batch_into_aligned_slices(ids, &mut destinations)
+            .await;
+        self.add(|m| &mut m.fused_source_us, elapsed(started));
+        drop(destinations);
+        let bytes = result.map_err(|e| {
+            self.add(|m| &mut m.source_failures, 1);
+            self.add(|m| &mut m.mapped_direct_io_rejections, 1);
+            e.to_string()
+        })?;
+        if bytes != ids.len() * FULL {
+            self.add(|m| &mut m.accounting_errors, 1);
+            return Err("short direct source set".into());
+        }
+        self.add(|m| &mut m.direct_source_reads, ids.len() as u64);
+        self.add(|m| &mut m.direct_source_bytes, bytes as u64);
+        self.add(|m| &mut m.odirect_observations, ids.len() as u64);
+        self.add(
+            |m| &mut m.direct_payload_bytes,
+            (ids.len() * PAYLOAD) as u64,
+        );
+        let mut shared = Vec::with_capacity(ids.len());
+        for ((&id, view), &offset) in ids.iter().zip(&views).zip(&offsets) {
+            let payload = checked_payload(&view[offset..offset + FULL])?;
+            let bytes = self.materialize_source_payload(id, payload, logical)?;
+            shared.push(bytes);
+        }
+        // Every view is gone before the first unmap, including error unwinds
+        // (views was declared after leases and therefore drops first).
+        drop(views);
+        let mut residents = Vec::with_capacity(ids.len());
+        for (((lease, offset), payload), capacity_lease) in
+            leases.iter_mut().zip(offsets).zip(shared).zip(buffers)
+        {
+            lease.offset = offset;
+            lease.payload = Some(payload.clone());
+            lease.unmap();
+            residents.push(Arc::new(ExpertResident::new_qualification_shared(
+                lease.id,
+                capacity_lease,
+                payload,
+            )));
+        }
+        let mut pending = self.pending.lock();
+        for lease in leases {
+            pending.insert(lease.id, lease);
+        }
+        Ok(residents)
+    }
+    fn materialize_source_payload(
+        &self,
+        id: u32,
+        payload: &[u8],
+        logical: &GpuExpertCache,
+    ) -> Result<Arc<[u8]>, String> {
+        let bytes = if let Some(admission) = logical.current_admission(id) {
+            let shared = admission
+                .resident()
+                .qualification_shared_payload()
+                .ok_or("logical backing changed during source read")?;
+            if shared.as_ref() != payload {
+                return Err("immutable source differs from shared logical payload".into());
+            }
+            self.add(|m| &mut m.shared_payload_reuse, 1);
+            shared.clone()
+        } else {
+            let start = Instant::now();
+            let shared: Arc<[u8]> = Arc::from(payload);
+            self.add(|m| &mut m.logical_materialization_us, elapsed(start));
+            self.add(|m| &mut m.logical_materialization_operations, 1);
+            self.add(
+                |m| &mut m.logical_materialization_bytes,
+                payload.len() as u64,
+            );
+            self.add(|m| &mut m.shared_payload_constructions, 1);
+            shared
+        };
+        Ok(bytes)
+    }
+
+    pub(crate) fn take_lease(
+        &self,
+        id: u32,
+        resident: &ExpertResident,
+    ) -> Result<Option<Lease>, String> {
+        let lease = self.pending.lock().remove(&id);
+        if let Some(lease) = &lease {
+            if self.arm != Arm::Treatment
+                || lease.id != resident.id
+                || !resident
+                    .qualification_shared_payload()
+                    .zip(lease.payload.as_ref())
+                    .is_some_and(|(a, b)| Arc::ptr_eq(a, b))
+                || *lease.slot().state.lock() != SlotState::Ready
+            {
+                self.add(|m| &mut m.accounting_errors, 1);
+                return Err("source/upload resident identity or unmap mismatch".into());
+            }
+        }
+        Ok(lease)
+    }
+    pub(crate) fn has_pending(&self, id: u32) -> bool {
+        self.pending.lock().contains_key(&id)
+    }
+    pub(crate) fn finish_request(&self) -> Result<(), String> {
+        if !self.pending.lock().is_empty() || self.active_leases() != 0 {
+            self.add(|m| &mut m.accounting_errors, 1);
+            self.pending.lock().clear();
+            return Err("unconsumed upload lease at demand completion".into());
+        }
+        Ok(())
+    }
+    pub(crate) fn abandon_pending(&self) {
+        self.pending.lock().clear();
+    }
+}
+
+pub(crate) struct Lease {
+    state: Arc<State>,
+    index: usize,
+    id: u32,
+    offset: usize,
+    payload: Option<Arc<[u8]>>,
+    consumed: bool,
+}
+
+/// One encoder for the physical install set. Concurrent stage jobs append
+/// their exact copies under this short lock. No mapping is published until
+/// submit returns; upload leases remain owned here through that submission.
+pub(crate) struct CopySet<'a> {
+    state: &'a State,
+    encoder: Mutex<Option<wgpu::CommandEncoder>>,
+    leases: Mutex<Vec<Lease>>,
+}
+impl<'a> CopySet<'a> {
+    pub(crate) fn new(state: &'a State) -> Self {
+        Self {
+            state,
+            encoder: Mutex::new(None),
+            leases: Mutex::new(Vec::new()),
+        }
+    }
+    pub(crate) fn encode(
+        &self,
+        lease: Lease,
+        device: &wgpu::Device,
+        destination: &wgpu::Buffer,
+        offset: u64,
+    ) -> Result<(), String> {
+        let start = Instant::now();
+        let source = lease.copy_source_offset()?;
+        if offset % 4 != 0
+            || offset
+                .checked_add(PAYLOAD as u64)
+                .is_none_or(|end| end > destination.size())
+        {
+            return Err("invalid physical upload destination".into());
+        }
+        let mut encoder = self.encoder.lock();
+        let encoder = encoder.get_or_insert_with(|| {
+            device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("qualification residency copy set"),
+            })
+        });
+        encoder.copy_buffer_to_buffer(lease.buffer(), source, destination, offset, PAYLOAD as u64);
+        self.leases.lock().push(lease);
+        self.state.add(|m| &mut m.copy_encode_us, elapsed(start));
+        Ok(())
+    }
+    pub(crate) fn submit(&self, executor: &GpuNativeExecutorContext) -> Result<(), String> {
+        let Some(encoder) = self.encoder.lock().take() else {
+            return Ok(());
+        };
+        let gpu = executor.authoritative_gpu().map_err(|e| e.to_string())?;
+        let mut leases = self.leases.lock();
+        if self.state.arm != Arm::Treatment || leases.is_empty() {
+            return Err("invalid qualification copy submission".into());
+        }
+        let command = encoder.finish();
+        self.state.add(|m| &mut m.copy_command_buffers, 1);
+        let start = Instant::now();
+        gpu.queue.submit(Some(command));
+        self.state.add(|m| &mut m.copy_submit_us, elapsed(start));
+        self.state.add(|m| &mut m.copy_submissions, 1);
+        self.state
+            .add(|m| &mut m.copied_experts, leases.len() as u64);
+        self.state
+            .add(|m| &mut m.copied_bytes, (leases.len() * PAYLOAD) as u64);
+        for lease in leases.iter_mut() {
+            lease.submitted()?;
+        }
+        // map_async on the next acquisition waits for this buffer's submitted
+        // copy to finish; no stable virtual address is assumed on remapping.
+        leases.clear();
+        executor.authoritative_gpu().map_err(|e| e.to_string())?;
+        Ok(())
+    }
+}
+impl Lease {
+    fn slot(&self) -> &Slot {
+        &self.state.ring.as_ref().expect("treatment ring").slots[self.index]
+    }
+    pub(crate) fn buffer(&self) -> &wgpu::Buffer {
+        &self.slot().buffer
+    }
+    pub(crate) fn copy_source_offset(&self) -> Result<u64, String> {
+        copy_source_offset(self.offset, UPLOAD_BYTES)
+    }
+    pub(crate) fn context_id(&self) -> u64 {
+        self.state.ring.as_ref().unwrap().executor.context_id()
+    }
+    fn unmap(&self) {
+        self.buffer().unmap();
+        *self.slot().state.lock() = SlotState::Ready;
+        self.state.add(|m| &mut m.unmaps, 1);
+    }
+    pub(crate) fn submitted(&mut self) -> Result<(), String> {
+        if self.consumed || *self.slot().state.lock() != SlotState::Ready {
+            return Err("upload lease consumed twice or while mapped".into());
+        }
+        self.consumed = true;
+        self.slot()
+            .state
+            .lock()
+            .transition(SlotState::Ready, SlotState::Submitted)?;
+        self.state.add(|m| &mut m.leases_consumed, 1);
+        Ok(())
+    }
+}
+impl Drop for Lease {
+    fn drop(&mut self) {
+        if matches!(
+            *self.slot().state.lock(),
+            SlotState::Mapping | SlotState::Mapped
+        ) {
+            self.unmap();
+        }
+        if !self.consumed {
+            self.state.add(|m| &mut m.leases_dropped_unconsumed, 1);
+        }
+        *self.slot().state.lock() = SlotState::Available;
+        self.state.add(|m| &mut m.leases_released, 1);
+    }
+}
+pub(crate) fn elapsed(start: Instant) -> u64 {
+    u64::try_from(start.elapsed().as_micros()).unwrap_or(u64::MAX)
+}
+pub(crate) fn aligned_offset(base: usize, capacity: usize) -> Result<usize, String> {
+    let offset = (ALIGN - base % ALIGN) % ALIGN;
+    if offset % 4 != 0
+        || offset.checked_add(FULL).is_none_or(|end| end > capacity)
+        || base.checked_add(offset).is_none_or(|p| p % ALIGN != 0)
+    {
+        return Err("invalid mapped alignment/range".into());
+    }
+    Ok(offset)
+}
+pub(crate) fn copy_source_offset(offset: usize, capacity: usize) -> Result<u64, String> {
+    if offset >= ALIGN
+        || offset % 4 != 0
+        || offset.checked_add(FULL).is_none_or(|end| end > capacity)
+    {
+        return Err("invalid upload copy range".into());
+    }
+    Ok((offset + ALIGN) as u64)
+}
+fn checked_payload(source: &[u8]) -> Result<&[u8], String> {
+    let (header, payload) = TensorHeader::strip(source, ALIGN);
+    let h = header.ok_or("missing UTH1")?;
+    if source.len() != FULL
+        || source.len() - payload.len() != ALIGN
+        || payload.len() != PAYLOAD
+        || h.dtype != UthDtypeId::Q4_0
+        || h.shape_rank != 3
+        || h.shape != [768, 2048, 3, 0]
+        || h.quant_scale_count != 0
+        || h.quant_scale_offset != 0
+    {
+        return Err("source/upload requires exact full-file Q4 geometry".into());
+    }
+    Ok(payload)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn source_upload_fresh_source_materializes_logical_host_payload_exactly_once() {
+        let state = State::cpu_test_state(Arm::Treatment);
+        let cache = GpuExpertCache::new(64, 0.0, 0);
+        let payload = [4u8; 16];
+        let shared = state
+            .materialize_source_payload(1, &payload, &cache)
+            .unwrap();
+        assert_eq!(shared.as_ref(), payload);
+        assert_ne!(shared.as_ptr(), payload.as_ptr());
+        assert_eq!(
+            state.snapshot().metrics.logical_materialization_operations,
+            1
+        );
+        assert_eq!(state.snapshot().metrics.logical_materialization_bytes, 16);
+        let pool = crate::buffer_pool::BufferPool::new(1, 4096, 4096);
+        let host = ExpertResident::new_qualification_shared(
+            1,
+            pool.try_acquire().unwrap(),
+            shared.clone(),
+        );
+        let logical = crate::expert_cache::GpuResident::new_qualification_shared(
+            1,
+            shared,
+            crate::inference::WeightDtype::Q4_0,
+        );
+        assert!(Arc::ptr_eq(
+            host.qualification_shared_payload().unwrap(),
+            logical.qualification_shared_payload().unwrap()
+        ));
+    }
+    #[test]
+    fn source_upload_existing_shared_logical_reuses_allocation_without_materialization() {
+        let state = State::cpu_test_state(Arm::Treatment);
+        let cache = GpuExpertCache::new(64, 0.0, 0);
+        let shared: Arc<[u8]> = Arc::from([3u8; 16].as_slice());
+        let resident = Arc::new(crate::expert_cache::GpuResident::new_qualification_shared(
+            1,
+            shared.clone(),
+            crate::inference::WeightDtype::Q4_0,
+        ));
+        let payloads = HashMap::from([(1, resident)]);
+        cache.demand_admit_set(&[1], &payloads).unwrap();
+        let generation = cache.current_admission(1).unwrap().generation();
+        let reused = state
+            .materialize_source_payload(1, &[3; 16], &cache)
+            .unwrap();
+        assert!(Arc::ptr_eq(&shared, &reused));
+        assert_eq!(
+            state.snapshot().metrics.logical_materialization_operations,
+            0
+        );
+        assert_eq!(state.snapshot().metrics.shared_payload_reuse, 1);
+        assert_eq!(cache.current_admission(1).unwrap().generation(), generation);
+        assert!(state
+            .materialize_source_payload(1, &[4; 16], &cache)
+            .is_err());
+    }
+    #[test]
+    fn source_upload_ordinary_logical_backing_fails_closed_without_extra_copy() {
+        let state = State::cpu_test_state(Arm::Treatment);
+        let cache = GpuExpertCache::new(64, 0.0, 0);
+        let resident = Arc::new(crate::expert_cache::GpuResident::new(1, vec![3u8; 16]));
+        cache
+            .demand_admit_set(&[1], &HashMap::from([(1, resident)]))
+            .unwrap();
+        assert!(state
+            .materialize_source_payload(1, &[3; 16], &cache)
+            .is_err());
+        assert_eq!(
+            state.snapshot().metrics.logical_materialization_operations,
+            0
+        );
+    }
+    #[test]
+    fn source_upload_full_source_header_and_payload_geometry_are_exact() {
+        let mut source = Vec::new();
+        TensorHeader::for_swiglu_expert(crate::inference::WeightDtype::Q4_0, 2048, 768)
+            .write_padded(ALIGN, &mut source);
+        source.resize(FULL, 0x37);
+        let payload = checked_payload(&source).unwrap();
+        assert_eq!(payload.len(), PAYLOAD);
+        assert!(payload.iter().all(|b| *b == 0x37));
+        assert!(checked_payload(payload).is_err());
+        assert!(checked_payload(&source[..FULL - 1]).is_err());
+        source[0] ^= 1;
+        assert!(checked_payload(&source).is_err());
+    }
+    #[test]
+    fn source_upload_alignment_is_recomputed_for_every_mapping() {
+        for base in (0x1000..0x4000).step_by(8) {
+            let offset = aligned_offset(base, UPLOAD_BYTES).unwrap();
+            assert_eq!((base + offset) % ALIGN, 0);
+            assert_eq!(
+                copy_source_offset(offset, UPLOAD_BYTES).unwrap(),
+                (offset + ALIGN) as u64
+            );
+            assert_eq!(offset + ALIGN + PAYLOAD, offset + FULL);
+        }
+        assert_ne!(
+            aligned_offset(0x1000, UPLOAD_BYTES).unwrap(),
+            aligned_offset(0x2008, UPLOAD_BYTES).unwrap()
+        );
+    }
+    #[test]
+    fn source_upload_copy_range_rejects_overflow_misalignment_and_short_buffer() {
+        for (offset, capacity) in [
+            (1, UPLOAD_BYTES),
+            (4096, UPLOAD_BYTES),
+            (8, FULL),
+            (usize::MAX, usize::MAX),
+        ] {
+            assert!(copy_source_offset(offset, capacity).is_err());
+        }
+        assert!(aligned_offset(usize::MAX - 4, UPLOAD_BYTES).is_err());
+        assert!(aligned_offset(0x1001, UPLOAD_BYTES).is_err());
+        assert!(aligned_offset(0x1000, FULL - 1).is_err());
+    }
+    #[test]
+    fn source_upload_ring_capacity_is_bounded_and_released_slots_reuse() {
+        let slots = (0..CAPACITY)
+            .map(|_| Mutex::new(SlotState::Available))
+            .collect::<Vec<_>>();
+        for i in 0..CAPACITY {
+            assert_eq!(reserve_slot(slots.iter()), Some(i));
+        }
+        assert_eq!(reserve_slot(slots.iter()), None);
+        *slots[7].lock() = SlotState::Available;
+        assert_eq!(reserve_slot(slots.iter()), Some(7));
+        assert_eq!(reserve_slot(slots.iter()), None);
+        assert_eq!(slots.len(), 16);
+    }
+    #[test]
+    fn source_upload_lease_map_unmap_submit_and_remap_transitions() {
+        let mut state = SlotState::Available;
+        for _ in 0..3 {
+            state
+                .transition(SlotState::Available, SlotState::Mapping)
+                .unwrap();
+            state
+                .transition(SlotState::Mapping, SlotState::Mapped)
+                .unwrap();
+            state
+                .transition(SlotState::Mapped, SlotState::Ready)
+                .unwrap();
+            state
+                .transition(SlotState::Ready, SlotState::Submitted)
+                .unwrap();
+            state
+                .transition(SlotState::Submitted, SlotState::Available)
+                .unwrap();
+        }
+    }
+    #[test]
+    fn source_upload_lease_consumption_is_exactly_once_and_requires_unmap() {
+        let mut state = SlotState::Mapped;
+        assert!(state
+            .transition(SlotState::Ready, SlotState::Submitted)
+            .is_err());
+        state
+            .transition(SlotState::Mapped, SlotState::Ready)
+            .unwrap();
+        state
+            .transition(SlotState::Ready, SlotState::Submitted)
+            .unwrap();
+        assert!(state
+            .transition(SlotState::Ready, SlotState::Submitted)
+            .is_err());
+    }
+    #[test]
+    fn source_upload_control_has_no_ring_or_lease_path() {
+        let state = State::cpu_test_state(Arm::Control);
+        assert!(state.acquire(1).is_err());
+        assert_eq!(state.snapshot().ring_capacity, 0);
+        assert_eq!(state.snapshot().metrics.leases_created, 0);
+        assert_eq!(state.snapshot().metrics.direct_source_reads, 0);
+    }
+    #[test]
+    fn source_upload_counter_overflow_is_a_visible_accounting_error() {
+        let mut metrics = Metrics::default();
+        metrics.direct_source_bytes = u64::MAX;
+        metrics.add(|m| &mut m.direct_source_bytes, 1);
+        assert_eq!(metrics.accounting_errors, 1);
+        assert_eq!(metrics.direct_source_bytes, u64::MAX);
+    }
+    #[test]
+    fn source_upload_nvme_and_generation_hashes_preserve_order() {
+        let a = State::cpu_test_state(Arm::Control);
+        let b = State::cpu_test_state(Arm::Control);
+        a.record_nvme(&[3, 1, 2]);
+        b.record_nvme(&[2, 1, 3]);
+        assert_ne!(
+            a.snapshot().ordered_nvme_ids_sha256,
+            b.snapshot().ordered_nvme_ids_sha256
+        );
+        a.record_logical(&[3, 1], &[9, 10], &[3, 1]);
+        b.record_logical(&[3, 1], &[10, 9], &[3, 1]);
+        assert_ne!(
+            a.snapshot().logical_generation_ids_sha256,
+            b.snapshot().logical_generation_ids_sha256
+        );
+        assert_eq!(
+            a.snapshot().logical_admission_ids_sha256,
+            b.snapshot().logical_admission_ids_sha256
+        );
+    }
+    #[test]
+    fn source_upload_source_owns_the_only_read_and_drops_views_before_unmap() {
+        let source = include_str!("gpu_native_source_upload.rs");
+        let body = source
+            .split("pub(crate) async fn read_source(")
+            .nth(1)
+            .unwrap()
+            .split("pub(crate) fn take_lease")
+            .next()
+            .unwrap();
+        assert_eq!(
+            body.matches(".read_experts_batch_into_aligned_slices(")
+                .count(),
+            1
+        );
+        assert!(
+            body.find("self.acquire(id)").unwrap()
+                < body
+                    .find(".read_experts_batch_into_aligned_slices(")
+                    .unwrap()
+        );
+        assert!(body.find("drop(views)").unwrap() < body.find("lease.unmap()").unwrap());
+        let physical = include_str!("backend/gpu_native.rs")
+            .split("pub(crate) fn stage_q4_expert_source_upload")
+            .nth(1)
+            .unwrap()
+            .split("pub(crate) fn commit_q4_expert_residency_production")
+            .next()
+            .unwrap();
+        for forbidden in [
+            "read_expert",
+            "NvmeStorage",
+            "write_buffer_with",
+            ".to_vec()",
+        ] {
+            assert!(!physical.contains(forbidden));
+        }
+        let residency = include_str!("gpu_native_residency.rs");
+        let submit = residency.find("copies.submit(&self.executor)").unwrap();
+        assert!(
+            submit
+                < residency[submit..]
+                    .find(".commit_q4_expert_residency_production_observed(")
+                    .unwrap()
+                    + submit
+        );
+    }
+}

--- a/rust-engine/src/io_provider.rs
+++ b/rust-engine/src/io_provider.rs
@@ -1351,6 +1351,100 @@ impl NvmeStorage {
         Ok(total)
     }
 
+    /// Qualification-only external destinations, with the production per-file
+    /// scheduler: resolve every fd, one blocking donation, scoped OS threads,
+    /// existing per-expert retries, and errors collected in original slot order.
+    /// There is no packed, buffered, or allocation fallback.
+    pub(crate) async fn read_experts_batch_into_aligned_slices(
+        &self,
+        ids: &[u32],
+        destinations: &mut [&mut [u8]],
+    ) -> io::Result<usize> {
+        if self.is_packed()
+            || ids.len() != destinations.len()
+            || self.cfg.expert_size != 2_658_304
+            || self.cfg.block_align != 4096
+            || destinations.iter().any(|dst| {
+                dst.len() != self.cfg.expert_size
+                    || dst.len() % self.cfg.block_align != 0
+                    || dst.as_ptr() as usize % self.cfg.block_align != 0
+            })
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "qualification requires unpacked full-file 4096-aligned external destinations",
+            ));
+        }
+        if ids.is_empty() {
+            return Ok(0);
+        }
+        let mut files: Vec<Arc<File>> = Vec::with_capacity(ids.len());
+        for &id in ids {
+            files.push(self.fd_for(id)?);
+        }
+        // Prove O_DIRECT on the actual Arc<File> passed to the retry helper;
+        // cache churn cannot substitute a different fd after this check.
+        for file in &files {
+            #[cfg(target_os = "linux")]
+            {
+                // SAFETY: files owns this live fd; F_GETFL has no third argument.
+                let flags = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_GETFL) };
+                if flags < 0 {
+                    return Err(io::Error::last_os_error());
+                }
+                if flags & libc::O_DIRECT == 0
+                    || file.metadata()?.len() != self.cfg.expert_size as u64
+                {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "qualification source fd must be O_DIRECT and exactly one full expert",
+                    ));
+                }
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                let _ = file;
+                return Err(io::Error::new(
+                    io::ErrorKind::Unsupported,
+                    "qualification direct source requires Linux O_DIRECT",
+                ));
+            }
+        }
+        let id_vec: Vec<u32> = ids.to_vec();
+        tokio::task::block_in_place(|| -> io::Result<usize> {
+            if id_vec.len() == 1 {
+                return self.read_at_with_retries(&files[0], id_vec[0], 0, destinations[0]);
+            }
+            let results: Vec<io::Result<usize>> = std::thread::scope(|scope| {
+                let handles: Vec<_> = files
+                    .iter()
+                    .zip(destinations.iter_mut())
+                    .zip(id_vec.iter())
+                    .map(|((file, dst), &id)| {
+                        let dst: &mut [u8] = dst;
+                        scope.spawn(move || self.read_at_with_retries(file, id, 0, dst))
+                    })
+                    .collect();
+                handles
+                    .into_iter()
+                    .zip(id_vec.iter())
+                    .map(|(h, &id)| {
+                        h.join().unwrap_or_else(|_| {
+                            Err(io::Error::other(format!(
+                                "read_experts_batch worker panicked reading expert {id}"
+                            )))
+                        })
+                    })
+                    .collect()
+            });
+            let mut total = 0usize;
+            for result in results {
+                total += result?;
+            }
+            Ok(total)
+        })
+    }
+
     /// **Tier 2.** Packed-blob sibling of [`Self::read_experts_batch`].
     ///
     /// Resolves every requested expert to its `(offset, len)` slot in the
@@ -3372,5 +3466,64 @@ mod source_to_upload_tests {
             assert!(s.files.lock().is_empty());
         }
         std::fs::remove_dir_all(path).unwrap();
+    }
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn source_upload_external_batch_rejects_bad_destinations_before_fd_or_io() {
+        let dir = directory();
+        let storage = NvmeStorage::new(StorageConfig {
+            base_path: dir.clone(),
+            expert_size: 2_658_304,
+            block_align: 4096,
+            use_direct_io: false,
+            num_experts_per_layer: None,
+        })
+        .unwrap();
+        let pool = crate::buffer_pool::BufferPool::new(1, 2_658_304 + 4096, 4096);
+        let mut buffer = pool.try_acquire().unwrap();
+        for (offset, len) in [(0, 2_658_303), (1, 2_658_304), (0, 2_654_208)] {
+            let mut destinations = vec![&mut buffer.as_mut_slice()[offset..offset + len]];
+            let error = storage
+                .read_experts_batch_into_aligned_slices(&[999], &mut destinations)
+                .await
+                .unwrap_err();
+            assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+        }
+        let error = storage
+            .read_experts_batch_into_aligned_slices(&[1], &mut [])
+            .await
+            .unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+    }
+    #[test]
+    fn source_upload_batch_preserves_production_scoped_thread_and_retry_shape() {
+        let source = include_str!("io_provider.rs");
+        let production = source
+            .split("pub async fn read_experts_batch(")
+            .nth(1)
+            .unwrap()
+            .split("pub(crate) async fn read_experts_batch_into_aligned_slices")
+            .next()
+            .unwrap();
+        let treatment = source
+            .split("pub(crate) async fn read_experts_batch_into_aligned_slices(")
+            .nth(1)
+            .unwrap()
+            .split("/// **Tier 2.**")
+            .next()
+            .unwrap();
+        for body in [production, treatment] {
+            assert_eq!(body.matches("tokio::task::block_in_place(").count(), 1);
+            assert_eq!(body.matches("std::thread::scope(").count(), 1);
+            assert!(body.contains("scope.spawn("));
+            assert!(body.contains("read_at_with_retries("));
+            assert!(
+                body.find("files.push(self.fd_for(id)?)").unwrap()
+                    < body.find("tokio::task::block_in_place(").unwrap()
+            );
+            assert!(body.contains(".zip(id_vec.iter())"));
+            assert!(body.contains("h.join()"));
+        }
+        assert!(!treatment.contains("read_expert("));
+        assert!(!treatment.contains("spawn_blocking"));
     }
 }

--- a/rust-engine/src/io_provider.rs
+++ b/rust-engine/src/io_provider.rs
@@ -1351,10 +1351,10 @@ impl NvmeStorage {
         Ok(total)
     }
 
-    /// Qualification-only external destinations, with the production per-file
-    /// scheduler: resolve every fd, one blocking donation, scoped OS threads,
-    /// existing per-expert retries, and errors collected in original slot order.
-    /// There is no packed, buffered, or allocation fallback.
+    /// Source/upload external destinations with the production per-file scheduler:
+    /// resolve every fd, one blocking donation, scoped OS threads, existing
+    /// per-expert retries, and errors collected in original slot order. There is
+    /// no packed, buffered, or allocation fallback.
     pub(crate) async fn read_experts_batch_into_aligned_slices(
         &self,
         ids: &[u32],
@@ -1372,7 +1372,7 @@ impl NvmeStorage {
         {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
-                "qualification requires unpacked full-file 4096-aligned external destinations",
+                "source/upload requires unpacked full-file 4096-aligned external destinations",
             ));
         }
         if ids.is_empty() {
@@ -1397,7 +1397,7 @@ impl NvmeStorage {
                 {
                     return Err(io::Error::new(
                         io::ErrorKind::InvalidInput,
-                        "qualification source fd must be O_DIRECT and exactly one full expert",
+                        "source/upload source fd must be O_DIRECT and exactly one full expert",
                     ));
                 }
             }
@@ -1406,7 +1406,7 @@ impl NvmeStorage {
                 let _ = file;
                 return Err(io::Error::new(
                     io::ErrorKind::Unsupported,
-                    "qualification direct source requires Linux O_DIRECT",
+                    "source/upload direct source requires Linux O_DIRECT",
                 ));
             }
         }

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -156,6 +156,7 @@ pub(crate) mod gpu_native_router_rank_diagnostics;
 pub(crate) mod gpu_native_semantic_parity_corpus;
 pub(crate) mod gpu_native_semantic_parity_v2;
 pub(crate) mod gpu_native_source_to_upload_copy_elision;
+pub(crate) mod gpu_native_source_upload;
 pub(crate) mod gpu_native_spanish_first_token_attribution;
 pub(crate) mod gpu_native_v2_holdout_failure_attribution;
 
@@ -1027,6 +1028,17 @@ enum Cmd {
     /// ordinary production concurrent complete overwrite with no explicit zero.
     #[command(name = "qualify-gpu-native-physical-zero-fill-production")]
     QualifyGpuNativePhysicalZeroFillProduction {
+        #[arg(long)]
+        config: PathBuf,
+        #[arg(long)]
+        expected_adapter_name: String,
+        #[arg(long)]
+        report_out: PathBuf,
+    },
+
+    /// Qualification-only single-read source to mapped-upload real-inference A/B.
+    #[command(name = "qualify-gpu-native-source-to-upload-copy-elision-production")]
+    QualifyGpuNativeSourceToUploadCopyElisionProduction {
         #[arg(long)]
         config: PathBuf,
         #[arg(long)]
@@ -2034,6 +2046,7 @@ fn startup_config_path(cmd: &Cmd) -> Option<&Path> {
         | Cmd::QualifyGpuNativePhysicalInstallStagingProduction { config, .. }
         | Cmd::QualifyGpuNativePhysicalInstallConcurrencyProduction { config, .. }
         | Cmd::QualifyGpuNativePhysicalZeroFillProduction { config, .. }
+        | Cmd::QualifyGpuNativeSourceToUploadCopyElisionProduction { config, .. }
         | Cmd::QualifyHybridQ4 { config, .. }
         | Cmd::QualifyHybridQ4Parity { config, .. }
         | Cmd::QualifyHybridQ4GreedyParity { config, .. }
@@ -2600,6 +2613,25 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .build()?;
             rt.block_on(
                 crate::gpu_native_physical_install_staging::zero_fill_production::run_command(
+                    crate::gpu_native_physical_install_staging::CommandArgs {
+                        config,
+                        expected_adapter_name,
+                        report_out,
+                        progress_watchdog,
+                    },
+                ),
+            )
+        }
+        Cmd::QualifyGpuNativeSourceToUploadCopyElisionProduction {
+            config,
+            expected_adapter_name,
+            report_out,
+        } => {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()?;
+            rt.block_on(
+                crate::gpu_native_physical_install_staging::source_to_upload_production::run_command(
                     crate::gpu_native_physical_install_staging::CommandArgs {
                         config,
                         expected_adapter_name,


### PR DESCRIPTION
## Summary
Productionizes the hardware-qualified single-read source-to-mapped-upload path for ordinary GPU-native demand residency while preserving exact source, routing, cache, victim, and workload semantics.

## Exact qualified lineage
- head: `a3d7287c7f7260d6b82f8a41305021d22ab623e9`
- parent: `0bb8b421f276321f2c543035f9c8c47b013fd022`
- tree: `df7ef590442baf6b0b9683671fa345569b59634b`
- tested patch SHA-256: `97c4f600b2de9a3390ef62a31fdb79a5f37fd1ef4ea7e2bbbc791cdb1ab8a495`

## Portable qualification
- frozen witness PASS
- focused source-upload tests: 28/28 PASS
- full tokenizer suite: 1,585 PASS / 0 failed / 15 ignored
- cargo check tests tokenizer PASS
- canonical release build PASS with `RUST_MIN_STACK` unset
- git diff --check PASS
- no touched-file formatting regression

## Authoritative Linux/L4 v2 FIRST
Frozen binary SHA-256: `3936eb523286bb75fdbfd1855022ab93983c92b261dcbcee703713f2ad86f361`

Typed report SHA-256: `2bb801821f4d2939aadb36cd9bdf72f43cb14378b2f2869d19eb5dd31fc48bfe`

Result:
- benchmark_complete=true
- qualification_pass=true
- all formal gates PASS
- performance_result=improved
- failure=null

Performance:
- decode: 1.109676824 -> 1.131750665 TPS (+1.9892%)
- E2E generated: 0.999603311 -> 1.018899364 TPS (+1.9304%)
- mean request wall: 128.050948 -> 125.625791 s (-1.8939%)
- TTFT: 13.602974 -> 13.410251 s (-1.4168%)

Causal/mechanism evidence:
- source work exact across arms: 88,029 NVMe reads / 234,007,842,816 B, 2,688 RAM hits, 88,029 RAM misses, 90,717 physical installs
- treatment fused 88,029 installs / 233,647,276,032 B (97.0369%) via GPU copy
- only 2,688 RAM-hit installs / 7,134,511,104 B remain on CPU fallback
- ring high-water 8/16; acquisition waits 0
- leases 88,029 created = consumed = released
- zero remap/alignment/direct-I/O/source-fallback/copy/accounting failures
- 19,023 fused install sets = 19,023 command buffers = 19,023 submissions
- production upload ownership gate PASS

Environment:
- FIRST started only after live systemd cgroup proved MemoryMax=12,884,901,888 and MemorySwapMax=0 with swap.current=0
- systemd final result success with MemoryMax/MemorySwapMax retained
- no kernel OOM lines in the FIRST window
- post-run cgroup peak/max-event telemetry was not retained because the transient cgroup was collected before the outer evidence tail; no rerun was performed or permitted

## Merge policy
Normal merge commit only. Do not squash, rebase, or amend the hardware-qualified head.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a GPU-native source-to-upload path that can reduce redundant data copying during expert residency installs.
  - Added support for direct, aligned expert reads into GPU-upload buffers with fallback handling for unsupported cases.
  - Added a qualification command for comparing control and optimized upload paths, including performance and accounting reports.
  - Added telemetry for upload bytes, fused and fallback installs, source failures, and timing.

- **Tests**
  - Added coverage for upload production wiring, memory-hit behavior, ordering, validation, and qualification report gates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->